### PR TITLE
AvroSimpleFeature return nulls for attrs that don't exist

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/avro/AvroSimpleFeature.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/avro/AvroSimpleFeature.scala
@@ -89,7 +89,7 @@ class AvroSimpleFeature(id: FeatureId, sft: SimpleFeatureType) extends SimpleFea
   def getIdentifier = id
   def getID = id.getID
 
-  def getAttribute(name: String) = nameIndex.get(name).map(getAttribute).getOrElse(throw new NullPointerException("Invalid attribute"))
+  def getAttribute(name: String) = nameIndex.get(name).map(getAttribute).getOrElse(null)
   def getAttribute(name: Name) = getAttribute(name.getLocalPart)
   def getAttribute(index: Int) = values(index)
 

--- a/geomesa-core/src/test/scala/geomesa/core/avro/AvroSimpleFeatureTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/avro/AvroSimpleFeatureTest.scala
@@ -7,6 +7,7 @@ import org.geotools.filter.identity.FeatureIdImpl
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
+import org.geotools.feature.simple.SimpleFeatureImpl
 
 @RunWith(classOf[JUnitRunner])
 class AvroSimpleFeatureTest extends Specification {
@@ -76,6 +77,20 @@ class AvroSimpleFeatureTest extends Specification {
       f.getAttributes.foreach { v => v must beNull}
 
       f.validate must not(throwA [org.opengis.feature.IllegalAttributeException])
+    }
+  }
+
+  "AvroSimpleFeature" should {
+    "give back a null when an attribute doesn't exist" in {
+
+      // Verify that AvroSimpleFeature returns null for attributes that do not exist like SimpleFeatureImpl
+      val sft = DataUtilities.createType("avrotesttype", "a:Integer,b:String")
+      val sf = new AvroSimpleFeature(new FeatureIdImpl("fakeid"), sft)
+      sf.getAttribute("c") must not(throwA[NullPointerException])
+      sf.getAttribute("c") should beNull
+
+      val oldSf = new SimpleFeatureImpl(List(null, null), sft, new FeatureIdImpl("fakeid"))
+      oldSf.getAttribute("c") should beNull
     }
   }
 }

--- a/geomesa-core/src/test/scala/geomesa/core/avro/FeatureSpecificReaderTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/avro/FeatureSpecificReaderTest.scala
@@ -146,8 +146,10 @@ class FeatureSpecificReaderTest {
     })
   }
 
-  @Test(expected = classOf[NullPointerException])
-  def testMemberNotInSubsetIsNull(): Unit = getSubsetData(0).getAttribute("f20")
+  @Test
+  def testMemberNotInSubsetIsNull(): Unit = {
+    Assert.assertNull(getSubsetData(0).getAttribute("f20"))
+  }
 
 
   @Test


### PR DESCRIPTION
AvroSimpleFeature return nulls for attrs that don't exist to mirror expected behavior in SimpleFeatureImpl instead of throwing a null pointer exception
