### PR TITLE
GEOMESA-179 Limit unit test logging

### DIFF
--- a/geomesa-core/src/test/scala/geomesa/core/iterators/SpatioTemporalIntersectingIteratorTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/SpatioTemporalIntersectingIteratorTest.scala
@@ -118,7 +118,7 @@ class SpatioTemporalIntersectingIteratorTest extends Specification with Logging 
     runQuery(q, bs)
   }
 
-  def runQuery(q: Query, bs: () => BatchScanner, doPrint: Boolean = true, label: String = "test") = {
+  def runQuery(q: Query, bs: () => BatchScanner, doPrint: Boolean = false, label: String = "test") = {
     val featureEncoder = SimpleFeatureEncoderFactory.defaultEncoder
     // create the schema, and require de-duplication
     val schema = IndexSchema(TestData.schemaEncoding, TestData.featureType, featureEncoder)
@@ -131,11 +131,12 @@ class SpatioTemporalIntersectingIteratorTest extends Specification with Logging 
       val results: List[SimpleFeature] = itr.toList
       results.map(simpleFeature => {
         val attrs = simpleFeature.getAttributes.map(attr => if (attr == null) "" else attr.toString).mkString("|")
-        println("[SII." + label + "] query-hit:  " + simpleFeature.getID + "=" + attrs)
+        println(s"[SII.$label] query-hit: ${simpleFeature.getID} = + $attrs")
       })
       results.size
     } else itr.size
 
+    println(s"[SII.$label] total query hits:$retval")
     itr.close()
     retval
   }

