### PR TITLE
GEOMESA-249 getUniqueGeohashSubstringsInPolygon fails if you don't speci...

### DIFF
--- a/geomesa-utils/src/main/scala/geomesa/utils/geohash/GeohashUtils.scala
+++ b/geomesa-utils/src/main/scala/geomesa/utils/geohash/GeohashUtils.scala
@@ -749,14 +749,14 @@ object GeohashUtils
   def getUniqueGeohashSubstringsInPolygon(poly: Polygon,
                                           offset: Int,
                                           bits: Int,
-                                          MAX_KEYS_IN_LIST: Int = Int.MaxValue,
+                                          MAX_KEYS_IN_LIST: Int = Int.MaxValue - 1,
                                           includeDots: Boolean = true): Seq[String] = {
 
     val maxBits = (offset + bits) * 5
     val minBits = offset * 5
     val usedBits = bits * 5
     val allResolutions = ResolutionRange(0, Math.min(35, maxBits), 1)
-    val maxKeys = Math.min(2 << usedBits, MAX_KEYS_IN_LIST)
+    val maxKeys = Math.min(2 << usedBits, Math.min(MAX_KEYS_IN_LIST, Int.MaxValue - 1))
     val polyCentroid = poly.getCentroid
 
     // find the smallest GeoHash you can that covers the target geometry

--- a/geomesa-utils/src/test/scala/geomesa/utils/geohash/GeohashUtilsTest.scala
+++ b/geomesa-utils/src/test/scala/geomesa/utils/geohash/GeohashUtilsTest.scala
@@ -101,7 +101,7 @@ class GeohashUtilsTest extends Specification with Logging {
 
   def validateGeohashSubstrings(geom: Geometry, offset: Int, bits: Int, subs: Seq[String]) {
     import java.io._
-    val file = File.createTempFile("subhashes_", ".txt", new File("/tmp"))
+    val file = File.createTempFile("subhashes_", ".txt")
     val pw = new PrintWriter(new BufferedWriter(new FileWriter(file)))
     pw.println(s"wkt\tweight")
 
@@ -133,7 +133,7 @@ class GeohashUtilsTest extends Specification with Logging {
 
     def testGeohashSubstringsInCharlottesville(offset: Int, bits: Int): Int = {
       val ghSubstrings = getUniqueGeohashSubstringsInPolygon(
-        polygonCharlottesville, offset, bits, 1 << 15)
+        polygonCharlottesville, offset, bits)
 
       if (DEBUG_OUTPUT)
         ghSubstrings.foreach { gh => logger.debug("[unique Charlottesville gh(2,3)] " + gh)}


### PR DESCRIPTION
...fy a maximum number of keys less than Int.MaxValue

Updated the unit tests to reproduce this error, and tweaked the
routine to compute the expected result.
