### PR TITLE
GEOMESA-67 Checking for visibilities before allowing write, enforcing existing schema if present

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStore.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStore.scala
@@ -17,28 +17,29 @@
 
 package geomesa.core.data
 
+import com.typesafe.scalalogging.slf4j.Logging
 import geomesa.core
 import geomesa.core.data.AccumuloFeatureWriter.{LocalRecordDeleter, LocalRecordWriter, MapReduceRecordWriter}
 import geomesa.core.data.FeatureEncoding.FeatureEncoding
 import geomesa.core.index.{Constants, IndexSchema}
 import geomesa.core.security.AuthorizationsProvider
-import java.io.Serializable
-import java.util.{Map=>JMap}
+import java.io.{IOException, Serializable}
+import java.util.{Map => JMap}
+import org.apache.accumulo.core.client._
 import org.apache.accumulo.core.client.mock.MockConnector
-import org.apache.accumulo.core.client.{BatchWriterConfig, IteratorSetting, Connector}
-import org.apache.accumulo.core.data.{Key, Mutation, Value, Range}
+import org.apache.accumulo.core.data.{Mutation, Value, Range}
 import org.apache.accumulo.core.file.keyfunctor.ColumnFamilyFunctor
 import org.apache.accumulo.core.iterators.user.VersioningIterator
+import org.apache.accumulo.core.security.ColumnVisibility
 import org.apache.hadoop.io.Text
 import org.geotools.data._
 import org.geotools.data.simple.SimpleFeatureSource
 import org.geotools.factory.Hints
-import org.geotools.feature.NameImpl
 import org.geotools.geometry.jts.ReferencedEnvelope
-import org.opengis.feature.`type`.Name
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 import org.opengis.referencing.crs.CoordinateReferenceSystem
+import scala.Some
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 
@@ -49,188 +50,418 @@ import scala.collection.JavaConverters._
  * @param authorizationsProvider   Provides the authorizations used to access data
  * @param writeVisibilities   Visibilities applied to any data written by this store
  *
- * This class handles DataStores which are stored in Accumulo Tables.  To be clear, one table may contain multiple
- * features addressed by their featureName.
+ *  This class handles DataStores which are stored in Accumulo Tables.  To be clear, one table may
+ *  contain multiple features addressed by their featureName.
  */
