### PR TITLE
GEOMESA-330 Avro SimpleFeature's getProperty should return a Property even when the value is null

### DIFF
--- a/geomesa-feature/src/main/scala/org/locationtech/geomesa/feature/AvroSimpleFeature.scala
+++ b/geomesa-feature/src/main/scala/org/locationtech/geomesa/feature/AvroSimpleFeature.scala
@@ -144,8 +144,8 @@ class AvroSimpleFeature(id: FeatureId, sft: SimpleFeatureType)
   def getProperties(name: String): JCollection[Property] = getProperties.filter(_.getName.toString == name)
   def getProperty(name: Name): Property = getProperty(name.getLocalPart)
   def getProperty(name: String): Property =
-    (Option(getAttribute(name)), Option(sft.getDescriptor(name))) match {
-      case (Some(attribute), Some(descriptor)) => new AttributeImpl(attribute, descriptor, id)
+    Option(sft.getDescriptor(name)) match {
+      case Some(descriptor) => new AttributeImpl(getAttribute(name), descriptor, id)
       case _ => null
     }
 

--- a/geomesa-feature/src/test/scala/org/locationtech/geomesa/feature/AvroSimpleFeatureTest.scala
+++ b/geomesa-feature/src/test/scala/org/locationtech/geomesa/feature/AvroSimpleFeatureTest.scala
@@ -159,5 +159,28 @@ class AvroSimpleFeatureTest extends Specification {
       val oldSf = new SimpleFeatureImpl(List(null, null), sft, new FeatureIdImpl("fakeid"))
       oldSf.getProperty("c") should beNull
     }
+    "give back a property when a property exists but the value is null" in {
+      // Verify that AvroSimpleFeature returns null for properties that do not exist like SimpleFeatureImpl
+      val sft = SimpleFeatureTypes.createType("avrotesttype", "a:Integer,b:String")
+      val sf = new AvroSimpleFeature(new FeatureIdImpl("fakeid"), sft)
+      sf.getProperty("b") must not(throwA[NullPointerException])
+      sf.getProperty("b") should not beNull
+
+      val oldSf = new SimpleFeatureImpl(List(null, null), sft, new FeatureIdImpl("fakeid"))
+      oldSf.getProperty("b") should not beNull
+    }
+    "give back a null when the property value is null" in {
+      // Verify that AvroSimpleFeature returns null for properties that do not exist like SimpleFeatureImpl
+      val sft = SimpleFeatureTypes.createType("avrotesttype", "a:Integer,b:String")
+      val sf = new AvroSimpleFeature(new FeatureIdImpl("fakeid"), sft)
+      sf.getProperty("b").getValue must not(throwA[NullPointerException])
+      sf.getProperty("b").getValue should beNull
+
+      val oldSf = new SimpleFeatureImpl(List(null, null), sft, new FeatureIdImpl("fakeid"))
+      oldSf.getProperty("b").getValue should beNull
+    }
+
+
+
   }
 }


### PR DESCRIPTION
This addresses an issue found by a user who was attempting to run the Quick Start tutorial  
