### PR TITLE
GEOMESA-107 keeping query stats

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStore.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/data/AccumuloDataStore.scala
@@ -838,7 +838,6 @@ class AccumuloDataStore(val connector: Connector,
    * @return
    */
   private def getFeatureName(featureType: SimpleFeatureType) = featureType.getName.getLocalPart
-
 }
 
 object AccumuloDataStore {
@@ -867,8 +866,16 @@ object AccumuloDataStore {
    * UTF8 characters (e.g. _2a_f3_8c) to make them safe for accumulo table names
    * but still human readable.
    */
-  def formatTableName(catalogTable: String, featureType: SimpleFeatureType, suffix: String) = {
-    val typeName = featureType.getTypeName
+  def formatTableName(catalogTable: String, featureType: SimpleFeatureType, suffix: String): String =
+    formatTableName(catalogTable, featureType.getTypeName, suffix)
+
+  /**
+   * Format a table name with a namespace. Non alpha-numeric characters present in
+   * featureType names will be underscore hex encoded (e.g. _2a) including multibyte
+   * UTF8 characters (e.g. _2a_f3_8c) to make them safe for accumulo table names
+   * but still human readable.
+   */
+  def formatTableName(catalogTable: String, typeName: String, suffix: String): String = {
     val safeTypeName: String =
       if(typeName.matches(SAFE_FEATURE_NAME_PATTERN)){
         typeName

--- a/geomesa-core/src/main/scala/geomesa/core/stats/MethodProfiling.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/stats/MethodProfiling.scala
@@ -1,0 +1,26 @@
+/*
+ *
+ *  Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the License);
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an AS IS BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package geomesa.core.stats
+
+trait MethodProfiling {
+
+  import System.{currentTimeMillis => ctm}
+
+  def profile[R](code: => R, startTime: Long = ctm) = (code, ctm - startTime)
+}

--- a/geomesa-core/src/main/scala/geomesa/core/stats/QueryStat.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/stats/QueryStat.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.core.stats
+
+import java.util.Map.Entry
+
+import geomesa.core.data._
+import geomesa.core.index.QueryHints._
+import org.apache.accumulo.core.data.{Key, Mutation, Value}
+import org.geotools.factory.Hints
+import org.opengis.filter.Filter
+
+/**
+ * Class for capturing query-related stats
+ */
+case class QueryStat(catalogTable:  String,
+                     featureName:   String,
+                     date:          Long,
+                     queryFilter:   String,
+                     queryHints:    String,
+                     planningTime:  Long,
+                     scanTime:      Long,
+                     numResults:    Int) extends Stat
+
+/**
+ * Maps query stats to accumulo
+ */
+object QueryStatTransform extends StatTransform[QueryStat] {
+
+  private val CQ_QUERY_FILTER = "queryFilter"
+  private val CQ_QUERY_HINTS = "queryHints"
+  private val CQ_PLANTIME = "timePlanning"
+  private val CQ_SCANTIME = "timeScanning"
+  private val CQ_TIME = "timeTotal"
+  private val CQ_HITS = "hits"
+
+  protected val getStatTableSuffix = "queries"
+
+  override def statToMutation(stat: QueryStat): Mutation = {
+    val mutation = createMutation(stat)
+    val cf = createRandomColumnFamily
+    mutation.put(cf, CQ_QUERY_FILTER, stat.queryFilter)
+    mutation.put(cf, CQ_QUERY_HINTS, stat.queryHints)
+    mutation.put(cf, CQ_PLANTIME, stat.planningTime + "ms")
+    mutation.put(cf, CQ_SCANTIME, stat.scanTime + "ms")
+    mutation.put(cf, CQ_TIME, (stat.scanTime + stat.planningTime) + "ms")
+    mutation.put(cf, CQ_HITS, stat.numResults.toString)
+    mutation
+  }
+
+  override def rowToStat(entries: Iterable[Entry[Key, Value]]): QueryStat = {
+    if (entries.isEmpty) {
+      return null
+    }
+
+    val date = StatTransform.dateFormat.parseMillis(entries.head.getKey.getRow.toString)
+    val values = collection.mutable.Map.empty[String, Any]
+
+    entries.foreach { e =>
+      e.getKey.getColumnQualifier.toString match {
+        case CQ_QUERY_FILTER => values.put(CQ_QUERY_FILTER, e.getValue.toString)
+        case CQ_QUERY_HINTS => values.put(CQ_QUERY_HINTS, e.getValue.toString)
+        case CQ_PLANTIME => values.put(CQ_PLANTIME, e.getValue.toString.stripSuffix("ms").toLong)
+        case CQ_SCANTIME => values.put(CQ_SCANTIME, e.getValue.toString.stripSuffix("ms").toLong)
+        case CQ_HITS => values.put(CQ_HITS, e.getValue.toString.toInt)
+        case CQ_TIME => // time is an aggregate, doesn't need to map back to anything
+        case _ => logger.warn(s"Unmapped entry in query stat: ${e.getKey.getColumnQualifier.toString}")
+      }
+    }
+
+    val queryHints = values.getOrElse(CQ_QUERY_HINTS, "").asInstanceOf[String]
+    val queryFilter = values.getOrElse(CQ_QUERY_FILTER, "").asInstanceOf[String]
+    val planTime = values.getOrElse(CQ_PLANTIME, 0L).asInstanceOf[Long]
+    val scanTime = values.getOrElse(CQ_SCANTIME, 0L).asInstanceOf[Long]
+    val hits = values.getOrElse(CQ_HITS, 0).asInstanceOf[Int]
+
+    // TODO do we care about table/schema? they would have to be known to query anything and get this far...
+    QueryStat(null, null, date, queryFilter, queryHints, planTime, scanTime, hits)
+  }
+
+  /**
+   * Converts a filter object to a string for persisting
+   *
+   * @param filter
+   * @return
+   */
+  def filterToString(filter: Filter): String = filter.toString
+
+  // list of query hints we want to persist
+  val QUERY_HINTS = List[Hints.Key](TRANSFORMS,
+                                    TRANSFORM_SCHEMA,
+                                    DENSITY_KEY,
+                                    BBOX_KEY,
+                                    WIDTH_KEY,
+                                    HEIGHT_KEY)
+
+  /**
+   * Converts a query hints object to a string for persisting
+   *
+   * @param hints
+   * @return
+   */
+  def hintsToString(hints: Hints): String =
+    QUERY_HINTS.flatMap { key =>
+      Option(hints.get(key)).map(v => s"${getString(key)}=${hints.get(key)}")
+    }.sorted.mkString(",")
+
+  /**
+   * Maps a query hint to a string. We need this since the classes themselves don't really have a
+   * decent toString representation.
+   *
+   * @param key
+   * @return
+   */
+  private def getString(key: Hints.Key) =
+    key match {
+      case TRANSFORMS => "TRANSFORMS"
+      case TRANSFORM_SCHEMA => "TRANSFORM_SCHEMA"
+      case DENSITY_KEY => "DENSITY_KEY"
+      case BBOX_KEY => "BBOX_KEY"
+      case WIDTH_KEY => "WIDTH_KEY"
+      case HEIGHT_KEY => "HEIGHT_KEY"
+      case _ => "unknown_hint"
+    }
+}

--- a/geomesa-core/src/main/scala/geomesa/core/stats/Stat.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/stats/Stat.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.core.stats
+
+import java.util.Map.Entry
+
+import com.typesafe.scalalogging.slf4j.Logging
+import geomesa.core.data.AccumuloDataStore
+import geomesa.core.util.{CloseableIterator, SelfClosingIterator}
+import org.apache.accumulo.core.client.Scanner
+import org.apache.accumulo.core.data.{Key, Mutation, Value}
+import org.joda.time.format.DateTimeFormat
+
+import scala.util.Random
+
+/**
+ * Base trait for all stat types
+ */
+trait Stat {
+  def catalogTable: String
+  def featureName: String
+  def date: Long
+}
+
+/**
+ * Trait for mapping stats to accumulo and back
+ */
+trait StatTransform[S <: Stat] extends Logging {
+
+  protected def createMutation(stat: Stat) = new Mutation(StatTransform.dateFormat.print(stat.date))
+
+  protected def createRandomColumnFamily = Random.nextInt(9999).formatted("%1$04d")
+
+  protected def getStatTableSuffix: String
+
+  /**
+   * Convert a stat to a mutation
+   *
+   * @param stat
+   * @return
+   */
+  def statToMutation(stat: S): Mutation
+
+  /**
+   * Convert accumulo scan results into a stat
+   *
+   * @param entries
+   * @return
+   */
+  def rowToStat(entries: Iterable[Entry[Key, Value]]): S
+
+  /**
+   * Gets the table used for a particular stat
+   *
+   * @param catalogTable
+   * @param featureName
+   * @return
+   */
+  def getStatTable(catalogTable: String, featureName: String): String =
+    AccumuloDataStore.formatTableName(catalogTable, featureName, getStatTableSuffix)
+
+  /**
+   * Creates an iterator that returns Stats from accumulo scans
+   *
+   * @param scanner
+   * @return
+   */
+  def iterator(scanner: Scanner): CloseableIterator[S] = {
+    val iter = scanner.iterator()
+
+    val wrappedIter = new CloseableIterator[S] {
+
+      var last: Option[Entry[Key, Value]] = None
+
+      override def close() = scanner.close()
+
+      override def next() = {
+        // get the data for the stat entry, which consists of a several CQ/values
+        val entries = collection.mutable.ListBuffer.empty[Entry[Key, Value]]
+        if (last.isEmpty) {
+          last = Some(iter.next())
+        }
+        val lastRowKey = last.get.getKey.getRow.toString
+        var next: Option[Entry[Key, Value]] = last
+        while (next.isDefined && next.get.getKey.getRow.toString == lastRowKey) {
+          entries.append(next.get)
+          next = if (iter.hasNext) Some(iter.next()) else None
+        }
+        last = next
+        // use the row data to return a Stat
+        rowToStat(entries)
+      }
+
+      override def hasNext = last.isDefined || iter.hasNext
+    }
+    SelfClosingIterator(wrappedIter)
+  }
+}
+
+object StatTransform {
+  val dateFormat = DateTimeFormat.forPattern("yyyyMMdd-HH:mm:ss.SSS").withZoneUTC()
+}

--- a/geomesa-core/src/main/scala/geomesa/core/stats/StatReader.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/stats/StatReader.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.core.stats
+
+import java.util.Date
+
+import org.apache.accumulo.core.client.{Connector, Scanner}
+import org.apache.accumulo.core.data.{Range => AccRange}
+import org.apache.accumulo.core.security.Authorizations
+
+/**
+ * Abstract class for querying stats
+ *
+ * @param connector
+ * @param catalogTable
+ * @tparam S
+ */
+abstract class StatReader[S <: Stat](connector: Connector, catalogTable: String) {
+
+  protected def statTransform: StatTransform[S]
+
+  /**
+   * Main query method based on date range. Subclasses can add additional query capability (on
+   * attributes, for instance).
+   *
+   * @param featureName
+   * @param start
+   * @param end
+   * @param authorizations
+   * @return
+   */
+  def query(featureName: String, start: Date, end: Date, authorizations: Authorizations): Iterator[S] = {
+    val table = statTransform.getStatTable(catalogTable, featureName)
+
+    val scanner = connector.createScanner(table, authorizations)
+    val rangeStart = StatTransform.dateFormat.print(start.getTime)
+    val rangeEnd = StatTransform.dateFormat.print(end.getTime)
+    scanner.setRange(new AccRange(rangeStart, rangeEnd))
+
+    configureScanner(scanner)
+
+    statTransform.iterator(scanner)
+  }
+
+  /**
+   * Can be implemented by subclasses to configure scans beyond a simple date range
+   *
+   * @param scanner
+   */
+  protected def configureScanner(scanner: Scanner)
+}
+
+/**
+ * Class for querying query stats
+ *
+ * @param connector
+ * @param catalogTable
+ */
+class QueryStatReader(connector: Connector, catalogTable: String)
+    extends StatReader[QueryStat](connector, catalogTable) {
+
+  override protected val statTransform = QueryStatTransform
+
+  override protected def configureScanner(scanner: Scanner) = {}
+}

--- a/geomesa-core/src/main/scala/geomesa/core/stats/StatWriter.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/stats/StatWriter.scala
@@ -1,0 +1,156 @@
+/*
+ *
+ *  Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the License);
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an AS IS BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package geomesa.core.stats
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{ScheduledThreadPoolExecutor, TimeUnit}
+
+import com.google.common.collect.Queues
+import com.google.common.util.concurrent.MoreExecutors
+import com.typesafe.scalalogging.slf4j.Logging
+import org.apache.accumulo.core.client.admin.TimeType
+import org.apache.accumulo.core.client.mock.MockConnector
+import org.apache.accumulo.core.client.{BatchWriterConfig, Connector}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+trait StatWriter {
+
+  def connector: Connector
+
+  // start the background thread now that we have a connector to use
+  StatWriter.startIfNeeded(connector)
+
+  /**
+   * Writes a stat to accumulo. This implementation adds the stat to a bounded queue, which should
+   * be fast, then asynchronously writes the data in the background.
+   *
+   * @param stat
+   */
+  def writeStat(stat: Stat): Unit = StatWriter.queueStat(stat)
+}
+
+/**
+ * Singleton object to manage writing of stats in a background thread.
+ */
+object StatWriter extends Runnable with Logging {
+
+  private val batchSize = 100
+
+  private val writeDelayMillis = 1000
+
+  private val batchWriterConfig = new BatchWriterConfig().setMaxMemory(10000L).setMaxWriteThreads(5)
+
+  // use the guava exiting executor so that this thread doesn't hold up the jvm shutdown
+  private val executor = MoreExecutors.getExitingScheduledExecutorService(new ScheduledThreadPoolExecutor(1))
+
+  private val running = new AtomicBoolean(false)
+
+  private val queue = Queues.newLinkedBlockingQueue[Stat](batchSize)
+
+  private val tableCache = new mutable.HashMap[String, Boolean] with mutable.SynchronizedMap[String, Boolean]
+
+  private var connector: Connector = null
+
+  sys.addShutdownHook {
+    executor.shutdownNow()
+  }
+
+  /**
+   * Starts the background thread for writing stats, if it hasn't already been started
+   *
+   * @param connector
+   */
+  private def startIfNeeded(connector: Connector) {
+    if (running.compareAndSet(false, true)) {
+      this.connector = connector
+      if(!connector.isInstanceOf[MockConnector]) {
+        // we want to wait between invocations to give more stats a chance to queue up
+        executor.scheduleWithFixedDelay(this, writeDelayMillis, writeDelayMillis, TimeUnit.MILLISECONDS)
+      }
+    }
+  }
+
+  /**
+   * Queues a stat for writing. We don't want to affect memory and accumulo performance too much...
+   * if we exceed the queue size, we drop any further stats
+   *
+   * @param stat
+   */
+  private def queueStat(stat: Stat): Unit = {
+    if (!queue.offer(stat)) {
+      logger.debug("Stat queue is full - stat being dropped")
+    }
+  }
+
+  /**
+   * Writes the stats.
+   *
+   * @param stats
+   * @param connector
+   */
+  def write(stats: Iterable[Stat], connector: Connector): Unit = {
+    stats.groupBy(s => s.getClass).foreach { case (clas, clasIter) =>
+      // get the appropriate transform for this type of stat
+      val transform = clas match {
+        case c if c == classOf[QueryStat] => QueryStatTransform.asInstanceOf[StatTransform[Stat]]
+        case _ => throw new RuntimeException("Not implemented")
+      }
+      // group stats by catalog and feature name
+      clasIter.groupBy(s => (s.catalogTable, s.featureName)).foreach { case ((catalogTable, featureName), iter) =>
+        val table = transform.getStatTable(catalogTable, featureName)
+        checkTable(table, connector)
+        val writer = connector.createBatchWriter(table, batchWriterConfig)
+        val mutations = iter.map(s => transform.statToMutation(s))
+        writer.addMutations(mutations.asJava)
+        writer.flush()
+        writer.close()
+      }
+    }
+  }
+
+  /**
+   * Create the stats table if it doesn't exist
+   * @param table
+   * @return
+   */
+  private def checkTable(table: String, connector: Connector) =
+    tableCache.getOrElseUpdate(table, {
+      val tableOps = connector.tableOperations()
+      if (!tableOps.exists(table)) {
+        tableOps.create(table, true, TimeType.LOGICAL)
+      }
+      true
+    })
+
+  override def run() = {
+    try {
+      // wait for a stat to be queued
+      val head = queue.take()
+      // drain out any other stats that have been queued while sleeping
+      val stats = collection.mutable.ListBuffer(head)
+      queue.drainTo(stats.asJava)
+      write(stats, connector)
+    } catch {
+      case e: InterruptedException => // thread has been terminated
+      case e: Exception => logger.error("Error in stat writing thread:", e)
+    }
+  }
+}

--- a/geomesa-core/src/test/resources/logback-test.xml
+++ b/geomesa-core/src/test/resources/logback-test.xml
@@ -35,6 +35,9 @@
         <appender-ref ref="FILE" />
     </root>
 
+    <logger name="org.apache.zookeeper" level="warn"/>
+    <logger name="hsqldb.db" level="warn"/>
+
     <!-- un-comment the following line to enable verbose log messages
          from the index query-planner; this can be helpful in debugging
          query plans -->

--- a/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/data/AccumuloDataStoreTest.scala
@@ -19,6 +19,7 @@ package geomesa.core.data
 import com.vividsolutions.jts.geom.Coordinate
 import geomesa.core.index.{IndexSchemaBuilder, SF_PROPERTY_START_TIME}
 import geomesa.core.security.{AuthorizationsProvider, DefaultAuthorizationsProvider, FilteringAuthorizationsProvider}
+import geomesa.core.util.CloseableIterator
 import geomesa.feature.AvroSimpleFeatureFactory
 import geomesa.utils.geotools.SimpleFeatureTypes
 import geomesa.utils.text.WKTUtils
@@ -520,7 +521,7 @@ class AccumuloDataStoreTest extends Specification {
       "query indexed attribute" >> {
         val q1 = ff.equals(ff.property("name"), ff.literal("one"))
         val fr = ds.getFeatureReader(sftName, new Query(sftName, q1))
-        val results = fr.iter.toList
+        val results = CloseableIterator(fr).toList
         results must haveLength(1)
         results.head.getAttribute("name") mustEqual "one"
       }
@@ -528,7 +529,7 @@ class AccumuloDataStoreTest extends Specification {
       "query non-indexed attributes" >> {
         val q2 = ff.equals(ff.property("numattr"), ff.literal(2))
         val fr = ds.getFeatureReader(sftName, new Query(sftName, q2))
-        val results = fr.iter.toList
+        val results = CloseableIterator(fr).toList
         results must haveLength(1)
         results.head.getAttribute("numattr") mustEqual 2
       }

--- a/geomesa-core/src/test/scala/geomesa/core/stats/LiveStatReaderTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/stats/LiveStatReaderTest.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.core.stats
+
+import java.util.Date
+
+import org.apache.accumulo.core.client.ZooKeeperInstance
+import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.security.Authorizations
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class LiveStatReaderTest extends Specification {
+
+  sequential
+
+  lazy val connector = new ZooKeeperInstance("mycloud", "zoo1,zoo2,zoo3")
+                         .getConnector("root", new PasswordToken("password"))
+
+  val table = "geomesa_catalog"
+  val feature = "twitter"
+
+  "StatReader" should {
+
+    "query accumulo" in {
+
+      skipped("Meant for integration")
+
+      val reader = new QueryStatReader(connector, table)
+
+      val results = reader.query(feature, new Date(0), new Date(), new Authorizations())
+
+      results.foreach(println)
+
+      success
+    }
+  }
+
+}

--- a/geomesa-core/src/test/scala/geomesa/core/stats/QueryStatTransformTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/stats/QueryStatTransformTest.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.core.stats
+
+import geomesa.core.index.QueryHints
+import org.apache.accumulo.core.client.BatchWriterConfig
+import org.apache.accumulo.core.client.mock.MockInstance
+import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.security.Authorizations
+import org.geotools.data.Query
+import org.geotools.filter.text.cql2.CQL
+import org.joda.time.format.DateTimeFormat
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConverters._
+
+@RunWith(classOf[JUnitRunner])
+class QueryStatTransformTest extends Specification {
+
+  val df = DateTimeFormat.forPattern("yyyy.MM.dd HH:mm:ss")
+
+  val table = "QueryStatTransformTest"
+  val featureName = "stat-writer-test"
+
+  val connector = new MockInstance().getConnector("user", new PasswordToken("password"))
+  connector.tableOperations().create(table)
+
+  "QueryStatTransform" should {
+
+    "convert query stats to and from accumulo" in {
+
+      // currently we don't restore table and feature in the query stat - thus setting them null here
+      val stat = QueryStat(null, null, 500L, "attr=1", "hint1=true", 101L, 201L, 11)
+
+      val writer = connector.createBatchWriter(table, new BatchWriterConfig())
+
+      writer.addMutation(QueryStatTransform.statToMutation(stat))
+      writer.flush()
+      writer.close()
+
+      val scanner = connector.createScanner(table, new Authorizations())
+
+      val converted = QueryStatTransform.rowToStat(scanner.iterator().asScala.toList)
+
+      converted mustEqual stat
+    }
+
+    "convert hints to readable string" in {
+
+      val query = new Query("test", CQL.toFilter("INCLUDE"))
+      query.getHints.put(QueryHints.DENSITY_KEY, java.lang.Boolean.TRUE)
+      query.getHints.put(QueryHints.WIDTH_KEY, 500)
+      query.getHints.put(QueryHints.HEIGHT_KEY, 500)
+
+      val hints = QueryStatTransform.hintsToString(query.getHints)
+
+      hints must contain("DENSITY_KEY=true")
+      hints must contain("WIDTH_KEY=500")
+      hints must contain("HEIGHT_KEY=500")
+    }
+  }
+}

--- a/geomesa-core/src/test/scala/geomesa/core/stats/StatReaderTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/stats/StatReaderTest.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.core.stats
+
+import java.util.Date
+
+import org.apache.accumulo.core.client.mock.MockInstance
+import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.security.Authorizations
+import org.joda.time.format.DateTimeFormat
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class StatReaderTest extends Specification {
+
+  val df = DateTimeFormat.forPattern("yyyy.MM.dd HH:mm:ss")
+
+  val catalogTable = "geomesa_catalog"
+  val featureName = "stat-reader-test"
+
+  val auths = new Authorizations()
+
+  "QueryStatReader" should {
+
+    val writer = new MockStatWriter
+
+    writer.writeStat(QueryStat(catalogTable,
+                                featureName,
+                                df.parseMillis("2014.07.26 13:20:01"),
+                                "query1",
+                                "hint1=true",
+                                101L,
+                                201L,
+                                11))
+    writer.writeStat(QueryStat(catalogTable,
+                                featureName,
+                                df.parseMillis("2014.07.26 14:20:01"),
+                                "query2",
+                                "hint2=true",
+                                102L,
+                                202L,
+                                12))
+    writer.writeStat(QueryStat(catalogTable,
+                                featureName,
+                                df.parseMillis("2014.07.27 13:20:01"),
+                                "query3",
+                                "hint3=true",
+                                102L,
+                                202L,
+                                12))
+
+    val reader = new QueryStatReader(writer.connector, catalogTable)
+
+    "query all stats in order" in {
+      val queries = reader.query(featureName, new Date(0), new Date(), auths)
+
+      queries must not beNull
+
+      val list = queries.toList
+
+      list.size mustEqual 3
+      list(0).queryFilter mustEqual "query1"
+      list(1).queryFilter mustEqual "query2"
+      list(2).queryFilter mustEqual "query3"
+    }
+
+    "query by day" in {
+      val queries = reader.query(featureName,
+                                  df.parseDateTime("2014.07.26 00:00:00").toDate,
+                                  df.parseDateTime("2014.07.26 23:59:59").toDate,
+                                  auths)
+
+      queries must not beNull
+
+      val list = queries.toList
+
+      list.size mustEqual 2
+      list(0).queryFilter mustEqual "query1"
+      list(1).queryFilter mustEqual "query2"
+    }
+
+    "query by hour" in {
+      val queries = reader.query(featureName,
+                                  df.parseDateTime("2014.07.26 13:00:00").toDate,
+                                  df.parseDateTime("2014.07.26 13:59:59").toDate,
+                                  auths)
+
+      queries must not beNull
+
+      val list = queries.toList
+
+      list.size mustEqual 1
+      list(0).queryFilter mustEqual "query1"
+    }
+
+  }
+
+}
+
+class MockStatWriter extends StatWriter {
+  val connector = new MockInstance().getConnector("user", new PasswordToken("password"))
+  override def writeStat(stat: Stat): Unit = StatWriter.write(List(stat), connector)
+}

--- a/geomesa-core/src/test/scala/geomesa/core/stats/StatWriterTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/stats/StatWriterTest.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.core.stats
+
+import java.util.Date
+
+import org.apache.accumulo.core.client.mock.MockInstance
+import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.client.{Connector, TableNotFoundException}
+import org.apache.accumulo.core.security.Authorizations
+import org.joda.time.format.DateTimeFormat
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class StatWriterTest extends Specification {
+
+  val df = DateTimeFormat.forPattern("yyyy.MM.dd HH:mm:ss")
+
+  val catalogTable = "geomesa_catalog"
+  val featureName = "stat-writer-test"
+
+  val auths = new Authorizations()
+
+  val connector = new MockInstance().getConnector("user", new PasswordToken("password"))
+
+  // mock class we can extend with statwriter
+  class MockWriter(c: Connector) {
+    val connector = c
+  }
+
+  val statReader = new QueryStatReader(connector, catalogTable)
+
+  "StatWriter" should {
+
+    "write query stats asynchronously" in {
+      val writer = new MockWriter(connector) with StatWriter
+
+      writer.writeStat(QueryStat(catalogTable,
+                                  featureName,
+                                  df.parseMillis("2014.07.26 13:20:01"),
+                                  "query1",
+                                  "hint1=true",
+                                  101L,
+                                  201L,
+                                  11))
+      writer.writeStat(QueryStat(catalogTable,
+                                  featureName,
+                                  df.parseMillis("2014.07.26 14:20:01"),
+                                  "query2",
+                                  "hint2=true",
+                                  102L,
+                                  202L,
+                                  12))
+      writer.writeStat(QueryStat(catalogTable,
+                                  featureName,
+                                  df.parseMillis("2014.07.27 13:20:01"),
+                                  "query3",
+                                  "hint3=true",
+                                  102L,
+                                  202L,
+                                  12))
+
+      try {
+        val unwritten = statReader.query(featureName, new Date(0), new Date(), auths).toList
+        unwritten must not beNull;
+        unwritten.size mustEqual 0
+      } catch {
+        case e: TableNotFoundException => // table doesn't exist yet, since no stats are written
+      }
+
+      // this should write the queued stats
+      StatWriter.run()
+
+      val written = statReader.query(featureName, new Date(0), new Date(), auths).toList
+
+      written must not beNull;
+      written.size mustEqual 3
+    }
+  }
+}


### PR DESCRIPTION
Adding an option to the data store config (default true) to collect query stats. Added instrumentation into the AccumuloFeatureReader.
The persisting of stats is done in an asynchronous background thread - not all stats are guaranteed to be written, but in exchange it consumes less resources.
The initial instrumentation is fairly light, as I didn't want to pollute the code too much. Considered using aspects, but it seemed like overkill at the moment - plus a lot of the underlying methods we'd be intercepting are undergoing change.
