### PR TITLE
GEOMESA-155 fix for non-thread-safe map 1.4

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/avro/AvroSimpleFeature.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/avro/AvroSimpleFeature.scala
@@ -217,7 +217,8 @@ object AvroSimpleFeature {
       new GenericDatumWriter[GenericRecord](avroSchemaCache.get(sft))
     }
 
-  val attributeNameLookUp = scala.collection.mutable.Map[String, String]()
+  private val attributeNameLookUp = new scala.collection.mutable.HashMap[String, String]()
+    with scala.collection.mutable.SynchronizedMap[String, String]
 
   final val FEATURE_ID_AVRO_FIELD_NAME: String = "__fid__"
   final val AVRO_SIMPLE_FEATURE_VERSION: String = "__version__"


### PR DESCRIPTION
this is the accumulo1.4 branch fix for geomesa-155, Changed attributeNameLookUp into a HashMap with SynchronizedMap traits. It should fix thread safety issues...
