### PR TITLE
GEOMESA-139 Remove inconsistent naming of temporal and geometry attributes in index

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/core.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/core.scala
@@ -21,6 +21,8 @@ package object core {
   // This first string is used as a SimpleFeature attribute name.
   //  Since we would like to be able to use ECQL filters, we are restricted to letters, numbers, and _'s.
   val DEFAULT_GEOMETRY_PROPERTY_NAME = "SF_PROPERTY_GEOMETRY"
+  val DEFAULT_DTG_PROPERTY_NAME = "dtg"
+  val DEFAULT_DTG_END_PROPERTY_NAME = "dtg_end_time"
 
   val DEFAULT_FEATURE_TYPE = "geomesa.feature.type"
   val DEFAULT_SCHEMA_NAME  = "geomesa.index.schema"

--- a/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStore.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStore.scala
@@ -166,7 +166,7 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
     // store each metadata in the associated column family
     val attributeMap = Map(ATTRIBUTES_CF          -> attributesValue,
                             SCHEMA_CF             -> schemaValue,
-                            DTGFIELD_CF           -> dtgValue.getOrElse(Constants.SF_PROPERTY_START_TIME),
+                            DTGFIELD_CF           -> dtgValue.getOrElse(core.DEFAULT_DTG_PROPERTY_NAME),
                             FEATURE_ENCODING_CF   -> featureEncodingValue,
                             VISIBILITIES_CF       -> writeVisibilities)
 
@@ -554,7 +554,7 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
   override def getSchema(featureName: String): SimpleFeatureType = {
     val sft = DataUtilities.createType(featureName, getAttributes(featureName))
     val dtgField = readMetadataItem(featureName, DTGFIELD_CF)
-                   .getOrElse(Constants.SF_PROPERTY_START_TIME)
+                   .getOrElse(core.DEFAULT_DTG_PROPERTY_NAME)
     sft.getUserData.put(core.index.SF_PROPERTY_START_TIME, dtgField)
     sft.getUserData.put(core.index.SF_PROPERTY_END_TIME, dtgField)
     sft

--- a/geomesa-core/src/main/scala/geomesa/core/data/package.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/package.scala
@@ -16,6 +16,7 @@
 
 package geomesa.core
 
+import geomesa.core._
 import org.apache.accumulo.core.data.{Key, Value}
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapreduce.TaskInputOutputContext
@@ -63,6 +64,6 @@ package object data {
       .filter { _.getUserData.contains(SF_PROPERTY_START_TIME) }
       .headOption
       .map { _.getName.toString }
-      .getOrElse(SF_PROPERTY_START_TIME)
+      .getOrElse(DEFAULT_DTG_PROPERTY_NAME)
 
 }

--- a/geomesa-core/src/main/scala/geomesa/core/index/IndexEntry.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/index/IndexEntry.scala
@@ -2,6 +2,7 @@ package geomesa.core.index
 
 import com.typesafe.scalalogging.slf4j.Logging
 import com.vividsolutions.jts.geom.Geometry
+import geomesa.core._
 import geomesa.core.data.DATA_CQ
 import geomesa.core.data.SimpleFeatureEncoder
 import geomesa.utils.geohash.{GeoHash, GeohashUtils}
@@ -17,8 +18,8 @@ object IndexEntry {
 
   implicit class IndexEntrySFT(sf: SimpleFeature) {
     lazy val userData = sf.getFeatureType.getUserData
-    lazy val dtgStartField = userData.getOrElse(SF_PROPERTY_START_TIME, SF_PROPERTY_START_TIME).asInstanceOf[String]
-    lazy val dtgEndField = userData.getOrElse(SF_PROPERTY_END_TIME, SF_PROPERTY_END_TIME).asInstanceOf[String]
+    lazy val dtgStartField = userData.getOrElse(SF_PROPERTY_START_TIME, DEFAULT_DTG_PROPERTY_NAME).asInstanceOf[String]
+    lazy val dtgEndField = userData.getOrElse(SF_PROPERTY_END_TIME, DEFAULT_DTG_END_PROPERTY_NAME).asInstanceOf[String]
 
     lazy val sid = sf.getID
     lazy val gh: GeoHash = GeohashUtils.reconstructGeohashFromGeometry(geometry)

--- a/geomesa-core/src/main/scala/geomesa/core/index/index.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/index/index.scala
@@ -39,7 +39,7 @@ package object index {
   def getDtgFieldName(sft: SimpleFeatureType) = Option(sft.getUserData.get(SF_PROPERTY_START_TIME)).map{_.toString}
   // wrapping function in option to protect against incorrect values in SF_PROPERTY_START_TIME
   def getDtgDescriptor(sft: SimpleFeatureType) = getDtgFieldName(sft).flatMap{name => Option(sft.getDescriptor(name))}
-  val spec = "geomesa_index_geometry:Geometry:srid=4326,geomesa_index_start_time:Date,geomesa_index_end_time:Date"
+  val spec = "geom:Geometry:srid=4326,dtg:Date,dtg_end_time:Date"
   val indexSFT = DataUtilities.createType("geomesa-idx", spec)
 
   implicit def string2id(s: String): FeatureId = new FeatureIdImpl(s)

--- a/geomesa-core/src/test/java/geomesa/core/DocumentationTest.java
+++ b/geomesa-core/src/test/java/geomesa/core/DocumentationTest.java
@@ -74,12 +74,9 @@ public class DocumentationTest {
       dataStore.getFeatureSource(featureName);
 
     // construct a filter that uses both geography and time
-    String bbox = "BBOX(" +
-      Constants.SF_PROPERTY_GEOMETRY + ", -78.0, 38.2, -77.3, 39.1)";
-    String period = "( NOT (" + Constants.SF_PROPERTY_START_TIME +
-      " AFTER 2012-12-31T23:59:59Z))" +
-      " AND ( NOT (" + Constants.SF_PROPERTY_END_TIME +
-      " BEFORE 2012-01-01T00:00:00Z))";
+    String bbox = "BBOX(geom, -78.0, 38.2, -77.3, 39.1)";
+    String period = "( NOT ( dtg AFTER 2012-12-31T23:59:59Z))" +
+                    "AND ( NOT ( dtg BEFORE 2012-01-01T00:00:00Z))";
     Filter cqlFilter = ECQL.toFilter(bbox + " AND " + period);
     Query query = new Query(featureName, cqlFilter);
 
@@ -94,10 +91,12 @@ public class DocumentationTest {
     String featureName = "Product";
 
     // create the feature-type (a "schema" in GeoTools parlance)
-    String featureSchema = "NAME:String,SKU:Long,COST:Double,SELL_BY:Date," +
+    String featureSchema =
+      "NAME:String,SKU:Long,COST:Double,SELL_BY:Date," +
       Constants.TYPE_SPEC;  // built-in geomesa attributes
     SimpleFeatureType featureType = DataUtilities.createType(featureName,
       featureSchema);
+    featureType.getUserData().put(Constants.SF_PROPERTY_START_TIME, "dtg");
     dataStore.createSchema(featureType);
 
     return featureType;
@@ -115,13 +114,14 @@ public class DocumentationTest {
       noValues, "SomeNewProductID");
 
     // initialize a few fields
-    newFeature.setDefaultGeometry((new WKTReader()).read("POINT(45.0 49.0)"));
+    // the first three attributes' names are taken from Constants.TYPE_SPEC
+    newFeature.setDefaultGeometry((new WKTReader()).read("POINT(45.0 49.0)"));  // name of attribute is geom
+    newFeature.setAttribute("dtg", new Date());
+    newFeature.setAttribute("dtg_end_time", new Date());
     newFeature.setAttribute("NAME", "New Product Name");
     newFeature.setAttribute("SKU", "011235813");
     newFeature.setAttribute("COST", 1.23);
     newFeature.setAttribute("SELL_BY", new Date());
-    newFeature.setAttribute(Constants.SF_PROPERTY_START_TIME, new Date());
-    newFeature.setAttribute(Constants.SF_PROPERTY_END_TIME, new Date());
 
     return newFeature;
   }

--- a/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
@@ -108,7 +108,7 @@ class AccumuloDataStoreTest extends Specification {
       val res = fs.addFeatures(featureCollection)
 
       // compose a CQL query that uses a reasonably-sized polygon for searching
-      val cqlFilter = CQL.toFilter(s"BBOX(geomesa_index_geometry, 44.9,48.9,45.1,49.1)")
+      val cqlFilter = CQL.toFilter(s"BBOX(geom, 44.9,48.9,45.1,49.1)")
       val query = new Query(sftName, cqlFilter)
 
       // Let's read out what we wrote.
@@ -149,7 +149,7 @@ class AccumuloDataStoreTest extends Specification {
       val res = fs.addFeatures(featureCollection)
 
       // compose a CQL query that uses a polygon that is disjoint with the feature bounds
-      val cqlFilter = CQL.toFilter(s"BBOX(geomesa_index_geometry, 64.9,68.9,65.1,69.1)")
+      val cqlFilter = CQL.toFilter(s"BBOX(geom, 64.9,68.9,65.1,69.1)")
       val query = new Query(sftName, cqlFilter)
 
       // Let's read out what we wrote.

--- a/geomesa-core/src/test/scala/geomesa/core/data/FeatureWritersTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/FeatureWritersTest.scala
@@ -273,22 +273,22 @@ class FeatureWritersTest extends Specification {
         writer.close
 
         // Verify old geo bbox doesn't return them
-        val map45 = getMap[String,Int](getFeatures(sftName, fs, "BBOX(geomesa_index_geometry, 44.9,48.9,45.1,49.1)"),"name", "age")
+        val map45 = getMap[String,Int](getFeatures(sftName, fs, "BBOX(geom, 44.9,48.9,45.1,49.1)"),"name", "age")
         map45.keySet.size should equalTo(3)
         map45.keySet should containAllOf(List("will", "george", "sue"))
 
         // Verify that new geometries are written with a bbox query that uses the index
-        val map50 = getMap[String,Int](getFeatures(sftName, fs, "BBOX(geomesa_index_geometry, 49.9,49.9,50.1,50.1)"),"name", "age")
+        val map50 = getMap[String,Int](getFeatures(sftName, fs, "BBOX(geom, 49.9,49.9,50.1,50.1)"),"name", "age")
         map50.keySet.size should equalTo(2)
         map50.keySet should containAllOf(List("bob", "karen"))
 
         // get them all
-        val mapLarge = getMap[String,Int](getFeatures(sftName, fs, "BBOX(geomesa_index_geometry, 44.0,44.0,51.0,51.0)"),"name", "age")
+        val mapLarge = getMap[String,Int](getFeatures(sftName, fs, "BBOX(geom, 44.0,44.0,51.0,51.0)"),"name", "age")
         mapLarge.keySet.size should equalTo(5)
         mapLarge.keySet should containAllOf(List("will", "george", "sue", "bob", "karen"))
 
         // get none
-        val mapNone = getMap[String,Int](getFeatures(sftName, fs, "BBOX(geomesa_index_geometry, 30.0,30.0,31.0,31.0)"),"name", "age")
+        val mapNone = getMap[String,Int](getFeatures(sftName, fs, "BBOX(geom, 30.0,30.0,31.0,31.0)"),"name", "age")
         mapNone.keySet.size should equalTo(0)
       }
 
@@ -296,7 +296,7 @@ class FeatureWritersTest extends Specification {
         val ds = createStore
         val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
 
-        val attr = index.SF_PROPERTY_START_TIME
+        val attr = "dtg"
 
         val filter = CQL.toFilter("name = 'will' or name='george'")
         val writer = ds.getFeatureWriter(sftName, filter, Transaction.AUTO_COMMIT)
@@ -304,7 +304,7 @@ class FeatureWritersTest extends Specification {
         val newDate = sdf.parse("20140202")
         while(writer.hasNext){
           val sf = writer.next
-          sf.setAttribute(index.SF_PROPERTY_START_TIME, newDate)
+          sf.setAttribute(attr, newDate)
           writer.write
         }
         writer.close
@@ -346,11 +346,11 @@ class FeatureWritersTest extends Specification {
 
         val filter = CQL.toFilter("include")
         val writer = ds.getFeatureWriter(sftName, filter, Transaction.AUTO_COMMIT)
-
+        val attr = "dtg"
         val newDate = sdf.parse("20120102")
         while(writer.hasNext){
           val sf = writer.next
-          sf.setAttribute(index.SF_PROPERTY_START_TIME, newDate)
+          sf.setAttribute(attr, newDate)
           sf.setDefaultGeometry(WKTUtils.read("POINT(10.0 10.0)"))
           writer.write
         }
@@ -373,7 +373,7 @@ class FeatureWritersTest extends Specification {
 
           o.getID must be equalTo(n.getID)
           o.getDefaultGeometry must not be equalTo(n.getDefaultGeometry)
-          o.getAttribute(index.SF_PROPERTY_START_TIME) must not be equalTo(n.getAttribute(index.SF_PROPERTY_START_TIME))
+          o.getAttribute(attr) must not be equalTo(n.getAttribute(attr))
         }
       }
 

--- a/geomesa-core/src/test/scala/geomesa/core/data/TableVersionTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/TableVersionTest.scala
@@ -53,7 +53,7 @@ class TableVersionTest extends Specification {
 
     // Insert metadata
     val metadataMutation = new Mutation(s"~METADATA_$sftName")
-    metadataMutation.put("attributes", "", s"name:String,geomesa_index_geometry:Geometry:srid=4326,geomesa_index_start_time:Date,geomesa_index_end_time:Date")
+    metadataMutation.put("attributes", "", s"name:String,geom:Geometry:srid=4326,dtg:Date,dtg_end_time:Date")
     metadataMutation.put("bounds", "", "45.0:45.0:49.0:49.0")
     metadataMutation.put("schema", "", s"%~#s%99#r%$sftName#cstr%0,3#gh%yyyyMMdd#d::%~#s%3,2#gh::%~#s%#id")
     bw.addMutation(metadataMutation)
@@ -97,9 +97,9 @@ class TableVersionTest extends Specification {
 
   def getFeatures = (0 until 6).map { i =>
     builder.reset
-    builder.set("geomesa_index_geometry", WKTUtils.read("POINT(45.0 45.0)"))
-    builder.set("geomesa_index_start_time", "2012-01-02T05:06:07.000Z")
-    builder.set("geomesa_index_end_time", "2012-01-02T05:06:07.000Z")
+    builder.set("geom", WKTUtils.read("POINT(45.0 45.0)"))
+    builder.set("dtg", "2012-01-02T05:06:07.000Z")
+    builder.set("dtg_end_time", "2012-01-02T05:06:07.000Z")
     builder.set("name",i.toString)
     val sf = builder.buildFeature(i.toString)
     sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
@@ -214,9 +214,9 @@ class TableVersionTest extends Specification {
       }
 
       builder.reset
-      builder.set("geomesa_index_geometry", WKTUtils.read("POINT(45.0 45.0)"))
-      builder.set("geomesa_index_start_time", "2012-01-02T05:06:07.000Z")
-      builder.set("geomesa_index_end_time", "2012-01-02T05:06:07.000Z")
+      builder.set("geom", WKTUtils.read("POINT(45.0 45.0)"))
+      builder.set("dtg", "2012-01-02T05:06:07.000Z")
+      builder.set("dtg_end_time", "2012-01-02T05:06:07.000Z")
       builder.set("name","random")
       val sf = builder.buildFeature("bigid")
       sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE

--- a/geomesa-core/src/test/scala/geomesa/core/filter/OrSplittingFilterTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/filter/OrSplittingFilterTest.scala
@@ -23,9 +23,9 @@ object OrSplittingFilterTest {
   def intToAttributeFilter(i: Int): Filter = s"attr$i = val$i"
   implicit def intToFilter(i: Int): RichFilter = intToAttributeFilter(i)
 
-  val geom1: Filter = "INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
-  val geom2: Filter = "INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23)))"
-  val date1: Filter = "(geomesa_index_start_time between '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z')"
+  val geom1: Filter = "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
+  val geom2: Filter = "INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23)))"
+  val date1: Filter = "(dtg between '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z')"
 }
 
 import OrSplittingFilterTest._

--- a/geomesa-core/src/test/scala/geomesa/core/index/IndexSchemaTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/index/IndexSchemaTest.scala
@@ -17,6 +17,7 @@
 package geomesa.core.index
 
 import com.vividsolutions.jts.geom._
+import geomesa.core._
 import geomesa.core.data.SimpleFeatureEncoderFactory
 import geomesa.utils.text.WKTUtils
 import org.apache.accumulo.core.data.Key
@@ -33,8 +34,8 @@ class IndexSchemaTest extends Specification {
 
   import collection.JavaConversions._
 
-  val dummyType = DataUtilities.createType("DummyType",s"foo:String,bar:Geometry,baz:Date,$SF_PROPERTY_GEOMETRY:Geometry,$SF_PROPERTY_START_TIME:Date,$SF_PROPERTY_END_TIME:Date")
-  val customType = DataUtilities.createType("DummyType",s"foo:String,bar:Geometry,baz:Date,*the_geom:Geometry,dt_start:Date,$SF_PROPERTY_END_TIME:Date")
+  val dummyType = DataUtilities.createType("DummyType",s"foo:String,bar:Geometry,baz:Date,$DEFAULT_GEOMETRY_PROPERTY_NAME:Geometry,$DEFAULT_DTG_PROPERTY_NAME:Date,$DEFAULT_DTG_END_PROPERTY_NAME:Date")
+  val customType = DataUtilities.createType("DummyType",s"foo:String,bar:Geometry,baz:Date,*the_geom:Geometry,dt_start:Date,$DEFAULT_DTG_END_PROPERTY_NAME:Date")
   customType.getUserData.put(SF_PROPERTY_START_TIME, "dt_start")
   val featureEncoder = SimpleFeatureEncoderFactory.defaultEncoder
 
@@ -147,7 +148,7 @@ class IndexSchemaTest extends Specification {
 
       // the decoded date will only be accurate to the (year, month, day)
       // (but beware time-zone effects for direct comparison!)
-      val dtOut = decoded.getAttribute(SF_PROPERTY_START_TIME).asInstanceOf[Option[DateTime]].getOrElse(
+      val dtOut = decoded.getAttribute(DEFAULT_DTG_PROPERTY_NAME).asInstanceOf[Option[DateTime]].getOrElse(
         throw new Exception("Invalid date field.")).toDate
       // time should be off by 12 hours and 5 minutes
       // (the portion beyond "yyyyMMdd")

--- a/geomesa-core/src/test/scala/geomesa/core/iterators/IndexIteratorTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/IndexIteratorTest.scala
@@ -107,9 +107,9 @@ class IndexIteratorTest extends SpatioTemporalIntersectingIteratorTest {
     //create the Feature Source
     val fs = IITest.setupMockFeatureSource(entries)
 
-    val gf = s"WITHIN(geomesa_index_geometry, ${polygon.toText})"
+    val gf = s"WITHIN(geom, ${polygon.toText})"
     val dt: Option[String] = Option(dtFilter).map(int =>
-      s"(geomesa_index_start_time between '${int.getStart}' AND '${int.getEnd}')"
+      s"(dtg between '${int.getStart}' AND '${int.getEnd}')"
     )
     def red(f: String, og: Option[String]) = og match {
       case Some(g) => s"$f AND $g"
@@ -123,7 +123,7 @@ class IndexIteratorTest extends SpatioTemporalIntersectingIteratorTest {
     // select a few attributes to trigger the IndexIterator
     // Note that since we are re-running all the tests from the IntersectingIteratorTest,
     // some of the tests may actually use the IntersectingIterator
-    val outputAttributes = Array("geomesa_index_geometry")
+    val outputAttributes = Array("geom")
     //val q = new Query(TestData.featureType.getTypeName, tf)
     val q = new Query(TestData.featureType.getTypeName, tf, outputAttributes)
     val sfCollection = fs.getFeatures(q)

--- a/geomesa-core/src/test/scala/geomesa/core/iterators/IteratorTriggerTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/IteratorTriggerTest.scala
@@ -46,7 +46,7 @@ class IteratorTriggerTest extends Specification {
 
     def testFeatureType: SimpleFeatureType = {
       val featureType: SimpleFeatureType = DataUtilities.createType(featureName, testFeatureTypeSpec)
-      featureType.getUserData.put(SF_PROPERTY_START_TIME, "geomesa_index_start_time")
+      featureType.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
       featureType
     }
 
@@ -111,26 +111,26 @@ class IteratorTriggerTest extends Specification {
     val anotherTrivialFilterString = "(INCLUDE)"
 
     val extraAttributeFilterString =
-      "WITHIN(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND (attr2 like '2nd___')"
+      "WITHIN(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND (attr2 like '2nd___')"
 
     val nonReducibleFilterString =
-      "WITHIN(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND (geomesa_index_start_time before 2010-08-08T23:59:59Z) AND (geomesa_index_end_time after 2010-08-08T00:00:00Z)"
+      "WITHIN(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND (dtg before 2010-08-08T23:59:59Z) AND (dtg_end_time after 2010-08-08T00:00:00Z)"
 
     val reducibleFilterString =
-      "WITHIN(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND (geomesa_index_start_time between '2010-08-08T00:00:00.000Z' AND '2010-08-08T23:59:59.000Z')"
+      "WITHIN(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND (dtg between '2010-08-08T00:00:00.000Z' AND '2010-08-08T23:59:59.000Z')"
 
     // transforms for testing
     val simpleTransformToIndex = {
-      Array("geomesa_index_geometry", "geomesa_index_start_time")
+      Array("geom", "dtg")
     }
     val renameTransformToIndex = {
-      Array("newgeo=geomesa_index_geometry", "geomesa_index_start_time")
+      Array("newgeo=geom", "dtg")
     }
     val complexTransformToIndex = {
-      Array("geomesa_index_geometry=buffer(geomesa_index_geometry,2)", "geomesa_index_start_time")
+      Array("geom=buffer(geom,2)", "dtg")
     }
     val simpleTransformToIndexPlusAnother = {
-      Array("geomesa_index_geometry", "geomesa_index_start_time", "attr2")
+      Array("geom", "dtg", "attr2")
     }
     val nullTransform = null
 

--- a/geomesa-core/src/test/scala/geomesa/core/iterators/SpatioTemporalIntersectingIteratorTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/SpatioTemporalIntersectingIteratorTest.scala
@@ -17,6 +17,7 @@
 package geomesa.core.iterators
 
 import com.vividsolutions.jts.geom.{Geometry, Polygon}
+import geomesa.core._
 import geomesa.core.data.SimpleFeatureEncoderFactory
 import geomesa.core.index._
 import geomesa.utils.text.WKTUtils
@@ -70,7 +71,7 @@ class SpatioTemporalIntersectingIteratorTest extends Specification {
     val featureName = "feature"
     val schemaEncoding = "%~#s%" + featureName + "#cstr%10#r%0,1#gh%yyyyMM#d::%~#s%1,3#gh::%~#s%4,3#gh%ddHH#d%10#id"
     val featureType: SimpleFeatureType = DataUtilities.createType(featureName, UnitTestEntryType.getTypeSpec)
-    featureType.getUserData.put(SF_PROPERTY_START_TIME, "geomesa_index_start_time")
+    featureType.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
 
     val index = IndexSchema(schemaEncoding, featureType, featureEncoder)
 
@@ -244,9 +245,9 @@ class SpatioTemporalIntersectingIteratorTest extends Specification {
     val c = TestData.setupMockAccumuloTable(entries, numExpectedDataIn)
     val bs = () => c.createBatchScanner(TEST_TABLE, TEST_AUTHORIZATIONS, 5)
 
-    val gf = s"WITHIN(geomesa_index_geometry, ${polygon.toText})"
+    val gf = s"WITHIN(geom, ${polygon.toText})"
     val dt: Option[String] = Option(dtFilter).map(int =>
-      s"(geomesa_index_start_time between '${int.getStart}' AND '${int.getEnd}')"
+      s"(dtg between '${int.getStart}' AND '${int.getEnd}')"
     )
 
     def red(f: String, og: Option[String]) = og match {
@@ -336,8 +337,8 @@ class SpatioTemporalIntersectingIteratorTest extends Specification {
 
   "Large Mock Accumulo with a meaningful attribute-filter" should {
     "return a partial results-set" in {
-      val ecqlFilter = "(not " + SF_PROPERTY_START_TIME +
-        " after 2010-08-08T23:59:59Z) and (not " + SF_PROPERTY_END_TIME +
+      val ecqlFilter = "(not " + DEFAULT_DTG_PROPERTY_NAME +
+        " after 2010-08-08T23:59:59Z) and (not " + DEFAULT_DTG_END_PROPERTY_NAME +
         " before 2010-08-08T00:00:00Z)"
 
       // run this query on regular data

--- a/geomesa-core/src/test/scala/geomesa/core/process/tube/TubeBinTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/process/tube/TubeBinTest.scala
@@ -2,6 +2,7 @@ package geomesa.core.process.tube
 
 import collection.JavaConversions._
 import com.vividsolutions.jts.geom.GeometryCollection
+import geomesa.core._
 import geomesa.utils.text.WKTUtils
 import org.apache.log4j.Logger
 import org.geotools.data.DataUtilities
@@ -35,7 +36,7 @@ class TubeBinTest extends Specification {
         val sf = SimpleFeatureBuilder.build(sft, List(), day.toString)
         val lat = 40+day
         sf.setDefaultGeometry(WKTUtils.read(f"POINT($lat%d $lat%d)"))
-        sf.setAttribute(geomesa.core.index.SF_PROPERTY_START_TIME, new DateTime(f"2011-01-$day%02dT00:00:00Z", DateTimeZone.UTC).toDate)
+        sf.setAttribute(DEFAULT_DTG_PROPERTY_NAME, new DateTime(f"2011-01-$day%02dT00:00:00Z", DateTimeZone.UTC).toDate)
         sf.setAttribute("type","test")
         sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
         sf
@@ -43,7 +44,7 @@ class TubeBinTest extends Specification {
 
       log.debug("features: "+features.size)
       val ngf = new NoGapFill(new DefaultFeatureCollection(sftName, sft), 1.0, 6)
-      val binnedFeatures = ngf.timeBinAndUnion(ngf.transform(new ListFeatureCollection(sft, features), Constants.SF_PROPERTY_START_TIME).toSeq, 6)
+      val binnedFeatures = ngf.timeBinAndUnion(ngf.transform(new ListFeatureCollection(sft, features),DEFAULT_DTG_PROPERTY_NAME).toSeq, 6)
 
       binnedFeatures.foreach { sf =>
         if (sf.getDefaultGeometry.isInstanceOf[GeometryCollection])
@@ -51,9 +52,9 @@ class TubeBinTest extends Specification {
         else log.debug("size: 1")
       }
 
-      ngf.timeBinAndUnion(ngf.transform(new ListFeatureCollection(sft, features), Constants.SF_PROPERTY_START_TIME).toSeq, 1).size should equalTo(1)
+      ngf.timeBinAndUnion(ngf.transform(new ListFeatureCollection(sft, features), DEFAULT_DTG_PROPERTY_NAME).toSeq, 1).size should equalTo(1)
 
-      ngf.timeBinAndUnion(ngf.transform(new ListFeatureCollection(sft, features), Constants.SF_PROPERTY_START_TIME).toSeq, 0).size should equalTo(1)
+      ngf.timeBinAndUnion(ngf.transform(new ListFeatureCollection(sft, features), DEFAULT_DTG_PROPERTY_NAME).toSeq, 0).size should equalTo(1)
     }
 
   }

--- a/geomesa-dist/src/docbkx/documentation.xml
+++ b/geomesa-dist/src/docbkx/documentation.xml
@@ -339,12 +339,9 @@ DataStore dataStore = createDataStore();
     dataStore.getFeatureSource(featureName);
 
   // construct a filter that uses both geography and time
-  String bbox = "BBOX(" +
-    Constants.SF_PROPERTY_GEOMETRY + ", -78.0, 38.2, -77.3, 39.1)";
-  String period = "(" + Constants.SF_PROPERTY_START_TIME +
-    " BEFORE 2012-12-31T23:59:59Z)" +
-    " AND (" + Constants.SF_PROPERTY_END_TIME +
-    " AFTER 2012-01-01T00:00:00Z)";
+  String bbox = "BBOX(geom, -78.0, 38.2, -77.3, 39.1)";
+  String period = "( NOT ( dtg AFTER 2012-12-31T23:59:59Z))" +
+                  " AND ( NOT ( dtg BEFORE 2012-01-01T00:00:00Z))";
   Filter cqlFilter = ECQL.toFilter(bbox + " AND " + period);
   Query query = new Query(featureName, cqlFilter);
 
@@ -353,35 +350,30 @@ DataStore dataStore = createDataStore();
 }]]></programlisting>
 
         <para>Note that fields such as
-            <code>Constants.SF_PROPERTY_GEOMETRY</code>
-            are place-holders for the built-in fields available to all simple
-            features handled by GeoMesa:
-        </para>
-
-        <itemizedlist>
+            <code>geom</code> and <code>dtg</code> are used in GeoMesa's spatio-temporal index scheme, in addition
+            to being simple feature attributes in their own right. The selection of the fields for the indexing is done in this fashion:
+         <itemizedlist>
             <listitem>
                 <para>
-                    <code>Constants.SF_PROPERTY_GEOMETRY</code>:
-                    the geometry for this feature; this field must always
+                    Geometry: Select a field whose name is
+                    preceded by an asterisk, or failing that, the first geometry field described in the <code>SimpleFeatureType</code>,
+                    as the default geometry field. This field must always
                     have a non-<code>NULL</code> value expressed in terms
                     of SRID 4326
                 </para>
             </listitem>
             <listitem>
                 <para>
-                    <code>Constants.SF_PROPERTY_START_TIME</code>:
-                    the earliest time associated with this feature;
-                    this field may contain a <code>NULL</code> value
+                    Time (Optional): Select a field whose name is taken from the map obtained using the method
+                    <code>getUserData()</code> on the <code>SimpleFeatureType</code>. In this map,
+                    the key <code>Constants.SF_PROPERTY_START_TIME </code> points to the
+                    relevant name. If no value is found, the first <code>Date</code> field found in the
+                    <code>SimpleFeatureType</code> itself is selected.
                 </para>
             </listitem>
-            <listitem>
-                <para>
-                    <code>Constants.SF_PROPERTY_END_TIME</code>:
-                    the latest time associated with this feature;
-                    this field must always have a non-<code>NULL</code> value
-                </para>
-            </listitem>
-        </itemizedlist>
+         </itemizedlist>
+        </para>
+
 
     </section>
 
@@ -422,10 +414,12 @@ DataStore dataStore = createDataStore();
 
   // create the feature-type (a "schema" in GeoTools parlance)
   // (will also create the Accumulo table, if it does not already exist)
-  String featureSchema = "NAME:String,SKU:java.lang.Long,COST:Double,SELL_BY:Date," +
+  String featureSchema =
+    "NAME:String,SKU:java.lang.Long,COST:Double,SELL_BY:Date," +
     IndexEntryType.getTypeSpec();  // built-in GeoMesa attributes
   SimpleFeatureType featureType = DataUtilities.createType(featureName,
     featureSchema);
+  featureType.getUserData().put(Constants.SF_PROPERTY_START_TIME, "dtg");
   dataStore.createSchema(featureType);
 
   return featureType;
@@ -436,7 +430,7 @@ DataStore dataStore = createDataStore();
         </para>
 
         <para>A word on identifiers: GeoTools presupposes that
-            there is a unique field per<code>FeatureType</code>.
+            there is a unique field per <code>FeatureType</code>.
             Though the system can generate a surrogate ID, it is
             typically more useful to take advantage of the domain
             to suggest a naturally identifying field.  Though it
@@ -459,14 +453,14 @@ DataStore dataStore = createDataStore();
     noValues, "SomeNewProductID");
 
   // initialize a few fields
+  // the first three attributes' names are taken from Constants.TYPE_SPEC
   newFeature.setDefaultGeometry((new WKTReader()).read("POINT(45.0 49.0)"));
+  newFeature.setAttribute("dtg", new Date());
+  newFeature.setAttribute("dtg_end_time", new Date());
   newFeature.setAttribute("NAME", "New Product Name");
   newFeature.setAttribute("SKU", "011235813");
   newFeature.setAttribute("COST", 1.23);
   newFeature.setAttribute("SELL_BY", new Date());
-  // start-date can be NULL, but end-date must not be
-  newFeature.setAttribute(Constants.SF_PROPERTY_START_TIME, new Date());
-  newFeature.setAttribute(Constants.SF_PROPERTY_END_TIME, new Date());
 
   return newFeature;
 }]]></programlisting>


### PR DESCRIPTION
Standardize on using geom/dtg for index attributes:
    geomesa_index_geometry   --> geom
    geomesa_index_start_time --> dtg
    and
    geomesa_index_end_time   --> dtg_end_time
