### PR TITLE
GEOMESA 306, 305, 296, 295 ingest split-off (accumulo1.4)

### DIFF
--- a/geomesa-tools/bin/geomesa
+++ b/geomesa-tools/bin/geomesa
@@ -36,6 +36,10 @@ if  [[ $1 = configure ]]; then
 else
     if [[ (-z "$GEOMESA_HOME") || (-z "$ACCUMULO_HOME") ||  (-z "$HADOOP_HOME")  ]]; then
         echo "Please ensure GEOMESA_HOME, ACCUMULO_HOME, and HADOOP_HOME are set before running geomesa-tools."
+    elif [[ $1 = ingest ]] && [[ (-z "$2") || ($2 = --help)  || ($2 = -help) || ($2 = help) ]]; then
+        java -cp "${GEOMESA_HOME}/geomesa-tools/target/geomesa-tools-accumulo1.5-1.0.0-SNAPSHOT-shaded.jar:$CLASSPATH" org.locationtech.geomesa.tools.Ingest --help
+    elif [[ $1 = ingest ]]; then
+        java -cp "${GEOMESA_HOME}/geomesa-tools/target/geomesa-tools-accumulo1.5-1.0.0-SNAPSHOT-shaded.jar:$CLASSPATH" org.locationtech.geomesa.tools.Ingest "${@:2}"
     elif [ -n "$*" ]; then
         java -cp "${GEOMESA_HOME}/geomesa-tools/target/geomesa-tools-accumulo1.4-1.0.0-SNAPSHOT-shaded.jar:$CLASSPATH" org.locationtech.geomesa.tools.Tools $*
     else

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/FeaturesTool.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/FeaturesTool.scala
@@ -17,11 +17,7 @@
 package org.locationtech.geomesa.tools
 
 import java.io.FileOutputStream
-import java.util.UUID
-
 import com.typesafe.scalalogging.slf4j.Logging
-import org.apache.accumulo.core.client.ZooKeeperInstance
-import org.apache.hadoop.fs.Path
 import org.geotools.data._
 import org.geotools.data.simple.SimpleFeatureCollection
 import org.geotools.filter.text.cql2.CQL
@@ -29,27 +25,11 @@ import org.geotools.filter.text.ecql.ECQL
 import org.locationtech.geomesa.core.data.{AccumuloDataStore, AccumuloFeatureReader, AccumuloFeatureStore}
 import org.locationtech.geomesa.core.index.SF_PROPERTY_START_TIME
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
-
 import scala.collection.JavaConversions._
 import scala.util.Try
-import scala.xml.XML
 
