### PR TITLE
GEOMESA-176 Implement an 'explain' query feature.

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/index/IndexSchema.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/index/IndexSchema.scala
@@ -102,6 +102,11 @@ case class IndexSchema(encoder: IndexEncoder,
     adaptIterator(accumuloIterator, query)
   }
 
+  // Writes out an explanation of how a query would be run.
+  def explainQuery(q: Query, output: (String => Unit) = println) = {
+     planner.getIterator(() => new ExplainingBatchScanner(output), q, output)
+  }
+
   // This function decodes/transforms that Iterator of Accumulo Key-Values into an Iterator of SimpleFeatures.
   def adaptIterator(accumuloIterator: CloseableIterator[Entry[Key,Value]], query: Query): CloseableIterator[SimpleFeature] = {
     val returnSFT = getReturnSFT(query)

--- a/geomesa-core/src/main/scala/geomesa/core/index/QueryPlanners.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/index/QueryPlanners.scala
@@ -263,7 +263,7 @@ object KeyUtils {
 }
 
 trait KeyPlanner {
-  def getKeyPlan(filter:KeyPlanningFilter): KeyPlan
+  def getKeyPlan(filter:KeyPlanningFilter, output: String => Unit): KeyPlan
 }
 
 trait ColumnFamilyPlanner {
@@ -306,8 +306,11 @@ trait GeoHashPlanner {
 }
 
 case class GeoHashKeyPlanner(offset: Int, bits: Int) extends KeyPlanner with GeoHashPlanner {
-  def getKeyPlan(filter: KeyPlanningFilter) = getKeyPlan(filter, offset, bits) match {
-    case KeyList(keys) => KeyListTiered(keys)
+  def getKeyPlan(filter: KeyPlanningFilter, output: String => Unit) = getKeyPlan(filter, offset, bits) match {
+    case KeyList(keys) => {
+      output(s"GeoHashKeyPlanner: $keys")
+      KeyListTiered(keys)
+    }
     case KeyAccept => KeyAccept
     case _ => KeyInvalid
   }
@@ -319,46 +322,57 @@ case class GeoHashColumnFamilyPlanner(offset: Int, bits: Int) extends ColumnFami
 
 case class RandomPartitionPlanner(numPartitions: Int) extends KeyPlanner {
   val numBits: Int = numPartitions.toString.length
-  def getKeyPlan(filter: KeyPlanningFilter) = KeyListTiered((0 to numPartitions).map(_.toString.reverse.padTo(numBits,"0").reverse.mkString))
+  def getKeyPlan(filter: KeyPlanningFilter, output: String => Unit) = {
+    val keys = (0 to numPartitions).map(_.toString.reverse.padTo(numBits,"0").reverse.mkString)
+    output(s"Random Partition Planner $keys")
+    KeyListTiered(keys)
+  }
 }
 
 case class ConstStringPlanner(cstr: String) extends KeyPlanner {
-  def getKeyPlan(filter:KeyPlanningFilter) = KeyListTiered(List(cstr))
+  def getKeyPlan(filter:KeyPlanningFilter, output: String => Unit) = KeyListTiered(List(cstr))
 }
 
 case class DatePlanner(formatter: DateTimeFormatter) extends KeyPlanner {
   val endDates = List(9999,12,31,23,59,59,999)
   val startDates = List(0,1,1,0,0,0,0)
-  def getKeyPlan(filter:KeyPlanningFilter) = filter match {
-    case DateFilter(dt) => KeyRange(formatter.print(dt),formatter.print(dt))
-    case SpatialDateFilter(_,dt) => KeyRange(formatter.print(dt),formatter.print(dt))
-    case DateRangeFilter(start,end) => {// @todo - add better ranges for wrap-around case
-      if (formatter.print(start).take(4).toInt == start.getYear && formatter.print(end).take(4).toInt == end.getYear) {
-        // ***ASSUME*** that time components have been provided in order (if they start with the year)!
-        KeyRangeTiered(formatter.print(start), formatter.print(end))
-      } else {
-        val matchedTime = getTimeComponents(start).zip(getTimeComponents(end)).takeWhile(tup => tup._1 == tup._2).map(_._1)
-        val zeroTimeHead: List[Int] = bufferMatchedTime(matchedTime, startDates, start)
-        val zeroTime = extractRelevantTimeUnits(zeroTimeHead, startDates)
-        val endTimeHead = bufferMatchedTime(matchedTime, endDates, end)
-        val endTime = extractRelevantTimeUnits(endTimeHead, endDates)
-        KeyRangeTiered(formatter.print(createDate(zeroTime)),formatter.print(createDate(endTime)))
+  def getKeyPlan(filter:KeyPlanningFilter, output: String => Unit) = {
+    val plan = filter match {
+      case DateFilter(dt) => KeyRange(formatter.print(dt), formatter.print(dt))
+      case SpatialDateFilter(_,dt) => KeyRange(formatter.print(dt), formatter.print(dt))
+      case DateRangeFilter(start,end) => {// @todo - add better ranges for wrap-around case
+        if (formatter.print(start).take(4).toInt == start.getYear && formatter.print(end).take(4).toInt == end.getYear) {
+          // ***ASSUME*** that time components have been provided in order (if they start with the year)!
+          KeyRangeTiered(formatter.print(start), formatter.print(end))
+        } else {
+          val matchedTime = getTimeComponents(start).zip(getTimeComponents(end)).takeWhile(tup => tup._1 == tup._2).map(_._1)
+          val zeroTimeHead: List[Int] = bufferMatchedTime(matchedTime, startDates, start)
+          val zeroTime = extractRelevantTimeUnits(zeroTimeHead, startDates)
+          val endTimeHead = bufferMatchedTime(matchedTime, endDates, end)
+          val endTime = extractRelevantTimeUnits(endTimeHead, endDates)
+          KeyRangeTiered(formatter.print(createDate(zeroTime)),formatter.print(createDate(endTime)))
+        }
       }
-    }
-    case SpatialDateRangeFilter(_,start,end) => {// @todo - add better ranges for wrap-around case
-      if (formatter.print(start).take(4).toInt == start.getYear && formatter.print(end).take(4).toInt == end.getYear) {
-        // ***ASSUME*** that time components have been provided in order (if they start with the year)!
-        KeyRangeTiered(formatter.print(start), formatter.print(end))
-      } else {
-        val matchedTime = getTimeComponents(start).zip(getTimeComponents(end)).takeWhile(tup => tup._1 == tup._2).map(_._1)
-        val zeroTimeHead: List[Int] = bufferMatchedTime(matchedTime, startDates, start)
-        val zeroTime = extractRelevantTimeUnits(zeroTimeHead, startDates)
-        val endTimeHead = bufferMatchedTime(matchedTime, endDates, end)
-        val endTime = extractRelevantTimeUnits(endTimeHead, endDates)
-        KeyRangeTiered(formatter.print(createDate(zeroTime)),formatter.print(createDate(endTime)))
+      case SpatialDateRangeFilter(_,start,end) => {// @todo - add better ranges for wrap-around case
+        if (formatter.print(start).take(4).toInt == start.getYear && formatter.print(end).take(4).toInt == end.getYear) {
+          // ***ASSUME*** that time components have been provided in order (if they start with the year)!
+          KeyRangeTiered(formatter.print(start), formatter.print(end))
+        } else {
+          val matchedTime = getTimeComponents(start).zip(getTimeComponents(end)).takeWhile(tup => tup._1 == tup._2).map(_._1)
+          val zeroTimeHead: List[Int] = bufferMatchedTime(matchedTime, startDates, start)
+          val zeroTime = extractRelevantTimeUnits(zeroTimeHead, startDates)
+          val endTimeHead = bufferMatchedTime(matchedTime, endDates, end)
+          val endTime = extractRelevantTimeUnits(endTimeHead, endDates)
+          KeyRangeTiered(formatter.print(createDate(zeroTime)),formatter.print(createDate(endTime)))
+        }
       }
+      case _ => defaultKeyRange
     }
-    case _ => defaultKeyRange
+    plan match {
+      case KeyRange(start, end) =>          output(s"DatePlanner: start: $start end: $end")
+      case KeyRangeTiered(start, end, _) => output(s"DatePlanner: start: $start end: $end")
+    }
+    plan
   }
 
   def bufferMatchedTime(matchedTime: List[Int], dates: List[Int], time: DateTime): List[Int] =
@@ -392,8 +406,8 @@ case class DatePlanner(formatter: DateTimeFormatter) extends KeyPlanner {
 }
 
 case class CompositePlanner(seq: Seq[KeyPlanner], sep: String) extends KeyPlanner {
-  def getKeyPlan(filter:KeyPlanningFilter): KeyPlan = {
-    val joined = seq.map(_.getKeyPlan(filter)).reduce(_.join(_, sep))
+  def getKeyPlan(filter: KeyPlanningFilter, output: String => Unit): KeyPlan = {
+    val joined = seq.map(_.getKeyPlan(filter, output)).reduce(_.join(_, sep))
     joined match {
       case kt:KeyTiered    => KeyRanges(kt.toRanges(sep))
       case KeyRegex(regex) => joined.join(KeyRegex(".*"), "")

--- a/geomesa-core/src/main/scala/geomesa/core/util/ExplainingBatchScanner.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/util/ExplainingBatchScanner.scala
@@ -1,0 +1,42 @@
+package geomesa.core.util
+
+import java.util
+import java.util.Map.Entry
+import java.util.concurrent.TimeUnit
+import org.apache.accumulo.core.client.{IteratorSetting, BatchScanner}
+import org.apache.accumulo.core.data.{Range, Value, Key}
+import org.apache.hadoop.io.Text
+
+class ExplainingBatchScanner(output: String => Unit = println) extends BatchScanner {
+
+  override def setRanges(ranges: util.Collection[Range]): Unit = {}
+
+  override def setTimeout(timeout: Long, timeUnit: TimeUnit): Unit = output(s"setTimeout($timeout, $timeUnit)")
+
+  override def close(): Unit = {}
+
+  override def updateScanIteratorOption(iteratorName: String, key: String, value: String): Unit =
+    output(s"updateScanIterator($iteratorName, $key, $value")
+
+  override def removeScanIterator(iteratorName: String): Unit = output(s"removeScanIterator($iteratorName)")
+
+  override def fetchColumnFamily(col: Text): Unit = {}
+
+  override def getTimeout(timeUnit: TimeUnit): Long = { output(s"getTimeout($timeUnit)"); 0 }
+
+  override def iterator(): util.Iterator[Entry[Key, Value]] = {
+    new util.Iterator[Entry[Key, Value]] {
+      override def next(): Entry[Key, Value] = null
+      override def remove(): Unit = {}
+      override def hasNext: Boolean = false
+    }
+  }
+
+  override def clearScanIterators(): Unit = output(s"clearScanIterators")
+
+  override def fetchColumn(colFam: Text, colQual: Text): Unit = {}
+
+  override def clearColumns(): Unit = output("clearColumns")
+
+  override def addScanIterator(cfg: IteratorSetting): Unit = output(s"addScanIterator($cfg")
+}

--- a/geomesa-core/src/test/scala/geomesa/core/index/QueryPlannersTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/index/QueryPlannersTest.scala
@@ -33,9 +33,9 @@ class QueryPlannersTest extends Specification {
         case p: Polygon => p
         case _ => throw new Exception("geohash c23j should have a polygon bounding box")
       }
-      DatePlanner(DateTimeFormat.forPattern("MM")).getKeyPlan(SpatialFilter(ghPoly)) must be equalTo(KeyRange("01", "12"))
-      DatePlanner(DateTimeFormat.forPattern("ss")).getKeyPlan(SpatialFilter(ghPoly)) must be equalTo(KeyRange("00", "59"))
-      DatePlanner(DateTimeFormat.forPattern("MM-dd")).getKeyPlan(SpatialFilter(ghPoly)) must be equalTo(KeyRange("01-01", "12-31"))
+      DatePlanner(DateTimeFormat.forPattern("MM")).getKeyPlan(SpatialFilter(ghPoly), println) must be equalTo(KeyRange("01", "12"))
+      DatePlanner(DateTimeFormat.forPattern("ss")).getKeyPlan(SpatialFilter(ghPoly), println) must be equalTo(KeyRange("00", "59"))
+      DatePlanner(DateTimeFormat.forPattern("MM-dd")).getKeyPlan(SpatialFilter(ghPoly), println) must be equalTo(KeyRange("01-01", "12-31"))
     }
     "return apprpriate ranges for date ranges" in {
       val dt1 = new DateTime(2005, 3, 3, 5, 7, DateTimeZone.forID("UTC"))
@@ -43,16 +43,16 @@ class QueryPlannersTest extends Specification {
       val dt3 = new DateTime(2001, 3, 3, 5, 7, DateTimeZone.forID("UTC"))
       val dt4 = new DateTime(2005, 3, 9, 5, 7, DateTimeZone.forID("UTC"))
       val dt5 = new DateTime(2005, 9, 9, 5, 7, DateTimeZone.forID("UTC"))
-      DatePlanner(DateTimeFormat.forPattern("MM")).getKeyPlan(DateRangeFilter(dt1, dt2)) must be equalTo(KeyRangeTiered("03", "10"))
-      DatePlanner(DateTimeFormat.forPattern("ss")).getKeyPlan(DateRangeFilter(dt1, dt2)) must be equalTo(KeyRangeTiered("00", "59"))
-      DatePlanner(DateTimeFormat.forPattern("MM")).getKeyPlan(DateRangeFilter(dt3, dt1)) must be equalTo(KeyRangeTiered("01", "12"))
-      DatePlanner(DateTimeFormat.forPattern("MM")).getKeyPlan(DateRangeFilter(dt1, dt4)) must be equalTo(KeyRangeTiered("03", "03"))
-      DatePlanner(DateTimeFormat.forPattern("MM")).getKeyPlan(DateRangeFilter(dt4, dt5)) must be equalTo(KeyRangeTiered("03", "09"))
+      DatePlanner(DateTimeFormat.forPattern("MM")).getKeyPlan(DateRangeFilter(dt1, dt2), println) must be equalTo(KeyRangeTiered("03", "10"))
+      DatePlanner(DateTimeFormat.forPattern("ss")).getKeyPlan(DateRangeFilter(dt1, dt2), println) must be equalTo(KeyRangeTiered("00", "59"))
+      DatePlanner(DateTimeFormat.forPattern("MM")).getKeyPlan(DateRangeFilter(dt3, dt1), println) must be equalTo(KeyRangeTiered("01", "12"))
+      DatePlanner(DateTimeFormat.forPattern("MM")).getKeyPlan(DateRangeFilter(dt1, dt4), println) must be equalTo(KeyRangeTiered("03", "03"))
+      DatePlanner(DateTimeFormat.forPattern("MM")).getKeyPlan(DateRangeFilter(dt4, dt5), println) must be equalTo(KeyRangeTiered("03", "09"))
     }
     "return appropriate regexes for regex" in {
       val planners = List(ConstStringPlanner("foo"), RandomPartitionPlanner(2), GeoHashKeyPlanner(0,1))
       val cp = CompositePlanner(planners, "~")
-      val kp = cp.getKeyPlan(SpatialFilter(WKTUtils.read("POLYGON((-109 31, -115 31, -115 37,-109 37,-109 31))").asInstanceOf[Polygon]))
+      val kp = cp.getKeyPlan(SpatialFilter(WKTUtils.read("POLYGON((-109 31, -115 31, -115 37,-109 37,-109 31))").asInstanceOf[Polygon]), println)
       val expectedKP = KeyRanges(List(
         KeyRange("foo~0~.","foo~0~."),
         KeyRange("foo~0~9","foo~0~9"),

--- a/geomesa-core/src/test/scala/geomesa/core/iterators/SpatioTemporalIntersectingIteratorTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/SpatioTemporalIntersectingIteratorTest.scala
@@ -17,7 +17,7 @@
 package geomesa.core.iterators
 
 import com.typesafe.scalalogging.slf4j.Logging
-import com.vividsolutions.jts.geom.{Geometry, Polygon}
+import com.vividsolutions.jts.geom.Polygon
 import geomesa.core._
 import geomesa.core.data.SimpleFeatureEncoderFactory
 import geomesa.core.index._
@@ -35,10 +35,8 @@ import org.junit.runner.RunWith
 import org.opengis.feature.simple.SimpleFeature
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-
 import scala.collection.GenSeq
 import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
 import scala.util.{Random, Try}
 
 object UnitTestEntryType  {


### PR DESCRIPTION
- Adds an 'explainQuery' feature.

As a rough example/guide try this in the Maven Scala console (i.e., run 'mvn scala:console -pl geomesa-core'):

import org.geotools.data._
import geomesa.core.filter.TestFilters._
import org.geotools.filter.text.ecql.ECQL

val aparams = Map(
  "instanceId" -> "INSTANCE_ID",
  "zookeepers" -> "ZOOKEEPERS",
  "user" -> "USERNAME",
  "password"-> new String("PASSWORD"),
  "auths"-> "AUTHS",
  "tableName"-> "TABLE_NAME",
  "useMapReduce" -> "false")
val ds = DataStoreFinder.getDataStore(aparams)

val q = new Query()
val t = Transaction.AUTO_COMMIT

q.setTypeName("gdelt")

val afr = ds.getFeatureReader(q, t).asInstanceOf[AccumuloFeatureReader]
val is = afr.indexSchema

is.explainQuery(q)

val fs = "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
val f = ECQL.toFilter(fs)
q.setFilter(f)

is.explainQuery(q)
