### PR TITLE
GEOMESA-134: DTG field treatment in package object 'index' not safe

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/index/index.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/index/index.scala
@@ -36,9 +36,9 @@ package object index {
   val SF_PROPERTY_START_TIME = "geomesa_index_start_time"
   val SF_PROPERTY_END_TIME   = "geomesa_index_end_time"
 
-  def getDtgFieldName(sft: SimpleFeatureType) =
-    sft.getUserData.get(SF_PROPERTY_START_TIME).toString
-  def getDtgDescriptor(sft: SimpleFeatureType) = sft.getDescriptor(getDtgFieldName(sft))
+  def getDtgFieldName(sft: SimpleFeatureType) = Option(sft.getUserData.get(SF_PROPERTY_START_TIME)).map{_.toString}
+  // wrapping function in option to protect against incorrect values in SF_PROPERTY_START_TIME
+  def getDtgDescriptor(sft: SimpleFeatureType) = getDtgFieldName(sft).flatMap{name => Option(sft.getDescriptor(name))}
   val spec = "geomesa_index_geometry:Geometry:srid=4326,geomesa_index_start_time:Date,geomesa_index_end_time:Date"
   val indexSFT = DataUtilities.createType("geomesa-idx", spec)
 


### PR DESCRIPTION
Wrap dtg variables in core.index in Options, since the temporal field in...

Also modify FilterToAccumulo to handle these changes.
