### PR TITLE
GEOMESA-192 Enabling BatchMultiScanner (1.4.x version)

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/util/BatchMultiScanner.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/util/BatchMultiScanner.scala
@@ -16,7 +16,7 @@
 
 package geomesa.core.util
 
-import java.util.concurrent.Executors
+import java.util.concurrent.{TimeUnit, Executors}
 import java.util.concurrent.atomic.AtomicBoolean
 
 import com.google.common.collect.Queues
@@ -26,17 +26,22 @@ import org.apache.accumulo.core.data.{Key, Value, Range => AccRange}
 
 import scala.collection.JavaConversions._
 
-// Unused for now.
 class BatchMultiScanner(in: Scanner,
                         out: BatchScanner,
-                        joinFn: java.util.Map.Entry[Key, Value] => AccRange)
-  extends Iterable[java.util.Map.Entry[Key, Value]] with Logging {
+                        joinFn: java.util.Map.Entry[Key, Value] => AccRange,
+                        batchSize: Int = 32768)
+  extends Iterable[java.util.Map.Entry[Key, Value]] with AutoCloseable with Logging {
 
-  type E = java.util.Map.Entry[Key, Value]
+  if(batchSize < 1) {
+    throw new IllegalArgumentException(f"Illegal batchSize($batchSize%d). Value must be > 0")
+  }
+  logger.trace(f"Creating BatchMultiScanner with batchSize $batchSize%d")
+
+  type KVEntry = java.util.Map.Entry[Key, Value]
   val inExecutor  = Executors.newSingleThreadExecutor()
   val outExecutor = Executors.newSingleThreadExecutor()
-  val inQ  = Queues.newLinkedBlockingQueue[E](32768)
-  val outQ = Queues.newArrayBlockingQueue[E](32768)
+  val inQ  = Queues.newLinkedBlockingQueue[KVEntry](batchSize)
+  val outQ = Queues.newArrayBlockingQueue[KVEntry](batchSize)
   val inDone  = new AtomicBoolean(false)
   val outDone = new AtomicBoolean(false)
 
@@ -50,24 +55,21 @@ class BatchMultiScanner(in: Scanner,
     }
   })
 
