### PR TITLE
GEOMESA-250 ExplainQuery can be cut short.

### DIFF
--- a/geomesa-core/src/main/scala/geomesa/core/util/CloseableIterator.scala
+++ b/geomesa-core/src/main/scala/geomesa/core/util/CloseableIterator.scala
@@ -44,8 +44,8 @@ trait CloseableIterator[+A] extends Iterator[A] {
   override def map[B](f: A => B): CloseableIterator[B] = CloseableIterator(super.map(f), self.close)
 
   // NB: Since we wish to be able to close the iterator currently in use, we can't call out to super.flatMap.
-  def flatMap[B](f: A => CloseableIterator[B]): CloseableIterator[B] = new SelfClosingIterator[B] {
-    private var cur: CloseableIterator[B] = empty
+  def ciFlatMap[B](f: A => CloseableIterator[B]): CloseableIterator[B] = new SelfClosingIterator[B] {
+    private var cur: CloseableIterator[B] = if(self.hasNext) f(self.next()) else empty
 
     // Add in the 'SelfClosing' behavior.
     def hasNext: Boolean = {

--- a/geomesa-core/src/test/scala/geomesa/core/index/IndexSchemaTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/index/IndexSchemaTest.scala
@@ -216,7 +216,7 @@ class IndexSchemaTest extends Specification {
       val schema = IndexSchema("%~#s%foo#cstr%99#r::%~#s%0,4#gh::%~#s%4,3#gh%15#id",
         dummyType, featureEncoder)
       val q = new Query()
-      val fs = "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
+      val fs = s"INTERSECTS(${dummyType.getGeometryDescriptor.getLocalName}, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
       val f = ECQL.toFilter(fs)
       q.setFilter(f)
 

--- a/geomesa-core/src/test/scala/geomesa/core/iterators/DeDuplicatingIteratorTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/DeDuplicatingIteratorTest.scala
@@ -24,6 +24,7 @@ import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class DeDuplicatingIteratorTest extends Specification {
+  sequential
 
   val key = new Key("test")
   val value = new Value(Array[Byte](2.toByte))


### PR DESCRIPTION
There seem to be two problems:
- The variable 'cur' in CloseableIterator needs to be set upfront.
- Naming the 'bind' in CloseableIterator flatMap causes confusion between the compiler and the developer.