-class AccumuloDataStore(val connector: Connector,
-                        val tableName: String,
+class AccumuloDataStore(val connector: Connector, val tableName: String,
                         val authorizationsProvider: AuthorizationsProvider,
-                        val writeVisibilities: String,
-                        val indexSchemaFormat: String = "DEFAULT",
+                        val writeVisibilities: String, val indexSchemaFormat: String = "DEFAULT",
                         val featureEncoding: FeatureEncoding = FeatureEncoding.AVRO)
-  extends AbstractDataStore(true) {
+    extends AbstractDataStore(true) with Logging {
 
   private def buildDefaultSchema(name: String) =
     s"%~#s%99#r%${name}#cstr%0,3#gh%yyyyMMdd#d::%~#s%3,2#gh::%~#s%#id"
 
   Hints.putSystemDefault(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, true)
 
-  val tableOps = connector.tableOperations()
-  type KVEntry = JMap.Entry[Key,Value]
-
-  def createTableIfNotExists(tableName: String,
-                             featureType: SimpleFeatureType,
-                             featureEncoding: FeatureEncoding) {
-    if (!tableOps.exists(tableName))
-      connector.tableOperations.create(tableName)
-
-    if(!connector.isInstanceOf[MockConnector])
-      configureNewTable(createIndexSchema(featureType), featureType, tableName, featureEncoding)
-  }
-
-  def configureNewTable(indexSchemaFormat: String, featureType: SimpleFeatureType, tableName: String, fe: FeatureEncoding) {
-    val encoder = SimpleFeatureEncoderFactory.createEncoder(fe)
-    val indexSchema = IndexSchema(indexSchemaFormat, featureType, encoder)
-    val maxShard = indexSchema.maxShard
-
-    val splits = (1 to maxShard).map { i => s"%0${maxShard.toString.length}d".format(i) }.map(new Text(_))
-    tableOps.addSplits(tableName, new java.util.TreeSet(splits))
-
-    // enable the column-family functor
-    tableOps.setProperty(tableName, "table.bloom.key.functor", classOf[ColumnFamilyFunctor].getCanonicalName)
-    tableOps.setProperty(tableName, "table.bloom.enabled", "true")
-
-    // isolate various metadata elements in locality groups
-    tableOps.setLocalityGroups(tableName,
-      Map(
-        ATTRIBUTES_CF.toString -> Set(ATTRIBUTES_CF).asJava,
-        SCHEMA_CF.toString     -> Set(SCHEMA_CF).asJava,
-        BOUNDS_CF.toString     -> Set(BOUNDS_CF).asJava))
-  }
-
-  override def createSchema(featureType: SimpleFeatureType) {
-    // Attempt to determine the encoding before possibly creating the table
-    val properEncoding = determineProperEncoding(featureType, featureEncoding)
-    createTableIfNotExists(tableName, featureType, properEncoding)
-    writeMetadata(featureType, properEncoding)
-  }
-
-  // If the table exists already use the feature encoding stored as metadata instead of
-  // the user provided feature encoding...if table exists but doesn't have metadata for
-  // feature encoding then default to TEXT for backwards compatability
-  def determineProperEncoding(featureType: SimpleFeatureType, providedEncoding: FeatureEncoding) = {
-    if (tableOps.exists(tableName)) getFeatureEncoder(featureType.getTypeName).getEncoding
-    else providedEncoding
-  }
-
-  def writeMetadata(sft: SimpleFeatureType, fe: FeatureEncoding) {
-    val featureName = sft.getName.getLocalPart
-    val attributesValue = new Value(DataUtilities.encodeType(sft).getBytes)
-    writeMetadataItem(featureName, ATTRIBUTES_CF, attributesValue)
-    val schemaValue = createIndexSchema(sft)
-    writeMetadataItem(featureName, SCHEMA_CF, new Value(schemaValue.getBytes))
-    val userData = sft.getUserData
-    if(userData.containsKey(core.index.SF_PROPERTY_START_TIME)) {
-      val dtgField = userData.get(core.index.SF_PROPERTY_START_TIME)
-      writeMetadataItem(featureName, DTGFIELD_CF, new Value(dtgField.asInstanceOf[String].getBytes))
-    }
-    writeMetadataItem(featureName, FEATURE_ENCODING_CF, new Value(fe.toString.getBytes()))
-  }
-
-  def createIndexSchema(sft: SimpleFeatureType) = indexSchemaFormat match {
-    case "DEFAULT" => buildDefaultSchema(sft.getTypeName)
-    case _         => indexSchemaFormat
-  }
-
-  def getMetadataRowID(featureName: String) = new Text(METADATA_TAG + "_" + featureName)
-
-  val MetadataRowIDRegex = (METADATA_TAG + """_(.*)""").r
-
-  def getFeatureNameFromMetadataRowID(rowID: String): String = {
-    val MetadataRowIDRegex(featureName) = rowID
-    featureName
-  }
+  private val validated = scala.collection.mutable.Map[String, String]()
 
   private val metaDataCache = scala.collection.mutable.HashMap[(String, Text), Option[String]]()
 
-  val batchWriterConfig =
-    new BatchWriterConfig()
-      .setMaxMemory(10000L)
-      .setMaxWriteThreads(10)
+  private val visibilityCheckCache = scala.collection.mutable.Map[(String, String), Boolean]()
 
-  // record a single piece of metadata
-  private def writeMetadataItem(featureName: String, colFam: Text, metadata: Value) {
-    val writer = connector.createBatchWriter(tableName, batchWriterConfig)
-    val mutation = new Mutation(getMetadataRowID(featureName))
-    mutation.put(colFam, EMPTY_COLQ, System.currentTimeMillis(), metadata)
-    writer.addMutation(mutation)
-    writer.flush()
-    writer.close()
+  // TODO config should be configurable...
+  private val batchWriterConfig =
+    new BatchWriterConfig().setMaxMemory(10000L).setMaxWriteThreads(10)
 
-    // pre-fetch this into cache
-    metaDataCache.put((featureName, colFam), Option(metadata).map(_.toString))
+  private val MetadataRowKeyRegex = (METADATA_TAG + """_(.*)""").r
+
+  private val tableOps = connector.tableOperations()
+
+  /**
+   * Creates the schema for the feature type. This will create the table in accumulo, if it doesn't
+   * exist. It will configure splits for the table based on the feature type. Note that if the table
+   * has already been configured for a different feature type (i.e. multiple features in one table)
+   * the splits from the previous feature will be used.
+   *
+   * @param featureType
+   */
+  override def createSchema(featureType: SimpleFeatureType) {
+    val indexSchema = getIndexSchemaString(featureType.getTypeName)
+    createAndConfigureTable(featureType, featureEncoding, indexSchema)
+    writeMetadata(featureType, featureEncoding, indexSchema)
   }
 
-  // Read metadata using scheme:  ~METADATA_featureName metadataFieldName: insertionTimestamp metadataValue
+  /**
+   * Creates and configures the accumulo table for this feature. Note that if the table has already
+   * been configured for a different feature type (i.e. multiple features in one table)
+   * the splits from the previous feature will be used.
+   *
+   * If the schema already exists for this feature type, it will throw an exception.
+   *
+   * @param featureType
+   * @param featureEncoding
+   */
+  private def createAndConfigureTable(featureType: SimpleFeatureType,
+                                      featureEncoding: FeatureEncoding,
+                                      indexSchemaString: String): Unit = {
+    if (!tableOps.exists(tableName))
+      connector.tableOperations.create(tableName)
+
+    val featureName = getFeatureName(featureType)
+
+    if (!getAttributes(featureName).isEmpty)
+      throw new IOException(s"Schema already exists for feature type $featureName")
+
+    // mock connector - skip configuration
+    if (connector.isInstanceOf[MockConnector])
+      return
+
+    // configure table splits
+    val existingSplits = tableOps.listSplits(tableName)
+    if (existingSplits == null || existingSplits.isEmpty) {
+      val encoder = SimpleFeatureEncoderFactory.createEncoder(featureEncoding)
+      val indexSchema = IndexSchema(indexSchemaString, featureType, encoder)
+      val maxShard = indexSchema.maxShard
+
+      val splits = (1 to maxShard).map { i => s"%0${maxShard.toString.length }d".format(i) }
+                   .map(new Text(_))
+      tableOps.addSplits(tableName, new java.util.TreeSet(splits))
+    } else
+        logger.warn(s"Table $tableName has pre-existing splits which will be used: $existingSplits")
+
+    // enable the column-family functor
+    tableOps.setProperty(tableName, "table.bloom.key.functor",
+                          classOf[ColumnFamilyFunctor].getCanonicalName)
+    tableOps.setProperty(tableName, "table.bloom.enabled", "true")
+
+    // isolate various metadata elements in locality groups
+    tableOps.setLocalityGroups(tableName, Map(ATTRIBUTES_CF.toString -> Set(ATTRIBUTES_CF).asJava,
+                                               SCHEMA_CF.toString -> Set(SCHEMA_CF).asJava,
+                                               BOUNDS_CF.toString -> Set(BOUNDS_CF).asJava))
+
+  }
+
+  /**
+   * Computes and writes the metadata for this feature type
+   *
+   * @param sft
+   * @param fe
+   */
+  private def writeMetadata(sft: SimpleFeatureType, fe: FeatureEncoding,
+                            indexSchemaString: String): Unit = {
+
+    val featureName = getFeatureName(sft)
+
+    // the mutation we'll be writing to
+    val mutation = getMetadataMutation(featureName)
+
+    // compute the metadata values
+    val attributesValue = DataUtilities.encodeType(sft)
+    val schemaValue = indexSchemaString
+    val dtgValue: Option[String] = {
+      val userData = sft.getUserData
+      if (userData.containsKey(core.index.SF_PROPERTY_START_TIME))
+        Option(userData.get(core.index.SF_PROPERTY_START_TIME).asInstanceOf[String])
+      else
+        None
+    }
+    val featureEncodingValue = fe.toString
+
+    // store each metadata in the associated column family
+    val attributeMap = Map(ATTRIBUTES_CF          -> attributesValue,
+                            SCHEMA_CF             -> schemaValue,
+                            DTGFIELD_CF           -> dtgValue.getOrElse(Constants.SF_PROPERTY_START_TIME),
+                            FEATURE_ENCODING_CF   -> featureEncodingValue,
+                            VISIBILITIES_CF       -> writeVisibilities)
+
+    attributeMap.foreach { case (cf, value) =>
+      putMetadata(featureName, mutation, cf, value)
+    }
+
+    // write out a visibilities protected entry that we can use to validate that a user can see
+    // data in this store
+    if (!writeVisibilities.isEmpty) {
+      mutation.put(VISIBILITIES_CHECK_CF, EMPTY_COLQ, new ColumnVisibility(writeVisibilities),
+                    new Value(writeVisibilities.getBytes))
+    }
+
+    // write out the mutation
+    writeMutations(mutation)
+  }
+
+  /**
+   * Handles creating a mutation for writing metadata
+   *
+   * @param featureName
+   * @return
+   */
+  private def getMetadataMutation(featureName: String) = new Mutation(getMetadataRowKey(featureName))
+
+  /**
+   * Handles encoding metadata into a mutation.
+   *
+   * @param featureName
+   * @param mutation
+   * @param columnFamily
+   * @param value
+   */
+  private def putMetadata(featureName: String, mutation: Mutation, columnFamily: Text,
+                          value: String): Unit = {
+    mutation.put(columnFamily, EMPTY_COLQ, System.currentTimeMillis(), new Value(value.getBytes))
+    // also pre-fetch into the cache
+    if (!value.isEmpty)
+      metaDataCache.put((featureName, columnFamily), Some(value))
+  }
+
+  /**
+   * Handles writing mutations
+   *
+   * @param mutations
+   */
+  private def writeMutations(mutations: Mutation*): Unit = {
+    val writer = connector.createBatchWriter(tableName, batchWriterConfig)
+    for (mutation <- mutations) {
+      writer.addMutation(mutation)
+    }
+    writer.flush()
+    writer.close()
+  }
+
+  /**
+   * Gets the index schema formatted string for this feature
+   *
+   * @param featureName
+   * @return
+   */
+  private def getIndexSchemaString(featureName: String): String = {
+    indexSchemaFormat match {
+      case "DEFAULT" => buildDefaultSchema(featureName)
+      case _         => indexSchemaFormat
+    }
+  }
+
+  /**
+   * Validates the configuration of this data store instance against the stored configuration in
+   * Accumulo, if any. This is used to ensure that the visibilities (in particular) do not change
+   * from one instance to the next. This will fill in any missing metadata that may occur in an
+   * older (0.1.0) version of a table.
+   */
+  protected def validateMetadata(featureName: String): Unit = {
+    readMetadataItem(featureName, ATTRIBUTES_CF)
+    .getOrElse(throw new RuntimeException(s"Feature '$featureName' has not been initialized. Please call 'createSchema' first."))
+
+    val ok = validated.get(featureName).getOrElse({
+      val errors = checkMetadata(featureName)
+      validated.put(featureName, errors)
+      errors
+    })
+
+    if (!ok.isEmpty)
+      throw new RuntimeException("Configuration of this DataStore does not match the schema values: " + ok)
+  }
+
+  /**
+   * Wraps the functionality of checking the metadata against this config
+   *
+   * @param featureName
+   * @return string with errors, or empty string
+   */
+  private def checkMetadata(featureName: String) = {
+    // validate that visibilities and schema have not changed
+    val errors = List((SCHEMA_CF,         getIndexSchemaString(featureName)),
+                      (VISIBILITIES_CF,   writeVisibilities)).map {
+      case (cf, expectedValue) =>
+        val existing = readMetadataItem(featureName, cf).getOrElse("")
+        if (existing != expectedValue)
+          Some(s"$cf = '$expectedValue', should be '$existing'")
+        else
+           None
+    }.flatten.mkString(", ")
+
+    // if no errors, check the feature encoding and update if needed
+    if (errors.isEmpty) {
+      // for feature encoding, we are more lenient - we will use whatever is stored in the table,
+      // or default to 'text' for backwards compatibility
+      if (readMetadataItem(featureName, FEATURE_ENCODING_CF).getOrElse("").isEmpty) {
+        // default to 'text' encoding for backwards compatibility
+        val mutation = getMetadataMutation(featureName)
+        putMetadata(featureName, mutation, FEATURE_ENCODING_CF, FeatureEncoding.TEXT.toString)
+        writeMutations(mutation)
+      }
+    }
+
+    errors
+  }
+
+  /**
+   * Checks whether the current user can write - based on whether they can read data in this
+   * data store.
+   *
+   * @param featureName
+   */
+  protected def checkWritePermissions(featureName: String): Unit = {
+    val visibilities = readMetadataItem(featureName, VISIBILITIES_CF).getOrElse("")
+    // if no visibilities set, no need to check
+    if (!visibilities.isEmpty) {
+      // create a key for the user's auths that we will use to check the cache
+      val authString = authorizationsProvider.getAuthorizations.getAuthorizations
+                      .map(a => new String(a)).sorted.mkString(",")
+      if (!checkWritePermissions(featureName, authString)) {
+        throw new RuntimeException(s"The current user does not have the required authorizations to write $featureName features. Required authorizations: '$visibilities', actual authorizations: '$authString'")
+      }
+    }
+  }
+
+  /**
+   * Wraps logic for checking write permissions for a given set of auths
+   *
+   * @param featureName
+   * @param authString
+   * @return
+   */
+  private def checkWritePermissions(featureName: String, authString: String) = {
+    // if cache contains an entry, use that
+    visibilityCheckCache.getOrElse((featureName, authString), {
+      // check the 'visibilities check' metadata - it has visibilities applied, so if the user
+      // can read that row, then they can read any data in the data store
+      val visCheck = readMetadataItemNoCache(featureName, VISIBILITIES_CHECK_CF)
+                      .isInstanceOf[Some[String]]
+      visibilityCheckCache.put((featureName, authString), visCheck)
+      visCheck
+    })
+  }
+
+  /**
+   * Creates the row id for a metadata entry
+   *
+   * @param featureName
+   * @return
+   */
+  private def getMetadataRowKey(featureName: String) = new Text(METADATA_TAG + "_" + featureName)
+
+  /**
+   * Reads metadata from cache or scans if not available
+   *
+   * @param featureName
+   * @param colFam
+   * @return
+   */
   private def readMetadataItem(featureName: String, colFam: Text): Option[String] =
     metaDataCache.getOrElse((featureName, colFam), {
-      val batchScanner = createBatchScanner
-      batchScanner.setRanges(List(new org.apache.accumulo.core.data.Range(s"${METADATA_TAG}_$featureName")))
-      batchScanner.fetchColumn(colFam, EMPTY_COLQ)
-
-      val name = "version-" + featureName + "-" + colFam.toString
-      val cfg = new IteratorSetting(1, name, classOf[VersioningIterator])
-      VersioningIterator.setMaxVersions(cfg, 1)
-      batchScanner.addScanIterator(cfg)
-
-      val iter = batchScanner.iterator
-      val result =
-        if(iter.hasNext) Some(iter.next.getValue.toString)
-        else None
-
-      batchScanner.close()
-
+      val result = readMetadataItemNoCache(featureName, colFam)
       metaDataCache.put((featureName, colFam), result)
       result
     })
 
-  // Returns a list of available layers.
-  // This populates the list of layers which can be "published" by Geoserver.
-  def createTypeNames(): java.util.List[Name] =
-    if (!tableOps.exists(tableName)) List()
-    else {
-      readTypeNamesMatching.map { row =>
-        val rowid = row.getKey.getRow.toString
-        val attr = getFeatureNameFromMetadataRowID(rowid)
-        new NameImpl(attr)
-      }
-    }
+  /**
+   * Gets metadata by scanning the table, without the local cache
+   *
+   * Read metadata using scheme:  ~METADATA_featureName metadataFieldName: insertionTimestamp metadataValue
+   *
+   * @param featureName
+   * @param colFam
+   * @return
+   */
+  private def readMetadataItemNoCache(featureName: String, colFam: Text): Option[String] = {
+    val scanner = createScanner
+    scanner.setRange(new Range(s"${METADATA_TAG }_$featureName"))
+    scanner.fetchColumn(colFam, EMPTY_COLQ)
 
-  def readTypeNamesMatching: Seq[KVEntry] = {
-    val batchScanner = createBatchScanner
-    batchScanner.setRanges(List[Range](new Range(METADATA_TAG, METADATA_TAG_END)))
-    batchScanner.fetchColumnFamily(ATTRIBUTES_CF)
-    val resultItr = new Iterator[KVEntry] {
-      val src = batchScanner.iterator()
-      def hasNext = src.hasNext
-      def next() = src.next()
-    }
-    val result = resultItr.toList
-    batchScanner.close()
+    val name = "version-" + featureName + "-" + colFam.toString
+    val cfg = new IteratorSetting(1, name, classOf[VersioningIterator])
+    VersioningIterator.setMaxVersions(cfg, 1)
+    scanner.addScanIterator(cfg)
+
+    val iter = scanner.iterator
+    val result =
+      if (iter.hasNext) Some(iter.next.getValue.toString)
+      else None
+
+    scanner.close()
     result
   }
 
-  def getFeatureTypes = createTypeNames().map(_.toString)
+  /**
+   * Implementation of AbstractDataStore getTypeNames
+   *
+   * @return
+   */
+  override def getTypeNames: Array[String] =
+    if (tableOps.exists(tableName)) readTypesFromMetadata
+    else Array()
 
-  def getTypeNames: Array[String] = getFeatureTypes.toArray
+  /**
+   * Scans metadata rows and pulls out the different feature types in the table
+   *
+   * @return
+   */
+  private def readTypesFromMetadata: Array[String] = {
+    val scanner = createScanner
+    scanner.setRange(new Range(METADATA_TAG, METADATA_TAG_END))
+    // restrict to just schema cf so we only get 1 hit per feature
+    scanner.fetchColumnFamily(SCHEMA_CF)
+    val resultItr = new Iterator[String] {
+      val src = scanner.iterator()
+
+      def hasNext = {
+        val next = src.hasNext
+        if (!next)
+          scanner.close()
+        next
+      }
+
+      def next() = src.next().getKey.getRow.toString
+    }
+    resultItr.toArray.map(getFeatureNameFromMetadataRowKey(_))
+  }
+
+  /**
+   * Reads the feature name from a given metadata row key
+   *
+   * @param rowKey
+   * @return
+   */
+  private def getFeatureNameFromMetadataRowKey(rowKey: String): String = {
+    val MetadataRowKeyRegex(featureName) = rowKey
+    featureName
+  }
 
   // NB:  By default, AbstractDataStore is "isWriteable".  This means that createFeatureSource returns
   // a featureStore
-  def createFeatureSource(featureName: String): SimpleFeatureSource =
+  override def getFeatureSource(featureName: String): SimpleFeatureSource = {
+    validateMetadata(featureName)
     new AccumuloFeatureStore(this, featureName)
+  }
 
-  override def getFeatureSource(featureName: String): SimpleFeatureSource =
-    createFeatureSource(featureName)
 
-  def getIndexSchemaFmt(featureName: String) =
+  /**
+   * Reads the index schema format out of the metadata
+   *
+   * @param featureName
+   * @return
+   */
+  protected def getIndexSchemaFmt(featureName: String) =
     readMetadataItem(featureName, SCHEMA_CF).getOrElse(EMPTY_STRING)
 
-  def getAttributes(featureName: String) =
+  /**
+   * Reads the attributes out of the metadata
+   *
+   * @param featureName
+   * @return
+   */
+  private def getAttributes(featureName: String) =
     readMetadataItem(featureName, ATTRIBUTES_CF).getOrElse(EMPTY_STRING)
 
-  // Default to TEXT if no metadata is found in the table
+  /**
+   * Reads the feature encoding from the metadata. Defaults to TEXT if there is no metadata.
+   *
+   * @param featureName
+   * @return
+   */
   def getFeatureEncoder(featureName: String) = {
-    val encodingString = readMetadataItem(featureName, FEATURE_ENCODING_CF).getOrElse(FeatureEncoding.TEXT.toString)
+    val encodingString = readMetadataItem(featureName, FEATURE_ENCODING_CF)
+                         .getOrElse(FeatureEncoding.TEXT.toString)
     SimpleFeatureEncoderFactory.createEncoder(encodingString)
   }
 
@@ -247,13 +478,20 @@ class AccumuloDataStore(val connector: Connector,
     stringToReferencedEnvelope(curBounds, crs)
   }
 
-  def stringToReferencedEnvelope(string: String, crs: CoordinateReferenceSystem): ReferencedEnvelope = {
+  private def stringToReferencedEnvelope(string: String,
+                                         crs: CoordinateReferenceSystem): ReferencedEnvelope = {
     val minMaxXY = string.split(":")
     require(minMaxXY.size == 4)
-    new ReferencedEnvelope(minMaxXY(0).toDouble, minMaxXY(1).toDouble,
-                           minMaxXY(2).toDouble, minMaxXY(3).toDouble, crs)
+    new ReferencedEnvelope(minMaxXY(0).toDouble, minMaxXY(1).toDouble, minMaxXY(2).toDouble,
+                            minMaxXY(3).toDouble, crs)
   }
 
+  /**
+   * Writes bounds for this feature
+   *
+   * @param featureName
+   * @param bounds
+   */
   def writeBounds(featureName: String, bounds: ReferencedEnvelope) {
     // prepare to write out properties to the Accumulo SHP-file table
     val newbounds = readMetadataItem(featureName, BOUNDS_CF) match {
@@ -263,31 +501,42 @@ class AccumuloDataStore(val connector: Connector,
 
     val minMaxXY = List(newbounds.getMinX, newbounds.getMaxX, newbounds.getMinY, newbounds.getMaxY)
     val encoded = minMaxXY.mkString(":")
-    writeMetadataItem(featureName, BOUNDS_CF, new Value(encoded.getBytes))
+
+    val mutation = getMetadataMutation(featureName)
+    putMetadata(featureName, mutation, BOUNDS_CF, encoded)
+    writeMutations(mutation)
   }
 
-
   private def getNewBounds(env: String, featureName: String, bounds: ReferencedEnvelope) = {
-    val oldBounds = stringToReferencedEnvelope(env, getSchema(featureName).getCoordinateReferenceSystem)
+    val oldBounds = stringToReferencedEnvelope(env,
+                                                getSchema(featureName).getCoordinateReferenceSystem)
     val projBounds = bounds.transform(oldBounds.getCoordinateReferenceSystem, true)
     projBounds.expandToInclude(oldBounds)
     projBounds
   }
 
-  // Implementation of Abstract method
-  def getSchema(featureName: String) = {
+  /**
+   * Implementation of abstract method
+   *
+   * @param featureName
+   * @return
+   */
+  override def getSchema(featureName: String): SimpleFeatureType = {
     val sft = DataUtilities.createType(featureName, getAttributes(featureName))
-    val dtgField = readMetadataItem(featureName, DTGFIELD_CF).getOrElse(Constants.SF_PROPERTY_START_TIME)
+    val dtgField = readMetadataItem(featureName, DTGFIELD_CF)
+                   .getOrElse(Constants.SF_PROPERTY_START_TIME)
     sft.getUserData.put(core.index.SF_PROPERTY_START_TIME, dtgField)
-    sft.getUserData.put(core.index.SF_PROPERTY_END_TIME,   dtgField)
+    sft.getUserData.put(core.index.SF_PROPERTY_END_TIME, dtgField)
     sft
   }
 
   // Implementation of Abstract method
-  def getFeatureReader(featureName: String): AccumuloFeatureReader = getFeatureReader(featureName, Query.ALL)
+  def getFeatureReader(featureName: String): AccumuloFeatureReader = getFeatureReader(featureName,
+                                                                                       Query.ALL)
 
   // This override is important as it allows us to optimize and plan our search with the Query.
   override def getFeatureReader(featureName: String, query: Query) = {
+    validateMetadata(featureName)
     val indexSchemaFmt = getIndexSchemaFmt(featureName)
     val sft = getSchema(featureName)
     val fe = getFeatureEncoder(featureName)
@@ -296,6 +545,8 @@ class AccumuloDataStore(val connector: Connector,
 
   /* create a general purpose writer that is capable of insert, deletes, and updates */
   override def createFeatureWriter(typeName: String, transaction: Transaction): SFFeatureWriter = {
+    validateMetadata(typeName)
+    checkWritePermissions(typeName)
     val featureType = getSchema(typeName)
     val indexSchemaFmt = getIndexSchemaFmt(typeName)
     val fe = getFeatureEncoder(typeName)
@@ -306,7 +557,10 @@ class AccumuloDataStore(val connector: Connector,
   }
 
   /* optimized for GeoTools API to return writer ONLY for appending (aka don't scan table) */
-  override def getFeatureWriterAppend(typeName: String, transaction: Transaction): SFFeatureWriter = {
+  override def getFeatureWriterAppend(typeName: String,
+                                      transaction: Transaction): SFFeatureWriter = {
+    validateMetadata(typeName)
+    checkWritePermissions(typeName)
     val featureType = getSchema(typeName)
     val indexSchemaFmt = getIndexSchemaFmt(typeName)
     val fe = getFeatureEncoder(typeName)
@@ -317,17 +571,37 @@ class AccumuloDataStore(val connector: Connector,
 
   override def getUnsupportedFilter(featureName: String, filter: Filter): Filter = Filter.INCLUDE
 
-  def createBatchScanner = {
+  /**
+   * Creates a scanner for the table underlying this data store
+   *
+   * @return
+   */
+  def createBatchScanner: BatchScanner = {
     connector.createBatchScanner(tableName, authorizationsProvider.getAuthorizations, 100)
   }
 
-  // Accumulo assumes that the failures directory exists.  This function assumes that you have already created it.
-  def importDirectory(tableName: String,
-                      dir: String,
-                      failureDir: String,
-                      disableGC: Boolean) {
-    connector.tableOperations().importDirectory(tableName, dir, failureDir, disableGC)
+  /**
+   * Creates a scanner for the table underlying this data store
+   *
+   * @return
+   */
+  def createScanner: Scanner = {
+    connector.createScanner(tableName, authorizationsProvider.getAuthorizations)
   }
+
+  // Accumulo assumes that the failures directory exists.  This function assumes that you have already created it.
+  def importDirectory(tableName: String, dir: String, failureDir: String, disableGC: Boolean) {
+    tableOps.importDirectory(tableName, dir, failureDir, disableGC)
+  }
+
+  /**
+   * Gets the feature name from a feature type
+   *
+   * @param featureType
+   * @return
+   */
+  private def getFeatureName(featureType: SimpleFeatureType) = featureType.getName.getLocalPart
+
 }
 
 /**
@@ -338,28 +612,29 @@ class AccumuloDataStore(val connector: Connector,
  * @param writeVisibilities visibilities to be applied to any data written by this store
  * @param params           The parameters used to create this datastore.
  *
- * This class provides an additional writer which can be accessed by
- *  createMapReduceFeatureWriter(featureName, context)
+ *                         This class provides an additional writer which can be accessed by
+ *                         createMapReduceFeatureWriter(featureName, context)
  *
- * This writer is appropriate for use inside a MapReduce job.  We explicitly do not override the default
- * createFeatureWriter so that we have both available.
+ *                         This writer is appropriate for use inside a MapReduce job.  We explicitly do not override the default
+ *                         createFeatureWriter so that we have both available.
  */
-class MapReduceAccumuloDataStore(connector: Connector,
-                                 tableName: String,
+class MapReduceAccumuloDataStore(connector: Connector, tableName: String,
                                  authorizationsProvider: AuthorizationsProvider,
-                                 writeVisibilities: String,
-                                 val params: JMap[String, Serializable],
+                                 writeVisibilities: String, val params: JMap[String, Serializable],
                                  indexSchemaFormat: String = "DEFAULT",
                                  featureEncoding: FeatureEncoding = FeatureEncoding.AVRO)
-  extends AccumuloDataStore(connector, tableName, authorizationsProvider, writeVisibilities, indexSchemaFormat, featureEncoding) {
+    extends AccumuloDataStore(connector, tableName, authorizationsProvider, writeVisibilities,
+                               indexSchemaFormat, featureEncoding) {
 
-  override def createFeatureSource(featureName: String): SimpleFeatureSource =
+  override def getFeatureSource(featureName: String): SimpleFeatureSource = {
+    validateMetadata(featureName)
+    checkWritePermissions(featureName)
     new MapReduceAccumuloFeatureStore(this, featureName)
-
-  override def getFeatureSource(featureName: String): SimpleFeatureSource =
-    createFeatureSource(featureName)
+  }
 
   def createMapReduceFeatureWriter(featureName: String, context: TASKIOCTX): SFFeatureWriter = {
+    validateMetadata(featureName)
+    checkWritePermissions(featureName)
     val featureType = getSchema(featureName)
     val idxFmt = getIndexSchemaFmt(featureName)
     val fe = getFeatureEncoder(featureName)

--- a/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStoreFactory.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStoreFactory.scala
@@ -25,7 +25,6 @@ import javax.imageio.spi.ServiceRegistry
 import org.apache.accumulo.core.client.mock.{MockConnector, MockInstance}
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
 import org.apache.accumulo.core.client.{Connector, ZooKeeperInstance}
-import org.apache.accumulo.core.security.Authorizations
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.Job
 import org.geotools.data.DataAccessFactory.Param
@@ -167,7 +166,7 @@ object AccumuloDataStoreFactory {
     val userParam         = new Param("user", classOf[String], "Accumulo user", true)
     val passwordParam     = new Param("password", classOf[String], "Password", true)
     val authsParam        = new Param("auths", classOf[String], "Super-set of authorizations that will be used for queries. The actual authorizations might differ, depending on the authorizations provider, but will be outside this set. Comma-delimited.", false)
-    val visibilityParam   = new Param("visibility", classOf[String], "Accumulo visibility label to apply to all written data", false)
+    val visibilityParam   = new Param("visibilities", classOf[String], "Accumulo visibilities to apply to all written data", false)
     val tableNameParam    = new Param("tableName", classOf[String], "The Accumulo Table Name", true)
     val idxSchemaParam    = new Param("indexSchemaFormat",
       classOf[String],
@@ -200,13 +199,13 @@ object AccumuloDataStoreFactory {
   }
 
   def getMRAccumuloConnectionParams(conf: Configuration): JMap[String,AnyRef] =
-    Map(zookeepersParam.key -> conf.get(ZOOKEEPERS),
-      instanceIdParam.key -> conf.get(INSTANCE_ID),
-      userParam.key -> conf.get(ACCUMULO_USER),
-      passwordParam.key -> conf.get(ACCUMULO_PASS),
-      tableNameParam.key -> conf.get(TABLE),
-      authsParam.key -> conf.get(AUTHS),
-      visibilityParam.key -> conf.get(VISIBILITY),
-      featureEncParam.key -> conf.get(FEATURE_ENCODING),
-      mapReduceParam.key -> "true")
+    Map(zookeepersParam.key   -> conf.get(ZOOKEEPERS),
+      instanceIdParam.key     -> conf.get(INSTANCE_ID),
+      userParam.key           -> conf.get(ACCUMULO_USER),
+      passwordParam.key       -> conf.get(ACCUMULO_PASS),
+      tableNameParam.key      -> conf.get(TABLE),
+      authsParam.key          -> conf.get(AUTHS),
+      visibilityParam.key     -> conf.get(VISIBILITY),
+      featureEncParam.key     -> conf.get(FEATURE_ENCODING),
+      mapReduceParam.key      -> "true")
 }

--- a/geomesa-core/src/main/scala/geomesa/core/data/package.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/package.scala
@@ -43,6 +43,8 @@ package object data {
   val SCHEMA_CF            = new Text("schema")
   val DTGFIELD_CF          = new Text("dtgfield")
   val FEATURE_ENCODING_CF  = new Text("featureEncoding")
+  val VISIBILITIES_CF      = new Text("visibilities")
+  val VISIBILITIES_CHECK_CF = new Text("visibilitiesCheck")
   val DATA_CQ              = new Text("SimpleFeatureAttribute")
   val METADATA_TAG         = "~METADATA"
   val METADATA_TAG_END     = s"$METADATA_TAG~~"

--- a/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
@@ -21,6 +21,7 @@ import com.vividsolutions.jts.geom.Coordinate
 import geomesa.core.security.{FilteringAuthorizationsProvider, AuthorizationsProvider, DefaultAuthorizationsProvider}
 import geomesa.utils.text.WKTUtils
 import org.apache.accumulo.core.security.Authorizations
+import org.geotools.data.collection.ListFeatureCollection
 import org.geotools.data.{Query, DataUtilities, Transaction, DataStoreFinder}
 import org.geotools.factory.{CommonFactoryFinder, Hints}
 import org.geotools.feature.DefaultFeatureCollection
@@ -29,6 +30,7 @@ import org.geotools.filter.text.cql2.CQL
 import org.geotools.geometry.jts.JTSFactoryFinder
 import org.geotools.process.vector.TransformProcess
 import org.junit.runner.RunWith
+import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -40,7 +42,11 @@ class AccumuloDataStoreTest extends Specification {
 
   val geotimeAttributes = geomesa.core.index.spec
 
-  def createStore: AccumuloDataStore =
+  var id = 0
+
+  def createStore: AccumuloDataStore = {
+    // need to add a unique ID, otherwise create schema will throw an exception
+    id = id + 1
     // the specific parameter values should not matter, as we
     // are requesting a mock data store connection to Accumulo
     DataStoreFinder.getDataStore(Map(
@@ -49,9 +55,10 @@ class AccumuloDataStoreTest extends Specification {
       "user"       -> "myuser",
       "password"   -> "mypassword",
       "auths"      -> "A,B,C",
-      "tableName"  -> "testwrite",
+      "tableName"  -> ("testwrite" + id),
       "useMock"    -> "true",
       "featureEncoding" -> "avro")).asInstanceOf[AccumuloDataStore]
+  }
 
   "AccumuloDataStore" should {
     "be accessible through DataStoreFinder" in {
@@ -290,14 +297,14 @@ class AccumuloDataStoreTest extends Specification {
                      "zookeepers" -> "zoo1:2181,zoo2:2181,zoo3:2181",
                      "user"       -> "myuser",
                      "password"   -> "mypassword",
-                     "auths"      -> "U",
+                     "auths"      -> "user",
                      "tableName"  -> "testwrite",
                      "useMock"    -> "true",
                      "featureEncoding" -> "avro")).asInstanceOf[AccumuloDataStore]
       ds should not be null
       ds.authorizationsProvider.isInstanceOf[FilteringAuthorizationsProvider] should be equalTo(true)
       ds.authorizationsProvider.asInstanceOf[FilteringAuthorizationsProvider].wrappedProvider.isInstanceOf[DefaultAuthorizationsProvider] should be equalTo(true)
-      ds.authorizationsProvider.asInstanceOf[AuthorizationsProvider].getAuthorizations should be equalTo(new Authorizations("U"))
+      ds.authorizationsProvider.asInstanceOf[AuthorizationsProvider].getAuthorizations should be equalTo(new Authorizations("user"))
     }
 
     "provide ability to configure auth provider by comma-delimited static auths" in {
@@ -307,16 +314,83 @@ class AccumuloDataStoreTest extends Specification {
                                                  "zookeepers" -> "zoo1:2181,zoo2:2181,zoo3:2181",
                                                  "user"       -> "myuser",
                                                  "password"   -> "mypassword",
-                                                 "auths"      -> "U,S,USA",
+                                                 "auths"      -> "user,admin,test",
                                                  "tableName"  -> "testwrite",
                                                  "useMock"    -> "true",
                                                  "featureEncoding" -> "avro")).asInstanceOf[AccumuloDataStore]
       ds should not be null
       ds.authorizationsProvider.isInstanceOf[FilteringAuthorizationsProvider] should be equalTo(true)
       ds.authorizationsProvider.asInstanceOf[FilteringAuthorizationsProvider].wrappedProvider.isInstanceOf[DefaultAuthorizationsProvider] should be equalTo(true)
-      ds.authorizationsProvider.asInstanceOf[AuthorizationsProvider].getAuthorizations should be equalTo(new Authorizations("U", "S", "USA"))
+      ds.authorizationsProvider.asInstanceOf[AuthorizationsProvider].getAuthorizations should be equalTo(new Authorizations("user", "admin", "test"))
     }
 
+    "allow users with sufficient auths to write data" in {
+      // create the data store
+      val ds = DataStoreFinder.getDataStore(Map(
+                                                 "instanceId" -> "mycloud",
+                                                 "zookeepers" -> "zoo1:2181,zoo2:2181,zoo3:2181",
+                                                 "user"       -> "myuser",
+                                                 "password"   -> "mypassword",
+                                                 "auths"      -> "user,admin",
+                                                 "visibilities" -> "user&admin",
+                                                 "tableName"  -> "testwrite",
+                                                 "useMock"    -> "true",
+                                                 "featureEncoding" -> "avro")).asInstanceOf[AccumuloDataStore]
+      ds should not be null
+
+      // create the schema - the auths for this user are sufficient to write data
+      val sftName = "authwritetest1"
+      val sft = DataUtilities.createType(sftName, s"name:String,dtg:Date,*geom:Point:srid=4326")
+      ds.createSchema(sft)
+
+      // write some data
+      val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
+      val written = fs.addFeatures(new ListFeatureCollection(sft, getFeatures(sft).toList))
+
+      written should not be null
+      written.length mustEqual(6)
+    }
+
+    "restrict users with insufficient auths from writing data" in {
+      // create the data store
+      val ds = DataStoreFinder.getDataStore(Map(
+                                                 "instanceId" -> "mycloud",
+                                                 "zookeepers" -> "zoo1:2181,zoo2:2181,zoo3:2181",
+                                                 "user"       -> "myuser",
+                                                 "password"   -> "mypassword",
+                                                 "auths"      -> "user",
+                                                 "visibilities" -> "user&admin",
+                                                 "tableName"  -> "testwrite",
+                                                 "useMock"    -> "true",
+                                                 "featureEncoding" -> "avro")).asInstanceOf[AccumuloDataStore]
+      ds should not be null
+
+      // create the schema - the auths for this user are less than the visibility used to write data
+      val sftName = "authwritetest2"
+      val sft = DataUtilities.createType(sftName, s"name:String,dtg:Date,*geom:Point:srid=4326")
+      ds.createSchema(sft)
+
+      // write some data
+      val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
+      try {
+        // this should throw an exception
+        fs.addFeatures(new ListFeatureCollection(sft, getFeatures(sft).toList))
+        failure("Should not be able to write data")
+      } catch {
+        case e: RuntimeException => success
+      }
+    }
+
+  }
+
+  def getFeatures(sft: SimpleFeatureType) = (0 until 6).map { i =>
+    val builder = new SimpleFeatureBuilder(sft)
+    builder.set("geom", WKTUtils.read("POINT(45.0 45.0)"))
+    builder.set("dtg", "2012-01-02T05:06:07.000Z")
+    builder.set("name",i.toString)
+    val sf = builder.buildFeature(i.toString)
+    sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+    sf
   }
 
   "AccumuloFeatureStore" should {

--- a/geomesa-core/src/test/scala/geomesa/core/data/LiveAccumuloDataStoreTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/LiveAccumuloDataStoreTest.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2013 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.core.data
+
+import scala.collection.JavaConversions._
+import com.vividsolutions.jts.geom.Coordinate
+import geomesa.core.security.{FilteringAuthorizationsProvider, AuthorizationsProvider, DefaultAuthorizationsProvider}
+import geomesa.utils.text.WKTUtils
+import org.apache.accumulo.core.security.Authorizations
+import org.geotools.data.collection.ListFeatureCollection
+import org.geotools.data._
+import org.geotools.factory.{CommonFactoryFinder, Hints}
+import org.geotools.feature.{FeatureIterator, FeatureCollection, DefaultFeatureCollection}
+import org.geotools.feature.simple.SimpleFeatureBuilder
+import org.geotools.filter.text.cql2.CQL
+import org.geotools.geometry.jts.JTSFactoryFinder
+import org.geotools.process.vector.TransformProcess
+import org.junit.runner.RunWith
+import org.opengis.feature.simple.SimpleFeatureType
+import org.opengis.filter.Filter
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import scala.collection
+import org.geotools.data.simple.SimpleFeatureIterator
+
+@RunWith(classOf[JUnitRunner])
+class LiveAccumuloDataStoreTest extends Specification {
+
+  sequential
+
+  /**
+   * WARNING: this test runs against a live accumulo instance and drops the table you run against
+   */
+
+  val params = Map(
+                    "instanceId" -> "mycloud",
+                    "zookeepers" -> "zoo1,zoo2,zoo3",
+                    "user"       -> "user",
+                    "password"   -> "password",
+                    "auths"      -> "user,admin",
+                    "visibilities" -> "user&admin",
+                    "tableName"  -> "test_auths",
+                    "useMock"    -> "false",
+                    "featureEncoding" -> "avro")
+
+  val sftName = "authwritetest"
+
+  def getDataStore: AccumuloDataStore = {
+    DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
+  }
+
+  def createSimpleFeatureType: SimpleFeatureType = {
+    DataUtilities.createType(sftName, s"name:String,dtg:Date,*geom:Point:srid=4326")
+  }
+
+  def initializeDataStore(ds: AccumuloDataStore): Unit = {
+    // truncate the table, if it exists
+    if (ds.connector.tableOperations.exists(params("tableName"))) {
+      ds.connector.tableOperations.deleteRows(params("tableName"), null, null)
+    }
+
+    // create the schema
+    ds.createSchema(createSimpleFeatureType)
+  }
+
+  def writeSampleData(ds: AccumuloDataStore): Unit = {
+    // write some data
+    val sft = createSimpleFeatureType
+    val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
+    val written = fs.addFeatures(new ListFeatureCollection(sft, getFeatures(sft).toList))
+  }
+
+  def getFeatures(sft: SimpleFeatureType) = (0 until 6).map { i =>
+    val builder = new SimpleFeatureBuilder(sft)
+    builder.set("geom", WKTUtils.read("POINT(45.0 45.0)"))
+    builder.set("dtg", "2012-01-02T05:06:07.000Z")
+    builder.set("name",i.toString)
+    val sf = builder.buildFeature(i.toString)
+    sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+    sf
+  }
+
+  def printFeatures(features: SimpleFeatureIterator): Unit = {
+    val resultItr = new Iterator[String] {
+      def hasNext = {
+        val next = features.hasNext
+        if (!next)
+          features.close
+        next
+      }
+
+      def next = features.next.getProperty("name").getValue.toString
+    }
+    println(resultItr.toList + "\n")
+  }
+
+  "AccumuloDataStore" should {
+
+    "restrict users with insufficient auths from writing data" in {
+
+      skipped("Meant for integration testing")
+
+      val ds = getDataStore
+//      initializeDataStore(ds)
+//      writeSampleData(ds)
+
+      val query = new Query(sftName, CQL.toFilter("INCLUDE"))
+
+      // get the feature store used to query the GeoMesa data
+      val featureStore = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
+
+      // execute the query
+      val results = featureStore.getFeatures(query)
+
+      // loop through all results
+      printFeatures(results.features)
+
+      success
+    }
+  }
+
+}

--- a/geomesa-core/src/test/scala/geomesa/core/process/tube/TubeSelectProcessTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/process/tube/TubeSelectProcessTest.scala
@@ -3,6 +3,7 @@ package geomesa.core.process.tube
 import collection.JavaConversions._
 import com.vividsolutions.jts.geom.{Point, Coordinate, GeometryFactory}
 import geomesa.core.data.{AccumuloFeatureStore, AccumuloDataStore}
+import geomesa.core.index.Constants
 import geomesa.utils.text.WKTUtils
 import org.geotools.data.collection.ListFeatureCollection
 import org.geotools.data.{Query, DataUtilities, DataStoreFinder}
@@ -15,7 +16,6 @@ import org.junit.runner.RunWith
 import org.opengis.filter.Filter
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import geomesa.core.index.Constants
 
 @RunWith(classOf[JUnitRunner])
 class TubeSelectProcessTest extends Specification {
@@ -309,7 +309,6 @@ class TubeSelectProcessTest extends Specification {
       val ts = new TubeSelectProcess
       val ds = createStore
 
-      ds.createSchema(sft)
       val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
 
       val q = new Query(sftName, Filter.INCLUDE)

--- a/geomesa-plugin/pom.xml
+++ b/geomesa-plugin/pom.xml
@@ -78,6 +78,18 @@
             <version>1.2.17</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- test deps -->
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2_2.10</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/geomesa-plugin/src/main/resources/geomesa/plugin/wfs/AccumuloDataStoreEditPanel.html
+++ b/geomesa-plugin/src/main/resources/geomesa/plugin/wfs/AccumuloDataStoreEditPanel.html
@@ -26,7 +26,7 @@
         <div><span wicket:id="password"></span></div>
         <div><span wicket:id="tableName"></span></div>
         <div><span wicket:id="auths"></span></div>
-        <div><span wicket:id="visibility"></span></div>
+        <div><span wicket:id="visibilities"></span></div>
     </fieldset>
 </wicket:panel>
 </body>

--- a/geomesa-plugin/src/main/scala/geomesa/plugin/wfs/AccumuloDataStoreEditPanel.scala
+++ b/geomesa-plugin/src/main/scala/geomesa/plugin/wfs/AccumuloDataStoreEditPanel.scala
@@ -40,10 +40,10 @@ class AccumuloDataStoreEditPanel (componentId: String, storeEditForm: Form[_])
   val user = addTextPanel(paramsModel, new Param("user", classOf[String], "User", true))
   val password = addPasswordPanel(paramsModel, new Param("password", classOf[String], "Password", true))
   val auths = addTextPanel(paramsModel, new Param("auths", classOf[String], "DataStore-level Authorizations", false))
-  val visibility = addTextPanel(paramsModel, new Param("visibility", classOf[String], "Accumulo visibility label that will be applied to data written by this DataStore", false))
+  val visibilities = addTextPanel(paramsModel, new Param("visibilities", classOf[String], "Accumulo visibilities that will be applied to data written by this DataStore", false))
   val tableName = addTextPanel(paramsModel, new Param("tableName", classOf[String], "The Accumulo Table Name", true))
 
-  val dependentFormComponents = Array[FormComponent[_]](instanceId, zookeepers, user, password, tableName, auths, visibility)
+  val dependentFormComponents = Array[FormComponent[_]](instanceId, zookeepers, user, password, tableName, auths, visibilities)
   dependentFormComponents.map(_.setOutputMarkupId(true))
 
   storeEditForm.add(new IFormValidator() {


### PR DESCRIPTION
In order to ensure that data does not get written with different visibilities (which could lead to duplicate rows), when a feature is accessed added checks to ensure that the datastore is configured the same as the existing feature. If not, it fails quickly (throws an exception). This behavior was deemed better than switching to the existing configuration, which might lead users to get unexpected results unless they peruse the logs for warnings.
Once the visibilities were locked down, added visibilities to one of the metadata rows, which allows us to check that the user can read data before the user is allowed to write data. Other metadata rows were left without visibilities for simplicity (metadata should not contain protected data anyway).
I refactored AccumuloDataStore fairly heavily in order to make it more obvious which methods were internal vs external and remove some old geotools methods that are no longer used.
