### PR TITLE
GEOMESA-251 added shape file ingest support 

### DIFF
--- a/geomesa-tools/README.md
+++ b/geomesa-tools/README.md
@@ -25,49 +25,50 @@ Next, run the command line tools jar with the following command from your root G
 This should print out the following usage text:
 
     GeoMesa Tools 1.0
-    Usage: geomesa-tools [export|list|explain|delete|create|ingest] [options]
-     --help
-           show help command
+    Usage: geomesa-tools [export|list|explain|delete|create|ingest-csv|ingest-tsv|ingest-shp] [options]
+    
+      --help
+            show help command
     Command: export [options]
     Export all or a set of features in csv, geojson, gml, or shp format
-     --catalog <value>
-           the name of the Accumulo table to use -- or create, if it does not already exist -- to contain the new data
-     --typeName <value>
-           the name of the feature to export
-     --format <value>
-           the format to export to (e.g. csv, tsv)
-     --attributes <value>
-           attributes to return in the export
-     --idAttribute <value>
-           feature ID attribute to query on
-     --latAttribute <value>
-           latitude attribute to query on
-     --lonAttribute <value>
-           longitude attribute to query on
-     --dateAttribute <value>
-           date attribute to query on
-     --maxFeatures <value>
-           max number of features to return
-     --query <value>
-           ECQL query to run on the features
+      --catalog <value>
+            the name of the Accumulo table to use -- or create, if it does not already exist -- to contain the new data
+      --typeName <value>
+            the name of the feature to export
+      --format <value>
+            the format to export to (e.g. csv, tsv)
+      --attributes <value>
+            attributes to return in the export
+      --idAttribute <value>
+            feature ID attribute to query on
+      --latAttribute <value>
+            latitude attribute to query on
+      --lonAttribute <value>
+            longitude attribute to query on
+      --dateAttribute <value>
+            date attribute to query on
+      --maxFeatures <value>
+            max number of features to return
+      --query <value>
+            ECQL query to run on the features
     Command: list [options]
     List the features in the specified Catalog Table
-     --catalog <value>
-           the name of the Accumulo table to use
+      --catalog <value>
+            the name of the Accumulo table to use
     Command: explain [options]
     Explain and plan a query in Geomesa
-     --catalog <value>
-           the name of the Accumulo table to use
-     --typeName <value>
-           the name of the new feature to be create
-     --filter <value>
-           the filter string
+      --catalog <value>
+            the name of the Accumulo table to use
+      --typeName <value>
+            the name of the new feature to be create
+      --filter <value>
+            the filter string
     Command: delete [options]
     Delete a feature from the specified Catalog Table in Geomesa
-     --catalog <value>
-           the name of the Accumulo table to use
-     --typeName <value>
-           the name of the new feature to be create
+      --catalog <value>
+            the name of the Accumulo table to use
+      --typeName <value>
+            the name of the new feature to be create
     Command: create [options]
     Create a feature in Geomesa
       --catalog <value>
@@ -76,12 +77,10 @@ This should print out the following usage text:
             the name of the new feature to be create
       --sft <value>
             the string representation of the SimpleFeatureType
-    Command: ingest [options]
-    Ingest a feature into GeoMesa
+    Command: ingest-csv [options]
+    Ingest a csv file into GeoMesa
       --file <value>
             the file you wish to ingest, e.g.: ~/capelookout.csv
-      --format <value>
-            the format of the file, it must be csv or tsv
       --table <value>
             the name of the Accumulo table to use -- or create, if it does not already exist -- to contain the new data
       --typeName <value>
@@ -92,6 +91,28 @@ This should print out the following usage text:
             the name of the datetime field in the sft
       --dtformat <value>
             the format of the datetime field
+    Command: ingest-tsv [options]
+    Ingest a csv file into GeoMesa
+      --file <value>
+            the file you wish to ingest, e.g.: ~/capelookout.tsv
+      --table <value>
+            the name of the Accumulo table to use -- or create, if it does not already exist -- to contain the new data
+      --typeName <value>
+            the name of the feature type to be ingested
+      -s <value> | --spec <value>
+            the sft specification for the file
+      --datetime <value>
+            the name of the datetime field in the sft
+      --dtformat <value>
+            the format of the datetime field
+    Command: ingest-shp [options]
+    Ingest a shapefile into GeoMesa
+      --file <value>
+            the file you wish to ingest, e.g.: ~/capelookout.shp
+      --table <value>
+            the name of the Accumulo table to use -- or create, if it does not already exist -- to contain the new data
+      --typeName <value>
+            the name of the feature type to be ingested
             
 This usage text gives a brief overview of how to use each command, and this is expanded upon below with example commands.  
 Note that each command should be prefixed by `java -jar geomesa-tools/target/geomesa-tools-accumulo1.5-1.0.0-SNAPSHOT-shaded.jar` on the command line.
