### PR TITLE
submodule for geoserver war creation using war overlay with additional jetty configuration for execution. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea/**
 target
 atlassian*
+**/META-INF/context.xml

--- a/geomesa-geoserver/pom.xml
+++ b/geomesa-geoserver/pom.xml
@@ -1,0 +1,76 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	
+	<parent>
+        <groupId>geomesa</groupId>
+        <artifactId>geomesa</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<gs.version>2.3.5</gs.version>
+		<jetty.port>8080</jetty.port>
+	</properties>
+
+	<groupId>geomesa</groupId>
+	<artifactId>geomesa-geoserver</artifactId>
+	<packaging>war</packaging>
+
+	<name>GeoServer WAR Overlay</name>
+	
+	<repositories>
+		<repository>
+			<id>opengeo</id>
+			<url>http://repo.opengeo.org</url>
+		</repository>
+	</repositories>
+	
+	<dependencies>
+		<dependency>
+			<groupId>org.geoserver.web</groupId>
+			<artifactId>web-app</artifactId>
+			<version>${geoserver.version}</version>
+			<type>war</type>
+		</dependency>
+		<dependency>
+			<groupId>geomesa</groupId>
+			<artifactId>geomesa-plugin</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<finalName>geoserver</finalName>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<version>2.4</version>
+				<configuration>
+					<overlays>
+						<overlay>
+							<groupId>org.geoserver.web</groupId>
+							<artifactId>web-app</artifactId>
+						</overlay>
+					</overlays>
+					<warSourceExcludes>WEB-INF/web.xml</warSourceExcludes>
+					<packagingExcludes>META-INF/context.xml</packagingExcludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.mortbay.jetty</groupId>
+				<artifactId>maven-jetty-plugin</artifactId>
+				<version>6.1.10</version>
+				<configuration>
+					<contextPath>geoserver</contextPath>
+					<connectors>
+						<connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
+							<port>${jetty.port}</port>
+							<maxIdleTime>60000</maxIdleTime>
+						</connector>
+					</connectors>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/geomesa-geoserver/src/main/webapp/WEB-INF/web.xml
+++ b/geomesa-geoserver/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+</web-app>


### PR DESCRIPTION
Creates an additional submodule that generates a geoserver war with the geomesa extension (and it's dependencies) injected.

The geoserver versions 2.4 or older the geoserver war will need to be added to a maven repository (local or remote). One can accomplish this with the following instructions from the command line:

```
mkdir geoserver-2.3.5-war
cd geoserver-2.3.5-war/
wget http://downloads.sourceforge.net/project/geoserver/GeoServer/2.3.5/geoserver-2.3.5-war.zip
unzip geoserver-2.3.5-war.zip
jar xf geoserver.war META-INF
mvn install:install-file -Dfile=geoserver.war -DpomFile=META-INF/maven/org.geoserver.web/web-app/pom.xml -DgroupId=org.geoserver.web -DartifactId=web-app -Dversion=2.3.5 -Dpackaging=war
```

The geoserver war can then be built with:

```
cd geomesa-geoserver
mvn clean install
```

The war built by this submodule can then be launched with

```
mvn jetty:run-war
```

The port for the jetty execution can be changed my passing with the property `jetty.port`, e.g.:

```
mvn jetty:run-war -Djetty.port=8081
```

The submodule is not added to the parent `pom.xml` since the geoserver war is not yet widely available in maven repositories.  
