### PR TITLE
GEOMESA-147 loading default auth provider outside SPI process

### DIFF
--- a/geomesa-core/src/main/resources/META-INF/services/geomesa.core.security.AuthorizationsProvider
+++ b/geomesa-core/src/main/resources/META-INF/services/geomesa.core.security.AuthorizationsProvider
@@ -1,1 +1,0 @@
-geomesa.core.security.DefaultAuthorizationsProvider

--- a/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStoreFactory.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStoreFactory.scala
@@ -72,24 +72,38 @@ class AccumuloDataStoreFactory extends DataStoreFactorySpi {
       else
         masterAuthsStrings.toList
 
-    val authProviderSystemProperty = System.getProperty(AuthorizationsProvider.AUTH_PROVIDER_SYS_PROPERTY)
+    // if the user specifies an auth provider to use, try to use that impl
+    val authProviderSystemProperty = Option(System.getProperty(AuthorizationsProvider.AUTH_PROVIDER_SYS_PROPERTY))
 
     // we wrap the authorizations provider in one that will filter based on the max auths configured for this store
     val authorizationsProvider = new FilteringAuthorizationsProvider ({
-        val providers = ServiceRegistry.lookupProviders(classOf[AuthorizationsProvider]).toBuffer
-        if (authProviderSystemProperty != null) {
-          providers.find(p => authProviderSystemProperty.equals(p.getClass.getName))
-            .getOrElse(throw new IllegalArgumentException(s"The service provider class $authProviderSystemProperty specified by ${AuthorizationsProvider.AUTH_PROVIDER_SYS_PROPERTY} could not be loaded"))
-        } else {
-          val nondefault = providers.filterNot(_.isInstanceOf[DefaultAuthorizationsProvider])
-          if (nondefault.length > 1)
-            throw new IllegalStateException(s"Found multiple AuthorizationProvider implementations. Please specify the one to use with the system property ${AuthorizationsProvider.AUTH_PROVIDER_SYS_PROPERTY} :: found $nondefault")
-          nondefault.headOption.getOrElse({
-            providers.find(_.isInstanceOf[DefaultAuthorizationsProvider])
-              .getOrElse(throw new IllegalStateException("No valid geomesa.core.security.AuthorizationsProvider could be loaded"))
-          })
-        }
-      })
+      val providers = ServiceRegistry.lookupProviders(classOf[AuthorizationsProvider]).toBuffer
+      authProviderSystemProperty match {
+        case Some(prop) =>
+          if (classOf[DefaultAuthorizationsProvider].getName == prop)
+            new DefaultAuthorizationsProvider
+          else
+            providers.find(_.getClass.getName == prop)
+            .getOrElse {
+              val message =
+                s"The service provider class '$prop' specified by " +
+                s"${AuthorizationsProvider.AUTH_PROVIDER_SYS_PROPERTY} could not be loaded"
+              throw new IllegalArgumentException(message)
+            }
+        case None =>
+          providers.length match {
+            case 0 => new DefaultAuthorizationsProvider
+            case 1 => providers.head
+            case _ =>
+              val message =
+                "Found multiple AuthorizationsProvider implementations. Please specify the one " +
+                "to use with the system property " +
+                s"'${AuthorizationsProvider.AUTH_PROVIDER_SYS_PROPERTY}' :: " +
+                s"${providers.map(_.getClass.getName).mkString(", ")}"
+              throw new IllegalStateException(message)
+          }
+      }
+    })
 
     // update the authorizations in the parameters and then configure the auth provider
     // we copy the map so as not to modify the original

--- a/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
@@ -302,9 +302,9 @@ class AccumuloDataStoreTest extends Specification {
                      "useMock"    -> "true",
                      "featureEncoding" -> "avro")).asInstanceOf[AccumuloDataStore]
       ds should not be null
-      ds.authorizationsProvider.isInstanceOf[FilteringAuthorizationsProvider] should be equalTo(true)
-      ds.authorizationsProvider.asInstanceOf[FilteringAuthorizationsProvider].wrappedProvider.isInstanceOf[DefaultAuthorizationsProvider] should be equalTo(true)
-      ds.authorizationsProvider.asInstanceOf[AuthorizationsProvider].getAuthorizations should be equalTo(new Authorizations("user"))
+      ds.authorizationsProvider should beAnInstanceOf[FilteringAuthorizationsProvider]
+      ds.authorizationsProvider.asInstanceOf[FilteringAuthorizationsProvider].wrappedProvider should beAnInstanceOf[DefaultAuthorizationsProvider]
+      ds.authorizationsProvider.asInstanceOf[AuthorizationsProvider].getAuthorizations should be equalTo new Authorizations("user")
     }
 
     "provide ability to configure auth provider by comma-delimited static auths" in {
@@ -319,9 +319,25 @@ class AccumuloDataStoreTest extends Specification {
                                                  "useMock"    -> "true",
                                                  "featureEncoding" -> "avro")).asInstanceOf[AccumuloDataStore]
       ds should not be null
-      ds.authorizationsProvider.isInstanceOf[FilteringAuthorizationsProvider] should be equalTo(true)
-      ds.authorizationsProvider.asInstanceOf[FilteringAuthorizationsProvider].wrappedProvider.isInstanceOf[DefaultAuthorizationsProvider] should be equalTo(true)
-      ds.authorizationsProvider.asInstanceOf[AuthorizationsProvider].getAuthorizations should be equalTo(new Authorizations("user", "admin", "test"))
+      ds.authorizationsProvider should beAnInstanceOf[FilteringAuthorizationsProvider]
+      ds.authorizationsProvider.asInstanceOf[FilteringAuthorizationsProvider].wrappedProvider should beAnInstanceOf[DefaultAuthorizationsProvider]
+      ds.authorizationsProvider.asInstanceOf[AuthorizationsProvider].getAuthorizations should be equalTo new Authorizations("user", "admin", "test")
+    }
+
+    "fail when auth provider system property does not match an actual class" in {
+      System.setProperty(AuthorizationsProvider.AUTH_PROVIDER_SYS_PROPERTY, "my.fake.Clas")
+      try {
+      // create the data store
+      DataStoreFinder.getDataStore(Map(
+                                       "instanceId" -> "mycloud",
+                                       "zookeepers" -> "zoo1:2181,zoo2:2181,zoo3:2181",
+                                       "user"       -> "myuser",
+                                       "password"   -> "mypassword",
+                                       "auths"      -> "user,admin,test",
+                                       "tableName"  -> "testwrite",
+                                       "useMock"    -> "true",
+                                       "featureEncoding" -> "avro")) should throwA[IllegalArgumentException]
+      } finally System.clearProperty(AuthorizationsProvider.AUTH_PROVIDER_SYS_PROPERTY)
     }
 
     "allow users with sufficient auths to write data" in {


### PR DESCRIPTION
The default auth provider is currently loaded through SPI. If the geomesa jar is packaged in certain ways, the SPI file can be lost, causing all data stores to throw errors. Change so that the default provider gets loaded by classname, regardless of presence of it in the SPI.