--- a/geomesa-utils/src/test/scala/geomesa/utils/geohash/GeoHashTest.scala
+++ b/geomesa-utils/src/test/scala/geomesa/utils/geohash/GeoHashTest.scala
@@ -29,6 +29,9 @@ import scala.math._
 class GeoHashTest extends Specification
                           with Logging {
 
+  // set to true to see test output
+  val DEBUG_OUPUT = false
+
   // compute tolerance based on precision
   val precToleranceMap = (0 to 63).map(i => (i, 360.0 * pow(0.5, floor(i/2)))).toMap
   def xTolerance(prec: Int) = precToleranceMap(prec)
@@ -126,7 +129,7 @@ class GeoHashTest extends Specification
       val x : Double = -78.0
       val y : Double = 38.0
       for (precision <- 20 to 63) yield {
-        logger.debug(s"precision: $precision")
+        if(DEBUG_OUPUT) logger.debug(s"precision: $precision")
 
         // encode this value
         val ghEncoded : GeoHash = GeoHash(x, y, precision)
@@ -146,7 +149,7 @@ class GeoHashTest extends Specification
         ghEncoded.bitset must equalTo(ghDecoded.bitset)
         ghEncoded.prec must equalTo(ghDecoded.prec)
 
-        logger.debug(s"decoded: ${ghDecoded.y}, ${ghDecoded.x}; encoded: ${ghEncoded.y}, ${ghEncoded.x}")
+        if(DEBUG_OUPUT) logger.debug(s"decoded: ${ghDecoded.y}, ${ghDecoded.x}; encoded: ${ghEncoded.y}, ${ghEncoded.x}")
 
         // the round-trip geometry must be within tolerance of the original
         ghDecoded.x must beCloseTo(x, xTolerance(precision))

--- a/geomesa-utils/src/test/scala/geomesa/utils/geohash/GeohashUtilsTest.scala
+++ b/geomesa-utils/src/test/scala/geomesa/utils/geohash/GeohashUtilsTest.scala
@@ -30,6 +30,9 @@ class GeohashUtilsTest extends Specification with Logging {
 
   val NO_VALUE : Int = -1
 
+  // Turn this on for debugging purposes
+  val DEBUG_OUTPUT = false
+
   // collection of WKT polygons
   val testData : Map[String,(Int,Int,String,String)] = Map(
     "[POINT] CCRi" -> (NO_VALUE, 1, "dqb0tg3k", "POINT(-78.4953560 38.0752150)"),
@@ -88,7 +91,8 @@ class GeohashUtilsTest extends Specification with Logging {
         // all geometry types should test decomposition
         "decompose into " + numDecompositions + " GeoHashes, the first of which should be '" + firstDecompositionHash + "'" in {
           val decomposedGHs = decomposeGeometry(geom, 100, indexResolutions)
-          decomposedGHs.map(gh => logger.debug(name + "\t" + gh.hash + "\t" + getGeohashWKT(gh)))
+          if(DEBUG_OUTPUT)
+            decomposedGHs.map(gh => logger.debug(name + "\t" + gh.hash + "\t" + getGeohashWKT(gh)))
           decomposedGHs.size must equalTo(numDecompositions)
           decomposedGHs(0).hash must equalTo(firstDecompositionHash)
         }
@@ -103,7 +107,8 @@ class GeohashUtilsTest extends Specification with Logging {
       val ghSubstrings = getUniqueGeohashSubstringsInPolygon(
         polygonCharlottesville, 2, 3, 1<<15)
 
-      ghSubstrings.foreach { gh => logger.debug("[unique Charlottesville gh(2,3)] " + gh)}
+      if(DEBUG_OUTPUT)
+        ghSubstrings.foreach { gh => logger.debug("[unique Charlottesville gh(2,3)] " + gh)}
 
       ghSubstrings.size must be equalTo(9)
     }

--- a/geomesa-utils/src/test/scala/geomesa/utils/geohash/RectangleGeoHashIteratorTest.scala
+++ b/geomesa-utils/src/test/scala/geomesa/utils/geohash/RectangleGeoHashIteratorTest.scala
@@ -23,6 +23,10 @@ import org.junit.Test
 
 
 class RectangleGeoHashIteratorTest {
+
+  // enable to debug output for tests
+  val DEBUG_OUTPUT = false
+
   @Test
   def testCorners() {
     val bitsPrecision = 35
@@ -37,7 +41,7 @@ class RectangleGeoHashIteratorTest {
 
     val length = rghi.foldLeft(0)({case (count, gh) => {
       Assert.assertNotNull("Fetched a NULL GeoHash.", gh)
-      System.out.println("RectangleGHI " + count + ".  " + gh)
+      if (DEBUG_OUTPUT) println("RectangleGHI " + count + ".  " + gh)
       val pt = geometryFactory.createPoint(new Coordinate(gh.x, gh.y))
       val s = s"${gh.toString} == (${pt.getY},${pt.getX}) <-> (${bbox.ll.getY},${bbox.ll.getX}::${bbox.ur.getY},${bbox.ur.getX})"
       Assert.assertEquals("Latitude too low " + s, false, pt.getY < bbox.ll.getY)
@@ -58,7 +62,7 @@ class RectangleGeoHashIteratorTest {
     val ptCenter = geometryFactory.createPoint(new Coordinate(longitude, latitude))
     val ptLL = VincentyModel.moveWithBearingAndDistance(ptCenter, -135.0, radiusMeters * 707.0 / 500.0)
     val ptUR = VincentyModel.moveWithBearingAndDistance(ptCenter,   45.0, radiusMeters * 707.0 / 500.0)
-    System.out.println(s"[RectangleGeoHashIterator]  On circle test-bed from $ptLL to $ptUR...")
+    if(DEBUG_OUTPUT) println(s"[RectangleGeoHashIterator]  On circle test-bed from $ptLL to $ptUR...")
     val rghi = new RectangleGeoHashIterator(ptLL.getY, ptLL.getX,
                                             ptUR.getY, ptUR.getX,
                                             bitsPrecision)
@@ -77,7 +81,7 @@ class RectangleGeoHashIteratorTest {
                         urgh.toBinaryString)
     val length = rghi.foldLeft(0)({case (count, gh) => {
       Assert.assertNotNull("Fetched a NULL GeoHash.", gh)
-      System.out.println("RectangleGHI " + count + ".  " + gh)
+      if (DEBUG_OUTPUT) println("RectangleGHI " + count + ".  " + gh)
       count + 1
     }})
     Assert.assertEquals("Wrong number of RGHI iterations found", 80, length)


### PR DESCRIPTION
Limited unit test logging for Travis CI to work. Added flag that can be enabled if developer wants to see output on command line.
