### PR TITLE
GEOMESA-185 Fix TemporalIndexCheckTest

### DIFF
--- a/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
@@ -17,6 +17,7 @@
 package geomesa.core.data
 
 import com.vividsolutions.jts.geom.Coordinate
+import geomesa.core.index.SF_PROPERTY_START_TIME
 import geomesa.core.security.{AuthorizationsProvider, DefaultAuthorizationsProvider, FilteringAuthorizationsProvider}
 import geomesa.feature.AvroSimpleFeatureFactory
 import geomesa.utils.text.WKTUtils
@@ -75,6 +76,7 @@ class AccumuloDataStoreTest extends Specification {
       val ds = createStore
       val sft = DataUtilities.createType("testType",
         s"NAME:String,$geotimeAttributes")
+      sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
       ds.createSchema(sft)
       val tx = Transaction.AUTO_COMMIT
       val fw = ds.getFeatureWriterAppend("testType", tx)
@@ -92,6 +94,7 @@ class AccumuloDataStoreTest extends Specification {
       val sftName = "testType"
       val sft = DataUtilities.createType(sftName,
         s"NAME:String,$geotimeAttributes")
+      sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
       ds.createSchema(sft)
       val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
 
@@ -134,6 +137,7 @@ class AccumuloDataStoreTest extends Specification {
       val ds = createStore
       val sftName = "testType"
       val sft = DataUtilities.createType(sftName, s"NAME:String,$geotimeAttributes")
+      sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
       ds.createSchema(sft)
       val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
 
@@ -170,6 +174,7 @@ class AccumuloDataStoreTest extends Specification {
       val ds = createStore
       val sftName = "dwithintest"
       val sft = DataUtilities.createType(sftName, s"NAME:String,dtg:Date,*geom:Point:srid=4326")
+      sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
       ds.createSchema(sft)
 
       val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
@@ -205,6 +210,7 @@ class AccumuloDataStoreTest extends Specification {
       val ds = createStore
       val sftName = "transformtest"
       val sft = DataUtilities.createType(sftName, s"name:String,dtg:Date,*geom:Point:srid=4326")
+      sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
       ds.createSchema(sft)
 
       val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
@@ -238,6 +244,7 @@ class AccumuloDataStoreTest extends Specification {
       val ds = createStore
       val sftName = "transformtest"
       val sft = DataUtilities.createType(sftName, s"name:String,attr:String,dtg:Date,*geom:Point:srid=4326")
+      sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
       ds.createSchema(sft)
 
       val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
@@ -271,6 +278,7 @@ class AccumuloDataStoreTest extends Specification {
       val ds = createStore
       val sftName = "transformtest"
       val sft = DataUtilities.createType(sftName, s"name:String,attr:String,dtg:Date,*geom:Point:srid=4326")
+      sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
       ds.createSchema(sft)
 
       val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
@@ -365,6 +373,7 @@ class AccumuloDataStoreTest extends Specification {
                                                  "featureEncoding" -> "avro")).asInstanceOf[AccumuloDataStore]
 
       val sft = DataUtilities.createType(sftName, s"name:String,dtg:Date,*geom:Point:srid=4326")
+      sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
       ds.createSchema(sft)
 
       val ds2 = DataStoreFinder.getDataStore(Map(
@@ -415,6 +424,7 @@ class AccumuloDataStoreTest extends Specification {
       // create the schema - the auths for this user are sufficient to write data
       val sftName = "authwritetest1"
       val sft = DataUtilities.createType(sftName, s"name:String,dtg:Date,*geom:Point:srid=4326")
+       sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
       ds.createSchema(sft)
 
       // write some data
@@ -442,6 +452,7 @@ class AccumuloDataStoreTest extends Specification {
       // create the schema - the auths for this user are less than the visibility used to write data
       val sftName = "authwritetest2"
       val sft = DataUtilities.createType(sftName, s"name:String,dtg:Date,*geom:Point:srid=4326")
+      sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
       ds.createSchema(sft)
 
       // write some data
@@ -470,6 +481,7 @@ class AccumuloDataStoreTest extends Specification {
   "AccumuloFeatureStore" should {
     "compute target schemas from transformation expressions" in {
       val origSFT = DataUtilities.createType("test", "name:String,dtg:Date,*geom:Point:srid=4326")
+      origSFT.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
       val definitions =
         TransformProcess.toDefinition("name=name;helloName=strConcat('hello', name);geom=geom")
 

--- a/geomesa-core/src/test/scala/geomesa/core/data/FeatureWritersTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/FeatureWritersTest.scala
@@ -17,6 +17,7 @@
 package geomesa.core.data
 
 import geomesa.core.index
+import geomesa.core.index.SF_PROPERTY_START_TIME
 import geomesa.feature.AvroSimpleFeatureFactory
 import geomesa.utils.text.WKTUtils
 import java.text.SimpleDateFormat
@@ -41,7 +42,7 @@ class FeatureWritersTest extends Specification {
   val geotimeAttributes = geomesa.core.index.spec
   val sftName = "mutableType"
   val sft = DataUtilities.createType(sftName, s"name:String,age:Integer,$geotimeAttributes")
-
+  sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
   val sdf = new SimpleDateFormat("yyyyMMdd")
   sdf.setTimeZone(TimeZone.getTimeZone("Zulu"))
   val dateToIndex = sdf.parse("20140102")

--- a/geomesa-core/src/test/scala/geomesa/core/data/TableVersionTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/TableVersionTest.scala
@@ -1,5 +1,6 @@
 package geomesa.core.data
 
+import geomesa.core.index.SF_PROPERTY_START_TIME
 import geomesa.feature.AvroSimpleFeatureFactory
 import geomesa.utils.geotools.Conversions._
 import geomesa.utils.text.WKTUtils
@@ -44,6 +45,7 @@ class TableVersionTest extends Specification {
 
   val sftName = "regressionTestType"
   val sft = DataUtilities.createType(sftName, s"name:String,$geotimeAttributes")
+  sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
 
   def buildManualTable(params: Map[String, String]) = {
     val instance = new MockInstance(params("instanceId"))

--- a/geomesa-core/src/test/scala/geomesa/core/filter/OrSplittingFilterTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/filter/OrSplittingFilterTest.scala
@@ -7,9 +7,9 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
 object OrSplittingFilterTest {
-  val geom1: Filter = "INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
-  val geom2: Filter = "INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23)))"
-  val date1: Filter = "(geomesa_index_start_time between '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z')"
+  val geom1: Filter = "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
+  val geom2: Filter = "INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23)))"
+  val date1: Filter = "(dtg between '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z')"
 }
 
 import geomesa.core.filter.OrSplittingFilterTest._

--- a/geomesa-core/src/test/scala/geomesa/core/filter/TestFilters.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/filter/TestFilters.scala
@@ -12,68 +12,68 @@ object TestFilters {
 
   val baseFilters: Seq[Filter] =
     Seq(
-      "INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))",
-      "INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23)))",
-      "NOT (INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))))",
-      "NOT (INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))))",
+      "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))",
+      "INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23)))",
+      "NOT (INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))))",
+      "NOT (INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))))",
       "attr56 = val56",
-      "geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z'",
-      "geomesa_index_start_time BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z'"
+      "dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z'",
+      "dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z'"
     )
 
   val oneLevelAndFilters: Seq[Filter] =
     Seq(
-      "(INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) AND attr17 = val17)",
-      "(INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))))",
-      "(INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND attr81 = val81)",
-      "(attr15 = val15 AND INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))))"
+      "(INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) AND attr17 = val17)",
+      "(INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))))",
+      "(INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND attr81 = val81)",
+      "(attr15 = val15 AND INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))))"
     )
 
   val oneLevelOrFilters: Seq[Filter] =
     Seq(
-      "(INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))) OR INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))))",
-      "(INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))) OR attr4 = val4)",
-      "(INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) OR INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) OR attr20 = val20)",
-      "(INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) OR attr36 = val36)",
-      "(INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) OR attr24 = val24)",
-      "(attr100 = val100 OR INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) OR attr54 = val54)",
+      "(INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))) OR INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))))",
+      "(INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))) OR attr4 = val4)",
+      "(INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) OR INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) OR attr20 = val20)",
+      "(INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) OR attr36 = val36)",
+      "(INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) OR attr24 = val24)",
+      "(attr100 = val100 OR INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) OR attr54 = val54)",
       "(attr19 = val19 OR attr75 = val75 OR attr72 = val72)",
       "(attr37 = val37 OR attr19 = val19)",
-      "(attr44 = val44 OR INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) OR attr32 = val32)",
-      "(attr95 = val95 OR INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))))"
+      "(attr44 = val44 OR INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) OR attr32 = val32)",
+      "(attr95 = val95 OR INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))))"
     )
 
   val simpleNotFilters: Seq[Filter] =
     Seq(
-      "NOT (INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))))",
-      "NOT (INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))))",
-      "NOT (INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))))",
+      "NOT (INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))))",
+      "NOT (INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))))",
+      "NOT (INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))))",
       "NOT (attr23 = val23)",
       "NOT (attr89 = val89)",
-      "NOT (geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z')",
-      "NOT (geomesa_index_start_time BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z')"
+      "NOT (dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z')",
+      "NOT (dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z')"
     )
 
   val andsOrsFilters: Seq[Filter] =
     Seq(
-      "((INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))) OR INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23)))) AND (geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' OR geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' OR attr22 = val22 OR attr86 = val86) AND (geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' AND geomesa_index_start_time BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z'))",
-      "((geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' AND INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))) OR (attr85 = val85 OR geomesa_index_start_time BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z') OR (INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) AND geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z'))",
-      "(geomesa_index_start_time BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z' OR attr31 = val31 OR geomesa_index_start_time BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z' OR geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z')",
-      "((attr32 = val32 AND geomesa_index_start_time BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z') AND (INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) OR attr82 = val82 OR INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))))",
-      "((attr44 = val44 AND INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23)))) OR (INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) OR INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) OR attr2 = val2))",
-      "(geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' OR attr51 = val51 OR attr39 = val39)"
+      "((INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))) OR INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23)))) AND (dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' OR dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' OR attr22 = val22 OR attr86 = val86) AND (dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' AND dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z'))",
+      "((dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' AND INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))) OR (attr85 = val85 OR dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z') OR (INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) AND dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z'))",
+      "(dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z' OR attr31 = val31 OR dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z' OR dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z')",
+      "((attr32 = val32 AND dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z') AND (INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) OR attr82 = val82 OR INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))))",
+      "((attr44 = val44 AND INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23)))) OR (INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) OR INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) OR attr2 = val2))",
+      "(dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' OR attr51 = val51 OR attr39 = val39)"
     )
 
   val oneGeomFilters: Seq[Filter] =
     Seq(
-      "((geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' OR geomesa_index_start_time BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z') OR (geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' AND INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))))",
-      "(INTERSECTS(geomesa_index_geometry, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))) OR geomesa_index_start_time BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z')",
-      "(INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) AND geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' AND geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z')",
-      "(INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) AND geomesa_index_start_time BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z')",
-      "(INTERSECTS(geomesa_index_geometry, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) OR geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' OR geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z')",
-      "(attr84 = val84 AND geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' AND INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))))",
-      "(geomesa_index_start_time BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' AND INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND geomesa_index_start_time BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z')",
-      "(geomesa_index_start_time BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z' AND attr92 = val92 AND INTERSECTS(geomesa_index_geometry, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))))"
+      "((dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' OR dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z') OR (dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' AND INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))))",
+      "(INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))) OR dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z')",
+      "(INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) AND dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' AND dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z')",
+      "(INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) AND dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z')",
+      "(INTERSECTS(geom, POLYGON ((44 23, 46 23, 46 25, 44 25, 44 23))) OR dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' OR dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z')",
+      "(attr84 = val84 AND dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' AND INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))))",
+      "(dtg BETWEEN '0000-01-01T00:00:00.000Z' AND '9999-12-31T23:59:59.000Z' AND INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z')",
+      "(dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z' AND attr92 = val92 AND INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))))"
     )
 
 

--- a/geomesa-core/src/test/scala/geomesa/core/index/TemporalIndexCheckTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/index/TemporalIndexCheckTest.scala
@@ -25,9 +25,9 @@ import org.specs2.runner.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class TemporalIndexCheckTest extends Specification {
   // setup the basic types
-  val noDTGType = DataUtilities.createType("noDTGType", s"foo:String,bar:Geometry,baz:String,$DEFAULT_GEOMETRY_PROPERTY_NAME:Geometry")
-  val oneDTGType = DataUtilities.createType("oneDTGType", s"foo:String,bar:Geometry,baz:String,$DEFAULT_GEOMETRY_PROPERTY_NAME:Geometry,$DEFAULT_DTG_PROPERTY_NAME:Date")
-  val twoDTGType = DataUtilities.createType("twoDTGType", s"foo:String,bar:Geometry,baz:String,$DEFAULT_GEOMETRY_PROPERTY_NAME:Geometry,$DEFAULT_DTG_PROPERTY_NAME:Date,$DEFAULT_DTG_END_PROPERTY_NAME:Date")
+  def noDTGType = DataUtilities.createType("noDTGType", s"foo:String,bar:Geometry,baz:String,$DEFAULT_GEOMETRY_PROPERTY_NAME:Geometry")
+  def oneDTGType = DataUtilities.createType("oneDTGType", s"foo:String,bar:Geometry,baz:String,$DEFAULT_GEOMETRY_PROPERTY_NAME:Geometry,$DEFAULT_DTG_PROPERTY_NAME:Date")
+  def twoDTGType = DataUtilities.createType("twoDTGType", s"foo:String,bar:Geometry,baz:String,$DEFAULT_GEOMETRY_PROPERTY_NAME:Geometry,$DEFAULT_DTG_PROPERTY_NAME:Date,$DEFAULT_DTG_END_PROPERTY_NAME:Date")
 
   "TemporalIndexCheck" should {
     "detect no valid DTG" in {

--- a/geomesa-core/src/test/scala/geomesa/core/iterators/TestData.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/TestData.scala
@@ -32,7 +32,7 @@ object TestData extends Logging {
   val featureName = "feature"
   val schemaEncoding = "%~#s%" + featureName + "#cstr%10#r%0,1#gh%yyyyMM#d::%~#s%1,3#gh::%~#s%4,3#gh%ddHH#d%10#id"
   val featureType: SimpleFeatureType = DataUtilities.createType(featureName, UnitTestEntryType.getTypeSpec)
-  featureType.getUserData.put(SF_PROPERTY_START_TIME, "geomesa_index_start_time")
+  featureType.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
 
   val index = IndexSchema(schemaEncoding, featureType, featureEncoder)
 


### PR DESCRIPTION
Use functions to generate the test SFTs to avoid state between test fragments.

Also modify the test codebase to remove triggers of the TemporalIndexCheckTest, and
remove a few new references to geomesa_index_\* as an attribute name.