-class FeaturesTool(config: ScoptArguments, password: String) extends Logging {
-  val accumuloConf = XML.loadFile(s"${System.getenv("ACCUMULO_HOME")}/conf/accumulo-site.xml")
-  val zookeepers = (accumuloConf \\ "property")
-    .filter(x => (x \ "name")
-    .text == "instance.zookeeper.host")
-    .map(y => (y \ "value").text)
-    .head
-  val instanceDfsDir = Try((accumuloConf \\ "property")
-    .filter(x => (x \ "name")
-    .text == "instance.dfs.dir")
-    .map(y => (y \ "value").text)
-    .head)
-    .getOrElse("/accumulo")
-  val instanceIdDir = new Path(instanceDfsDir, "instance_id")
-  val instanceIdStr = ZooKeeperInstance.getInstanceIDFromHdfs(instanceIdDir)
-  val instanceName = new ZooKeeperInstance(UUID.fromString(instanceIdStr), zookeepers).getInstanceName
+class FeaturesTool(config: ScoptArguments, password: String) extends Logging with AccumuloProperties {
+
   val ds: AccumuloDataStore = Try({
     DataStoreFinder.getDataStore(Map(
       "instanceId" -> instanceName,

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Ingest.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Ingest.scala
@@ -16,50 +16,36 @@
 
 package org.locationtech.geomesa.tools
 
-import java.util.UUID
-
 import com.typesafe.scalalogging.slf4j.Logging
-import org.apache.accumulo.core.client.ZooKeeperInstance
-import org.apache.hadoop.fs.Path
 
-import scala.util.Try
-import scala.xml.XML
+class Ingest() extends Logging with AccumuloProperties {
 
-class Ingest() extends Logging {
-  val accumuloConf = XML.loadFile(s"${System.getenv("ACCUMULO_HOME")}/conf/accumulo-site.xml")
-  val zookeepers = (accumuloConf \\ "property")
-    .filter(x => (x \ "name")
-    .text == "instance.zookeeper.host")
-    .map(y => (y \ "value").text)
-    .head
-  val instanceDfsDir = Try((accumuloConf \\ "property")
-    .filter(x => (x \ "name")
-    .text == "instance.dfs.dir")
-    .map(y => (y \ "value").text)
-    .head)
-    .getOrElse("/accumulo")
-  val instanceIdDir = new Path(instanceDfsDir, "instance_id")
-  val instanceName = new ZooKeeperInstance(UUID.fromString(ZooKeeperInstance.getInstanceIDFromHdfs(instanceIdDir)), zookeepers).getInstanceName
-
-  def getAccumuloDataStoreConf(config: ScoptArguments, password: String) = Map (
-    "instanceId"   ->  instanceName,
-    "zookeepers"   ->  zookeepers,
-    "user"         ->  config.username,
-    "password"     ->  password,
-    "auths"        ->  sys.env.getOrElse("GEOMESA_AUTHS", ""),
-    "visibilities" ->  sys.env.getOrElse("GEOMESA_VISIBILITIES", ""),
-    "tableName"    ->  config.catalog
+  def getAccumuloDataStoreConf(config: IngestArguments, password: String) = collection.mutable.Map (
+    "instanceId"        ->  instanceName,
+    "zookeepers"        ->  zookeepers,
+    "user"              ->  config.username,
+    "password"          ->  password,
+    "auths"             ->  config.auths.getOrElse(""),
+    "visibilities"      ->  config.visibilities.getOrElse(""),
+    "tableName"         ->  config.catalog
   )
 
-  def defineIngestJob(config: ScoptArguments, password: String): Boolean = {
+  def defineIngestJob(config: IngestArguments, password: String): Boolean = {
     //ensure that geomesa classes are loaded so that the subsequent
     val dsConfig = getAccumuloDataStoreConf(config, password)
+    // add the maxShards variable if present prior to connecting to data store, make sure both are not set!
+    if (config.maxShards.isDefined && config.indexSchemaFormat.isEmpty) {
+      dsConfig.updated("maxShard", config.maxShards.get)
+    }
+    if (config.maxShards.isEmpty && config.indexSchemaFormat.isDefined) {
+      dsConfig.updated("indexSchemaFormat", config.indexSchemaFormat.get)
+    }
     config.format.toUpperCase match {
       case "CSV" | "TSV" =>
         config.method.toLowerCase match {
           case "local" =>
             logger.info("Ingest has started, please wait.")
-            val ingest = new SVIngest(config, dsConfig)
+            val ingest = new SVIngest(config, dsConfig.toMap)
             ingest.runIngest()
             true
           case _ =>
@@ -73,3 +59,80 @@ class Ingest() extends Logging {
     }
   }
 }
+
+object Ingest extends App with Logging with GetPassword {
+  val parser = new scopt.OptionParser[IngestArguments]("geomesa-tools ingest") {
+    head("GeoMesa Tools Ingest", "1.0")
+    note("A single format flag must be set, eg: either --csv or --tsv")
+    opt[Unit]("csv") action { (_, c) =>
+      c.copy(format = "CSV") } text "partially optional csv format flag" optional()
+    opt[Unit]("tsv") action { (_, c) =>
+      c.copy(format = "TSV") } text "partially optional tsv format flag" optional()
+    opt[String]('u', "username") action { (x, c) =>
+      c.copy(username = x) } text "Accumulo username" required()
+    opt[String]('p', "password") action { (x, c) =>
+      c.copy(password = x) } text "Accumulo password, This can also be provided after entering a command" optional()
+    opt[String]('c', "catalog").action { (s, c) =>
+      c.copy(catalog = s) } text "the name of the Accumulo table to use -- or create" required()
+    opt[String]('a', "auths") action { (s, c) =>
+      c.copy(auths = Option(s)) } text "Accumulo auths (optional)" optional()
+    opt[String]('v', "visibilities") action { (s, c) =>
+      c.copy(visibilities = Option(s)) } text "Accumulo visibilities (optional)" optional()
+    opt[String]('i', "indexSchemaFormat") action { (s, c) =>
+      c.copy(indexSchemaFormat = Option(s)) } text "Accumulo index schema format (optional)" optional()
+    opt[Int]("shards") action { (i, c) =>
+      c.copy(maxShards = Option(i)) } text "Accumulo number of shards to use (optional)" optional()
+    opt[String]('f', "feature-name").action { (s, c) =>
+      c.copy(featureName = s) } text "the name of the feature" required()
+    opt[String]('s', "sftspec").action { (s, c) =>
+      c.copy(spec = s) } text "the sft specification of the file," +
+      " must match number of columns and order of ingest file if csv or tsv formatted" required()
+    opt[String]("datetime").action { (s, c) =>
+      c.copy(dtField = Option(s)) } text "the name of the datetime field in the sft" required()
+    opt[String]("dtformat").action { (s, c) =>
+      c.copy(dtFormat = s) } text "the format of the datetime field" required()
+    opt[String]("idfields").action { (s, c) =>
+      c.copy(idFields = Option(s)) } text "the set of attributes of each feature used" +
+      " to encode the feature name" optional()
+    opt[Unit]('h', "hash")action { (_, c) =>
+      c.copy(doHash = true) } text "flag to md5 hash to identity of each feature" optional()
+    opt[String]("lon").action { (s, c) =>
+      c.copy(lonAttribute = Option(s)) } text "the name of the longitude field in the sft if ingesting point data" optional()
+    opt[String]("lat").action { (s, c) =>
+      c.copy(latAttribute = Option(s)) } text "the name of the latitude field in the sft if ingesting point data" optional()
+    opt[Unit]("skip-header").action { (b, c) =>
+      c.copy(skipHeader = true) } text "flag for skipping first line in file" optional()
+    opt[String]("file").action { (s, c) =>
+      c.copy(file = s) } text "the file to be ingested" required()
+    help("help").text("show help command")
+    checkConfig{ c =>
+      if (c.format.isEmpty) {
+        failure("No format set for ingest, user must use one of the following flags for first argument: --csv, --tsv")
+      } else if (c.maxShards.isDefined && c.indexSchemaFormat.isDefined) {
+        failure("Error: the options for setting the max shards and the index schema format cannot both be set")
+      } else {
+        success
+      } }
+  }
+
+  try {
+    parser.parse(args, IngestArguments()).map { config =>
+      val pw = password(config.password)
+
+      val ingest = new Ingest()
+      ingest.defineIngestJob(config, pw) match {
+        case true => logger.info(s"Successful ingest of file: '${config.file}'")
+        case false => logger.error(s"Error: could not successfully ingest file: '${config.file}'")
+      }
+
+    } getOrElse {
+      logger.error("Error: command not recognized.")
+    }
+  }
+  catch {
+    case npe: NullPointerException => logger.error("Missing options and or unknown arguments on ingest." +
+                                                   "\n\t See 'geomesa ingest --help'")
+  }
+
+}
+

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/SVIngest.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/SVIngest.scala
@@ -38,11 +38,10 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
-class SVIngest(config: ScoptArguments, dsConfig: Map[String, _]) extends Logging {
+class SVIngest(config: IngestArguments, dsConfig: Map[String, _]) extends Logging {
 
   import scala.collection.JavaConversions._
 
-  lazy val table            = dsConfig.get("tableName")
   lazy val idFields         = config.idFields.orNull
   lazy val path             = config.file
   lazy val featureName      = config.featureName
@@ -53,9 +52,11 @@ class SVIngest(config: ScoptArguments, dsConfig: Map[String, _]) extends Logging
   lazy val latField         = config.latAttribute.orNull
   lazy val lonField         = config.lonAttribute.orNull
   lazy val skipHeader       = config.skipHeader
+  lazy val doHash           = config.doHash
   var lineNumber            = 0
-  var errors                = 0
+  var failures              = 0
   var successes             = 0
+  val maxShard: Option[Int] = config.maxShards
 
   lazy val dropHeader = skipHeader match {
     case true => 1
@@ -69,16 +70,28 @@ class SVIngest(config: ScoptArguments, dsConfig: Map[String, _]) extends Logging
 
   val ds = DataStoreFinder.getDataStore(dsConfig).asInstanceOf[AccumuloDataStore]
 
-  if(ds.getSchema(featureName) == null){
+  if (ds.getSchema(featureName) == null) {
     logger.info("\tCreating GeoMesa tables...")
     val startTime = System.currentTimeMillis()
-    ds.createSchema(sft)
+    if (maxShard.isDefined)
+      ds.createSchema(sft, maxShard.get)
+    else
+      ds.createSchema(sft)
     val createTime = System.currentTimeMillis() - startTime
-    logger.info(s"\tCreated schema in: $createTime ms")
-  } else {
-    logger.info("GeoMesa tables extant")
-  }
+    val numShards = ds.getSpatioTemporalMaxShard(sft)
+    val shardPvsS = if (numShards == 1) "Shard" else "Shards"
+    logger.info(s"\tCreated schema in: $createTime ms using $numShards $shardPvsS.")
 
+  } else {
+    val numShards = ds.getSpatioTemporalMaxShard(sft)
+    val shardPvsS = if (numShards == 1) "Shard" else "Shards"
+
+    maxShard match {
+      case None => logger.info(s"GeoMesa tables extant, using $numShards $shardPvsS.")
+      case Some(x) => logger.warn(s"GeoMesa tables extant, ignoring user request, using schema's $numShards $shardPvsS")
+    }
+
+  }
 
   lazy val sft = {
     val ret = SimpleFeatureTypes.createType(featureName, sftSpec)
@@ -112,7 +125,9 @@ class SVIngest(config: ScoptArguments, dsConfig: Map[String, _]) extends Logging
         finally {
           cfw.release()
           ds.dispose()
-          logger.info(s"For file $path - added $successes features and failed $errors")
+          val successPvsS = if (successes == 1) "feature" else "features"
+          val failurePvsS = if (failures == 1) "feature" else "features"
+          logger.info(s"For file $path - added $successes $successPvsS and failed on $failures $failurePvsS")
         }
       case _ =>
         logger.error(s"Error, no such SV ingest method: ${config.method.toLowerCase}")
@@ -121,8 +136,16 @@ class SVIngest(config: ScoptArguments, dsConfig: Map[String, _]) extends Logging
 
   def performIngest(cfw: CloseableFeatureWriter, lines: Iterator[String]) = {
     linesToFeatures(lines).foreach {
-      case Success(ft) => successes +=1; writeFeature(cfw.fw, ft)
-      case Failure(ex) => errors +=1; logger.error(s"Could not write feature due to: ${ex.getLocalizedMessage}")
+      case Success(ft) =>
+        writeFeature(cfw.fw, ft)
+        // Log info to user that ingest is still working, might be in wrong spot however...
+        if ( lineNumber % 10000 == 0 ) {
+          val successPvsS = if (successes == 1) "feature" else "features"
+          val failurePvsS = if (failures == 1) "feature" else "features"
+          logger.info(s"Ingest proceeding, on line number: $lineNumber," +
+            s" with $successes $successPvsS and $failures $failurePvsS.")
+        }
+      case Failure(ex) => failures +=1; logger.error(s"Could not write feature due to: ${ex.getLocalizedMessage}")
     }
   }
 
@@ -132,10 +155,6 @@ class SVIngest(config: ScoptArguments, dsConfig: Map[String, _]) extends Logging
 
   def lineToFeature(line: String): Try[AvroSimpleFeature] = Try{
     lineNumber += 1
-    // Log info to user that ingest is still working, might be in wrong spot however...
-    if ( lineNumber % 10000 == 0 ) {
-      logger.info(s"Ingest proceeding, on line number: $lineNumber")
-    }
     // CsvReader is being used to just split the line up. this may be refactored out when
     // scalding support is added however it may be necessary for local only ingest
     val reader = new CsvReader(IOUtils.toInputStream(line), delim, Charset.defaultCharset())
@@ -161,7 +180,7 @@ class SVIngest(config: ScoptArguments, dsConfig: Map[String, _]) extends Logging
         feature.setAttribute(dtgField, date)
       } catch {
         case e: Exception => throw new Exception(s"Could not form Date object from field" +
-          s" using $dtFormat, on line number: $lineNumber")
+          s" using dt-format: $dtgFmt, on line number: $lineNumber")
       }
     }
 
@@ -171,6 +190,7 @@ class SVIngest(config: ScoptArguments, dsConfig: Map[String, _]) extends Logging
       case e: Exception => throw new Exception(s"Could not find date-time field: \'${dtgField}\' " +
         s"in line: \'${line}\', number: $lineNumber")
     }
+
     feature.setAttribute(dtgTargetField, dtg.toDate)
     // Support for point data method
     val lon = Option(feature.getAttribute(lonField)).map(_.asInstanceOf[Double])
@@ -192,21 +212,30 @@ class SVIngest(config: ScoptArguments, dsConfig: Map[String, _]) extends Logging
       toWrite.getIdentifier.asInstanceOf[FeatureIdImpl].setID(feature.getID)
       toWrite.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
       fw.write()
+      successes +=1
     } catch {
-      case e: Exception => logger.error(s"Cannot ingest avro simple feature: $feature", e)
+      case e: Exception =>
+        logger.error(s"Cannot ingest avro simple feature: $feature", e)
+        failures +=1
     }
   }
 
   def getAttributeIndexInLine(attribute: String) = attributes.indexOf(sft.getDescriptor(attribute))
 
   def buildIDBuilder: (Array[String]) => String = {
-     idFields match {
-       case s: String =>
+    (idFields, doHash) match {
+       case (s: String, false) =>
          val idSplit = idFields.split(",").map { f => sft.indexOf(f) }
          attrs => idSplit.map { idx => attrs(idx) }.mkString("_")
+       case (s: String, true) =>
+         val hashFn = Hashing.md5()
+         val idSplit = idFields.split(",").map { f => sft.indexOf(f) }
+         attrs => hashFn.newHasher().putString(idSplit.map { idx => attrs(idx) }.mkString("_"),
+           Charset.defaultCharset()).hash().toString
        case _         =>
          val hashFn = Hashing.md5()
-         attrs => hashFn.newHasher().putString(attrs.mkString ("|"), Charset.defaultCharset()).hash().toString
+         attrs => hashFn.newHasher().putString(attrs.mkString ("_"),
+           Charset.defaultCharset()).hash().toString
      }
   }
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Utils.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Utils.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.tools
+
+import java.util.UUID
+
+import org.apache.accumulo.core.client.ZooKeeperInstance
+import org.apache.hadoop.fs.Path
+
+import scala.util.Try
+import scala.xml.XML
+
+/*  ScoptArguments is a case Class used by scopt, args are stored in it and default values can be set in Config also.*/
+case class ScoptArguments(username: String = null,
+                          password: String = null,
+                          mode: String = null,
+                          spec: String = null,
+                          idFields: Option[String] = None,
+                          dtField: Option[String] = None,
+                          dtFormat: String = null,
+                          method: String = "local",
+                          file: String = null,
+                          featureName: String = null,
+                          format: String = null,
+                          toStdOut:Boolean = false,
+                          catalog: String = null,
+                          maxFeatures: Int = -1,
+                          defaultDate: String = null,
+                          filterString: String = null,
+                          attributes: String = null,
+                          lonAttribute: Option[String] = None,
+                          latAttribute: Option[String] = None,
+                          query: String = null,
+                          skipHeader: Boolean = false)
+
+/*  ScoptArguments is a case Class used by scopt, args are stored in it and default values can be set in Config also.*/
+case class IngestArguments(username: String = null,
+                           password: String = null,
+                           catalog: String = null,
+                           auths: Option[String] = None,
+                           visibilities: Option[String] = None,
+                           indexSchemaFormat: Option[String] = None,
+                           spec: String = null,
+                           idFields: Option[String] = None,
+                           dtField: Option[String] = None,
+                           dtFormat: String = null,
+                           method: String = "local",
+                           file: String = null,
+                           featureName: String = null,
+                           format: String = null,
+                           lonAttribute: Option[String] = None,
+                           latAttribute: Option[String] = None,
+                           skipHeader: Boolean = false,
+                           doHash: Boolean = false,
+                           maxShards: Option[Int] = None )
+
+/* get password trait */
+trait GetPassword {
+  def password(s: String) = s match {
+    case pw: String => pw
+    case _ =>
+      val standardIn = System.console()
+      print("Password> ")
+      standardIn.readPassword().mkString
+  }
+}
+
+/* Accumulo properties trait */
+trait AccumuloProperties {
+  val accumuloConf = XML.loadFile(s"${System.getenv("ACCUMULO_HOME")}/conf/accumulo-site.xml")
+  val zookeepers = (accumuloConf \\ "property")
+    .filter(x => (x \ "name")
+    .text == "instance.zookeeper.host")
+    .map(y => (y \ "value").text)
+    .head
+  val instanceDfsDir = Try((accumuloConf \\ "property")
+    .filter(x => (x \ "name")
+    .text == "instance.dfs.dir")
+    .map(y => (y \ "value").text)
+    .head)
+    .getOrElse("/accumulo")
+  val instanceIdDir = new Path(instanceDfsDir, "instance_id")
+  val instanceIdStr = ZooKeeperInstance.getInstanceIDFromHdfs(instanceIdDir)
+  val instanceName = new ZooKeeperInstance(UUID.fromString(instanceIdStr), zookeepers).getInstanceName
+}
+
+

--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/SVIngestTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/SVIngestTest.scala
@@ -30,12 +30,12 @@ class SVIngestTest extends Specification{
 
   sequential
   var id = 0
-  var csvConfig = new ScoptArguments(spec = "id:Double,time:Date,lon:Double,lat:Double,*geom:Point:srid=4326",
+  var csvConfig = new IngestArguments(spec = "id:Double,time:Date,lon:Double,lat:Double,*geom:Point:srid=4326",
     idFields = None, dtField = Option("time"), lonAttribute = Option("lon"), latAttribute = Option("lat"),
     dtFormat = "yyyy-MM-dd", skipHeader = false, featureName = "test_type",
     method = "local", file = "none", format = "CSV")
 
-  var csvWktConfig = new ScoptArguments(spec = "id:Double,time:Date,*geom:Geometry", idFields = None,
+  var csvWktConfig = new IngestArguments(spec = "id:Double,time:Date,*geom:Geometry", idFields = None,
     dtField = Option("time"), dtFormat = "yyyy-MM-dd", skipHeader = false, featureName = "test_type",
     method = "local", file = "none", format = "CSV")
 
@@ -49,7 +49,6 @@ class SVIngestTest extends Specification{
       "user"            -> "myuser",
       "password"        -> "mypassword",
       "tableName"       -> currentCatalog,
-      "featureEncoding" -> "avro",
       "useMock"         -> "true")
   }
 


### PR DESCRIPTION
- Split off ingest from Tools class, to ensure case class does not reach max size.
- Updated geomesa bash script to properly pipe to ingest, and not split inputs containing spaces (G-306).
- Allowed User to optionally hash feature IDs depending.
- Added optional arguments for: maxShard, auths, visibilities, and indexSchemaformat
- Made changes to how successes vs failures are counted and logged in SVIngest
- Made checks to ensure maxShard and indexschemaformat could not be both set.
- Made Utils.scala to contain common code.
- Updated Readme to be current.
