### PR TITLE
GEOMESA-6, GEOMESA-198 Secondary Indexing

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStore.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStore.scala
@@ -17,20 +17,25 @@
 
 package geomesa.core.data
 
+import java.io.Serializable
+import java.util.{Map => JMap}
+
+import com.google.common.collect.ImmutableSortedSet
 import com.typesafe.scalalogging.slf4j.Logging
 import geomesa.core
-import geomesa.core.data.AccumuloFeatureWriter.{LocalRecordDeleter, LocalRecordWriter, MapReduceRecordWriter}
+import geomesa.core.data.AccumuloDataStore._
+import geomesa.core.data.AccumuloFeatureWriter.MapReduceRecordWriter
 import geomesa.core.data.FeatureEncoding.FeatureEncoding
-import geomesa.core.index.{TemporalIndexCheck, Constants, IndexSchema}
+import geomesa.core.index.{IndexSchema, TemporalIndexCheck}
 import geomesa.core.security.AuthorizationsProvider
-import java.io.{IOException, Serializable}
-import java.util.{Map => JMap}
 import org.apache.accumulo.core.client._
+import org.apache.accumulo.core.client.admin.TimeType
 import org.apache.accumulo.core.client.mock.MockConnector
-import org.apache.accumulo.core.data.{Mutation, Range, Value}
+import org.apache.accumulo.core.data.{Key, Mutation, Range, Value}
 import org.apache.accumulo.core.file.keyfunctor.ColumnFamilyFunctor
 import org.apache.accumulo.core.iterators.user.VersioningIterator
 import org.apache.accumulo.core.security.ColumnVisibility
+import org.apache.commons.codec.binary.Hex
 import org.apache.hadoop.io.Text
 import org.geotools.data._
 import org.geotools.data.simple.SimpleFeatureSource
@@ -39,27 +44,39 @@ import org.geotools.geometry.jts.ReferencedEnvelope
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 import org.opengis.referencing.crs.CoordinateReferenceSystem
+
 import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
 
 /**
  *
- * @param connector        Accumulo connector
- * @param tableName        The name of the Accumulo table contains the various features
- * @param authorizationsProvider   Provides the authorizations used to access data
+ * @param connector Accumulo connector
+ * @param catalogTable Table name in Accumulo to store metadata about featureTypes. For pre-catalog
+ *                     single-table stores this equates to the spatiotemporal table name
+ * @param authorizationsProvider Provides the authorizations used to access data
  * @param writeVisibilities   Visibilities applied to any data written by this store
  *
  *  This class handles DataStores which are stored in Accumulo Tables.  To be clear, one table may
  *  contain multiple features addressed by their featureName.
  */