@@ -136,28 +157,62 @@ Specify the feature to delete with `--typeName`.
 #### Example command:
     delete --catalog test_delete --typeName testing
   
-### ingest
-Ingests TSV and CSV files containing WKT geometries with the following caveat:CSV files must surround values with double quotation marks, e.g.: `"37266103","2013-07-17","POINT(0.0 0.0)"` the first and last quotation marks are optional however. Also the WKT Geometry is assumed to be the last column of the CSV/TSV file.
-#### Usage
-    ingest --file <> --format <> --table <> --typeName <> --spec <> --datetime <> --dtformat <>
-
-note: *the `<>` marks are where user values would go*
-
-with the following parameters:
+### ingest-csv
+Ingests  CSV files containing WKT geometries with the following caveat: CSV files must surround values with double quotation marks, e.g.: `"37266103","2013-07-17","POINT(0.0 0.0)"` the first and last quotation marks are optional however. Also the WKT Geometry is assumed to be the last column of the CSV file.
+#### Required flags:
      
-`--file` The file path to the csv file or tsv file being ingested.
-
-`--format` The format of that file, either CSV or TSV.
+`--file` The file path to the csv file being ingested.
 
 `--table` The accumulo table name, the table will be created if not already extant.
 
 `--typeName` The name of the SimpleFeatureType to be used.
 
-`--spec` The SimpleFeatureType of the CSV or TSV file, must match the layout of columns in the CSV/TSV file
+`--spec` The SimpleFeatureType of the CSV file, must match the layout of columns in the CSV file.
 
 `--datetime` The name of the field in the SFT spec above that corresponds to the the *time* column in the data being ingested.
 
 `--dtformat` The Joda DateTimeFormat string for the date-time field, e.g.: "MM/dd/yyyy HH:mm:ss"
+
+#### Example command:
+   
+    ingest-csv --file capefear.csv --table outerbanks --typeName cape
+                --spec id:Double,time:Date,*geom:Geometry --datetime time --dtformat MM/dd/yyyy
+
+
+### ingest-shp
+Ingest SHP files into GeoMesa.
+#### Required flags:
+
+`--file` The file path to the shapefile being ingested.
+
+`--table` The accumulo table name, the table will be created if not already extant.
+
+`--typeName` The name of the SimpleFeatureType to be used.
+
+#### Example command:
+
+    ingest-shp --file capelookout.shp --table outerbanks --typeName cape
+
+### ingest-tsv
+Ingests TSV files containing WKT geometries, which are assumed to be the last column of the TSV file.
+#### Required flags:
+     
+`--file` The file path to the tsv file being ingested.
+
+`--table` The accumulo table name, the table will be created if not already extant.
+
+`--typeName` The name of the SimpleFeatureType to be used.
+
+`--spec` The SimpleFeatureType of the TSV file, must match the layout of columns in the TSV file.
+
+`--datetime` The name of the field in the SFT spec above that corresponds to the the *time* column in the data being ingested.
+
+`--dtformat` The Joda DateTimeFormat string for the date-time field, e.g.: "MM/dd/yyyy HH:mm:ss"
+
+####Example command:
+   
+    ingest-tsv --file capehatteras.tsv --table outerbanks --typeName cape
+                --spec id:Double,time:Date,*geom:Geometry --datetime time --dtformat MM/dd/yyyy
 
 
 ### explain
@@ -168,3 +223,4 @@ Specify the feature to create with the `--typeName`.
 Specify the filter string with `--filter`.
 #### Example command:
     explain --catalog geomesa_catalog --typeName twittersmall --filter "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
+    

--- a/geomesa-tools/src/main/resources/log4j.properties
+++ b/geomesa-tools/src/main/resources/log4j.properties
@@ -25,7 +25,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 
 log4j.appender.file=org.apache.log4j.RollingFileAppender
-log4j.appender.file.File=mini-cluster.log
+log4j.appender.file.File=geomesa-tools.log
 log4j.appender.file.MaxFileSize=1000KB
 log4j.appender.file.MaxBackupIndex=4
 log4j.appender.file.layout=org.apache.log4j.PatternLayout

--- a/geomesa-tools/src/main/scala/geomesa/tools/Ingest.scala
+++ b/geomesa-tools/src/main/scala/geomesa/tools/Ingest.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package geomesa.tools
 
 import com.typesafe.scalalogging.slf4j.Logging
