### PR TITLE
GEOMESA-269 refactor ingest command structure

### DIFF
--- a/geomesa-tools/README.md
+++ b/geomesa-tools/README.md
@@ -26,48 +26,49 @@ This should print out the following usage text:
 
     GeoMesa Tools 1.0
     Usage: geomesa-tools [export|list|explain|delete|create|ingest] [options]
-     --help
-           show help command
+    
+      --help
+            show help command
     Command: export [options]
     Export all or a set of features in csv, geojson, gml, or shp format
-     --catalog <value>
-           the name of the Accumulo table to use -- or create, if it does not already exist -- to contain the new data
-     --typeName <value>
-           the name of the feature to export
-     --format <value>
-           the format to export to (e.g. csv, tsv)
-     --attributes <value>
-           attributes to return in the export
-     --idAttribute <value>
-           feature ID attribute to query on
-     --latAttribute <value>
-           latitude attribute to query on
-     --lonAttribute <value>
-           longitude attribute to query on
-     --dateAttribute <value>
-           date attribute to query on
-     --maxFeatures <value>
-           max number of features to return
-     --query <value>
-           ECQL query to run on the features
+      --catalog <value>
+            the name of the Accumulo table to use -- or create, if it does not already exist -- to contain the new data
+      --typeName <value>
+            the name of the feature to export
+      --format <value>
+            the format to export to (e.g. csv, tsv)
+      --attributes <value>
+            attributes to return in the export
+      --idAttribute <value>
+            feature ID attribute to query on
+      --latAttribute <value>
+            latitude attribute to query on
+      --lonAttribute <value>
+            longitude attribute to query on
+      --dateAttribute <value>
+            date attribute to query on
+      --maxFeatures <value>
+            max number of features to return
+      --query <value>
+            ECQL query to run on the features
     Command: list [options]
     List the features in the specified Catalog Table
-     --catalog <value>
-           the name of the Accumulo table to use
+      --catalog <value>
+            the name of the Accumulo table to use
     Command: explain [options]
     Explain and plan a query in Geomesa
-     --catalog <value>
-           the name of the Accumulo table to use
-     --typeName <value>
-           the name of the new feature to be create
-     --filter <value>
-           the filter string
+      --catalog <value>
+            the name of the Accumulo table to use
+      --typeName <value>
+            the name of the new feature to be create
+      --filter <value>
+            the filter string
     Command: delete [options]
     Delete a feature from the specified Catalog Table in Geomesa
-     --catalog <value>
-           the name of the Accumulo table to use
-     --typeName <value>
-           the name of the new feature to be create
+      --catalog <value>
+            the name of the Accumulo table to use
+      --typeName <value>
+            the name of the new feature to be create
     Command: create [options]
     Create a feature in Geomesa
       --catalog <value>
@@ -76,12 +77,26 @@ This should print out the following usage text:
             the name of the new feature to be create
       --sft <value>
             the string representation of the SimpleFeatureType
-    Command: ingest [options]
-    Ingest a feature into GeoMesa
+    Command: ingest [csv|tsv]
+    Ingest a file into GeoMesa
+    Command: ingest csv [options]
+    Ingest a csv file
       --file <value>
             the file you wish to ingest, e.g.: ~/capelookout.csv
-      --format <value>
-            the format of the file, it must be csv or tsv
+      --table <value>
+            the name of the Accumulo table to use -- or create, if it does not already exist -- to contain the new data
+      --typeName <value>
+            the name of the feature type to be ingested
+      -s <value> | --spec <value>
+            the sft specification for the file
+      --datetime <value>
+            the name of the datetime field in the sft
+      --dtformat <value>
+            the format of the datetime field
+    Command: ingest tsv [options]
+    Ingest a tsv file
+      --file <value>
+            the file you wish to ingest, e.g.: ~/capelookout.tsv
       --table <value>
             the name of the Accumulo table to use -- or create, if it does not already exist -- to contain the new data
       --typeName <value>
@@ -137,28 +152,54 @@ Specify the feature to delete with `--typeName`.
     delete --catalog test_delete --typeName testing
   
 ### ingest
-Ingests TSV and CSV files containing WKT geometries with the following caveat:CSV files must surround values with double quotation marks, e.g.: `"37266103","2013-07-17","POINT(0.0 0.0)"` the first and last quotation marks are optional however. Also the WKT Geometry is assumed to be the last column of the CSV/TSV file.
-#### Usage
-    ingest --file <> --format <> --table <> --typeName <> --spec <> --datetime <> --dtformat <>
+Ingests files into GeoMesa.
 
