### PR TITLE
GEOMESASUP-111 Spinoza unable to ingest large AOs

### DIFF
--- a/geomesa-utils/src/main/scala/geomesa/utils/geohash/GeohashUtils.scala
+++ b/geomesa-utils/src/main/scala/geomesa/utils/geohash/GeohashUtils.scala
@@ -326,7 +326,7 @@ object GeohashUtils
       lazy val geomCatcher = catching(classOf[Exception])
 
       // compute the MBR enclosing the target geometry
-      val ghMBR = getMinimumBoundingGeohash(geom, resolutions)
+      val ghMBR = getMinimumBoundingGeohash(geom, new ResolutionRange(1, 63, 2))
 
       // compute the ratio of the area of the target geometry to its MBR
       val areaMBR = ghMBR.getArea

--- a/geomesa-utils/src/test/scala/geomesa/utils/geohash/GeohashUtilsTest.scala
+++ b/geomesa-utils/src/test/scala/geomesa/utils/geohash/GeohashUtilsTest.scala
@@ -17,6 +17,7 @@
 package geomesa.utils.geohash
 
 import com.vividsolutions.jts.geom._
+import geomesa.utils.geohash.GeohashUtils.GeometrySizingUtilities.RecommendedResolution
 import geomesa.utils.geohash.GeohashUtils._
 import geomesa.utils.text.WKTUtils
 import org.junit.Ignore
@@ -62,6 +63,14 @@ class GeohashUtilsTest extends Specification with Logging {
     "[MULTIPOLYGON] out span" ->("MULTIPOLYGON(((-170 80, -190 80, -190 70, -170 70, -170 80)),((30 30, 30 40, 40 40, 40 30, 30 30)))", "POINT(175 75)", "POINT(30 25)"),
     "[MULTIPOINT] out span" ->("MULTIPOINT(-200 50, 40 20)", "POINT(160 50)", "POINT(159 60)"),
     "[POINT] out point no span" ->("POINT(-190 40)", "POINT(170 40)", "POINT(40 40)")
+  )
+
+  val recommendedBitsTestPolygons = Seq(
+    ("POLYGON((33 -14, 82 -14, 82 24, 33 24, 33 -14))", 23, 241044),
+    ("POLYGON((36 23, 36 18, 43 9, 50 10, 38 -4, 40 -14, 60 -14, 78 7, 76 8, 73 21, 71 23, 58 23, 57 19, 45 13, 40 20, 39 23, 36 23))", 23, 132496),
+    ("POLYGON((0 0, 0 10, -5 25, -15 35, -25 35, -40 10, -20 0, -30 15, -20 25, -10 20, -10 10, -15 0, -25 -5, -35 -15, -40 -35, -25 -35, -15 -25, -5 -35, 0 -25, -10 -10, -25 -25, -20 -10, 0 0))", 23, 184472)
+    // area bigger than ~2310 failing on Exception("Could not satisfy constraints, resolutions... ln 361
+    // crossing prime merridian and int'l date line failing on Could not find a suitable 1-bit MBR for the target geometry
   )
 
   // (reasonable) odd GeoHash resolutions
@@ -177,6 +186,17 @@ class GeohashUtilsTest extends Specification with Logging {
             decomposed.contains(includedPoint) must equalTo(true)
             decomposed.contains(excludedPoint) must equalTo(false)
         }
+      }
+    }
+  }
+
+  import GeohashUtils.GeometrySizingUtilities._
+
+  recommendedBitsTestPolygons.foreach{ case (testPolygon, recommendedBits, recommendedNumBoxes) =>
+    "getRecommendedBitsResolutionForPolygon" should {
+      s"return the expected value for the polygon $testPolygon" in {
+        val geom = wkt2geom(testPolygon)
+        getRecommendedBitsResolutionForPolygon(geom) must equalTo(RecommendedResolution(recommendedBits, recommendedNumBoxes))
       }
     }
   }


### PR DESCRIPTION
When getting the MinimumBoundingGeohash, added a ResolutionRange parameter with a lower min. This allowed the Somalia AO to pass, but other even larger ones still fail, though at a different point.
