### PR TITLE
GEOMESA-203 Upgrade joda-time to version 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,12 +99,12 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.1</version>
+                <version>2.3</version>
             </dependency>
             <dependency>
                 <groupId>org.joda</groupId>
                 <artifactId>joda-convert</artifactId>
-                <version>1.2</version>
+                <version>1.6</version>
             </dependency>
             <dependency>
                 <groupId>com.vividsolutions</groupId>


### PR DESCRIPTION
This is to streamline the IP review by the Eclipse Foundation.