-note: *the `<>` marks are where user values would go*
+#### Sub Commands:
+The following sub commands correspond to the file type you are attempting to ingest. The required flags used depend on the sub command.
 
-with the following parameters:
-     
-`--file` The file path to the csv file or tsv file being ingested.
+#### csv
+ for ingesting csv files containing WKT geometries in the last column width the following caveat: CSV files must surround values with double quotation marks, e.g.:
+ `"37266103","2013-07-17","POINT(0.0 0.0)"`.
+ 
+###### csv required flags:
+         
+    `--file` The file path to the csv file being ingested.
+    
+    `--table` The accumulo table name, the table will be created if not already extant.
+    
+    `--typeName` The name of the SimpleFeatureType to be used.
+    
+    `--spec` The SimpleFeatureType of the CSV file, must match the layout of columns in the CSV file.
+    
+    `--datetime` The name of the field in the SFT spec above that corresponds to the the *time* column in the data being ingested.
+    
+    `--dtformat` The Joda DateTimeFormat string for the date-time field, e.g.: "MM/dd/yyyy HH:mm:ss"
 
-`--format` The format of that file, either CSV or TSV.
+#### tsv
+ for ingesting tsv files containing WKT geometries in the last column.
 
-`--table` The accumulo table name, the table will be created if not already extant.
+ 
+###### tsv required flags:
+         
+    `--file` The file path to the tsv file being ingested.
+    
+    `--table` The accumulo table name, the table will be created if not already extant.
+    
+    `--typeName` The name of the SimpleFeatureType to be used.
+    
+    `--spec` The SimpleFeatureType of the TSV file, must match the layout of columns in the TSV file.
+    
+    `--datetime` The name of the field in the SFT spec above that corresponds to the the *time* column in the data being ingested.
+    
+    `--dtformat` The Joda DateTimeFormat string for the date-time field, e.g.: "MM/dd/yyyy HH:mm:ss"
 
-`--typeName` The name of the SimpleFeatureType to be used.
-
-`--spec` The SimpleFeatureType of the CSV or TSV file, must match the layout of columns in the CSV/TSV file
-
-`--datetime` The name of the field in the SFT spec above that corresponds to the the *time* column in the data being ingested.
-
-`--dtformat` The Joda DateTimeFormat string for the date-time field, e.g.: "MM/dd/yyyy HH:mm:ss"
-
+#### Example commands:
+   
+    ingest csv --file capefear.csv --table outerbanks --typeName cape
+                --spec id:Double,time:Date,*geom:Geometry --datetime time --dtformat MM/dd/yyyy
+                
+    ingest tsv --file capehatteras.tsv --table outerbanks --typeName cape
+                    --spec id:Double,time:Date,*geom:Geometry --datetime time --dtformat MM/dd/yyyy
 
 ### explain
 To ask GeoMesa how it intends to satisfy a given query, use the `explain` command.
@@ -168,3 +209,4 @@ Specify the feature to create with the `--typeName`.
 Specify the filter string with `--filter`.
 #### Example command:
     explain --catalog geomesa_catalog --typeName twittersmall --filter "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
+    

--- a/geomesa-tools/src/main/resources/log4j.properties
+++ b/geomesa-tools/src/main/resources/log4j.properties
@@ -25,7 +25,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 
 log4j.appender.file=org.apache.log4j.RollingFileAppender
-log4j.appender.file.File=mini-cluster.log
+log4j.appender.file.File=geomesa-tools.log
 log4j.appender.file.MaxFileSize=1000KB
 log4j.appender.file.MaxBackupIndex=4
 log4j.appender.file.layout=org.apache.log4j.PatternLayout

--- a/geomesa-tools/src/main/scala/geomesa/tools/Ingest.scala
+++ b/geomesa-tools/src/main/scala/geomesa/tools/Ingest.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package geomesa.tools
 
 import com.typesafe.scalalogging.slf4j.Logging