@@ -34,8 +35,6 @@ class Ingest() extends Logging {
     config.format.toUpperCase match {
       case "CSV" | "TSV" =>
         config.method.toLowerCase match {
-          case "mapreduce" =>
-            true
           case "local" =>
             new SVIngest(config, dsConfig)
             true
@@ -43,6 +42,17 @@ class Ingest() extends Logging {
             logger.error("Error, no such ingest method for CSV or TSV found, no data ingested")
             false
         }
+
+      case "SHP" | "SHAPEFILE" =>
+        config.method.toLowerCase match {
+          case "local" =>
+            val shi = new ShapefileIngest(config, dsConfig)
+            shi.runIngest
+          case _ =>
+            logger.error("Error, no such ingest method for Shapefile found, no data ingested")
+            false
+        }
+
       case _ =>
         logger.error(s"Error, format: \'${config.format}\' not supported. Supported formats include: CSV, TSV")
         false

--- a/geomesa-tools/src/main/scala/geomesa/tools/ShapefileIngest.scala
+++ b/geomesa-tools/src/main/scala/geomesa/tools/ShapefileIngest.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geomesa.tools
+
+import com.typesafe.scalalogging.slf4j.Logging
+import geomesa.utils.geotools.GeneralShapefileIngest
+import scala.collection.JavaConversions._
+
+class ShapefileIngest(config: ScoptArguments, dsConfig: Map[String, _]) extends Logging {
+
+  lazy val path             = config.file
+  lazy val typeName         = config.typeName
+
+  def runIngest: Boolean = {
+    try {
+      GeneralShapefileIngest.shpToDataStoreViaParams(path, dsConfig.asInstanceOf[Map[String, Serializable]], typeName)
+      true
+    } catch {
+      case e: Exception => logger.error(s"Cannot ingest $path", e)
+      false
+    }
+  }
+
+}

--- a/geomesa-tools/src/main/scala/geomesa/tools/Tools.scala
+++ b/geomesa-tools/src/main/scala/geomesa/tools/Tools.scala
@@ -81,12 +81,10 @@ object Tools extends App {
         c.copy(sft = s) } text "the string representation of the SimpleFeatureType" required()
       )
 
-    cmd("ingest") action { (_, c) =>
-      c.copy(mode = "ingest") } text "Ingest a feature into GeoMesa" children (
+    cmd("ingest-csv") action { (_, c) =>
+      c.copy(mode = "ingest", format="csv") } text "Ingest a csv file into GeoMesa" children (
       opt[String]("file").action { (s, c) =>
         c.copy(file = s) } text "the file you wish to ingest, e.g.: ~/capelookout.csv" required(),
-      opt[String]("format").action { (s, c) =>
-        c.copy(format = s.toUpperCase) } text "the format of the file, it must be csv or tsv" required(),
       opt[String]("table").action { (s, c) =>
         c.copy(table = s) } text "the name of the Accumulo table to use -- or create, " +
         "if it does not already exist -- to contain the new data" required(),
@@ -99,6 +97,35 @@ object Tools extends App {
       opt[String]("dtformat").action { (s, c) =>
         c.copy(dtFormat = s) } text "the format of the datetime field" required()
       )
+
+    cmd("ingest-shp") action { (_, c) =>
+      c.copy(mode = "ingest", format="shp") } text "Ingest a shapefile into GeoMesa" children (
+      opt[String]("file").action { (s, c) =>
+        c.copy(file = s) } text "the file you wish to ingest, e.g.: ~/capelookout.shp" required(),
+      opt[String]("table").action { (s, c) =>
+        c.copy(table = s) } text "the name of the Accumulo table to use -- or create, " +
+        "if it does not already exist -- to contain the new data" required(),
+      opt[String]("typeName").action { (s, c) =>
+        c.copy(typeName = s) } text "the name of the feature type to be ingested" required()
+      )
+
+    cmd("ingest-tsv") action { (_, c) =>
+      c.copy(mode = "ingest", format="tsv") } text "Ingest a csv file into GeoMesa" children (
+      opt[String]("file").action { (s, c) =>
+        c.copy(file = s) } text "the file you wish to ingest, e.g.: ~/capelookout.tsv" required(),
+      opt[String]("table").action { (s, c) =>
+        c.copy(table = s) } text "the name of the Accumulo table to use -- or create, " +
+        "if it does not already exist -- to contain the new data" required(),
+      opt[String]("typeName").action { (s, c) =>
+        c.copy(typeName = s) } text "the name of the feature type to be ingested" required(),
+      opt[String]('s', "spec").action { (s, c) =>
+        c.copy(spec = s) } text "the sft specification for the file" required(),
+      opt[String]("datetime").action { (s, c) =>
+        c.copy(dtField = s) } text "the name of the datetime field in the sft" required(),
+      opt[String]("dtformat").action { (s, c) =>
+        c.copy(dtFormat = s) } text "the format of the datetime field" required()
+      )
+
   }
 
   parser.parse(args, ScoptArguments()).map(config =>


### PR DESCRIPTION
Improved README to have better example commands for ingest functions. This includes the change to split the various ingest command formats into separate ingest commands as a cleaner way of dealing with changing input parameters. This change also reduced the number of required user parameters by one as now the format is tied to the command name. Also fixed a typo in the log4j properties. 