-  def moreInQ = !(inDone.get && inQ.isEmpty)
+  def mightHaveAnother = !inDone.get || !inQ.isEmpty
 
   outExecutor.submit(new Runnable {
     override def run(): Unit = {
       try {
-        while(moreInQ) {
-          val entry = inQ.take()
-          if(entry != null) {
-            val entries = new collection.mutable.ListBuffer[E]()
-            val count = inQ.drainTo(entries)
-            if (count > 0) {
-              val ranges = (List(entry) ++ entries).map(joinFn)
-              out.setRanges(ranges)
-              out.iterator().foreach(e => outQ.put(e))
-            }
+        while (mightHaveAnother) {
+          val entry = inQ.poll(5, TimeUnit.MILLISECONDS)
+          if (entry != null) {
+            val entries = new collection.mutable.ListBuffer[KVEntry]()
+            inQ.drainTo(entries)
+            val ranges = (List(entry) ++ entries).map(joinFn)
+            out.setRanges(ranges)
+            out.iterator().foreach(outQ.put)
           }
         }
-        outDone.set(true)
       } catch {
         case _: InterruptedException =>
       } finally {
@@ -76,16 +78,43 @@ class BatchMultiScanner(in: Scanner,
     }
   })
 
-  override def iterator: Iterator[java.util.Map.Entry[Key, Value]] = new Iterator[E] {
-    override def hasNext: Boolean = {
-      val ret = !(outQ.isEmpty && inDone.get() && outDone.get())
-      if(!ret) {
-        inExecutor.shutdownNow()
-        outExecutor.shutdownNow()
+  override def close() {
+    if (!inExecutor.isShutdown) inExecutor.shutdownNow()
+    if (!outExecutor.isShutdown) outExecutor.shutdownNow()
+    in.clearScanIterators()
+    out.close()
+  }
+
+  override def iterator: Iterator[KVEntry] = new Iterator[KVEntry] {
+
+    var prefetch: KVEntry = null
+
+    // Indicate there MAY be one more in the outQ but not for sure
+    def mightHaveAnother = !outDone.get || !outQ.isEmpty
+
+    def prefetchIfNull() = {
+      if (prefetch == null) {
+        // loop while we might have another and we haven't set prefetch
+        while (mightHaveAnother && prefetch == null) {
+          prefetch = outQ.poll
+        }
       }
-      ret
     }
 
-    override def next(): E = outQ.take()
+    // must attempt a prefetch since we don't know whether or not the outQ
+    // will actually be filled with an item (filters may not match and the
+    // in scanner may never return a range)
+    override def hasNext(): Boolean = {
+      prefetchIfNull()
+      prefetch != null
+    }
+
+    override def next(): KVEntry = {
+      prefetchIfNull()
+
+      val ret = prefetch
+      prefetch = null
+      ret
+    }
   }
 }

--- a/geomesa-core/src/test/scala/geomesa/core/util/BatchMultiScannerTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/util/BatchMultiScannerTest.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.core.util
+
+import java.nio.charset.StandardCharsets
+import java.text.SimpleDateFormat
+import java.util.TimeZone
+
+import geomesa.core.data._
+import geomesa.core.index.IndexSchema
+import geomesa.utils.geotools.SimpleFeatureTypes
+import geomesa.utils.text.WKTUtils
+import org.apache.accumulo.core.client.mock.MockInstance
+import org.apache.accumulo.core.data.{Key, Value, Range => ARange}
+import org.apache.accumulo.core.security.Authorizations
+import org.apache.hadoop.io.Text
+import org.geotools.data.DataStoreFinder
+import org.geotools.factory.Hints
+import org.geotools.feature.DefaultFeatureCollection
+import org.geotools.feature.simple.SimpleFeatureBuilder
+import org.joda.time.{DateTime, DateTimeZone}
+import org.junit.runner.RunWith
+import org.opengis.feature.simple.SimpleFeature
+import org.specs2.execute.Success
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class BatchMultiScannerTest extends Specification {
+
+  val sftName = "bmstest"
+  val sft = SimpleFeatureTypes.createType(sftName, s"name:String:index=true,age:String:index=true,idStr:String:index=true,dtg:Date,*geom:Geometry:srid=4326")
+
+  val sdf = new SimpleDateFormat("yyyyMMdd")
+  sdf.setTimeZone(TimeZone.getTimeZone("Zulu"))
+  val dateToIndex = sdf.parse("20140102")
+
+  val catalogTable = "bmstestcatalog"
+  val user = "myuser"
+  val pass = "mypassword"
+  val instanceName = "bmsTestInst"
+
+  def createStore: AccumuloDataStore =
+  // the specific parameter values should not matter, as we
+  // are requesting a mock data store connection to Accumulo
+    DataStoreFinder.getDataStore(
+      Map(
+        "instanceId" -> instanceName,
+        "zookeepers" -> "zoo1:2181,zoo2:2181,zoo3:2181",
+        "user"       -> user,
+        "password"   -> pass,
+        "tableName"  -> catalogTable,
+        "useMock"    -> "true")
+    ).asInstanceOf[AccumuloDataStore]
+
+  val ds = createStore
+  ds.createSchema(sft)
+  val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
+
+  val featureCollection = new DefaultFeatureCollection(sftName, sft)
+
+  for (
+    name  <- List("a", "b", "c", "d");
+    tuple <- List(1, 2, 3, 4).zip(List(45, 46, 47, 48))
+  ) tuple match { case (i, lat) =>
+    val sf = SimpleFeatureBuilder.build(sft, List(), name + i.toString)
+    sf.setDefaultGeometry(WKTUtils.read(f"POINT($lat%d $lat%d)"))
+    sf.setAttribute("dtg", new DateTime("2011-01-01T00:00:00Z", DateTimeZone.UTC).toDate)
+    sf.setAttribute("name", name)
+    sf.setAttribute("idStr", sf.getID)
+    sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+    featureCollection.add(sf)
+  }
+
+  fs.addFeatures(featureCollection)
+
+  val nullByte = Array[Byte](0.toByte)
+  private val nullString = "<null>"
+  private def valOrNull(o: AnyRef) = if (o == null) nullString else o.toString
+
+  case class PutOrDeleteMutation(row: Array[Byte], cf: Text, cq: Text, v: Value)
+
+  def getAttrIdxMutations(feature: SimpleFeature, cf: Text) =
+    feature.getFeatureType.getAttributeDescriptors.map { attr =>
+      val attrName = attr.getLocalName.getBytes(StandardCharsets.UTF_8)
+      val attrValue = valOrNull(feature.getAttribute(attr.getName)).getBytes(StandardCharsets.UTF_8)
+      val row = attrName ++ nullByte ++ attrValue
+      val value = IndexSchema.encodeIndexValue(feature)
+      PutOrDeleteMutation(row, cf, EMPTY_COLQ, value)
+    }
+
+  def attrIdxEqualQuery(attr: String, value: String, batchSize: Int): Int = {
+    val instance = new MockInstance(instanceName)
+    val conn = instance.getConnector(user, pass.getBytes("UTF8"))
+
+    val attrIdxTable = AccumuloDataStore.formatAttrIdxTableName(catalogTable, sft)
+    conn.tableOperations.exists(attrIdxTable) must beTrue
+    val attrScanner = conn.createScanner(attrIdxTable, new Authorizations())
+    attrScanner.setRange(new ARange(new Text(attr.getBytes ++ nullByte ++ value.getBytes)))
+
+    val recordTable = AccumuloDataStore.formatRecordTableName(catalogTable, sft)
+    conn.tableOperations().exists(recordTable) must beTrue
+    val recordScanner = conn.createBatchScanner(recordTable, new Authorizations(), 5)
+
+    val joinFunction = (kv: java.util.Map.Entry[Key, Value]) => new ARange(kv.getKey.getColumnFamily)
+    val bms = new BatchMultiScanner(attrScanner, recordScanner, joinFunction, batchSize)
+
+    val retrieved = bms.iterator.toList
+    retrieved.foreach { e =>
+      val sf = SimpleFeatureEncoderFactory.defaultEncoder.decode(sft, e.getValue)
+      if (value != nullString) {
+        sf.getAttribute(attr) mustEqual value
+      }
+    }
+
+    retrieved.size
+  }
+
+  "BatchMultiScanner" should {
+    "handle corner cases for attr index queries" in {
+      List(1, 2, 3, 4, 5, 6, 8, 15, 16, 17, 200).foreach { batchSize =>
+        // test something that exists
+        attrIdxEqualQuery("name", "b", batchSize) mustEqual 4
+
+        // test something that doesn't exist!
+        attrIdxEqualQuery("name", "doesn't exist", batchSize) mustEqual 0
+
+        // test size of 1
+        attrIdxEqualQuery("idStr", "c1", batchSize) mustEqual 1
+
+        // test something that was stored as a null
+        attrIdxEqualQuery("age", "43", batchSize) mustEqual 0
+
+        // find nullstring...ugh
+        attrIdxEqualQuery("age", "<null>", batchSize) mustEqual 16
+      }
+      Success()
+    }
+
+    "should throw an exception on a bad batch size" in {
+      attrIdxEqualQuery("age", "43", 0) must throwA[IllegalArgumentException]
+      attrIdxEqualQuery("age", "43", -1) must throwA[IllegalArgumentException]
+    }
+  }
+
+}


### PR DESCRIPTION
- Enable BatchMultiScanner for secondary index. Allows batching of results from
  the attribute index to the record table.
- Prevents using up client memory on large secondary index queries
- Fixed corner cases in BatchMultiScanner
