### PR TITLE
GEOMESA-208 getSchema(featureTypeName) should return NULL when the featu...

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStore.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStore.scala
@@ -655,16 +655,21 @@ class AccumuloDataStore(val connector: Connector,
    * Implementation of abstract method
    *
    * @param featureName
-   * @return
+   * @return the corresponding feature type (schema) for this feature name,
+   *         or NULL if this feature name does not appear to exist
    */
-  override def getSchema(featureName: String): SimpleFeatureType = {
-    val sft = DataUtilities.createType(featureName, getAttributes(featureName))
-    val dtgField = readMetadataItem(featureName, DTGFIELD_CF)
-                   .getOrElse(core.DEFAULT_DTG_PROPERTY_NAME)
-    sft.getUserData.put(core.index.SF_PROPERTY_START_TIME, dtgField)
-    sft.getUserData.put(core.index.SF_PROPERTY_END_TIME, dtgField)
-    sft
-  }
+  override def getSchema(featureName: String): SimpleFeatureType =
+    getAttributes(featureName) match {
+      case attributes if attributes.isEmpty =>
+        null
+      case attributes                       =>
+        val sft = DataUtilities.createType(featureName, attributes)
+        val dtgField = readMetadataItem(featureName, DTGFIELD_CF)
+          .getOrElse(core.DEFAULT_DTG_PROPERTY_NAME)
+        sft.getUserData.put(core.index.SF_PROPERTY_START_TIME, dtgField)
+        sft.getUserData.put(core.index.SF_PROPERTY_END_TIME, dtgField)
+        sft
+    }
 
   // Implementation of Abstract method
   def getFeatureReader(featureName: String): AccumuloFeatureReader = getFeatureReader(featureName,

--- a/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
@@ -91,6 +91,24 @@ class AccumuloDataStoreTest extends Specification {
   }
 
   "AccumuloDataStore" should {
+    "return non-NULL when a feature name does exist" in {
+      val ds = createStore
+      val sftName = "testTypeThatDoesExist"
+      val sft = DataUtilities.createType(sftName,
+        s"NAME:String,$geotimeAttributes")
+      sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
+      ds.createSchema(sft)
+      ds.getSchema(sftName) must not be null
+    }
+
+    "return NULL when a feature name does not exist" in {
+      val ds = createStore
+      val sftName = "testTypeThatDoesNotExist"
+      ds.getSchema(sftName) must beNull
+    }
+  }
+
+  "AccumuloDataStore" should {
     "provide ability to write using the feature source and read what it wrote" in {
       // create the data store
       val ds = createStore


### PR DESCRIPTION
...re type name does not exist

Iff the feature type cannot be found by name -- here defined as whether
the attributes list can be fetched -- then the `getSchema` call should
return null.  This commit adds a pair of unit tests.
