### PR TITLE
GEOMESA-138 encode avrosimplefeature field name

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/avro/FeatureSpecificReader.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/avro/FeatureSpecificReader.scala
@@ -28,10 +28,10 @@ class FeatureSpecificReader(oldType: SimpleFeatureType, newType: SimpleFeatureTy
   val dataFields = oldSchema.getFields.filter { isDataField }
 
   val typeMap: Map[String, Class[_]] =
-    oldType.getAttributeDescriptors.map { ad => ad.getLocalName -> ad.getType.getBinding }.toMap
+    oldType.getAttributeDescriptors.map { ad => encodeAttributeName(ad.getLocalName) -> ad.getType.getBinding }.toMap
 
   val nullMap: Map[String, Boolean] =
-    oldType.getAttributeDescriptors.map { ad => ad.getLocalName -> ad.isNillable }.toMap
+    oldType.getAttributeDescriptors.map { ad => encodeAttributeName(ad.getLocalName) -> ad.isNillable }.toMap
 
   def setSchema(schema:Schema) = oldSchema = schema
 
@@ -46,13 +46,13 @@ class FeatureSpecificReader(oldType: SimpleFeatureType, newType: SimpleFeatureTy
     val sf = new AvroSimpleFeature(id, newType)
     if(dataFields.size != fieldsDesired.size)
       dataFields.foreach { f =>
-        if(checkNull(f.name(), in)) in.readNull()
-        else setOrConsume(sf, f.name, in, typeMap.get(f.name).get)
+        if(checkNull(f.name, in)) in.readNull()
+        else setOrConsume(sf, decodeAttributeName(f.name), in, typeMap.get(f.name).get)
       }
     else
       dataFields.foreach { f =>
-        if(checkNull(f.name(), in)) in.readNull()
-        else set(sf, f.name, in, typeMap.get(f.name).get)
+        if(checkNull(f.name, in)) in.readNull()
+        else set(sf, decodeAttributeName(f.name), in, typeMap.get(f.name).get)
       }
     sf
   }

--- a/geomesa-core/src/test/scala/geomesa/core/avro/AvroSimpleFeatureTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/avro/AvroSimpleFeatureTest.scala
@@ -39,6 +39,19 @@ class AvroSimpleFeatureTest extends Specification {
       f.validate must not(throwA [org.opengis.feature.IllegalAttributeException])
     }
 
+    "properly validate multiple AvroSimpleFeature Objects with odd names and unicode characters, including colons" in {
+      val typeList = List("tower_u1234", "tower:type", "☕你好:世界♓", "tower_‽", "‽_‽:‽", "_‽", "a__u1234")
+
+      for(typeName <- typeList) {
+        val sft = DataUtilities.createType(typeName, "a⬨_⬨b:Integer,☕☄crazy☄☕_☕name&such➿:Date,*geom:Point:srid=4326")
+        val f = new AvroSimpleFeature(new FeatureIdImpl("fakeid"), sft)
+        f.setAttribute(0,"1")
+        f.setAttribute(1,"2013-01-02T00:00:00.000Z") // this date format should be converted
+        f.setAttribute(2,"POINT(45.0 49.0)")
+        f.validate must not(throwA[org.opengis.feature.IllegalAttributeException])
+      }
+    }
+
     "fail to validate a correct object" in {
       val sft = DataUtilities.createType("testType", "a:Integer,b:Date,*geom:Point:srid=4326")
 

--- a/geomesa-core/src/test/scala/geomesa/core/avro/FeatureSpecificReaderTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/avro/FeatureSpecificReaderTest.scala
@@ -303,6 +303,4 @@ class FeatureSpecificReaderTest {
 
   }
 
-
-
 }


### PR DESCRIPTION
Added unicode encoding of feature names and attribute names using Hex, with tests.