-class AccumuloDataStore(val connector: Connector, val tableName: String,
+class AccumuloDataStore(val connector: Connector,
+                        val catalogTable: String,
                         val authorizationsProvider: AuthorizationsProvider,
-                        val writeVisibilities: String, val indexSchemaFormat: String = "DEFAULT",
+                        val writeVisibilities: String,
+                        val spatioTemporalIdxSchemaFmt: String = "DEFAULT",
                         val featureEncoding: FeatureEncoding = FeatureEncoding.AVRO)
     extends AbstractDataStore(true) with Logging {
 
-  private def buildDefaultSchema(name: String) =
-    s"%~#s%99#r%${name}#cstr%0,3#gh%yyyyMMdd#d::%~#s%3,2#gh::%~#s%#id"
+  // TODO default to zero shards (needs testing)
+  private val DEFAULT_MAX_SHARD = 99
+
+  // TODO configurable and lower default
+  private val DEFAULT_SPATIO_TEMPORAL_IDX_SCAN_THREADS = 100
+
+  // TODO configurable and lower default
+  private val DEFAULT_RECORD_SCAN_THREADS = 20
+
+  private def buildDefaultSpatioTemporalSchema(name: String, maxShard: Int) =
+    s"%~#s%$maxShard#r%${name}#cstr%0,3#gh%yyyyMMdd#d::%~#s%3,2#gh::%~#s%#id"
 
   Hints.putSystemDefault(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, true)
 
@@ -73,68 +90,8 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
 
   private val tableOps = connector.tableOperations()
 
-  /**
-   * Creates the schema for the feature type. This will create the table in accumulo, if it doesn't
-   * exist. It will configure splits for the table based on the feature type. Note that if the table
-   * has already been configured for a different feature type (i.e. multiple features in one table)
-   * the splits from the previous feature will be used.
-   *
-   * @param featureType
-   */
-  override def createSchema(featureType: SimpleFeatureType) {
-    val indexSchema = getIndexSchemaString(featureType.getTypeName)
-    createAndConfigureTable(featureType, featureEncoding, indexSchema)
-    writeMetadata(featureType, featureEncoding, indexSchema)
-  }
-
-  /**
-   * Creates and configures the accumulo table for this feature. Note that if the table has already
-   * been configured for a different feature type (i.e. multiple features in one table)
-   * the splits from the previous feature will be used.
-   *
-   * If the schema already exists for this feature type, it will throw an exception.
-   *
-   * @param featureType
-   * @param featureEncoding
-   */
-  private def createAndConfigureTable(featureType: SimpleFeatureType,
-                                      featureEncoding: FeatureEncoding,
-                                      indexSchemaString: String): Unit = {
-    if (!tableOps.exists(tableName))
-      connector.tableOperations.create(tableName)
-
-    val featureName = getFeatureName(featureType)
-
-    if (!getAttributes(featureName).isEmpty)
-      throw new IOException(s"Schema already exists for feature type $featureName")
-
-    // mock connector - skip configuration
-    if (connector.isInstanceOf[MockConnector])
-      return
-
-    // configure table splits
-    val existingSplits = tableOps.getSplits(tableName)
-    if (existingSplits == null || existingSplits.isEmpty) {
-      val encoder = SimpleFeatureEncoderFactory.createEncoder(featureEncoding)
-      val indexSchema = IndexSchema(indexSchemaString, featureType, encoder)
-      val maxShard = indexSchema.maxShard
-
-      val splits = (1 to maxShard).map { i => s"%0${maxShard.toString.length }d".format(i) }
-                   .map(new Text(_))
-      tableOps.addSplits(tableName, new java.util.TreeSet(splits))
-    } else
-        logger.warn(s"Table $tableName has pre-existing splits which will be used: $existingSplits")
-
-    // enable the column-family functor
-    tableOps.setProperty(tableName, "table.bloom.key.functor",
-                          classOf[ColumnFamilyFunctor].getCanonicalName)
-    tableOps.setProperty(tableName, "table.bloom.enabled", "true")
-
-    // isolate various metadata elements in locality groups
-    tableOps.setLocalityGroups(tableName, Map(ATTRIBUTES_CF.toString -> Set(ATTRIBUTES_CF).asJava,
-                                               SCHEMA_CF.toString -> Set(SCHEMA_CF).asJava,
-                                               BOUNDS_CF.toString -> Set(BOUNDS_CF).asJava))
-
+  if (!tableOps.exists(catalogTable)) {
+    tableOps.create(catalogTable)
   }
 
   /**
@@ -143,8 +100,10 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
    * @param sft
    * @param fe
    */
-  private def writeMetadata(sft: SimpleFeatureType, fe: FeatureEncoding,
-                            indexSchemaString: String): Unit = {
+  private def writeMetadata(sft: SimpleFeatureType,
+                            fe: FeatureEncoding,
+                            spatioTemporalSchemaValue: String,
+                            maxShard: Int) {
 
     val featureName = getFeatureName(sft)
 
@@ -153,25 +112,33 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
 
     // compute the metadata values
     val attributesValue = DataUtilities.encodeType(sft)
-    val schemaValue = indexSchemaString
     val dtgValue: Option[String] = {
       val userData = sft.getUserData
       // inspect, warn and set SF_PROPERTY_START_TIME if appropriate
       TemporalIndexCheck.extractNewDTGFieldCandidate(sft)
         .foreach { name => userData.put(core.index.SF_PROPERTY_START_TIME, name) }
-      if (userData.containsKey(core.index.SF_PROPERTY_START_TIME))
+      if (userData.containsKey(core.index.SF_PROPERTY_START_TIME)) {
         Option(userData.get(core.index.SF_PROPERTY_START_TIME).asInstanceOf[String])
-      else
+      } else {
         None
+      }
     }
-    val featureEncodingValue = fe.toString
+    val featureEncodingValue        = fe.toString
+    val spatioTemporalIdxTableValue = formatSpatioTemporalIdxTableName(catalogTable, sft)
+    val attrIdxTableValue           = formatAttrIdxTableName(catalogTable, sft)
+    val recordTableValue            = formatRecordTableName(catalogTable, sft)
+    val maxShardValue               = maxShard.toString
+    val dtgFieldValue               = dtgValue.getOrElse(core.DEFAULT_DTG_PROPERTY_NAME)
 
     // store each metadata in the associated column family
-    val attributeMap = Map(ATTRIBUTES_CF          -> attributesValue,
-                            SCHEMA_CF             -> schemaValue,
-                            DTGFIELD_CF           -> dtgValue.getOrElse(core.DEFAULT_DTG_PROPERTY_NAME),
-                            FEATURE_ENCODING_CF   -> featureEncodingValue,
-                            VISIBILITIES_CF       -> writeVisibilities)
+    val attributeMap = Map(ATTRIBUTES_CF        -> attributesValue,
+                           SCHEMA_CF            -> spatioTemporalSchemaValue,
+                           DTGFIELD_CF          -> dtgFieldValue,
+                           FEATURE_ENCODING_CF  -> featureEncodingValue,
+                           VISIBILITIES_CF      -> writeVisibilities,
+                           ST_IDX_TABLE_CF      -> spatioTemporalIdxTableValue,
+                           ATTR_IDX_TABLE_CF    -> attrIdxTableValue,
+                           RECORD_TABLE_CF      -> recordTableValue)
 
     attributeMap.foreach { case (cf, value) =>
       putMetadata(featureName, mutation, cf, value)
@@ -187,6 +154,125 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
     // write out the mutation
     writeMutations(mutation)
   }
+
+  type KVEntry = JMap.Entry[Key,Value]
+
+  /**
+   * Read Record table name from store metadata
+   */
+  def getRecordTableForType(featureType: SimpleFeatureType) =
+    readRequiredMetadataItem(featureType, RECORD_TABLE_CF)
+
+  /**
+   * Read SpatioTemporal Index table name from store metadata
+   */
+  def getSpatioTemporalIdxTableName(featureType: SimpleFeatureType) =
+    if (catalogTableFormat(featureType)) {
+      readRequiredMetadataItem(featureType, ST_IDX_TABLE_CF)
+    } else {
+      catalogTable
+    }
+
+  /**
+   * Read Attribute Index table name from store metadata
+   */
+  def getAttrIdxTableName(featureType: SimpleFeatureType) =
+    readRequiredMetadataItem(featureType, ATTR_IDX_TABLE_CF)
+
+  /**
+   * Read SpatioTemporal Index table name from store metadata
+   */
+  def getSpatioTemporalMaxShard(featureType: SimpleFeatureType): Int = {
+    val indexSchemaFmt = readMetadataItem(featureType.getTypeName, SCHEMA_CF)
+      .getOrElse(throw new RuntimeException(s"Unable to find required metadata property for $SCHEMA_CF"))
+    val featureEncoder = getFeatureEncoder(featureType.getTypeName)
+    val indexSchema = IndexSchema(indexSchemaFmt, featureType, featureEncoder)
+    indexSchema.maxShard
+  }
+
+  /**
+   * Check if this featureType is stored with catalog table format (i.e. a catalog
+   * table with attribute, spatiotemporal, and record tables) or the old style
+   * single spatiotemporal table
+   *
+   * @param featureType
+   * @return true if the storage is catalog-style, false if spatiotemporal table only
+   */
+  def catalogTableFormat(featureType: SimpleFeatureType): Boolean =
+    readMetadataItem(featureType.getTypeName, ST_IDX_TABLE_CF).nonEmpty
+
+  def createTablesForType(featureType: SimpleFeatureType, maxShard: Int) {
+    val spatioTemporalIdxTable = formatSpatioTemporalIdxTableName(catalogTable, featureType)
+    val attributeIndexTable    = formatAttrIdxTableName(catalogTable, featureType)
+    val recordTable            = formatRecordTableName(catalogTable, featureType)
+    
+    List(spatioTemporalIdxTable, attributeIndexTable, recordTable).foreach { t =>
+      if (!tableOps.exists(t)) {
+        connector.tableOperations.create(t, true, TimeType.LOGICAL)
+      }
+    }
+
+    if (!connector.isInstanceOf[MockConnector]) {
+      configureRecordTable(featureType, recordTable)
+      configureAttrIdxTable(featureType, attributeIndexTable)
+      configureSpatioTemporalIdxTable(maxShard, featureType, spatioTemporalIdxTable)
+    }
+  }
+
+  // if using UUID as FeatureID, configure splits with hex characters
+  private val HEX_SPLITS = "0,1,2,3,4,5,6,7,8,9,A,a,B,b,C,c,D,d,E,e,F,f".split(",").map(s => new Text(s))
+  private val RECORDS_SPLITS = ImmutableSortedSet.copyOf(HEX_SPLITS)
+  def configureRecordTable(featureType: SimpleFeatureType, recordTable: String): Unit = {
+    tableOps.addSplits(recordTable, RECORDS_SPLITS)
+  }
+
+  // configure splits for each of the attribute names
+  def configureAttrIdxTable(featureType: SimpleFeatureType, attributeIndexTable: String): Unit = {
+    val names = featureType.getAttributeDescriptors.map(_.getLocalName).map(new Text(_)).toArray
+    val splits = ImmutableSortedSet.copyOf(names)
+    tableOps.addSplits(attributeIndexTable, splits)
+  }
+
+  def configureSpatioTemporalIdxTable(maxShard: Int,
+                                      featureType: SimpleFeatureType,
+                                      tableName: String) {
+
+    val splits = (1 to maxShard).map { i => s"%0${maxShard.toString.length}d".format(i) }.map(new Text(_))
+    tableOps.addSplits(tableName, new java.util.TreeSet(splits))
+
+    // enable the column-family functor
+    tableOps.setProperty(tableName, "table.bloom.key.functor", classOf[ColumnFamilyFunctor].getCanonicalName)
+    tableOps.setProperty(tableName, "table.bloom.enabled", "true")
+  }
+
+  // Computes the schema, checking for the "DEFAULT" flag
+  def computeSpatioTemporalSchema(featureName: String, maxShard: Int): String =
+    if (spatioTemporalIdxSchemaFmt.equalsIgnoreCase("DEFAULT")) {
+      buildDefaultSpatioTemporalSchema(featureName, maxShard)
+    } else {
+      spatioTemporalIdxSchemaFmt
+    }
+
+  /**
+   * Compute the GeoMesa SpatioTemporal Schema, create tables, and write metadata to catalog
+   *
+   * @param featureType
+   * @param maxShard numerical id of the max shard (creates maxShard + 1 splits)
+   */
+  def createSchema(featureType: SimpleFeatureType, maxShard: Int) {
+    val spatioTemporalSchema = computeSpatioTemporalSchema(getFeatureName(featureType), maxShard)
+    createTablesForType(featureType, maxShard)
+    writeMetadata(featureType, featureEncoding, spatioTemporalSchema, maxShard)
+  }
+
+  /**
+   * GeoTools API createSchema() method for a featureType...creates tables with
+   * DEFAULT_MAX_SHARD + 1 splits. To control the number of splits use the
+   * createSchema(featureType, maxShard) method
+   *
+   * @param featureType
+   */
+  override def createSchema(featureType: SimpleFeatureType) = createSchema(featureType, DEFAULT_MAX_SHARD)
 
   /**
    * Handles creating a mutation for writing metadata
@@ -204,12 +290,15 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
    * @param columnFamily
    * @param value
    */
-  private def putMetadata(featureName: String, mutation: Mutation, columnFamily: Text,
-                          value: String): Unit = {
+  private def putMetadata(featureName: String,
+                          mutation: Mutation,
+                          columnFamily: Text,
+                          value: String) {
     mutation.put(columnFamily, EMPTY_COLQ, System.currentTimeMillis(), new Value(value.getBytes))
     // also pre-fetch into the cache
-    if (!value.isEmpty)
+    if (!value.isEmpty) {
       metaDataCache.put((featureName, columnFamily), Some(value))
+    }
   }
 
   /**
@@ -219,25 +308,12 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
    */
   private def writeMutations(mutations: Mutation*): Unit = {
     // TODO config should be configurable...
-    val writer = connector.createBatchWriter(tableName,  10000L, 300, 10)
+    val writer = connector.createBatchWriter(catalogTable,  10000L, 300, 10)
     for (mutation <- mutations) {
       writer.addMutation(mutation)
     }
     writer.flush()
     writer.close()
-  }
-
-  /**
-   * Gets the index schema formatted string for this feature
-   *
-   * @param featureName
-   * @return
-   */
-  private def getIndexSchemaString(featureName: String): String = {
-    indexSchemaFormat match {
-      case "DEFAULT" => buildDefaultSchema(featureName)
-      case _         => indexSchemaFormat
-    }
   }
 
   /**
@@ -252,8 +328,9 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
 
     val ok = validated.getOrElseUpdate(featureName, checkMetadata(featureName))
 
-    if (!ok.isEmpty)
+    if (!ok.isEmpty) {
       throw new RuntimeException("Configuration of this DataStore does not match the schema values: " + ok)
+    }
   }
 
   /**
@@ -286,10 +363,11 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
   private def checkVisibilitiesMetadata(featureName: String): Option[String] = {
     // validate that visibilities have not changed
     val storedVisibilities = readMetadataItem(featureName, VISIBILITIES_CF).getOrElse("")
-    if (storedVisibilities != writeVisibilities)
+    if (storedVisibilities != writeVisibilities) {
       Some(s"$VISIBILITIES_CF = '$writeVisibilities', should be '$storedVisibilities'")
-    else
+    } else {
       None
+    }
   }
 
   /**
@@ -300,14 +378,15 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
    */
   private def checkSchemaMetadata(featureName: String): Option[String] = {
     // validate the index schema
-    val configuredSchema = getIndexSchemaString(featureName)
+    val configuredSchema = computeSpatioTemporalSchema(featureName, DEFAULT_MAX_SHARD)
     val storedSchema = readMetadataItem(featureName, SCHEMA_CF).getOrElse("")
     // if they did not specify a custom schema (e.g. indexSchemaFormat == DEFAULT), just use the
     // stored metadata
-    if (storedSchema != configuredSchema && indexSchemaFormat != "DEFAULT")
+    if (storedSchema != configuredSchema && spatioTemporalIdxSchemaFmt != "DEFAULT") {
       Some(s"$SCHEMA_CF = '$configuredSchema', should be '$storedSchema'")
-    else
+    } else {
       None
+    }
   }
 
   /**
@@ -341,7 +420,9 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
       val authString = authorizationsProvider.getAuthorizations.getAuthorizations
                       .map(a => new String(a)).sorted.mkString(",")
       if (!checkWritePermissions(featureName, authString)) {
-        throw new RuntimeException(s"The current user does not have the required authorizations to write $featureName features. Required authorizations: '$visibilities', actual authorizations: '$authString'")
+        throw new RuntimeException(s"The current user does not have the required authorizations to " +
+          s"write $featureName features. Required authorizations: '$visibilities', " +
+          s"actual authorizations: '$authString'")
       }
     }
   }
@@ -387,6 +468,18 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
       result
     })
 
+  private def readRequiredMetadataItem(featureName: String, colFam: Text): String =
+    readMetadataItem(featureName, colFam)
+      .getOrElse(throw new RuntimeException(s"Unable to find required metadata property for $colFam"))
+
+  private def readRequiredMetadataItem(featureType: SimpleFeatureType, colFam: Text): String =
+    readRequiredMetadataItem(featureType.getTypeName, colFam)
+
+  /**
+   * Create an Accumulo Scanner to the Catalog table to query Metadata for this store
+   */
+  def createCatalogScanner = connector.createScanner(catalogTable, authorizationsProvider.getAuthorizations)
+
   /**
    * Gets metadata by scanning the table, without the local cache
    *
@@ -397,7 +490,7 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
    * @return
    */
   private def readMetadataItemNoCache(featureName: String, colFam: Text): Option[String] = {
-    val scanner = createScanner
+    val scanner = createCatalogScanner
     scanner.setRange(new Range(s"${METADATA_TAG }_$featureName"))
     scanner.fetchColumn(colFam, EMPTY_COLQ)
 
@@ -408,8 +501,11 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
 
     val iter = scanner.iterator
     val result =
-      if (iter.hasNext) Some(iter.next.getValue.toString)
-      else None
+      if (iter.hasNext) {
+        Some(iter.next.getValue.toString)
+      } else {
+        None
+      }
 
     scanner.clearScanIterators
     result
@@ -421,8 +517,12 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
    * @return
    */
   override def getTypeNames: Array[String] =
-    if (tableOps.exists(tableName)) readTypesFromMetadata
-    else Array()
+    if (tableOps.exists(catalogTable)) {
+      readTypesFromMetadata
+    }
+    else {
+      Array()
+    }
 
   /**
    * Scans metadata rows and pulls out the different feature types in the table
@@ -430,7 +530,7 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
    * @return
    */
   private def readTypesFromMetadata: Array[String] = {
-    val scanner = createScanner
+    val scanner = createCatalogScanner
     scanner.setRange(new Range(METADATA_TAG, METADATA_TAG_END))
     // restrict to just schema cf so we only get 1 hit per feature
     scanner.fetchColumnFamily(SCHEMA_CF)
@@ -439,14 +539,15 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
 
       def hasNext = {
         val next = src.hasNext
-        if (!next)
+        if (!next) {
           scanner.clearScanIterators
+        }
         next
       }
 
       def next() = src.next().getKey.getRow.toString
     }
-    resultItr.toArray.map(getFeatureNameFromMetadataRowKey(_))
+    resultItr.toArray.map(getFeatureNameFromMetadataRowKey)
   }
 
   /**
@@ -466,7 +567,6 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
     validateMetadata(featureName)
     new AccumuloFeatureStore(this, featureName)
   }
-
 
   /**
    * Reads the index schema format out of the metadata
@@ -584,9 +684,7 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
     val indexSchemaFmt = getIndexSchemaFmt(typeName)
     val fe = getFeatureEncoder(typeName)
     val schema = IndexSchema(indexSchemaFmt, featureType, fe)
-    val writer = new LocalRecordWriter(tableName, connector)
-    val deleter = new LocalRecordDeleter(tableName, connector)
-    new ModifyAccumuloFeatureWriter(featureType, schema, writer, writeVisibilities, deleter, this)
+    new ModifyAccumuloFeatureWriter(featureType, schema, connector, fe, writeVisibilities, this)
   }
 
   /* optimized for GeoTools API to return writer ONLY for appending (aka don't scan table) */
@@ -598,28 +696,63 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
     val indexSchemaFmt = getIndexSchemaFmt(typeName)
     val fe = getFeatureEncoder(typeName)
     val schema = IndexSchema(indexSchemaFmt, featureType, fe)
-    val writer = new LocalRecordWriter(tableName, connector)
-    new AppendAccumuloFeatureWriter(featureType, schema, writer, writeVisibilities)
+    new AppendAccumuloFeatureWriter(featureType, schema, connector, fe, writeVisibilities, this)
   }
 
   override def getUnsupportedFilter(featureName: String, filter: Filter): Filter = Filter.INCLUDE
 
   /**
-   * Creates a scanner for the table underlying this data store
+   * Create a BatchScanner for the SpatioTemporal Index Table
    *
-   * @return
+   * @param numThreads number of threads for the BatchScanner
    */
-  def createBatchScanner(): BatchScanner = {
-    connector.createBatchScanner(tableName, authorizationsProvider.getAuthorizations, 100)
+  def createSpatioTemporalIdxScanner(sft: SimpleFeatureType, numThreads: Int): BatchScanner = {
+    logger.trace(s"Creating ST batch scanner with $numThreads threads")
+    if (catalogTableFormat(sft)) {
+      connector.createBatchScanner(getSpatioTemporalIdxTableName(sft), 
+                                   authorizationsProvider.getAuthorizations, 
+                                   numThreads)
+    } else {
+      connector.createBatchScanner(catalogTable, authorizationsProvider.getAuthorizations, numThreads)
+    }
   }
 
   /**
-   * Creates a scanner for the table underlying this data store
-   *
-   * @return
+   * Create a BatchScanner for the SpatioTemporal Index Table
    */
-  def createScanner: Scanner = {
-    connector.createScanner(tableName, authorizationsProvider.getAuthorizations)
+  def createSTIdxScanner(sft: SimpleFeatureType): BatchScanner = {
+    val numThreads =
+      if (catalogTableFormat(sft)) {
+        getSpatioTemporalMaxShard(sft) + 1 // num splits is maxShard + 1
+      } else {
+        DEFAULT_SPATIO_TEMPORAL_IDX_SCAN_THREADS
+      }
+
+    createSpatioTemporalIdxScanner(sft, numThreads)
+  }
+
+  /**
+   * Create a Scanner for the Attribute Table (Inverted Index Table)
+   */
+  def createAttrIdxScanner(sft: SimpleFeatureType) =
+    if (catalogTableFormat(sft)) {
+      connector.createScanner(getAttrIdxTableName(sft), authorizationsProvider.getAuthorizations)
+    } else {
+      throw new RuntimeException("Cannot create Attribute Index Scanner - " +
+        "attribute index table does not exist for this version of the data store")
+    }
+
+  /**
+   * Create a BatchScanner to retrieve only Records (SimpleFeatures)
+   */
+  def createRecordScanner(sft: SimpleFeatureType, numThreads: Int = DEFAULT_RECORD_SCAN_THREADS) = {
+    logger.trace(s"Creating record scanne with $numThreads threads")
+    if (catalogTableFormat(sft)) {
+      connector.createBatchScanner(getRecordTableForType(sft), authorizationsProvider.getAuthorizations, numThreads)
+    } else {
+      throw new RuntimeException("Cannot create Record Scanner - record table does not exist for this version" +
+        "of the datastore")
+    }
   }
 
   // Accumulo assumes that the failures directory exists.  This function assumes that you have already created it.
@@ -637,6 +770,70 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
 
 }
 
+object AccumuloDataStore {
+
+  // Format record table name for Accumulo...table name is stored in metadata for other usage
+  // and provide compatibility moving forward if table names change
+  def formatRecordTableName(catalogTable: String, featureType: SimpleFeatureType) =
+    formatTableName(catalogTable, featureType, "records")
+
+  // Format record table name for Accumulo...table name is stored in metadata for other usage
+  // and provide compatibility moving forward if table names change
+  def formatSpatioTemporalIdxTableName(catalogTable: String, featureType: SimpleFeatureType) =
+    formatTableName(catalogTable, featureType, "st_idx")
+
+  // Format record table name for Accumulo...table name is stored in metadata for other usage
+  // and provide compatibility moving forward if table names change
+  def formatAttrIdxTableName(catalogTable: String, featureType: SimpleFeatureType) =
+    formatTableName(catalogTable, featureType, "attr_idx")
+
+  // only alphanumeric is safe
+  val SAFE_FEATURE_NAME_PATTERN = "^[a-zA-Z0-9]+$"
+
+  /**
+   * Format a table name with a namespace. Non alpha-numeric characters present in
+   * featureType names will be underscore hex encoded (e.g. _2a) including multibyte
+   * UTF8 characters (e.g. _2a_f3_8c) to make them safe for accumulo table names
+   * but still human readable.
+   */
+  def formatTableName(catalogTable: String, featureType: SimpleFeatureType, suffix: String) = {
+    val typeName = featureType.getTypeName
+    val safeTypeName: String =
+      if(typeName.matches(SAFE_FEATURE_NAME_PATTERN)){
+        typeName
+      } else {
+        hexEncodeNonAlphaNumeric(typeName)
+      }
+
+    List(catalogTable, safeTypeName, suffix).mkString("_")
+  }
+
+  val alphaNumeric = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')
+
+  /**
+   * Encode non-alphanumeric characters in a string with
+   * underscore plus hex digits representing the bytes. Note
+   * that multibyte characters will be represented with multiple
+   * underscores and bytes...e.g. _8a_2f_3b
+   */
+  def hexEncodeNonAlphaNumeric(input: String): String = {
+    val sb = new StringBuilder
+    input.toCharArray.foreach { c =>
+      if (alphaNumeric.contains(c)) {
+        sb.append(c)
+      } else {
+        val encoded =
+          Hex.encodeHex(c.toString.getBytes("UTF8")).grouped(2)
+            .map{ arr => "_" + arr(0) + arr(1) }.mkString.toLowerCase
+        sb.append(encoded)
+      }
+    }
+    sb.toString
+  }
+
+
+}
+
 /**
  *
  * @param connector        Accumulo connector
@@ -651,9 +848,11 @@ class AccumuloDataStore(val connector: Connector, val tableName: String,
  *                         This writer is appropriate for use inside a MapReduce job.  We explicitly do not override the default
  *                         createFeatureWriter so that we have both available.
  */
-class MapReduceAccumuloDataStore(connector: Connector, tableName: String,
+class MapReduceAccumuloDataStore(connector: Connector,
+                                 tableName: String,
                                  authorizationsProvider: AuthorizationsProvider,
-                                 writeVisibilities: String, val params: JMap[String, Serializable],
+                                 writeVisibilities: String,
+                                 val params: JMap[String, Serializable],
                                  indexSchemaFormat: String = "DEFAULT",
                                  featureEncoding: FeatureEncoding = FeatureEncoding.AVRO)
     extends AccumuloDataStore(connector, tableName, authorizationsProvider, writeVisibilities,
@@ -674,7 +873,7 @@ class MapReduceAccumuloDataStore(connector: Connector, tableName: String,
     val idx = IndexSchema(idxFmt, featureType, fe)
     val writer = new MapReduceRecordWriter(context)
     // TODO allow deletes? modifications?
-    new AppendAccumuloFeatureWriter(featureType, idx, writer, writeVisibilities)
+    new AppendAccumuloFeatureWriter(featureType, idx, connector, fe, writeVisibilities, this)
   }
 
 }

--- a/geomesa-core/src/main/scala/geomesa/core/data/AccumuloFeatureReader.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/AccumuloFeatureReader.scala
@@ -29,7 +29,7 @@ class AccumuloFeatureReader(dataStore: AccumuloDataStore,
   extends FeatureReader[SimpleFeatureType, SimpleFeature] {
 
   val indexSchema = IndexSchema(indexSchemaFmt, sft, featureEncoder)
-  val iter: CloseableIterator[SimpleFeature] = indexSchema.query(query, dataStore.createBatchScanner)
+  val iter = indexSchema.query(query, dataStore)
 
   override def getFeatureType = sft
 

--- a/geomesa-core/src/main/scala/geomesa/core/data/AccumuloFeatureStore.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/AccumuloFeatureStore.scala
@@ -122,7 +122,7 @@ class MapReduceAccumuloFeatureStore(dataStore: MapReduceAccumuloDataStore,
     val mapredCSVFilePath = new Path(outputDir, featureName + ".csv")
     fs.copyFromLocalFile(new Path(geomesaDir + Path.SEPARATOR + featureName + ".csv"), mapredCSVFilePath)
 
-    val tableName = dataStore.tableName
+    val tableName = dataStore.catalogTable
 
     runMapReduceJob(
                      tableName,

--- a/geomesa-core/src/main/scala/geomesa/core/data/AccumuloFeatureWriter.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/AccumuloFeatureWriter.scala
@@ -16,14 +16,16 @@
 
 package geomesa.core.data
 
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import com.typesafe.scalalogging.slf4j.Logging
 import geomesa.core.index._
 import geomesa.feature.{AvroSimpleFeature, AvroSimpleFeatureFactory}
-import org.apache.accumulo.core.client.Connector
-import org.apache.accumulo.core.data.{Key, Mutation, PartialKey, Value}
+import org.apache.accumulo.core.client.{BatchWriter, Connector}
+import org.apache.accumulo.core.data.{Key, Mutation, PartialKey, Value, Range => ARange}
 import org.apache.accumulo.core.security.ColumnVisibility
+import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapred.{RecordWriter, Reporter}
 import org.apache.hadoop.mapreduce.TaskInputOutputContext
 import org.geotools.data.DataUtilities
@@ -32,33 +34,21 @@ import org.geotools.factory.Hints
 import org.geotools.filter.identity.FeatureIdImpl
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
 object AccumuloFeatureWriter {
 
-  type AccumuloRecordWriter = RecordWriter[Key,Value]
+  type AccumuloRecordWriter = RecordWriter[Key, Value]
 
   val EMPTY_VALUE = new Value()
-
-  class LocalRecordWriter(tableName: String, connector: Connector) extends AccumuloRecordWriter {
-    private val bw = connector.createBatchWriter(tableName, 1024L, 10L, 10)
-
-    def write(key: Key, value: Value) {
-      val m = new Mutation(key.getRow)
-      m.put(key.getColumnFamily, key.getColumnQualifier, new ColumnVisibility(key.getColumnVisibility), key.getTimestamp, value)
-      bw.addMutation(m)
-    }
-
-    def close(reporter: Reporter) {
-      bw.flush()
-      bw.close()
-    }
-  }
 
   class LocalRecordDeleter(tableName: String, connector: Connector) extends AccumuloRecordWriter {
     private val bw = connector.createBatchWriter(tableName, 1024L, 10L, 10)
 
     def write(key: Key, value: Value) {
       val m = new Mutation(key.getRow)
-      m.putDelete(key.getColumnFamily, key.getColumnQualifier, new ColumnVisibility(key.getColumnVisibility), key.getTimestamp)
+      m.putDelete(key.getColumnFamily, key.getColumnQualifier, new ColumnVisibility(key.getColumnVisibility))
       bw.addMutation(m)
     }
 
@@ -79,10 +69,38 @@ object AccumuloFeatureWriter {
 
 abstract class AccumuloFeatureWriter(featureType: SimpleFeatureType,
                                      indexer: IndexSchema,
-                                     recordWriter: RecordWriter[Key,Value],
+                                     encoder: SimpleFeatureEncoder,
+                                     ds: AccumuloDataStore,
                                      visibility: String)
   extends SimpleFeatureWriter
           with Logging {
+
+  val NULLBYTE = Array[Byte](0.toByte)
+  val connector = ds.connector
+
+  protected val multiBWWriter = connector.createMultiTableBatchWriter(1000L, 300, 10)
+
+  // A "writer" is a function that takes a simple feature and writes
+  // it to an index or table. This list is configured to match the
+  // version of the datastore (i.e. single table vs catalog
+  // table + index tables)
+  protected val writers: List[SimpleFeature => Unit] = {
+    val stTable = ds.getSpatioTemporalIdxTableName(featureType)
+    val stWriter = List(spatioTemporalWriter(multiBWWriter.getBatchWriter(stTable)))
+
+    val attrWriters: List[SimpleFeature => Unit] =
+      if (ds.catalogTableFormat(featureType)) {
+        val attrTable = ds.getAttrIdxTableName(featureType)
+        val recTable = ds.getRecordTableForType(featureType)
+        List(
+          attrWriter(multiBWWriter.getBatchWriter(attrTable)),
+          recordWriter(multiBWWriter.getBatchWriter(recTable)))
+      } else {
+        List.empty
+      }
+
+    stWriter ::: attrWriters
+  }
 
   def getFeatureType: SimpleFeatureType = featureType
 
@@ -91,7 +109,7 @@ abstract class AccumuloFeatureWriter(featureType: SimpleFeatureType,
 
   protected val builder = AvroSimpleFeatureFactory.featureBuilder(featureType)
 
-  protected def writeToAccumulo(feature: SimpleFeature) = {
+  protected def writeToAccumulo(feature: SimpleFeature): Unit = {
     // see if there's a suggested ID to use for this feature
     // (relevant when this insertion is wrapped inside a Transaction)
     val toWrite =
@@ -102,16 +120,64 @@ abstract class AccumuloFeatureWriter(featureType: SimpleFeatureType,
       else feature
 
     // require non-null geometry to write to geomesa (can't index null geo yo!)
-    val kvPairsToWrite =
-      if (toWrite.getDefaultGeometry != null) indexer.encode(toWrite, visibility)
-      else {
-        logger.warn("Invalid feature to write:  " + DataUtilities.encodeFeature(toWrite))
-        List()
-      }
-    kvPairsToWrite.foreach { case (k,v) => recordWriter.write(k,v) }
+    if (toWrite.getDefaultGeometry != null) {
+      writers.foreach { w => w(toWrite) }
+    } else {
+      logger.warn("Invalid feature to write (no default geometry):  " + DataUtilities.encodeFeature(toWrite))
+    }
   }
 
-  def close = recordWriter.close(null)
+  /** Creates a function to write a feature to the Record Table **/
+  private def recordWriter(bw: BatchWriter): SimpleFeature => Unit =
+    (feature: SimpleFeature) => {
+      val m = new Mutation(feature.getID)
+      m.put(SFT_CF, EMPTY_COLQ, new ColumnVisibility(visibility), encoder.encode(feature))
+      bw.addMutation(m)
+    }
+
+  /** Creates a function to write a feature to the spatio temporal index **/
+  private def spatioTemporalWriter(bw: BatchWriter): SimpleFeature => Unit =
+    (feature: SimpleFeature) => {
+      val KVs = indexer.encode(feature)
+      val m = KVs.groupBy { case (k, _) => k.getRow }.map { case (row, kvs) => kvsToMutations(row, kvs) }
+      bw.addMutations(m.asJava)
+    }
+
+  /** Creates a function to write a feature to the attribute index **/
+  private def attrWriter(bw: BatchWriter): SimpleFeature => Unit =
+    (feature: SimpleFeature) => {
+      val muts = getAttrIdxMutations(feature, new Text(feature.getID)).map {
+        case PutOrDeleteMutation(row, cf, cq, v) =>
+          val m = new Mutation(new Text(row))
+          m.put(cf, cq, new ColumnVisibility(visibility), v)
+          m
+      }
+      bw.addMutations(muts)
+    }
+
+  case class PutOrDeleteMutation(row: Array[Byte], cf: Text, cq: Text, v: Value)
+
+  def getAttrIdxMutations(feature: SimpleFeature, cf: Text) =
+    featureType.getAttributeDescriptors.map { attr =>
+      val attrName = attr.getLocalName.getBytes(StandardCharsets.UTF_8)
+      val attrValue = valOrNull(feature.getAttribute(attr.getName)).getBytes(StandardCharsets.UTF_8)
+      val row = attrName ++ NULLBYTE ++ attrValue
+      val value = IndexSchema.encodeIndexValue(feature)
+      PutOrDeleteMutation(row, cf, EMPTY_COLQ, value)
+    }
+
+  private val nullString = "<null>"
+  private def valOrNull(o: AnyRef) = if(o == null) nullString else o.toString
+
+  private def kvsToMutations(row: Text, kvs: Seq[(Key, Value)]): Mutation = {
+    val m = new Mutation(row)
+    kvs.foreach { case (k, v) =>
+      m.put(k.getColumnFamily, k.getColumnQualifier, new ColumnVisibility(k.getColumnVisibility), v)
+    }
+    m
+  }
+
+  def close() = multiBWWriter.close()
 
   def remove() {}
 
@@ -120,9 +186,11 @@ abstract class AccumuloFeatureWriter(featureType: SimpleFeatureType,
 
 class AppendAccumuloFeatureWriter(featureType: SimpleFeatureType,
                                   indexer: IndexSchema,
-                                  recordWriter: RecordWriter[Key,Value],
-                                  visibility: String)
-  extends AccumuloFeatureWriter(featureType, indexer, recordWriter, visibility) {
+                                  connector: Connector,
+                                  encoder: SimpleFeatureEncoder,
+                                  visibility: String,
+                                  ds: AccumuloDataStore)
+  extends AccumuloFeatureWriter(featureType, indexer, encoder, ds, visibility) {
 
   var currentFeature: SimpleFeature = null
 
@@ -140,26 +208,90 @@ class AppendAccumuloFeatureWriter(featureType: SimpleFeatureType,
 }
 
 class ModifyAccumuloFeatureWriter(featureType: SimpleFeatureType,
-                                      indexer: IndexSchema,
-                                      recordWriter: RecordWriter[Key,Value],
-                                      visibility: String,
-                                      deleter: RecordWriter[Key, Value],
-                                      dataStore: AccumuloDataStore)
-  extends AccumuloFeatureWriter(featureType, indexer, recordWriter, visibility) {
+                                  indexer: IndexSchema,
+                                  connector: Connector,
+                                  encoder: SimpleFeatureEncoder,
+                                  visibility: String,
+                                  dataStore: AccumuloDataStore)
+  extends AccumuloFeatureWriter(featureType, indexer, encoder, dataStore, visibility) {
 
   val reader = dataStore.getFeatureReader(featureType.getName.toString)
   var live: SimpleFeature = null      /* feature to let user modify   */
   var original: SimpleFeature = null  /* feature returned from reader */
 
-  override def remove = if (original != null) indexer.encode(original).foreach { case (k,v) => deleter.write(k,v) }
+  // A remover is a function that removes a feature from an
+  // index or table. This list is configured to match the
+  // version of the datastore (i.e. single table vs catalog
+  // table + index tables)
+  val removers: List[SimpleFeature => Unit] = {
+    val stTable = dataStore.getSpatioTemporalIdxTableName(featureType)
+    val stWriter = List(removeSpatioTemporalIdx(multiBWWriter.getBatchWriter(stTable)))
+
+    val attrWriters: List[SimpleFeature => Unit] =
+      if (dataStore.catalogTableFormat(featureType)) {
+        val attrTable = dataStore.getAttrIdxTableName(featureType)
+        val recTable = dataStore.getRecordTableForType(featureType)
+        List(
+          removeAttrIdx(multiBWWriter.getBatchWriter(attrTable)),
+          removeRecord(multiBWWriter.getBatchWriter(recTable)))
+      } else {
+        List.empty
+      }
+
+    stWriter ::: attrWriters
+  }
+
+  /** Creates a function to remove a feature from the record table **/
+  private def removeRecord(bw: BatchWriter): SimpleFeature => Unit =
+    (feature: SimpleFeature) => {
+      val row = new Text(feature.getID)
+      val mutation = new Mutation(row)
+
+      val scanner = dataStore.createRecordScanner(featureType)
+      scanner.setRanges(List(new ARange(row, true, row, true)))
+      scanner.iterator().foreach { entry =>
+        val key = entry.getKey
+        mutation.putDelete(key.getColumnFamily, key.getColumnQualifier, new ColumnVisibility(key.getColumnVisibility))
+      }
+      bw.addMutation(mutation)
+      bw.flush()
+    }
+
+  /** Creates a function to remove spatio temporal index entries for a feature **/
+  private def removeSpatioTemporalIdx(bw: BatchWriter): SimpleFeature => Unit =
+    (feature: SimpleFeature) => {
+      indexer.encode(original).foreach { case (key, _) =>
+        val m = new Mutation(key.getRow)
+        m.putDelete(key.getColumnFamily, key.getColumnQualifier, new ColumnVisibility(key.getColumnVisibility))
+        bw.addMutation(m)
+      }
+    }
+
+  val emptyVis = new ColumnVisibility()
+
+  /** Creates a function to remove attribute index entries for a feature **/
+  private def removeAttrIdx(bw: BatchWriter): SimpleFeature => Unit =
+    (feature: SimpleFeature) => {
+      getAttrIdxMutations(feature, new Text(feature.getID)).map {
+        case PutOrDeleteMutation(row, cf, cq, _) =>
+          val m = new Mutation(new Text(row))
+          m.putDelete(cf, cq, emptyVis)
+          bw.addMutation(m)
+      }
+    }
+
+  override def remove() =
+    if (original != null) {
+      removers.foreach { r => r(original)}
+    }
 
   override def hasNext = reader.hasNext
 
   /* only write if non null and it hasn't changed...*/
   /* original should be null only when reader runs out */
-  override def write =
+  override def write() =
     if(!live.equals(original)) {  // This depends on having the same SimpleFeature concrete class
-      if(original != null) keysToDelete.foreach { k => deleter.write(k, EMPTY_VALUE)}
+      if(original != null) remove()
       writeToAccumulo(live)
     }
 
@@ -176,8 +308,8 @@ class ModifyAccumuloFeatureWriter(featureType: SimpleFeatureType,
   override def next: SimpleFeature = {
     original = null
     live =
-      if(hasNext) {
-        original = reader.next
+      if (hasNext) {
+        original = reader.next()
         builder.init(original)
         builder.buildFeature(original.getID)
       } else {
@@ -186,10 +318,9 @@ class ModifyAccumuloFeatureWriter(featureType: SimpleFeatureType,
     live
   }
 
-  override def close = {
+  override def close() = {
     super.close() //closes writer
-    deleter.close(null)
-    reader.close
+    reader.close()
   }
 
 }

--- a/geomesa-core/src/main/scala/geomesa/core/data/SimpleFeatureEncoder.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/SimpleFeatureEncoder.scala
@@ -22,7 +22,7 @@ import com.google.common.cache.LoadingCache
 import geomesa.core.data.FeatureEncoding.FeatureEncoding
 import geomesa.feature.{AvroSimpleFeature, FeatureSpecificReader}
 import geomesa.utils.text.ObjectPoolFactory
-import org.apache.accumulo.core.data.Value
+import org.apache.accumulo.core.data.{ Value => AValue }
 import org.apache.avro.io.DecoderFactory
 import org.geotools.data.DataUtilities
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -38,9 +38,9 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
  */
 
 trait SimpleFeatureEncoder {
-  def encode(feature:SimpleFeature) : Value
-  def decode(simpleFeatureType: SimpleFeatureType, featureValue: Value) : SimpleFeature
-  def extractFeatureId(value: Value): String
+  def encode(feature:SimpleFeature) : AValue
+  def decode(simpleFeatureType: SimpleFeatureType, featureValue: AValue) : SimpleFeature
+  def extractFeatureId(value: AValue): String
   def getName = getEncoding.toString
   def getEncoding: FeatureEncoding
 }
@@ -52,15 +52,15 @@ object FeatureEncoding extends Enumeration {
 }
 
 class TextFeatureEncoder extends SimpleFeatureEncoder{
-  def encode(feature:SimpleFeature) : Value =
-    new Value(ThreadSafeDataUtilities.encodeFeature(feature).getBytes)
+  def encode(feature:SimpleFeature) : AValue =
+    new AValue(ThreadSafeDataUtilities.encodeFeature(feature).getBytes)
 
-  def decode(simpleFeatureType: SimpleFeatureType, featureValue: Value) = {
+  def decode(simpleFeatureType: SimpleFeatureType, featureValue: AValue) = {
     ThreadSafeDataUtilities.createFeature(simpleFeatureType, featureValue.toString)
   }
 
   // This is derived from the knowledge of the GeoTools encoding in DataUtilities
-  def extractFeatureId(value: Value): String = {
+  def extractFeatureId(value: AValue): String = {
     val vString = value.toString
     vString.substring(0, vString.indexOf("="))
   }
@@ -88,23 +88,23 @@ object ThreadSafeDataUtilities {
 // TODO the AvroFeatureEncoder may not be threadsafe...evaluate.
 class AvroFeatureEncoder extends SimpleFeatureEncoder {
 
-  def encode(feature: SimpleFeature): Value = {
+  def encode(feature: SimpleFeature): AValue = {
     val asf = feature.getClass match {
       case c if classOf[AvroSimpleFeature].isAssignableFrom(c) => feature.asInstanceOf[AvroSimpleFeature]
       case _ =>  AvroSimpleFeature(feature)
     }
     val baos = new ByteArrayOutputStream()
     asf.write(baos)
-    new Value(baos.toByteArray)
+    new AValue(baos.toByteArray)
   }
 
-  def decode(simpleFeatureType: SimpleFeatureType, featureValue: Value) = {
-    val bais = new ByteArrayInputStream(featureValue.get())
+  def decode(simpleFeatureType: SimpleFeatureType, featureAValue: AValue) = {
+    val bais = new ByteArrayInputStream(featureAValue.get())
     val decoder = DecoderFactory.get().binaryDecoder(bais, null)
     readerCache.get(simpleFeatureType).read(null, decoder)
   }
 
-  def extractFeatureId(value: Value) = FeatureSpecificReader.extractId(new ByteArrayInputStream(value.get()))
+  def extractFeatureId(aValue: AValue) = FeatureSpecificReader.extractId(new ByteArrayInputStream(aValue.get()))
 
   val readerCache: LoadingCache[SimpleFeatureType, FeatureSpecificReader] =
     AvroSimpleFeature.loadingCacheBuilder { sft => FeatureSpecificReader(sft) }

--- a/geomesa-core/src/main/scala/geomesa/core/data/package.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/package.scala
@@ -16,18 +16,18 @@
 
 package geomesa.core
 
-import geomesa.core._
 import org.apache.accumulo.core.data.{Key, Value}
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapreduce.TaskInputOutputContext
 import org.geotools.data.FeatureWriter
 import org.geotools.factory.Hints.ClassKey
-import org.opengis.feature.simple.{SimpleFeatureType, SimpleFeature}
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 package object data {
 
-  import collection.JavaConversions._
   import geomesa.core.index._
+
+import scala.collection.JavaConversions._
 
   val INSTANCE_ID          = "geomesa.instance.id"
   val ZOOKEEPERS           = "geomesa.zookeepers"
@@ -47,6 +47,10 @@ package object data {
   val VISIBILITIES_CF      = new Text("visibilities")
   val VISIBILITIES_CHECK_CF = new Text("visibilitiesCheck")
   val DATA_CQ              = new Text("SimpleFeatureAttribute")
+  val SFT_CF               = new Text("SFT")
+  val ST_IDX_TABLE_CF      = new Text("tables.idx.st.name")
+  val ATTR_IDX_TABLE_CF    = new Text("tables.idx.attr.name")
+  val RECORD_TABLE_CF      = new Text("tables.record.name")
   val METADATA_TAG         = "~METADATA"
   val METADATA_TAG_END     = s"$METADATA_TAG~~"
   val EMPTY_STRING         = ""

--- a/geomesa-core/src/main/scala/geomesa/core/index/IndexEntry.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/index/IndexEntry.scala
@@ -95,7 +95,7 @@ case class IndexEncoder(rowf: TextFormatter[SimpleFeature],
     // remember the resulting index-entries
     val keys = entries.map { entry =>
       val Array(r, cf, cq) = formats.map { _.format(entry) }
-      new Key(r, cf, cq, v, entry.dt.map(_.getMillis).getOrElse(DateTime.now().getMillis))
+      new Key(r, cf, cq, v)
     }
     val rowIDs = keys.map(_.getRow)
     val id = new Text(featureToEncode.sid)

--- a/geomesa-core/src/main/scala/geomesa/core/index/IndexQueryPlanner.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/index/IndexQueryPlanner.scala
@@ -1,5 +1,11 @@
 package geomesa.core.index
 
+
+import java.nio.charset.StandardCharsets
+import java.util.Map.Entry
+
+import com.google.common.collect.Iterators
+import com.typesafe.scalalogging.slf4j.Logging
 import com.vividsolutions.jts.geom.Polygon
 import geomesa.core._
 import geomesa.core.data._
@@ -7,20 +13,22 @@ import geomesa.core.filter._
 import geomesa.core.index.QueryHints._
 import geomesa.core.iterators.{FEATURE_ENCODING, _}
 import geomesa.core.util.{CloseableIterator, SelfClosingBatchScanner}
-import java.util.Map.Entry
 import org.apache.accumulo.core.client.{BatchScanner, IteratorSetting}
-import org.apache.accumulo.core.data.{Key, Value}
+import org.apache.accumulo.core.data.{Key, Value, Range => AccRange}
 import org.apache.accumulo.core.iterators.user.RegExFilter
 import org.apache.hadoop.io.Text
-import org.apache.log4j.Logger
 import org.geotools.data.{DataUtilities, Query}
 import org.geotools.factory.CommonFactoryFinder
 import org.geotools.filter.text.ecql.ECQL
 import org.geotools.geometry.jts.ReferencedEnvelope
 import org.joda.time.Interval
 import org.opengis.feature.simple.SimpleFeatureType
+import org.opengis.filter._
+import org.opengis.filter.expression.{Literal, PropertyName}
+
 import scala.collection.JavaConversions._
 import scala.util.Random
+
 
 object IndexQueryPlanner {
   val iteratorPriority_RowRegex                       = 0
@@ -35,9 +43,7 @@ case class IndexQueryPlanner(keyPlanner: KeyPlanner,
                              cfPlanner: ColumnFamilyPlanner,
                              schema:String,
                              featureType: SimpleFeatureType,
-                             featureEncoder: SimpleFeatureEncoder) {
-
-  private val log = Logger.getLogger(classOf[IndexQueryPlanner])
+                             featureEncoder: SimpleFeatureEncoder) extends Logging {
 
   def buildFilter(poly: Polygon, interval: Interval): KeyPlanningFilter =
     (IndexSchema.somewhere(poly), IndexSchema.somewhen(interval)) match {
@@ -68,16 +74,17 @@ case class IndexQueryPlanner(keyPlanner: KeyPlanner,
 
   // As a pre-processing step, we examine the query/filter and split it into multiple queries.
   // TODO: Work to make the queries non-overlapping.
-  def getIterator(buildBatchScanner: () => BatchScanner, query: Query) : CloseableIterator[Entry[Key,Value]] = {
+  def getIterator(ds: AccumuloDataStore, sft: SimpleFeatureType, query: Query): CloseableIterator[Entry[Key,Value]] = {
     val ff = CommonFactoryFinder.getFilterFactory2
+    val isDensity = query.getHints.containsKey(BBOX_KEY)
     val queries: Iterator[Query] =
-      if(query.getHints.containsKey(BBOX_KEY)) {
+      if(isDensity) {
         val env = query.getHints.get(BBOX_KEY).asInstanceOf[ReferencedEnvelope]
         val q1 = new Query(featureType.getTypeName, ff.bbox(ff.property(featureType.getGeometryDescriptor.getLocalName), env))
         Iterator(DataUtilities.mixQueries(q1, query, "geomesa.mixed.query"))
       } else splitQueryOnOrs(query)
 
-    queries.flatMap(runQuery(buildBatchScanner, _))
+    queries.flatMap(runQuery(ds, sft, _, isDensity))
   }
   
   def splitQueryOnOrs(query: Query): Iterator[Query] = {
@@ -98,15 +105,181 @@ case class IndexQueryPlanner(keyPlanner: KeyPlanner,
     }.toIterator
   }
 
-  // Strategy:
-  // 1. Inspect the query
-  // 2. Set up the base iterators/scans.
-  // 3. Set up the rest of the iterator stack.
-  private def runQuery(buildBatchScanner: () => BatchScanner, query: Query) = {
-    val bs: BatchScanner = buildBatchScanner()
-
+  /**
+   * Helper method to execute a query against an AccumuloDataStore
+   *
+   * If the query contains ONLY an eligible LIKE
+   * or EQUALTO query then satisfy the query with the attribute index
+   * table...else use the spatio-temporal index table
+   *
+   * If the query is a density query use the spatio-temporal index table only
+   */
+  private def runQuery(ds: AccumuloDataStore, sft: SimpleFeatureType, derivedQuery: Query, isDensity: Boolean) = {
     val filterVisitor = new FilterToAccumulo(featureType)
-    val rewrittenCQL = filterVisitor.visit(query)
+    val rewrittenFilter = filterVisitor.visit(derivedQuery)
+    if(ds.catalogTableFormat(sft)){
+      // If we have attr index table try it
+      runAttrIdxQuery(ds, derivedQuery, rewrittenFilter, filterVisitor, isDensity)
+    } else {
+      // datastore doesn't support attr index use spatiotemporal only
+      stIdxQuery(ds, derivedQuery, rewrittenFilter, filterVisitor)
+    }
+  }
+
+  /**
+   * Attempt to run a query against the attribute index if it can be satisfied 
+   * there...if not run against the SpatioTemporal
+   */
+  def runAttrIdxQuery(ds: AccumuloDataStore,
+                      derivedQuery: Query,
+                      rewrittenFilter: Filter,
+                      filterVisitor: FilterToAccumulo,
+                      isDensity: Boolean) = {
+
+    rewrittenFilter match {
+      case isEqualTo: PropertyIsEqualTo if !isDensity =>
+        attrIdxEqualToQuery(ds, derivedQuery, isEqualTo, filterVisitor)
+
+      case like: PropertyIsLike if !isDensity =>
+        if(likeEligible(like))
+          attrIdxLikeQuery(ds, derivedQuery, like, filterVisitor)
+        else
+          stIdxQuery(ds, derivedQuery, like, filterVisitor)
+
+      case cql =>
+        stIdxQuery(ds, derivedQuery, cql, filterVisitor)
+    }
+  }
+
+  val iteratorPriority_AttributeIndexFilteringIterator = 10
+
+  // TODO try to use wildcard values from the Filter itself
+  // Currently pulling the wildcard values from the filter
+  // leads to inconsistent results...so use % as wildcard
+  val MULTICHAR_WILDCARD = "%"
+  val SINGLE_CHAR_WILDCARD = "_"
+  val NULLBYTE = Array[Byte](0.toByte)
+
+  /* Like queries that can be handled by current reverse index */
+  def likeEligible(filter: PropertyIsLike) = containsNoSingles(filter) && trailingOnlyWildcard(filter)
+
+  /* contains no single character wildcards */
+  def containsNoSingles(filter: PropertyIsLike) =
+    !(filter.getLiteral.replace("\\\\", "").replace(s"\\$SINGLE_CHAR_WILDCARD", "").contains(SINGLE_CHAR_WILDCARD))
+
+  def trailingOnlyWildcard(filter: PropertyIsLike) =
+    (filter.getLiteral.endsWith(MULTICHAR_WILDCARD) &&
+      filter.getLiteral.indexOf(MULTICHAR_WILDCARD) == filter.getLiteral.length - MULTICHAR_WILDCARD.length) ||
+      filter.getLiteral.indexOf(MULTICHAR_WILDCARD) == -1
+
+  /**
+   * Get an iterator that performs an eligible LIKE query against the Attribute Index Table
+   */
+  def attrIdxLikeQuery(dataStore: AccumuloDataStore,
+                       derivedQuery: Query,
+                       filter: PropertyIsLike,
+                       filterVisitor: FilterToAccumulo) = {
+
+    val expr = filter.getExpression
+    val prop = expr match {
+      case p: PropertyName => p.getPropertyName
+    }
+
+    // Remove the trailing wilcard and create a range prefix
+    val literal = filter.getLiteral
+    val value =
+      if(literal.endsWith(MULTICHAR_WILDCARD))
+        literal.substring(0, literal.length - MULTICHAR_WILDCARD.length)
+      else
+        literal
+
+    val range = AccRange.prefix(formatAttrIdxRow(prop, value))
+
+    attrIdxQuery(dataStore, derivedQuery, filterVisitor, range)
+  }
+
+  def formatAttrIdxRow(prop: String, lit: String) =
+    new Text(prop.getBytes(StandardCharsets.UTF_8) ++ NULLBYTE ++ lit.getBytes(StandardCharsets.UTF_8))
+
+  /**
+   * Get an iterator that performs an EqualTo query against the Attribute Index Table
+   */
+  def attrIdxEqualToQuery(dataStore: AccumuloDataStore,
+                          derivedQuery: Query,
+                          filter: PropertyIsEqualTo,
+                          filterVisitor: FilterToAccumulo) = {
+
+    val one = filter.getExpression1
+    val two = filter.getExpression2
+    val (prop, lit) = (one, two) match {
+      case (p: PropertyName, l: Literal) => (p.getPropertyName, l.getValue.toString)
+      case (l: Literal, p: PropertyName) => (p.getPropertyName, l.getValue.toString)
+      case _ =>
+        val msg =
+          s"""Unhandled equalTo Query (expr1 type: ${one.getClass.getName}, expr2 type: ${two.getClass.getName}
+            |Supported types are literal = propertyName and propertyName = literal
+          """.stripMargin
+        throw new RuntimeException(msg)
+    }
+
+    val range = new AccRange(formatAttrIdxRow(prop, lit))
+
+    attrIdxQuery(dataStore, derivedQuery, filterVisitor, range)
+  }
+
+  /**
+   * Perform scan against the Attribute Index Table and get an iterator returning records from the Record table
+   */
+  def attrIdxQuery(dataStore: AccumuloDataStore,
+                   derivedQuery: Query,
+                   filterVisitor: FilterToAccumulo,
+                   range: AccRange) = {
+
+    logger.trace(s"Scanning attribute table for feature type ${featureType.getTypeName}")
+    val attrScanner = dataStore.createAttrIdxScanner(featureType)
+
+    val spatialOpt =
+      for {
+          sp    <- Option(filterVisitor.spatialPredicate)
+          env  = sp.getEnvelopeInternal
+          bbox = List(env.getMinX, env.getMinY, env.getMaxX, env.getMaxY).mkString(",")
+      } yield AttributeIndexFilteringIterator.BBOX_KEY -> bbox
+
+    val dtgOpt = Option(filterVisitor.temporalPredicate).map(AttributeIndexFilteringIterator.INTERVAL_KEY -> _.toString)
+    val opts = List(spatialOpt, dtgOpt).flatten.toMap
+    if(!opts.isEmpty) {
+      val cfg = new IteratorSetting(iteratorPriority_AttributeIndexFilteringIterator,
+        "attrIndexFilter",
+        classOf[AttributeIndexFilteringIterator].getCanonicalName,
+        opts)
+      attrScanner.addScanIterator(cfg)
+    }
+
+    logger.trace(s"Attribute Scan Range: ${range.toString}")
+    attrScanner.setRange(range)
+
+    import scala.collection.JavaConversions._
+    val ranges = attrScanner.iterator.map(_.getKey.getColumnFamily).map(new AccRange(_))
+
+    val recScanner = if(ranges.hasNext) {
+      val recordScanner = dataStore.createRecordScanner(featureType)
+      recordScanner.setRanges(ranges.toList)
+      configureSimpleFeatureFilteringIterator(recordScanner, featureType, None, derivedQuery)
+      Some(recordScanner)
+    } else None
+
+    val iter = recScanner.map(_.iterator()).getOrElse(Iterators.emptyIterator[Entry[Key, Value]])
+
+    def close(): Unit = {
+      recScanner.foreach(_.close)
+      attrScanner.clearScanIterators()
+    }
+
+    CloseableIterator(iter, close)
+  }
+
+  def stIdxQuery(ds: AccumuloDataStore, query: Query, rewrittenCQL: Filter, filterVisitor: FilterToAccumulo) = {
+    logger.trace(s"Scanning ST index table for feature type ${featureType.getTypeName}")
     val ecql = Option(ECQL.toCQL(rewrittenCQL))
 
     val spatial = filterVisitor.spatialPredicate
@@ -124,16 +297,15 @@ case class IndexQueryPlanner(keyPlanner: KeyPlanner,
     val oint  = IndexSchema.somewhen(interval)
 
     // set up row ranges and regular expression filter
+    val bs = ds.createSTIdxScanner(featureType)
     planQuery(bs, filter)
 
-    if(log.isTraceEnabled) {
-      log.trace("Configuring batch scanner: ")
-      log.trace("Poly: "+ opoly.getOrElse("No poly"))
-      log.trace("Interval: " + oint.getOrElse("No interval"))
-      log.trace("Filter: " + Option(filter).getOrElse("No Filter"))
-      log.trace("ECQL: " + Option(ecql).getOrElse("No ecql"))
-      log.trace("Query: " + Option(query).getOrElse("no query"))
-    }
+    logger.trace("Configuring batch scanner for ST table: " +
+                 "Poly: "+ opoly.getOrElse("No poly")+
+                 "Interval: " + oint.getOrElse("No interval")+
+                 "Filter: " + Option(filter).getOrElse("No Filter")+
+                 "ECQL: " + Option(ecql).getOrElse("No ecql")+
+                 "Query: " + Option(query).getOrElse("no query"))
 
     val iteratorConfig = IteratorTrigger.chooseIterator(ecql, query, featureType)
 

--- a/geomesa-core/src/main/scala/geomesa/core/iterators/AttributeIndexFilteringIterator.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/iterators/AttributeIndexFilteringIterator.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.core.iterators
+
+import java.util.{Map => JMap}
+
+import com.typesafe.scalalogging.slf4j.Logging
+import com.vividsolutions.jts.geom.{Geometry, Polygon}
+import geomesa.core.index.IndexSchema
+import geomesa.core.index.IndexSchema.DecodedIndexValue
+import org.apache.accumulo.core.data.{Key, Value}
+import org.apache.accumulo.core.iterators.{Filter, IteratorEnvironment, SortedKeyValueIterator}
+import org.geotools.geometry.jts.{JTS, ReferencedEnvelope}
+import org.geotools.referencing.crs.DefaultGeographicCRS
+import org.joda.time.Interval
+
+class AttributeIndexFilteringIterator extends Filter with Logging {
+
+  protected var bbox: Polygon = null
+  protected var interval: Interval = null
+
+  override def init(source: SortedKeyValueIterator[Key, Value],
+                    options: JMap[String, String],
+                    env: IteratorEnvironment) {
+    super.init(source, options, env)
+    if(options.containsKey(AttributeIndexFilteringIterator.BBOX_KEY)) {
+      // TODO validate bbox option
+      val Array(minx, miny, maxx, maxy) = options.get(AttributeIndexFilteringIterator.BBOX_KEY).split(",").map(_.toDouble)
+      val re = new ReferencedEnvelope(minx, maxx, miny, maxy, DefaultGeographicCRS.WGS84)
+      bbox = JTS.toGeometry(re)
+      logger.info(s"Set bounding box for values ${bbox.toString}")
+    }
+    if(options.containsKey(AttributeIndexFilteringIterator.INTERVAL_KEY)) {
+      // TODO validate interval option
+      interval = Interval.parse(options.get(AttributeIndexFilteringIterator.INTERVAL_KEY))
+      logger.info(s"Set interval to ${interval.toString}")
+    }
+  }
+
+  override def deepCopy(env: IteratorEnvironment) = {
+    val copy = super.deepCopy(env).asInstanceOf[AttributeIndexFilteringIterator]
+    copy.bbox = bbox.clone.asInstanceOf[Polygon]
+    copy.interval = interval //interval is immutable - no need to deep copy
+    copy
+  }
+
+  override def accept(k: Key, v: Value): Boolean = {
+    val DecodedIndexValue(_, geom, dtgOpt) = IndexSchema.decodeIndexValue(v)
+
+    // TODO This might be made more efficient
+    filterBbox(geom) && dtgOpt.map(dtg => filterInterval(dtg)).getOrElse(true)
+  }
+
+  // Intersect, not contains for geometry that hits this bbox
+  protected def filterBbox(geom: Geometry) = Option(bbox).map(b => b.intersects(geom)).getOrElse(true)
+
+  protected def filterInterval(dtg: Long) = Option(interval).map(i => i.contains(dtg)).getOrElse(true)
+
+}
+
+object AttributeIndexFilteringIterator {
+  val BBOX_KEY = "geomesa.bbox"
+  val INTERVAL_KEY = "geomesa.interval"
+}

--- a/geomesa-core/src/main/scala/geomesa/core/iterators/DensityIterator.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/iterators/DensityIterator.scala
@@ -163,7 +163,7 @@ object DensityIterator extends Logging {
           }
         }
       case Failure(e) =>
-        logger.error(s"Error expanding encoded raster ${sf.getAttribute(ENCODED_RASTER_ATTRIBUTE)}: ${e.toString}")
+        logger.error(s"Error expanding encoded raster ${sf.getAttribute(ENCODED_RASTER_ATTRIBUTE)}: ${e.toString}", e)
         List(builder.buildFeature(sf.getID, Array(1, sf.point).asInstanceOf[Array[AnyRef]]))
     }
   }

--- a/geomesa-core/src/main/scala/geomesa/core/process/tube/TubeSelectProcess.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/process/tube/TubeSelectProcess.scala
@@ -138,7 +138,7 @@ class TubeVisitor(
 
   def tubeSelect(source: SimpleFeatureSource, query: Query): SimpleFeatureCollection = {
 
-    log.info("Visting source type: "+source.getClass.getName)
+    log.info("Visiting source type: "+source.getClass.getName)
 
     val geomProperty = ff.property(source.getSchema.getGeometryDescriptor.getName)
     val dateProperty = ff.property(source.getSchema.getUserData.get(Constants.SF_PROPERTY_START_TIME).asInstanceOf[String])

--- a/geomesa-core/src/main/scala/geomesa/core/util/BatchMultiScanner.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/util/BatchMultiScanner.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2013 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.core.util
+
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+import com.google.common.collect.Queues
+import com.typesafe.scalalogging.slf4j.Logging
+import org.apache.accumulo.core.client.{BatchScanner, Scanner}
+import org.apache.accumulo.core.data.{Key, Value, Range => AccRange}
+
+import scala.collection.JavaConversions._
+
+// Unused for now.
+class BatchMultiScanner(in: Scanner,
+                        out: BatchScanner,
+                        joinFn: java.util.Map.Entry[Key, Value] => AccRange)
+  extends Iterable[java.util.Map.Entry[Key, Value]] with Logging {
+
+  type E = java.util.Map.Entry[Key, Value]
+  val inExecutor  = Executors.newSingleThreadExecutor()
+  val outExecutor = Executors.newSingleThreadExecutor()
+  val inQ  = Queues.newLinkedBlockingQueue[E](32768)
+  val outQ = Queues.newArrayBlockingQueue[E](32768)
+  val inDone  = new AtomicBoolean(false)
+  val outDone = new AtomicBoolean(false)
+
+  inExecutor.submit(new Runnable {
+    override def run(): Unit = {
+      try {
+        in.iterator().foreach(inQ.put)
+      } finally {
+        inDone.set(true)
+      }
+    }
+  })
+
+  def moreInQ = !(inDone.get && inQ.isEmpty)
+
+  outExecutor.submit(new Runnable {
+    override def run(): Unit = {
+      try {
+        while(moreInQ) {
+          val entry = inQ.take()
+          if(entry != null) {
+            val entries = new collection.mutable.ListBuffer[E]()
+            val count = inQ.drainTo(entries)
+            if (count > 0) {
+              val ranges = (List(entry) ++ entries).map(joinFn)
+              out.setRanges(ranges)
+              out.iterator().foreach(e => outQ.put(e))
+            }
+          }
+        }
+        outDone.set(true)
+      } catch {
+        case _: InterruptedException =>
+      } finally {
+        outDone.set(true)
+      }
+    }
+  })
+
+  override def iterator: Iterator[java.util.Map.Entry[Key, Value]] = new Iterator[E] {
+    override def hasNext: Boolean = {
+      val ret = !(outQ.isEmpty && inDone.get() && outDone.get())
+      if(!ret) {
+        inExecutor.shutdownNow()
+        outExecutor.shutdownNow()
+      }
+      ret
+    }
+
+    override def next(): E = outQ.take()
+  }
+}

--- a/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
@@ -21,7 +21,9 @@ import geomesa.core.index.SF_PROPERTY_START_TIME
 import geomesa.core.security.{AuthorizationsProvider, DefaultAuthorizationsProvider, FilteringAuthorizationsProvider}
 import geomesa.feature.AvroSimpleFeatureFactory
 import geomesa.utils.text.WKTUtils
+import org.apache.accumulo.core.client.mock.MockInstance
 import org.apache.accumulo.core.security.Authorizations
+import org.apache.commons.codec.binary.Hex
 import org.geotools.data.collection.ListFeatureCollection
 import org.geotools.data.{DataStoreFinder, DataUtilities, Query, Transaction}
 import org.geotools.factory.{CommonFactoryFinder, Hints}
@@ -127,9 +129,9 @@ class AccumuloDataStoreTest extends Specification {
         containsGeometry = containsGeometry | features.next.getDefaultGeometry.equals(geom)
       }
 
-      results.getSchema should be equalTo(sft)
-      containsGeometry should be equalTo(true)
-      res.length should be equalTo(1)
+      results.getSchema should be equalTo sft
+      containsGeometry should be equalTo true
+      res.length should be equalTo 1
     }
 
     "return an empty iterator correctly" in {
@@ -164,9 +166,9 @@ class AccumuloDataStoreTest extends Specification {
       // Let's read out what we wrote.
       val results = fs.getFeatures(query)
       val features = results.features
-      results.getSchema should be equalTo(sft)
-      res.length should be equalTo(1)
-      features.hasNext should be equalTo(false)
+      results.getSchema should be equalTo sft
+      res.length should be equalTo 1
+      features.hasNext should be equalTo false
     }
 
     "process a DWithin query correctly" in {
@@ -189,7 +191,7 @@ class AccumuloDataStoreTest extends Specification {
       liveFeature.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
       val featureCollection = new DefaultFeatureCollection(sftName, sft)
       featureCollection.add(liveFeature)
-      val res = fs.addFeatures(featureCollection)
+      fs.addFeatures(featureCollection)
 
       // compose a CQL query that uses a polygon that is disjoint with the feature bounds
       val ff = CommonFactoryFinder.getFilterFactory2
@@ -464,6 +466,107 @@ class AccumuloDataStoreTest extends Specification {
       } catch {
         case e: RuntimeException => success
       }
+    }
+
+    "create proper tables for secondary indexing" in {
+      val table = "testing_secondary_index"
+      val ds = DataStoreFinder.getDataStore(Map(
+        "instanceId" -> "mycloud",
+        "zookeepers" -> "zoo1:2181,zoo2:2181,zoo3:2181",
+        "user"       -> "myuser",
+        "password"   -> "mypassword",
+        "tableName"  -> table,
+        "useMock"    -> "true")).asInstanceOf[AccumuloDataStore]
+
+      ds should not be null
+
+      // accumulo supports only alphanum + underscore aka ^\\w+$
+      // this should be OK
+      val sftName = "somethingsaf3"
+      val sft = DataUtilities.createType(sftName, s"name:String,dtg:Date,*geom:Point:srid=4326")
+      ds.createSchema(sft)
+
+      val mockInstance = new MockInstance("mycloud")
+      val c = mockInstance.getConnector("myuser", "mypassword".getBytes("UTF8"))
+
+      c.tableOperations().exists(table) must beTrue
+      c.tableOperations().exists(s"${table}_${sftName}_st_idx") must beTrue
+      c.tableOperations().exists(s"${table}_${sftName}_records") must beTrue
+      c.tableOperations().exists(s"${table}_${sftName}_attr_idx") must beTrue
+    }
+
+    "hex encode non accumulo table name safe feature type names" in {
+
+      val table = "testing_bad_features"
+      val ds = DataStoreFinder.getDataStore(Map(
+        "instanceId" -> "mycloud",
+        "zookeepers" -> "zoo1:2181,zoo2:2181,zoo3:2181",
+        "user"       -> "myuser",
+        "password"   -> "mypassword",
+        "tableName"  -> table,
+        "useMock"    -> "true")).asInstanceOf[AccumuloDataStore]
+
+      ds should not be null
+
+      // accumulo supports only alphanum + underscore aka ^\\w+$
+      // this should end up hex encoded
+      val sftName = "some_thing:bad!"
+      val sft = DataUtilities.createType(sftName, s"name:String,dtg:Date,*geom:Point:srid=4326")
+      ds.createSchema(sft)
+
+      val mockInstance = new MockInstance("mycloud")
+      val c = mockInstance.getConnector("myuser", "mypassword".getBytes("UTF8"))
+
+      def enc(s: String) = "_" + Hex.encodeHexString(s.getBytes("UTF8")).toLowerCase
+
+      val hexSft = "some" + enc("_") + "thing" + enc(":") + "bad" + enc("!")
+
+      c.tableOperations().exists(table) must beTrue
+      c.tableOperations().exists(s"${table}_${hexSft}_st_idx") must beTrue
+      c.tableOperations().exists(s"${table}_${hexSft}_records") must beTrue
+      c.tableOperations().exists(s"${table}_${hexSft}_attr_idx") must beTrue
+    }
+
+    "hex encode multibyte chars as multiple underscore + hex" in {
+      val table = "testing_chinese_features"
+      val ds = DataStoreFinder.getDataStore(Map(
+        "instanceId" -> "mycloud",
+        "zookeepers" -> "zoo1:2181,zoo2:2181,zoo3:2181",
+        "user"       -> "myuser",
+        "password"   -> "mypassword",
+        "tableName"  -> table,
+        "useMock"    -> "true")).asInstanceOf[AccumuloDataStore]
+
+      ds should not be null
+
+      // accumulo supports only alphanum + underscore aka ^\\w+$
+      // this should end up hex encoded
+      val sftName = "nihao你好"
+      val sft = DataUtilities.createType(sftName, s"name:String,dtg:Date,*geom:Point:srid=4326")
+      ds.createSchema(sft)
+
+      val mockInstance = new MockInstance("mycloud")
+      val c = mockInstance.getConnector("myuser", "mypassword".getBytes("UTF8"))
+
+      // encode groups of 2 hex chars since we are doing multibyte chars
+      def enc(s: String): String = Hex.encodeHex(s.getBytes("UTF8")).grouped(2)
+        .map{ c => "_" + c(0) + c(1) }.mkString.toLowerCase
+
+      // three byte UTF8 chars result in 9 char string
+      enc("你").length mustEqual 9
+      enc("好").length mustEqual 9
+
+      val encodedSFT = "nihao" + enc("你") + enc("好")
+      encodedSFT mustEqual AccumuloDataStore.hexEncodeNonAlphaNumeric(sftName)
+
+      AccumuloDataStore.formatSpatioTemporalIdxTableName(table, sft) mustEqual s"${table}_${encodedSFT}_st_idx"
+      AccumuloDataStore.formatRecordTableName(table, sft) mustEqual s"${table}_${encodedSFT}_records"
+      AccumuloDataStore.formatAttrIdxTableName(table, sft) mustEqual s"${table}_${encodedSFT}_attr_idx"
+
+      c.tableOperations().exists(table) must beTrue
+      c.tableOperations().exists(s"${table}_${encodedSFT}_st_idx") must beTrue
+      c.tableOperations().exists(s"${table}_${encodedSFT}_records") must beTrue
+      c.tableOperations().exists(s"${table}_${encodedSFT}_attr_idx") must beTrue
     }
 
   }

--- a/geomesa-core/src/test/scala/geomesa/core/data/FeatureWritersTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/FeatureWritersTest.scala
@@ -16,12 +16,12 @@
 
 package geomesa.core.data
 
-import geomesa.core.index
+import java.text.SimpleDateFormat
+import java.util.TimeZone
+
 import geomesa.core.index.SF_PROPERTY_START_TIME
 import geomesa.feature.AvroSimpleFeatureFactory
 import geomesa.utils.text.WKTUtils
-import java.text.SimpleDateFormat
-import java.util.TimeZone
 import org.geotools.data._
 import org.geotools.data.simple.SimpleFeatureIterator
 import org.geotools.factory.Hints
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith
 import org.opengis.feature.simple.SimpleFeature
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
+
 import scala.collection
 import scala.collection.JavaConversions._
 
@@ -102,11 +103,12 @@ class FeatureWritersTest extends Specification {
 
         /* write the feature to the store */
         fs.addFeatures(featureCollection)
+        fs.flush()
 
         val store = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
 
         /* turn fred into billy */
-        val filter = CQL.toFilter("name = 'fred'");
+        val filter = CQL.toFilter("name = 'fred'")
         store.modifyFeatures(Array("name", "age"), Array("billy", 25.asInstanceOf[AnyRef]), filter)
 
         /* delete kyle */
@@ -115,7 +117,6 @@ class FeatureWritersTest extends Specification {
 
         /* query everything */
         val cqlFilter = CQL.toFilter("include")
-        val query = new Query(sftName, cqlFilter)
 
         /* Let's read out what we wrote...we should only get tom and billy back out */
         val nameAgeMap = getMap[String, Int](getFeatures(sftName, fs, "include"), "name", "age")
@@ -139,7 +140,7 @@ class FeatureWritersTest extends Specification {
 
         while(writer.hasNext){
           writer.next
-          writer.remove
+          writer.remove()
         }
 
         // cannot do anything here until the writer is closed.
@@ -159,10 +160,11 @@ class FeatureWritersTest extends Specification {
           c.zip(ids).foreach { case (feature, id) =>
             val writerCreatedFeature = writer.next()
             writerCreatedFeature.setAttributes(feature.getAttributes)
-            writerCreatedFeature.getUserData()(Hints.PROVIDED_FID) = id
-            writer.write
+            writerCreatedFeature.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+            writerCreatedFeature.getUserData.put(Hints.PROVIDED_FID, id)
+            writer.write()
           }
-        } finally { writer.close }
+        } finally { writer.close() }
 
         countFeatures(fs, sftName) should equalTo(5)
 

--- a/geomesa-core/src/test/scala/geomesa/core/data/TableVersionTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/TableVersionTest.scala
@@ -21,10 +21,10 @@ import scala.collection.JavaConversions._
 
 
 /**
- * The purpose of this test is to ensure that the table version is backwards compatible with
- * older versions (e.g. 0.10.x). The table format should not be changed without some sort of
- * transition map/reduce job to convert table formats.
- */
+* The purpose of this test is to ensure that the table version is backwards compatible with
+* older versions (e.g. 0.10.x). The table format should not be changed without some sort of
+* transition map/reduce job to convert table formats.
+*/
 @RunWith(classOf[JUnitRunner])
 class TableVersionTest extends Specification {
 
@@ -128,8 +128,8 @@ class TableVersionTest extends Specification {
       val geomesaStore = DataStoreFinder.getDataStore(geomesaParams).asInstanceOf[AccumuloDataStore]
       val geomesaSource = geomesaStore.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
 
-      val manualFeatures = manualSource.getFeatures(query).features
-      val geomesaFeatures = geomesaSource.getFeatures(query).features
+      val manualFeatures = manualSource.getFeatures(query).features.toList.sortBy(_.getID.toInt)
+      val geomesaFeatures = geomesaSource.getFeatures(query).features.toList.sortBy(_.getID.toInt)
 
       manualFeatures.zip(geomesaFeatures).foreach {case (m, g) =>
         m should equalTo(g)

--- a/geomesa-core/src/test/scala/geomesa/core/iterators/AttributeIndexFilteringIteratorTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/AttributeIndexFilteringIteratorTest.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2013 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.core.iterators
+
+import java.text.SimpleDateFormat
+import java.util.TimeZone
+
+import com.vividsolutions.jts.geom.Geometry
+import geomesa.core.data.{AccumuloDataStore, AccumuloFeatureStore}
+import geomesa.utils.geotools.Conversions._
+import geomesa.utils.text.WKTUtils
+import org.geotools.data.{DataStoreFinder, DataUtilities, Query}
+import org.geotools.factory.{CommonFactoryFinder, Hints}
+import org.geotools.feature.DefaultFeatureCollection
+import org.geotools.feature.simple.SimpleFeatureBuilder
+import org.geotools.filter.text.ecql.ECQL
+import org.joda.time.{DateTime, DateTimeZone}
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class AttributeIndexFilteringIteratorTest extends Specification {
+
+  val sftName = "AttributeIndexFilteringIteratorTest"
+  val sft = DataUtilities.createType(sftName, s"name:String,age:Integer,dtg:Date,*geom:Geometry:srid=4326")
+
+  val sdf = new SimpleDateFormat("yyyyMMdd")
+  sdf.setTimeZone(TimeZone.getTimeZone("Zulu"))
+  val dateToIndex = sdf.parse("20140102")
+
+  def createStore: AccumuloDataStore =
+  // the specific parameter values should not matter, as we
+  // are requesting a mock data store connection to Accumulo
+    DataStoreFinder.getDataStore(
+      Map(
+        "instanceId" -> "mycloud",
+        "zookeepers" -> "zoo1:2181,zoo2:2181,zoo3:2181",
+        "user"       -> "myuser",
+        "password"   -> "mypassword",
+        "auths"      -> "A,B,C",
+        "tableName"  -> "AttributeIndexFilteringIteratorTest",
+        "useMock"    -> "true")
+    ).asInstanceOf[AccumuloDataStore]
+
+  val ds = createStore
+
+  ds.createSchema(sft)
+  val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
+
+  val featureCollection = new DefaultFeatureCollection(sftName, sft)
+
+  List("a", "b", "c", "d").foreach { name =>
+    List(1, 2, 3, 4).zip(List(45, 46, 47, 48)).foreach { case (i, lat) =>
+      val sf = SimpleFeatureBuilder.build(sft, List(), name + i.toString)
+      sf.setDefaultGeometry(WKTUtils.read(f"POINT($lat%d $lat%d)"))
+      sf.setAttribute("dtg", new DateTime("2011-01-01T00:00:00Z", DateTimeZone.UTC).toDate)
+      sf.setAttribute("name", name)
+      sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+      featureCollection.add(sf)
+    }
+  }
+
+  fs.addFeatures(featureCollection)
+
+  val ff = CommonFactoryFinder.getFilterFactory2
+
+  "AttributeIndexFilteringIterator" should {
+    "handle like queries" in {
+      // Try out wildcard queries using the % wildcard syntax.
+      // Test single wildcard, trailing, leading, and both trailing & leading wildcards
+
+      // % should return all features
+      fs.getFeatures(ff.like(ff.property("name"),"%")).features.size should equalTo(16)
+
+      List("a", "b", "c", "d").foreach { letter =>
+        // 4 features for this letter
+        fs.getFeatures(ff.like(ff.property("name"),s"%$letter")).features.size should equalTo(4)
+
+        // should return the 4 features for this letter
+        fs.getFeatures(ff.like(ff.property("name"),s"%$letter%")).features.size should equalTo(4)
+
+        // should return the 4 features for this letter
+        fs.getFeatures(ff.like(ff.property("name"),s"$letter%")).features.size should equalTo(4)
+      }
+
+    }
+
+    "handle transforms" in {
+      // transform to only return the attribute geom - dropping dtg and name
+      List("a", "b", "c", "d").foreach { letter =>
+        val query = new Query(sftName, ECQL.toFilter(s"name <> '$letter'"), Array("geom"))
+        val features = fs.getFeatures(query)
+
+        features.size should equalTo(12)
+        features.features.foreach { sf =>
+          sf.getAttributeCount should equalTo(1)
+          sf.getAttribute(0) should beAnInstanceOf[Geometry]
+        }
+      }
+    }
+  }
+
+}

--- a/geomesa-core/src/test/scala/geomesa/core/iterators/IndexIteratorTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/IndexIteratorTest.scala
@@ -16,23 +16,21 @@
 
 package geomesa.core.iterators
 
-import collection.JavaConversions._
-import com.vividsolutions.jts.geom.{Polygon, Geometry}
+import com.vividsolutions.jts.geom.Polygon
 import geomesa.core.data._
 import geomesa.core.index._
 import geomesa.core.iterators.TestData._
 import geomesa.utils.text.WKTUtils
 import org.apache.accumulo.core.client.mock.MockInstance
 import org.geotools.data.simple.SimpleFeatureStore
-import org.geotools.data.{Query, DataUtilities}
-import org.geotools.factory.Hints
-import org.geotools.feature.simple.SimpleFeatureBuilder
+import org.geotools.data.{DataUtilities, Query}
 import org.geotools.filter.text.ecql.ECQL
-import org.joda.time.{Duration, Interval, DateTime}
+import org.joda.time.Interval
 import org.junit.runner.RunWith
-import org.opengis.feature.simple.SimpleFeature
 import org.specs2.runner.JUnitRunner
+
 import scala.collection.GenSeq
+import scala.collection.JavaConversions._
 
 @RunWith(classOf[JUnitRunner])
 class IndexIteratorTest extends SpatioTemporalIntersectingIteratorTest {
@@ -42,15 +40,22 @@ class IndexIteratorTest extends SpatioTemporalIntersectingIteratorTest {
   object IITest {
 
     def setupMockFeatureSource(entries: GenSeq[TestData.Entry]): SimpleFeatureStore = {
-      val TEST_TABLE = "test_table"
+      val CATALOG_TABLE = "test_table"
 
       val mockInstance = new MockInstance("dummy")
       val c = mockInstance.getConnector("user", "pass".getBytes)
-      if (c.tableOperations.exists(TEST_TABLE)) c.tableOperations.delete(TEST_TABLE)
+
+      // Remember we need to delete all 4 tables now
+      List(
+        CATALOG_TABLE,
+        s"${CATALOG_TABLE}_${TestData.featureType.getTypeName}_st_idx",
+        s"${CATALOG_TABLE}_${TestData.featureType.getTypeName}_records",
+        s"${CATALOG_TABLE}_${TestData.featureType.getTypeName}_attr_idx"
+      ).foreach { t => if (c.tableOperations.exists(t)) c.tableOperations.delete(t) }
 
       val dsf = new AccumuloDataStoreFactory
 
-      import AccumuloDataStoreFactory.params._
+      import geomesa.core.data.AccumuloDataStoreFactory.params._
 
       val ds = dsf.createDataStore(
         Map(

--- a/geomesa-core/src/test/scala/geomesa/core/iterators/SpatioTemporalIntersectingIteratorTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/SpatioTemporalIntersectingIteratorTest.scala
@@ -19,13 +19,15 @@ package geomesa.core.iterators
 import com.typesafe.scalalogging.slf4j.Logging
 import com.vividsolutions.jts.geom.Polygon
 import geomesa.core._
-import geomesa.core.data.SimpleFeatureEncoderFactory
+import geomesa.core.data.{AccumuloDataStore, SimpleFeatureEncoderFactory}
 import geomesa.core.index._
 import geomesa.core.iterators.TestData._
+import geomesa.core.security.DefaultAuthorizationsProvider
 import geomesa.utils.text.WKTUtils
 import org.apache.accumulo.core.client.mock.MockInstance
-import org.apache.accumulo.core.client.{BatchScanner, Connector, IteratorSetting}
-import org.apache.accumulo.core.data._
+import org.apache.accumulo.core.client.{Connector, IteratorSetting}
+import org.apache.accumulo.core.data.Mutation
+
 import org.apache.hadoop.io.Text
 import org.geotools.data.Query
 import org.geotools.filter.text.ecql.ECQL
@@ -99,7 +101,7 @@ class SpatioTemporalIntersectingIteratorTest extends Specification with Logging 
 
     // create the batch scanner
     val c = setupMockAccumuloTable(entries)
-    val bs = () => c.createBatchScanner(TEST_TABLE, TEST_AUTHORIZATIONS, 5)
+    val ds = new AccumuloDataStore(c, TEST_TABLE, new DefaultAuthorizationsProvider, "")
 
     val gf = s"WITHIN(geom, ${polygon.toText})"
     val dt: Option[String] = Option(dtFilter).map(int =>
@@ -115,16 +117,16 @@ class SpatioTemporalIntersectingIteratorTest extends Specification with Logging 
     val tf = ECQL.toFilter(tfString)
 
     val q = new Query(TestData.featureType.getTypeName, tf)
-    runQuery(q, bs)
+    runQuery(q, ds)
   }
 
-  def runQuery(q: Query, bs: () => BatchScanner, doPrint: Boolean = false, label: String = "test") = {
+  def runQuery(q: Query, ds: AccumuloDataStore, doPrint: Boolean = false, label: String = "test") = {
     val featureEncoder = SimpleFeatureEncoderFactory.defaultEncoder
     // create the schema, and require de-duplication
     val schema = IndexSchema(TestData.schemaEncoding, TestData.featureType, featureEncoder)
 
     // fetch results from the schema!
-    val itr = schema.query(q, bs)
+    val itr = schema.query(q, ds)
 
     // print out the hits
     val retval = if (doPrint) {

--- a/geomesa-core/src/test/scala/geomesa/core/iterators/TestData.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/TestData.scala
@@ -55,7 +55,11 @@ object TestData extends Logging {
 
   def createSF(e: Entry): SimpleFeature = {
     val geometry: Geometry = WKTUtils.read(e.wkt)
-    val entry = SimpleFeatureBuilder.build(featureType, List(null, null, null, null, geometry, e.dt.toDate, e.dt.toDate), s"|data|${e.id}")
+    val entry =
+      AvroSimpleFeatureFactory.buildAvroFeature(
+        featureType,
+        List(null, null, null, null, geometry, e.dt.toDate, e.dt.toDate),
+        s"|data|${e.id}")
     entry.setAttribute("attr2", "2nd" + e.id)
     entry
   }

--- a/geomesa-plugin/src/main/scala/geomesa/plugin/ui/GeoMesaDataStoresPage.scala
+++ b/geomesa-plugin/src/main/scala/geomesa/plugin/ui/GeoMesaDataStoresPage.scala
@@ -79,8 +79,8 @@ class GeoMesaDataStoresPage extends GeoMesaBasePage {
   dataStores.foreach {
     d =>
       val id = d.toString
-      dataStoreNames.put(id, s"${d.connector.getInstance.getInstanceName}: ${d.tableName}")
-      val table = d.tableName
+      dataStoreNames.put(id, s"${d.connector.getInstance.getInstanceName}: ${d.catalogTable}")
+      val table = d.catalogTable
       tables.put(id, table)
       metadata.put(id, getTableMetadata(d.connector, table))
       val typeNames = d.getTypeNames.toList

--- a/geomesa-plugin/src/test/resources/wps/import/test.xml
+++ b/geomesa-plugin/src/test/resources/wps/import/test.xml
@@ -63,6 +63,12 @@
                 <wps:LiteralData>LAYER_NAME_HERE</wps:LiteralData>
             </wps:Data>
         </wps:Input>
+        <wps:Input>
+            <ows:Identifier>numShards</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>8</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
     </wps:DataInputs>
     <wps:ResponseForm>
         <wps:RawDataOutput>


### PR DESCRIPTION
- Table layout consists of a catalog table to store metadata and three tables
  per simple feature type (spatiotemporal index, attribute index, record table)
- Queries consisting of only isEqualTo and LIKE with trailing wildcard are satisfied
  by the attribute index (an inverted text index)
- Backward compatibility is maintined with Old-style 0.10.x spatiotemporal index tables
  containing embedded simple feature type metadata
- The number of shards is now configurable per simple feature type
- SpatioTemporal Index, Attribute Index, and Record Tables are all presplit
- Bug fixed in imports in FeatureEncoder
- Implementing AttributeIndexFilteringIterator as a subclass of Filter
