### PR TITLE
GEOMESA-133 SimpleFeature UserData lost in IndexQueryPlanner

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/iterators/IndexIterator.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/iterators/IndexIterator.scala
@@ -54,6 +54,7 @@ class IndexIterator extends SpatioTemporalIntersectingIterator with SortedKeyVal
     val simpleFeatureTypeSpec = options.get(GEOMESA_ITERATORS_SIMPLE_FEATURE_TYPE)
 
     val simpleFeatureType = DataUtilities.createType(this.getClass.getCanonicalName, simpleFeatureTypeSpec)
+    simpleFeatureType.decodeUserData(options, GEOMESA_ITERATORS_SIMPLE_FEATURE_TYPE)
 
     // default to text if not found for backwards compatibility
     val encodingOpt = Option(options.get(FEATURE_ENCODING)).getOrElse(FeatureEncoding.TEXT.toString)

--- a/geomesa-core/src/main/scala/geomesa/core/iterators/IteratorTrigger.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/iterators/IteratorTrigger.scala
@@ -24,21 +24,19 @@ object IteratorTrigger {
    */
   implicit class IndexAttributeNames(sft: SimpleFeatureType) {
     def geoName = sft.getGeometryDescriptor.getLocalName
-    // can use this logic if the UserData may be present in the SimpleFeatureType
-    //def startTimeName = Option(sft.getUserData.get(SF_PROPERTY_START_TIME)).map { y => y.toString}
-    //def endTimeName = Option(sft.getUserData.get(SF_PROPERTY_END_TIME)).map { y => y.toString}
 
-    // must use this logic if the UserData may not be present in the SimpleFeatureType
     def startTimeName =  attributeNameHandler(SF_PROPERTY_START_TIME)
     def endTimeName   =  attributeNameHandler(SF_PROPERTY_END_TIME)
 
     def attributeNameHandler(attributeKey: String): Option[String] = {
-      // try to get the name from the user data, which may not exist
-      val nameFromUserData = Option(sft.getUserData.get(attributeKey)).map { y => y.toString}
-      // check if an attribute with this name(which is the default) exists. If so, use the name and ignore the descriptor
-      val nameFromDefault = Option(sft.getDescriptor(attributeKey)).map {y => attributeKey}
+      // try to get the name from the user data, which may not exist, then check if the attribute exists
+      val nameFromUserData = Option(sft.getUserData.get(attributeKey)).map { _.toString }.filter { attributePresent }
+      // check if an attribute with this name(which is the default) exists.
+      val nameFromDefault = Some(attributeKey).filter { attributePresent }
       nameFromUserData orElse nameFromDefault
     }
+
+    def attributePresent(attributeKey: String): Boolean = Option(sft.getDescriptor(attributeKey)).isDefined
 
     def indexAttributeNames = List(geoName) ++ startTimeName ++ endTimeName
   }
@@ -46,8 +44,8 @@ object IteratorTrigger {
   /**
    * Scans the ECQL, query, and sourceSFTspec and determines which Iterators should be configured.
    */
-  def chooseIterator(ecqlPredicate: Option[String], query: Query, sourceSFTSpec: String): IteratorConfig = {
-    if(useIndexOnlyIterator(ecqlPredicate, query, sourceSFTSpec)) IteratorConfig(IndexOnlyIterator, false)
+  def chooseIterator(ecqlPredicate: Option[String], query: Query, sourceSFT: SimpleFeatureType): IteratorConfig = {
+    if(useIndexOnlyIterator(ecqlPredicate, query, sourceSFT)) IteratorConfig(IndexOnlyIterator, false)
     else IteratorConfig(SpatioTemporalIterator, useSimpleFeatureFilteringIterator(ecqlPredicate, query))    
   } 
   
@@ -56,10 +54,9 @@ object IteratorTrigger {
    * used/requested, and thus the IndexIterator can be used
    *
    */
-  def useIndexOnlyIterator(ecqlPredicate: Option[String], query: Query, sourceSFTSpec: String): Boolean = {
+  def useIndexOnlyIterator(ecqlPredicate: Option[String], query: Query, sourceSFT: SimpleFeatureType): Boolean = {
     // get transforms if they exist
     val transformDefs = Option(query.getHints.get(TRANSFORMS)).map (_.asInstanceOf[String])
-    val sourceSFT = DataUtilities.createType("DUMMY", sourceSFTSpec)
 
     // if the transforms exist, check if the transform is simple enough to be handled by the IndexIterator
     // if it does not exist, then set this variable to false

--- a/geomesa-core/src/main/scala/geomesa/core/iterators/SimpleFeatureFilteringIterator.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/iterators/SimpleFeatureFilteringIterator.scala
@@ -75,11 +75,14 @@ class SimpleFeatureFilteringIterator(other: SimpleFeatureFilteringIterator, env:
 
     val simpleFeatureTypeSpec = options.get(GEOMESA_ITERATORS_SIMPLE_FEATURE_TYPE)
     simpleFeatureType = DataUtilities.createType(this.getClass.getCanonicalName, simpleFeatureTypeSpec)
+    simpleFeatureType.decodeUserData(options, GEOMESA_ITERATORS_SIMPLE_FEATURE_TYPE)
 
     val transformSchema = options.get(GEOMESA_ITERATORS_TRANSFORM_SCHEMA)
     targetFeatureType =
       if (transformSchema != null) DataUtilities.createType(this.getClass.getCanonicalName, transformSchema)
       else simpleFeatureType
+    // if the targetFeatureType comes from a transform, also insert the UserData
+    if (transformSchema != null) targetFeatureType.decodeUserData(options, GEOMESA_ITERATORS_TRANSFORM_SCHEMA)
 
     val transformString = options.get(GEOMESA_ITERATORS_TRANSFORM)
     transform =
@@ -151,17 +154,7 @@ object SimpleFeatureFilteringIterator {
 
   import geomesa.core._
 
-  def setFeatureType(cfg: IteratorSetting, featureType: String) {
-    cfg.addOption(GEOMESA_ITERATORS_SIMPLE_FEATURE_TYPE, featureType)
-  }
-
   def setECQLFilter(cfg: IteratorSetting, ecql: String) {
     cfg.addOption(GEOMESA_ITERATORS_ECQL_FILTER, ecql)
   }
-
-  def setTransforms(cfg: IteratorSetting, transform: String, schema: Option[SimpleFeatureType]) {
-    cfg.addOption(GEOMESA_ITERATORS_TRANSFORM, transform)
-    schema.map(sft => cfg.addOption(GEOMESA_ITERATORS_TRANSFORM_SCHEMA, DataUtilities.encodeType(sft)))
-  }
-
 }

--- a/geomesa-core/src/main/scala/geomesa/core/iterators/SpatioTemporalIntersectingIterator.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/iterators/SpatioTemporalIntersectingIterator.scala
@@ -31,7 +31,7 @@ import org.apache.accumulo.core.iterators.{IteratorEnvironment, SortedKeyValueIt
 import org.apache.hadoop.io.Text
 import org.geotools.data.DataUtilities
 import org.joda.time.{DateTimeZone, DateTime, Interval}
-import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import org.opengis.feature.simple.SimpleFeature
 import scala.util.Try
 
 case class Attribute(name: Text, value: Text)
@@ -85,6 +85,7 @@ class SpatioTemporalIntersectingIterator
            env: IteratorEnvironment) {
 
     val featureType = DataUtilities.createType("DummyType", options.get(GEOMESA_ITERATORS_SIMPLE_FEATURE_TYPE))
+    featureType.decodeUserData(options, GEOMESA_ITERATORS_SIMPLE_FEATURE_TYPE)
 
     val schemaEncoding = options.get(DEFAULT_SCHEMA_NAME)
     decoder = IndexSchema.getIndexEntryDecoder(schemaEncoding)
@@ -376,12 +377,10 @@ trait IteratorHelpers  {
     Attribute(attribute, value)
   }
 
-  def setOptions(cfg: IteratorSetting, schema: String, poly: Option[Polygon], interval: Option[Interval],
-                 featureType: String) {
+  def setOptions(cfg: IteratorSetting, schema: String, poly: Option[Polygon], interval: Option[Interval]) {
     cfg.addOption(DEFAULT_SCHEMA_NAME, schema)
     poly.foreach { p => cfg.addOption(DEFAULT_POLY_PROPERTY_NAME, p.toText) }
     interval.foreach { int => cfg.addOption(DEFAULT_INTERVAL_PROPERTY_NAME, encodeInterval(int)) }
-    cfg.addOption(GEOMESA_ITERATORS_SIMPLE_FEATURE_TYPE, featureType)
   }
 
   protected def encodeInterval(interval: Interval): String =

--- a/geomesa-core/src/main/scala/geomesa/core/iterators/package.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/iterators/package.scala
@@ -1,5 +1,40 @@
 package geomesa.core
 
+import collection.JavaConversions._
+import org.apache.accumulo.core.client.IteratorSetting
+import org.opengis.feature.simple.SimpleFeatureType
+
+
 package object iterators {
   val FEATURE_ENCODING   = "geomesa.feature.encoding"
+  val USER_DATA = ".userdata."
+
+  implicit class RichIteratorSetting(cfg: IteratorSetting) {
+    /**
+     *  Copy UserData entries taken from a SimpleFeatureType into an IteratorSetting for later transfer back into
+     *  a SimpleFeatureType
+     *
+     *  This works around the fact that DataUtilities.encodeType ignores the UserData
+     *
+     */
+    def encodeUserData(userData: java.util.Map[AnyRef,AnyRef], keyPrefix: String)  {
+      val fullPrefix = keyPrefix + USER_DATA
+      userData.foreach { case (k, v) => cfg.addOption(fullPrefix + k.toString, v.toString)}
+    }
+  }
+  implicit class RichIteratorSimpleFeatureType(sft: SimpleFeatureType) {
+    /**
+     *  Copy UserData entries taken from an IteratorSetting/Options back into
+     *  a SimpleFeatureType
+     *
+     *  This works around the fact that DataUtilities.encodeType ignores the UserData
+     *
+     */
+    def decodeUserData(options: java.util.Map[String,String], keyPrefix:String)  {
+      val fullPrefix = keyPrefix + USER_DATA
+      options
+        .filter {  case (k, _) => k.startsWith(fullPrefix) }
+        .foreach { case (k, v) => sft.getUserData.put(k.stripPrefix(fullPrefix), v) }
+    }
+  }
 }

--- a/geomesa-core/src/test/scala/geomesa/core/iterators/IteratorTriggerTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/IteratorTriggerTest.scala
@@ -145,7 +145,7 @@ class IteratorTriggerTest extends Specification {
     def useIndexOnlyIteratorTest(ecqlPred: String, transformText: Array[String]): Boolean = {
       val aQuery = TestTable.sampleQuery(ECQL.toFilter(ecqlPred), transformText)
       val modECQLPred = TestTable.extractReWrittenCQL(aQuery, TestTable.testFeatureType)
-      IteratorTrigger.useIndexOnlyIterator(modECQLPred, aQuery, TestTable.testFeatureTypeSpec)
+      IteratorTrigger.useIndexOnlyIterator(modECQLPred, aQuery, TestTable.testFeatureType)
     }
 
     /**


### PR DESCRIPTION
Add functions to transfer the SimpleFeatureType UserData into and out of IteratorSettings, which would otherwise be lost
when passed to the Iterators via DataUtilities.encodeType