@@ -34,8 +35,6 @@ class Ingest() extends Logging {
     config.format.toUpperCase match {
       case "CSV" | "TSV" =>
         config.method.toLowerCase match {
-          case "mapreduce" =>
-            true
           case "local" =>
             new SVIngest(config, dsConfig)
             true
@@ -43,6 +42,7 @@ class Ingest() extends Logging {
             logger.error("Error, no such ingest method for CSV or TSV found, no data ingested")
             false
         }
+
       case _ =>
         logger.error(s"Error, format: \'${config.format}\' not supported. Supported formats include: CSV, TSV")
         false

--- a/geomesa-tools/src/main/scala/geomesa/tools/Tools.scala
+++ b/geomesa-tools/src/main/scala/geomesa/tools/Tools.scala
@@ -78,27 +78,58 @@ object Tools extends App {
       opt[String]("typeName").action { (s, c) =>
         c.copy(typeName = s) } text "the name of the new feature to be create" required(),
       opt[String]("sft").action { (s, c) =>
-        c.copy(sft = s) } text "the string representation of the SimpleFeatureType" required()
+        c.copy(sft = s)
+      } text "the string representation of the SimpleFeatureType" required()
       )
 
-    cmd("ingest") action { (_, c) =>
-      c.copy(mode = "ingest") } text "Ingest a feature into GeoMesa" children (
-      opt[String]("file").action { (s, c) =>
-        c.copy(file = s) } text "the file you wish to ingest, e.g.: ~/capelookout.csv" required(),
-      opt[String]("format").action { (s, c) =>
-        c.copy(format = s.toUpperCase) } text "the format of the file, it must be csv or tsv" required(),
-      opt[String]("table").action { (s, c) =>
-        c.copy(table = s) } text "the name of the Accumulo table to use -- or create, " +
-        "if it does not already exist -- to contain the new data" required(),
-      opt[String]("typeName").action { (s, c) =>
-        c.copy(typeName = s) } text "the name of the feature type to be ingested" required(),
-      opt[String]('s', "spec").action { (s, c) =>
-        c.copy(spec = s) } text "the sft specification for the file" required(),
-      opt[String]("datetime").action { (s, c) =>
-        c.copy(dtField = s) } text "the name of the datetime field in the sft" required(),
-      opt[String]("dtformat").action { (s, c) =>
-        c.copy(dtFormat = s) } text "the format of the datetime field" required()
+    cmd("ingest") text "Ingest a file into GeoMesa" action { (x, c) => c.copy(mode = "ingest") }  children(
+
+      cmd("csv") action { (_, c) => c.copy(format = "csv") } text "Ingest a csv file" children(
+        opt[String]("file").action { (s, c) =>
+          c.copy(file = s)
+        } text "the file you wish to ingest, e.g.: ~/capelookout.csv" required(),
+        opt[String]("table").action { (s, c) =>
+          c.copy(table = s)
+        } text "the name of the Accumulo table to use -- or create, " +
+          "if it does not already exist -- to contain the new data" required(),
+        opt[String]("typeName").action { (s, c) =>
+          c.copy(typeName = s)
+        } text "the name of the feature type to be ingested" required(),
+        opt[String]('s', "spec").action { (s, c) =>
+          c.copy(spec = s)
+        } text "the sft specification for the file" required(),
+        opt[String]("datetime").action { (s, c) =>
+          c.copy(dtField = s)
+        } text "the name of the datetime field in the sft" required(),
+        opt[String]("dtformat").action { (s, c) =>
+          c.copy(dtFormat = s)
+        } text "the format of the datetime field" required()
+        ),
+
+      cmd("tsv") action { (_, c) => c.copy(format = "tsv") } text "Ingest a tsv file" children(
+        opt[String]("file").action { (s, c) =>
+          c.copy(file = s)
+        } text "the file you wish to ingest, e.g.: ~/capefear.tsv" required(),
+        opt[String]("table").action { (s, c) =>
+          c.copy(table = s)
+        } text "the name of the Accumulo table to use -- or create, " +
+          "if it does not already exist -- to contain the new data" required(),
+        opt[String]("typeName").action { (s, c) =>
+          c.copy(typeName = s)
+        } text "the name of the feature type to be ingested" required(),
+        opt[String]('s', "spec").action { (s, c) =>
+          c.copy(spec = s)
+        } text "the sft specification for the file" required(),
+        opt[String]("datetime").action { (s, c) =>
+          c.copy(dtField = s)
+        } text "the name of the datetime field in the sft" required(),
+        opt[String]("dtformat").action { (s, c) =>
+          c.copy(dtFormat = s)
+        } text "the format of the datetime field" required()
+        )
+
       )
+
   }
 
   parser.parse(args, ScoptArguments()).map(config =>


### PR DESCRIPTION
ingest command now splits up into sub-commands per format type supported. e.g.: ingest csv <csv options>, ingest tsv <tsv options>, etc. This will allow for future formats to be included easily. Also fixed a typo in the log4j config. 
