### PR TITLE
GEOMESA-93 Implement KNN as a WPS function

### DIFF
--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloFeatureSource.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloFeatureSource.scala
@@ -21,6 +21,7 @@ import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
 import org.geotools.feature.visitor.{BoundsVisitor, MaxVisitor, MinVisitor}
 import org.geotools.process.vector.TransformProcess
 import org.joda.time.DateTime
+import org.locationtech.geomesa.core.process.knn.KNNVisitor
 import org.locationtech.geomesa.core.process.proximity.ProximityVisitor
 import org.locationtech.geomesa.core.process.query.QueryVisitor
 import org.locationtech.geomesa.core.process.tube.TubeVisitor
@@ -105,6 +106,7 @@ class AccumuloFeatureCollection(source: SimpleFeatureSource,
     case v: TubeVisitor      => v.setValue(v.tubeSelect(source, query))
     case v: ProximityVisitor => v.setValue(v.proximitySearch(source, query))
     case v: QueryVisitor     => v.setValue(v.query(source, query))
+    case v: KNNVisitor       => v.setValue(v.kNNSearch(source,query))
     case _                   => super.accepts(visitor, progress)
   }
 

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/process/knn/GeoHashSpiral.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/process/knn/GeoHashSpiral.scala
@@ -1,0 +1,160 @@
+/*
+* Copyright 2014 Commonwealth Computer Research, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.locationtech.geomesa.core.process.knn
+
+import com.vividsolutions.jts.geom.Point
+import org.locationtech.geomesa.utils.geohash._
+import org.locationtech.geomesa.utils.geotools.Conversions.RichSimpleFeature
+import org.opengis.feature.simple.SimpleFeature
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+// used for ordering GeoHashes within a PriorityQueue
+case class GeoHashWithDistance(gh: GeoHash, dist: Double)
+
+/**
+ * Object and Class for the GeoHashSpiral
+ *
+ * This provides a Iterator[GeoHash] which generates GeoHashes in order from the geodetic distance from a single POINT.
+ */
+
+trait GeoHashDistanceFilter {
+  // distance in meters used by the filter
+  var statefulFilterDistance: Double
+
+  // modifies statefulFiilterDistance if a new distance is smaller
+  def mutateFilterDistance(theNewMaxDistance: Double) {
+    if (theNewMaxDistance < statefulFilterDistance) statefulFilterDistance = theNewMaxDistance
+  }
+  // removes GeoHashes that are further than a certain distance from a feature or point
+  def statefulDistanceFilter(x: GeoHashWithDistance): Boolean =
+    { x.dist < statefulFilterDistance }
+}
+
+trait GeoHashAutoSize {
+  // find the smallest GeoHash whose minimumSize is larger than the desiredSizeInMeters
+  def geoHashToSize(pointInside: Point, desiredSizeInMeters: Double ): GeoHash = {
+    import org.locationtech.geomesa.utils.geohash.GeohashUtils._
+    // typically 25 bits are encoded in the Index Key
+    val allowablePrecisions = List(25,30,35,40).reverse
+    allowablePrecisions.map { prec => GeoHash(pointInside,prec) }
+                       .find { gh    => getGeohashMinDimensionMeters(gh) > desiredSizeInMeters }
+                       .getOrElse (GeoHash (pointInside, allowablePrecisions.last) )
+  }
+}
+
+object GeoHashSpiral extends GeoHashAutoSize {
+  def apply(centerFeature: SimpleFeature, distanceGuess: Double, maxDistance: Double): GeoHashSpiral = {
+    centerFeature.point match {
+      case aPoint: Point => GeoHashSpiral(aPoint, distanceGuess, maxDistance)
+      case _ => throw new RuntimeException("GeoHashSpiral not implemented for non-point geometries")
+    }
+  }
+
+  def apply(centerPoint: Point, distanceGuess: Double, maxDistance: Double): GeoHashSpiral = {
+
+    // generate the central GeoHash as a seed with precision/size governed by distanceGuess
+    val seedGH = geoHashToSize(centerPoint, distanceGuess)
+    val seedWithDistance = GeoHashWithDistance(seedGH, 0.0)
+
+    // These are helpers for distance calculations and ordering.
+    def distanceCalc(gh:GeoHash) =
+      GeohashUtils.getMinimumGeodeticDistance(gh.bbox, centerPoint, exhaustive = true)
+
+    implicit val orderedGH: Ordering[GeoHashWithDistance] = Ordering.by { _.dist}
+
+    // Create a new GeoHash PriorityQueue and enqueue with a seed.
+    val ghPQ = new mutable.PriorityQueue[GeoHashWithDistance]()(orderedGH.reverse) { enqueue(seedWithDistance) }
+
+    new GeoHashSpiral(ghPQ, distanceCalc, maxDistance)
+  }
+}
+
+class GeoHashSpiral(pq: mutable.PriorityQueue[GeoHashWithDistance],
+                     val distance: (GeoHash) => Double,
+                     var statefulFilterDistance: Double) extends GeoHashDistanceFilter with BufferedIterator[GeoHash] {
+
+  // running set of GeoHashes which have already been encountered -- used to prevent visiting a GeoHash more than once
+  val oldGH = new mutable.HashSet[GeoHash] ++= pq.toSet[GeoHashWithDistance].map{ _.gh }
+
+  // these are used to setup a modified on-deck pattern: a PriorityQueue backed by a generator
+  var onDeck: Option[GeoHashWithDistance] = None
+  var nextGHFromPQ: Option[GeoHashWithDistance] = None
+
+  // prime the on deck pattern
+  loadNextGHFromPQ()
+  loadNextGHFromTouching()
+  loadNext()
+
+  // method used to find the next element in the PQ that passes a filter
+  @tailrec
+  private def loadNextGHFromPQ() {
+    if (pq.isEmpty) nextGHFromPQ = None
+    else {
+      val theHead = pq.dequeue()  // removes elements from pq
+
+      if (statefulDistanceFilter(theHead)) nextGHFromPQ = Option(theHead)
+
+      else loadNextGHFromPQ()
+    }
+  }
+
+  // method to load the neighbors of the next GeoHash to be visited into the PriorityQueue
+  private def loadNextGHFromTouching() {
+    // use the GeoHash already taken from the head of the PriorityQueue as a seed
+    nextGHFromPQ.foreach { newSeedGH =>
+      // obtain only *new* GeoHashes that touch
+      val newTouchingGH = TouchingGeoHashes.touching(newSeedGH.gh).filterNot(oldGH contains)
+
+      // enrich the GeoHashes with distances
+      val withDistance = newTouchingGH.map { aGH => GeoHashWithDistance(aGH, distance(aGH))}
+
+      // remove the GeoHashes that are located too far away
+      val withinDistance = withDistance.filter(statefulDistanceFilter)
+
+      // add all GeoHashes which pass the filter to the PQ
+      withinDistance.foreach { ghWD => pq.enqueue(ghWD)}
+
+      // also add the new GeoHashes to the set of old GeoHashes
+      // note: we add newTouchingGH now, since the cost of having many extra GeoHashes will likely
+      // be less than that of computing the distance for the same GeoHash multiple times,
+      // which is what happens if withinDistance is used.
+      oldGH ++= newTouchingGH
+    }
+  }
+
+  // loads the head element in the PQ into onDeck, and adds GeoHashes to the PQ
+  private def loadNext() {
+    nextGHFromPQ match {
+      case None    => onDeck = None // nothing left in the priorityQueue
+      case Some(x) => loadNextGHFromPQ(); loadNextGHFromTouching(); onDeck = Some(x)
+    }
+  }
+
+  // filter applied here to account for mutations in the filter AFTER onDeck is loaded
+  def head = onDeck.filter(statefulDistanceFilter) match {
+    case Some(nextGH) => nextGH.gh
+    case None => throw new Exception
+  }
+
+  // filter applied here to account for mutations in the filter AFTER onDeck is loaded
+  def hasNext = onDeck.filter(statefulDistanceFilter).isDefined
+
+  def next() = head match {case nextGH:GeoHash => loadNext() ; nextGH }
+
+}

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/process/knn/KNNQuery.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/process/knn/KNNQuery.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.process.knn
+
+import com.typesafe.scalalogging.slf4j.Logging
+import org.geotools.data.Query
+import org.geotools.data.simple.SimpleFeatureSource
+import org.geotools.geometry.jts.ReferencedEnvelope
+import org.locationtech.geomesa.core.filter._
+import org.locationtech.geomesa.utils.geohash.GeoHash
+import org.opengis.feature.simple.SimpleFeature
+
+import scala.annotation.tailrec
+
+/**
+ * This object contains the main algorithm for the GeoHash-based iterative KNN search.
+ */
+
+
+object KNNQuery extends Logging {
+  /**
+   * Method to kick off a new KNN query about aFeatureForSearch
+   *
+   * Situations where maxDistanceInMeters is set too small may cause the search to not actually find the K nearest neighbors,
+   * but still permit K neighbors to be found, resulting in incorrect results. To be addressed in GEOMESA-285.
+   */
+  def runNewKNNQuery(source: SimpleFeatureSource,
+                     query: Query,
+                     numDesired: Int,
+                     searchDistanceInMeters: Double,
+                     maxDistanceInMeters: Double,
+                     aFeatureForSearch: SimpleFeature): NearestNeighbors = {
+
+    // setup the GeoHashSpiral -- it requires the search point,
+    // an estimate of the area containing the K Nearest Neighbors,
+    // and a maximum distance for search as a safeguard
+    val geoHashPQ = GeoHashSpiral(aFeatureForSearch, searchDistanceInMeters, maxDistanceInMeters)
+
+    // setup the NearestNeighbors PriorityQueue -- this is the last usage of aFeatureForSearch
+    val sfPQ = NearestNeighbors(aFeatureForSearch, numDesired)
+
+    // begin the search with the recursive method
+    runKNNQuery(source, query, geoHashPQ, sfPQ)
+  }
+
+  /**
+   * Recursive function to iteratively query a number of geohashes and insert their results into a
+   * NearestNeighbors priority queue
+   */
+  @tailrec
+  def runKNNQuery(source: SimpleFeatureSource,
+                   query: Query,
+                   ghPQ: GeoHashSpiral,
+                   sfPQ: NearestNeighbors
+                 )     : NearestNeighbors = {
+    import org.locationtech.geomesa.utils.geotools.Conversions.toRichSimpleFeatureIterator
+    if (!ghPQ.hasNext) sfPQ
+    else {
+        val newGH = ghPQ.next()
+        // copy the query in order to pass the original to the next recursion
+        val newQuery = generateKNNQuery(newGH, query, source)
+
+        val newFeatures = source.getFeatures(newQuery).features
+
+        // insert the SimpleFeature and its distance into sfPQ
+
+        newFeatures.foreach { sf => sfPQ.add( SimpleFeatureWithDistance(sf,sfPQ.distance(sf)) ) }
+        // apply filter to ghPQ if we've found k neighbors
+        if (sfPQ.isFull) sfPQ.maxDistance.foreach { x => ghPQ.mutateFilterDistance(x)}
+        lazy val subQueryInfo = s"${newGH.hash}, ${sfPQ.maxDistance.getOrElse(0.0)}, ${sfPQ.size}"
+        logger.trace (s"KNN Status: Completed subQuery: (hash,distance, PQ size) = $subQueryInfo ")
+        // iterate after trimming sfPQ to the best K
+        runKNNQuery(source, query, ghPQ, sfPQ.getKNN)
+    }
+  }
+
+  /**
+   * Generate a new query by narrowing another down to a single GeoHash
+   */
+  def generateKNNQuery(gh: GeoHash, oldQuery: Query, source: SimpleFeatureSource): Query = {
+
+    // setup a new BBOX filter to add to the original suite
+    val geomProp = ff.property(source.getSchema.getGeometryDescriptor.getName)
+
+    val newGHEnv = new ReferencedEnvelope(gh.bbox, oldQuery.getCoordinateSystem)
+
+    val newGHFilter = ff.bbox(geomProp, newGHEnv)
+
+    // could ALSO apply a dwithin filter if k neighbors have been found.
+    // copy the original query before mutation
+    val newQuery = new Query(oldQuery)
+    // AND the new GeoHash filter with the original filter
+    newQuery.setFilter(ff.and(newGHFilter, oldQuery.getFilter))
+    newQuery
+  }
+}

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/process/knn/KNearestNeighborSearchProcess.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/process/knn/KNearestNeighborSearchProcess.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.process.knn
+
+import com.typesafe.scalalogging.slf4j.Logging
+import com.vividsolutions.jts.geom.Point
+import org.geotools.data.Query
+import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
+import org.geotools.data.store.ReTypingFeatureCollection
+import org.geotools.feature.DefaultFeatureCollection
+import org.geotools.feature.visitor.{AbstractCalcResult, CalcResult, FeatureCalc}
+import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
+import org.geotools.util.NullProgressListener
+import org.locationtech.geomesa.core.data.AccumuloFeatureCollection
+import org.locationtech.geomesa.utils.geotools.Conversions.RichSimpleFeatureIterator
+import org.opengis.feature.Feature
+
+import scala.collection.JavaConverters._
+
+
+@DescribeProcess(
+  title = "Geomesa-enabled K Nearest Neighbor Search",
+  description = "Performs a K Nearest Neighbor search on a Geomesa feature collection using another feature collection as input"
+)
+class KNearestNeighborSearchProcess extends Logging {
+
+  @DescribeResult(description = "Output feature collection")
+  def execute(
+               @DescribeParameter(
+                 name = "inputFeatures",
+                 description = "Input feature collection that defines the KNN search")
+               inputFeatures: SimpleFeatureCollection,
+
+               @DescribeParameter(
+                 name = "dataFeatures",
+                 description = "The data set to query for matching features")
+               dataFeatures: SimpleFeatureCollection,
+
+               @DescribeParameter(
+                 name = "numDesired",
+                 description = "K: number of nearest neighbors to return")
+               numDesired: java.lang.Integer,
+
+               @DescribeParameter(
+                 name = "estimatedDistance",
+                 description = "Estimate of Search Distance in meters for K neighbors---used to set the granularity of the search")
+               estimatedDistance: java.lang.Double,
+
+               @DescribeParameter(
+                 name = "maxSearchDistance",
+                 description = "Maximum search distance in meters---used to prevent runaway queries of the entire table")
+               maxSearchDistance: java.lang.Double
+               ): SimpleFeatureCollection = {
+
+    logger.info("Attempting Geomesa K-Nearest Neighbor Search on collection type " + dataFeatures.getClass.getName)
+
+    if(!dataFeatures.isInstanceOf[AccumuloFeatureCollection]) {
+      logger.warn("The provided data feature collection type may not support geomesa KNN search: "+dataFeatures.getClass.getName)
+    }
+    if(dataFeatures.isInstanceOf[ReTypingFeatureCollection]) {
+      logger.warn("WARNING: layer name in geoserver must match feature type name in geomesa")
+    }
+    val visitor = new KNNVisitor(inputFeatures, dataFeatures, numDesired, estimatedDistance, maxSearchDistance)
+    dataFeatures.accepts(visitor, new NullProgressListener)
+    visitor.getResult.asInstanceOf[KNNResult].results
+  }
+}
+
+/**
+ *  The main visitor class for the KNN search process
+ */
+
+class KNNVisitor( inputFeatures:     SimpleFeatureCollection,
+                  dataFeatures:      SimpleFeatureCollection,
+                  numDesired:        java.lang.Integer,
+                  estimatedDistance: java.lang.Double,
+                  maxSearchDistance: java.lang.Double
+                ) extends FeatureCalc with Logging {
+
+  val manualVisitResults = new DefaultFeatureCollection(null, dataFeatures.getSchema)
+
+  // called for non AccumuloFeatureCollections
+  // FIXME Implement as detailed in  GEOMESA-284
+  def visit(feature: Feature): Unit = {}
+
+  var resultCalc: KNNResult = new KNNResult(manualVisitResults)
+
+  override def getResult: CalcResult = resultCalc
+
+  def setValue(r: SimpleFeatureCollection) = resultCalc = KNNResult(r)
+
+  /** The KNN-Search interface for the WPS process.
+    *
+    * Takes as input a Query and SimpleFeatureSource, in addition to
+    * inputFeatures which define one or more SimpleFeatures for which to find KNN of each
+    *
+    * Note that the results are NOT de-duplicated!
+    *
+    */
+  def kNNSearch(source: SimpleFeatureSource, query: Query) = {
+    logger.info("Running Geomesa K-Nearest Neighbor Search on source type " + source.getClass.getName)
+
+    // create a new Feature collection to hold the results of the KNN search around each point
+    val resultCollection = new DefaultFeatureCollection
+    val searchFeatureIterator = new RichSimpleFeatureIterator(inputFeatures.features())
+
+    // for each entry in the inputFeatures collection:
+    while (searchFeatureIterator.hasNext) {
+      val aFeatureForSearch = searchFeatureIterator.next()
+      aFeatureForSearch.getDefaultGeometry match {
+        case geo: Point =>
+          val knnResults = KNNQuery.runNewKNNQuery(source, query, numDesired, estimatedDistance, maxSearchDistance, aFeatureForSearch)
+          // extract the SimpleFeatures and convert to a Collection. Ordering will not be preserved.
+          val sfList = knnResults.getK.map {_.sf}.asJavaCollection
+          resultCollection.addAll(sfList)
+        case _ => logger.warn("K Nearest Neighbor Search not implemented for non-point geometries, skipping this Feature")
+      }
+    }
+    resultCollection
+  }
+}
+case class KNNResult(results: SimpleFeatureCollection) extends AbstractCalcResult

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/process/knn/NearestNeighbors.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/process/knn/NearestNeighbors.scala
@@ -1,0 +1,130 @@
+/*
+* Copyright 2014 Commonwealth Computer Research, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.locationtech.geomesa.core.process.knn
+
+import com.vividsolutions.jts.geom.Point
+import org.locationtech.geomesa.utils.geohash.VincentyModel
+import org.locationtech.geomesa.utils.geotools.Conversions.RichSimpleFeature
+import org.opengis.feature.simple.SimpleFeature
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+case class SimpleFeatureWithDistance(sf: SimpleFeature, dist: Double)
+
+trait NearestNeighborsMethods {
+  // distance to reference point
+  def distance(sf: SimpleFeature): Double
+
+  // distance of kth point from reference point, or furthest found so far if size is < K
+  def maxDistance: Option[Double]
+
+  // this is "k" --- the desired number of nearest neighbors
+  def maxSize: Int
+
+  // current size of the collection, which may be more or less than maxSize in the current implementation
+  def size: Int
+
+  // indicates if size is >= maxSize
+  def isFull: Boolean
+
+  //  provides a view of the Kth nearest neighbor, or furthest found if the size is < K
+  def peekLast: Option[SimpleFeatureWithDistance]
+
+  // adds a collection of SimpleFeatureWithDistance to the NearestNeighbors
+  def add(sfWDC: Iterable[SimpleFeatureWithDistance]): Unit
+
+  // adds a single SimpleFeatureWithDistance to the NearestNeighbors
+  def add(sfWD: SimpleFeatureWithDistance): Unit
+
+  // returns a NearestNeighbors object, trimmed to contain the "best K" neighbors
+  def getKNN: NearestNeighbors
+
+  // return a List of the K NearestNeighbors in sorted order.
+  def getK: List[SimpleFeatureWithDistance]
+}
+
+/**
+ *  This class provides a collection of SimpleFeatures sorted by distance from a central POINT.
+ *  This is currently implemented using transactions with a scala mutable PriorityQueue
+ *
+ */
+object NearestNeighbors {
+  def apply(aFeatureForSearch: SimpleFeature, numDesired: Int): NearestNeighbors = {
+    aFeatureForSearch.point match {
+      case aPoint: Point => NearestNeighbors(aPoint, numDesired)
+      case _ => throw new RuntimeException("NearestNeighbors not implemented for non-point geometries")
+    }
+  }
+
+  def apply(aPointForSearch: Point, numDesired: Int): NearestNeighbors = {
+
+    def distanceCalc(sf: SimpleFeature) =
+      VincentyModel.getDistanceBetweenTwoPoints(aPointForSearch, sf.point).getDistanceInMeters
+
+    implicit val orderedSF: Ordering[SimpleFeatureWithDistance] = Ordering.by {_.dist}
+
+    new NearestNeighbors(numDesired, distanceCalc)(orderedSF.reverse)
+  }
+}
+
+class NearestNeighbors(val maxSize: Int,
+                       distanceCalc: SimpleFeature => Double)(implicit ord: Ordering[SimpleFeatureWithDistance])
+  extends NearestNeighborsMethods {
+
+  val corePQ = mutable.PriorityQueue[SimpleFeatureWithDistance]()
+
+  def distance(sf: SimpleFeature) = distanceCalc(sf)
+
+  def maxDistance = peekLast.map {_.dist}
+
+  def isFull = !(corePQ.length < maxSize)
+
+  @tailrec
+  final def dequeueN(n: Int, list:List[SimpleFeatureWithDistance]): List[SimpleFeatureWithDistance] = {
+    if (corePQ.isEmpty || list.length == n) list.reverse
+    else {
+      val newList = corePQ.dequeue() :: list
+      dequeueN(n,newList)
+    }
+  }
+
+  def peekLast = getK.lastOption
+
+  def getKNN = {
+    if (isFull) {
+      val that = new NearestNeighbors(maxSize, distance)
+      that.add(this.dequeueN(maxSize,List[SimpleFeatureWithDistance]()))
+      that
+    } else this
+  }
+
+  def getK = clone().dequeueN(maxSize,List[SimpleFeatureWithDistance]())
+
+  def add(sfWDC: Iterable[SimpleFeatureWithDistance]) = sfWDC.map(add)
+
+  def add(sfWD: SimpleFeatureWithDistance) = corePQ.enqueue(sfWD)
+
+  def size = corePQ.size
+
+  override def clone() = {
+    val that = new NearestNeighbors(maxSize, distance)
+    that.corePQ ++= this.corePQ
+    that
+  }
+}
+

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/process/knn/TouchingGeoHashes.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/process/knn/TouchingGeoHashes.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.process.knn
+
+import com.vividsolutions.jts.geom.Coordinate
+import org.locationtech.geomesa.utils.geohash.GeoHash
+
+/**
+ * This object provides a method for obtaining a set of GeoHashes which are in "contact" with a seed GeoHash.
+ * Sets are used throughout to avoid duplication.
+ *
+ * These methods exploit the symmetry of GeoHashes to ensure that they are both antimeridian
+ * (aka International Data Line) and "pole" safe. For the latter, any GeoHash that touches the pole
+ * has all such GeoHashes as "touching" neighbors
+ */
+
+object TouchingGeoHashes {
+
+  // generates directions for stepping N,NE,E, etc...
+  val shiftPattern = for {
+    i <- Set(-1, 0, 1)
+    j <- Set(-1, 0, 1)
+  } yield new Coordinate(i, j)
+
+  // generates a set of all touching neighbors
+  def touching(gh: GeoHash): Set[GeoHash] = {
+
+    val thisLocVector = gh.getPoint.getCoordinate
+
+    val thisPrec = gh.prec
+
+    val thisPrecVector = new Coordinate(GeoHash.longitudeDeltaForPrecision(thisPrec),
+      GeoHash.latitudeDeltaForPrecision(thisPrec))
+
+    // these are actually coordinate candidates, some may be over the poles or past the antimeridian
+    val newCoords = for {
+      jumpUnitVector <- shiftPattern
+      newX = thisLocVector.x + (jumpUnitVector.x * thisPrecVector.x)
+      newY = thisLocVector.y + (jumpUnitVector.y * thisPrecVector.y)
+    } yield new Coordinate(newX, newY)
+
+    // now process the coordinate candidates, treating both the antimeridian and the polar regions
+    val safeCoords = newCoords.flatMap { generateIDLSafeCoordinates }.
+                               flatMap { generatePolarSafeCoordinates(_, thisPrecVector, thisLocVector) }
+    // use the now safe coordinates to generate GeoHashes, removing the seed GeoHash
+    safeCoords.map { coord => GeoHash(coord.x, coord.y, thisPrec) }.filter { _ != gh }
+  }
+
+  // handles cases where the seed geohash is in contact with the antimeridian
+  def generateIDLSafeCoordinates(xyPair: Coordinate): Set[Coordinate] =
+    if (math.abs(xyPair.x) > 180.0) generateIDLMirrorPair(xyPair) else Set(xyPair)
+
+  // use symmetry about the antimeridian to find the correct coordinate on the other side
+  def generateIDLMirrorPair(xyPair: Coordinate): Set[Coordinate] = {
+    val newLat = xyPair.y
+    val newLon = xyPair.x + degreesLonTranslation(xyPair.x)
+    Set(new Coordinate(newLon, newLat))
+  }
+
+  // taken from inside  getInternationalDateLineSafeGeometry
+  // FIXME refactor getInternationalDateLineSafeGeometry to expose the method as detailed in GEOMESA-283
+
+  def degreesLonTranslation(lon: Double): Double = (((lon + 180) / 360.0).floor * -360).toInt
+
+  // handles cases where the seed geohash is in contact with a pole
+  def generatePolarSafeCoordinates(xyPair: Coordinate,
+                                   precVector: Coordinate,
+                                   startingPair: Coordinate): Set[Coordinate] =
+    if (math.abs(xyPair.y) > 90.0) polarCap(xyPair, precVector, startingPair) else Set(xyPair)
+
+  // generate a Set of GeoHashes which all touch this pole, at the same precision as the seed
+  def polarCap(xyPair: Coordinate, precVector: Coordinate, startingPair: Coordinate): Set[Coordinate] = {
+    val newLat = startingPair.y
+    val begin: Double = -180.0 + (0.5 * precVector.x)
+    val end: Double = 180.0 - (0.5 * precVector.x)
+    val step: Double = precVector.x
+    val newLons = begin to(end, step)
+    newLons.map(newLon => new Coordinate(newLon, newLat)).toSet
+  }
+}
+
+
+
+

--- a/geomesa-core/src/test/resources/process/knn/KNNAboutWhiteHouse.xml
+++ b/geomesa-core/src/test/resources/process/knn/KNNAboutWhiteHouse.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- execute a KNN search -->
+<!-- run with command: -->
+<!-- curl -u admin:geoserver -H 'Content-type: xml' -XPOST -d@'KNNAboutWhiteHouse.xml' http://localhost:8080/geoserver/wps | json_pp -->
+<wps:Execute version="1.0.0" service="WPS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns="http://www.opengis.net/wps/1.0.0" xmlns:wfs="http://www.opengis.net/wfs"
+             xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1"
+             xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc"
+             xmlns:wcs="http://www.opengis.net/wcs/1.1.1" xmlns:xlink="http://www.w3.org/1999/xlink"
+             xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd">
+    <ows:Identifier>geomesa:KNearestNeighborSearch</ows:Identifier>
+    <wps:DataInputs>
+        <wps:Input>
+            <ows:Identifier>inputFeatures</ows:Identifier>
+            <wps:Data>
+                <wps:ComplexData mimeType="application/json">
+                    <![CDATA[
+                    {
+                     "features" : [
+                       {
+                            "id" : "0",
+                            "geometry" : {
+                                "coordinates": [-77.034917, 38.894967],
+                                "type" : "Point"
+                            },
+                            "type" : "Feature",
+                            "properties" : {
+                                "dtg" : "2014-05-17T15:33:16.000+0000",
+                            }
+                       }
+                      ],
+                      "type" : "FeatureCollection"
+                     }
+                ]]>
+                </wps:ComplexData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>dataFeatures</ows:Identifier>
+            <wps:Reference mimeType="text/xml" xlink:href="http://geoserver/wfs" method="POST">
+                <wps:Body>
+                    <wfs:GetFeature service="WFS" version="1.0.0" outputFormat="GML2" xmlns:geomesa="geomesa">
+                        <wfs:Query typeName="geomesa:fr"/>
+                    </wfs:GetFeature>
+                </wps:Body>
+            </wps:Reference>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>numDesired</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>1</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>estimatedDistance</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>100</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>maxSearchDistance</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>1000</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+    </wps:DataInputs>
+    <wps:ResponseForm>
+        <wps:RawDataOutput mimeType="application/json">
+            <ows:Identifier>result</ows:Identifier>
+        </wps:RawDataOutput>
+    </wps:ResponseForm>
+</wps:Execute>

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/process/knn/GenerateKNNQueryTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/process/knn/GenerateKNNQueryTest.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.process.knn
+
+import org.geotools.data.{DataStoreFinder, Query}
+import org.geotools.factory.CommonFactoryFinder
+import org.geotools.referencing.CRS
+import org.geotools.referencing.crs.DefaultGeographicCRS
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.core.data._
+import org.locationtech.geomesa.core.index.{Constants, FilterHelper}
+import org.locationtech.geomesa.core.{filter, index}
+import org.locationtech.geomesa.utils.geohash.GeoHash
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.filter.expression.Literal
+import org.opengis.filter.spatial.BBOX
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConverters._
+
+@RunWith(classOf[JUnitRunner])
+class GenerateKNNQueryTest extends Specification {
+
+  def createStore: AccumuloDataStore =
+  // the specific parameter values should not matter, as we
+  // are requesting a mock data store connection to Accumulo
+    DataStoreFinder.getDataStore(Map(
+      "instanceId" -> "mycloud",
+      "zookeepers" -> "zoo1:2181,zoo2:2181,zoo3:2181",
+      "user" -> "myuser",
+      "password" -> "mypassword",
+      "auths" -> "A,B,C",
+      "tableName" -> "testwrite",
+      "useMock" -> "true",
+      "featureEncoding" -> "avro").asJava).asInstanceOf[AccumuloDataStore]
+
+  val sftName = "test"
+  val sft = SimpleFeatureTypes.createType(sftName, index.spec)
+  sft.getUserData.put(Constants.SF_PROPERTY_START_TIME, "dtg")
+
+  val ds = createStore
+
+  ds.createSchema(sft)
+
+  val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
+
+  val smallGH = GeoHash("dqb0tg")
+
+  val ff = CommonFactoryFinder.getFilterFactory2
+
+  val WGS84 = DefaultGeographicCRS.WGS84
+
+
+  "GenerateKNNQuery" should {
+    " inject a small BBOX into a larger query and confirm that the original is untouched" in {
+      val q =
+        ff.and(
+          ff.like(ff.property("prop"), "foo"),
+          ff.bbox("geom", -80.0, 30, -70, 40, CRS.toSRS(WGS84))
+        )
+
+      // use the above to generate a Query
+      val oldQuery = new Query(sftName, q)
+
+      // and then generate a new one
+      val newQuery = KNNQuery.generateKNNQuery(smallGH, oldQuery, fs)
+
+      // check that oldQuery is untouched
+      val oldFilter = oldQuery.getFilter
+
+      // confirm that the oldFilter was not mutated by operations on the new filter
+      // this confirms that the deep copy on the oldQuery was done properly
+      oldFilter mustEqual q
+    }
+
+    "inject a small BBOX into a larger query and have the spatial predicate be equal to the GeoHash boundary" in {
+      //define a loose BBOX
+      val q =
+        ff.and(
+          ff.like(ff.property("prop"), "foo"),
+          ff.bbox("geom", -80.0, 30, -70, 40, CRS.toSRS(WGS84))
+        )
+
+      // use the above to generate a Query
+      val oldQuery = new Query(sftName, q)
+
+      // and then generate a new one
+      val newQuery = KNNQuery.generateKNNQuery(smallGH, oldQuery, fs)
+
+      // get the newFilter
+      val newFilter =  newQuery.getFilter
+
+      // process the newFilter to split out the geometry part
+      val (geomFilters, otherFilters) = filter.partitionGeom(newFilter)
+
+      // rewrite the geometry filter
+      val tweakedGeoms = geomFilters.map ( FilterHelper.updateTopologicalFilters(_, sft) )
+
+      //there can be only one
+      tweakedGeoms.length mustEqual(1)
+
+      val oneBBOX = tweakedGeoms.head.asInstanceOf[BBOX]
+
+      val bboxPoly=oneBBOX.getExpression2.asInstanceOf[Literal].evaluate(null)
+
+      // confirm that the extracted spatial predicate matches the GeoHash BBOX.
+      bboxPoly.equals(smallGH.geom) must beTrue
+    }
+  }
+}

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/process/knn/GeoHashSpiralTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/process/knn/GeoHashSpiralTest.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.process.knn
+
+import org.geotools.factory.Hints
+import org.geotools.feature.simple.SimpleFeatureBuilder
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.core._
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.text.WKTUtils
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class GeoHashSpiralTest extends Specification {
+
+  def generateCvilleSF = {
+    val sftName = "geomesaKNNTestQueryFeature"
+
+    val sft = SimpleFeatureTypes.createType(sftName, index.spec)
+
+    val cvilleSF = SimpleFeatureBuilder.build(sft, List(), "charlottesville")
+    cvilleSF.setDefaultGeometry(WKTUtils.read(f"POINT(-78.4953560 38.0752150 )"))
+    cvilleSF.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+    cvilleSF
+  }
+
+  def generateLineSF = {
+    val sftName = "geomesaKNNTestQueryFeature"
+
+    val sft = SimpleFeatureTypes.createType(sftName, index.spec)
+
+    val lineSF = SimpleFeatureBuilder.build(sft, List(), "route 29")
+    lineSF.setDefaultGeometry(WKTUtils.read(f"LINESTRING(-78.491 38.062, -78.474 38.082)"))
+    lineSF.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+    lineSF
+  }
+
+  "Geomesa GeoHashSpiral PriorityQueue" should {
+
+    "order GeoHashes correctly around Charlottesville" in {
+      val cvilleSF = generateCvilleSF
+
+      val cvillePQ = GeoHashSpiral(cvilleSF, 500.0, 5000.0)
+
+      val cvillePQ2List = cvillePQ.toList
+
+      val nearest9ByCalculation = cvillePQ2List.take(9).map{_.hash}
+
+      // the below are ordered by geodetic distances
+      val nearest9ByVisualInspection = List (
+      "dqb0tg",
+      "dqb0te",
+      "dqb0tf",
+      "dqb0td",
+      "dqb0tu",
+      "dqb0ts",
+      "dqb0w5",
+      "dqb0w4",
+      "dqb0tc")
+
+
+      nearest9ByCalculation must equalTo(nearest9ByVisualInspection)
+    }
+
+    "use the statefulDistanceFilter around Charlottesville correctly before pulling GeoHashes" in {
+      val cvilleSF = generateCvilleSF
+
+      val cvillePQ = GeoHashSpiral(cvilleSF, 500.0, 10000.0)
+      cvillePQ.mutateFilterDistance(1000.0)  // units are meters
+
+      val numHashesAfterFilter = cvillePQ.toList.length
+
+      numHashesAfterFilter must equalTo(12)
+    }
+
+    "use the statefulDistanceFilter around Charlottesville correctly after pulling GeoHashes " in {
+      val cvilleSF = generateCvilleSF
+
+      val cvillePQ = GeoHashSpiral(cvilleSF, 500.0, 10000.0)
+
+      // take the 20 closest GeoHashes
+      val ghBeforeFilter = cvillePQ.take(20)
+
+      ghBeforeFilter.length must equalTo(20)
+
+      // now mutate the filter -- this is restrictive enough that no further GeoHashes should pass
+      cvillePQ.mutateFilterDistance(1000.0)  // units are meters
+
+      // attempt to take five more
+      val ghAfterFilter =  cvillePQ.take(5)
+
+      ghAfterFilter.length must equalTo(0)
+    }
+
+    "throw an exception if given a non-point geometry"  in {
+       val route29SF = generateLineSF
+
+       GeoHashSpiral(route29SF, 500.0, 10000.0) should throwAn[RuntimeException]
+    }
+  }
+}

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/process/knn/KNearestNeighborSearchProcessTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/process/knn/KNearestNeighborSearchProcessTest.scala
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.process.knn
+
+import org.geotools.data.{DataStoreFinder, Query}
+import org.geotools.factory.Hints
+import org.geotools.feature.DefaultFeatureCollection
+import org.geotools.feature.simple.SimpleFeatureBuilder
+import org.geotools.filter.text.ecql.ECQL
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.core.data.{AccumuloDataStore, AccumuloFeatureStore}
+import org.locationtech.geomesa.core.index
+import org.locationtech.geomesa.core.index.{Constants, IndexSchemaBuilder}
+import org.locationtech.geomesa.feature.AvroSimpleFeatureFactory
+import org.locationtech.geomesa.utils.geohash.VincentyModel
+import org.locationtech.geomesa.utils.geotools.Conversions._
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.text.WKTUtils
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConversions._
+import scala.util.Random
+
+case class TestEntry(wkt: String, id: String, dt: DateTime = new DateTime())
+
+@RunWith(classOf[JUnitRunner])
+class KNearestNeighborSearchProcessTest extends Specification {
+
+  val sftName = "geomesaKNNTestType"
+  val sft = SimpleFeatureTypes.createType(sftName, index.spec)
+  sft.getUserData.put(Constants.SF_PROPERTY_START_TIME,"dtg")
+
+  val ds = createStore
+  ds.createSchema(sft)
+
+  val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
+
+  val featureCollection = new DefaultFeatureCollection(sftName, sft)
+
+  val clusterOfPoints = List[TestEntry](
+    TestEntry("POINT( -78.503547 38.035475 )", "rotunda"),
+    TestEntry("POINT( -78.503923 38.035536 )", "pavilion I"),
+    TestEntry("POINT( -78.504059 38.035308 )", "pavilion III"),
+    TestEntry("POINT( -78.504276 38.034971 )", "pavilion V"),
+    TestEntry("POINT( -78.504424 38.034628 )", "pavilion VII"),
+    TestEntry("POINT( -78.504617 38.034208 )", "pavilion IX"),
+    TestEntry("POINT( -78.503833 38.033938 )", "pavilion X"),
+    TestEntry("POINT( -78.503601 38.034343 )", "pavilion VIII"),
+    TestEntry("POINT( -78.503424 38.034721 )", "pavilion VI"),
+    TestEntry("POINT( -78.503180 38.035039 )", "pavilion IV"),
+    TestEntry("POINT( -78.503109 38.035278 )", "pavilion II"),
+    TestEntry("POINT( -78.505152 38.032704 )", "cabell"),
+    TestEntry("POINT( -78.510295 38.034283 )", "beams"),
+    TestEntry("POINT( -78.522288 38.032844 )", "mccormick"),
+    TestEntry("POINT( -78.520019 38.034511 )", "hep")
+  )
+
+  val distributedPoints = generateTestData(1000, 38.149894, -79.073639, 0.30)
+
+  // add the test points to the feature collection
+  addTestData(clusterOfPoints)
+  addTestData(distributedPoints)
+
+  // write the feature to the store
+  fs.addFeatures(featureCollection)
+
+
+  def createStore: AccumuloDataStore =
+  // the specific parameter values should not matter, as we
+  // are requesting a mock data store connection to Accumulo
+    DataStoreFinder.getDataStore(Map(
+      "instanceId" -> "mycloud",
+      "zookeepers" -> "zoo1:2181,zoo2:2181,zoo3:2181",
+      "user" -> "myuser",
+      "password" -> "mypassword",
+      "auths" -> "A,B,C",
+      "tableName" -> "testwrite",
+      "useMock" -> "true",
+      "indexSchemaFormat" -> new IndexSchemaBuilder("~").randomNumber(3).constant("TEST").geoHash(0, 3).date("yyyyMMdd").nextPart().geoHash(3, 2).nextPart().id().build(),
+      "featureEncoding" -> "avro")).asInstanceOf[AccumuloDataStore]
+
+  // utility method to generate random points about a central point
+  // note that these points will be uniform in cartesian space only
+  def generateTestData(num: Int, centerLat: Double, centerLon: Double, width: Double) = {
+    val rng = new Random(0)
+    (1 to num).map(i => {
+      val wkt = "POINT(" +
+        (centerLon + width * (rng.nextDouble() - 0.5)).toString + " " +
+        (centerLat + width * (rng.nextDouble() - 0.5)).toString + " " +
+        ")"
+      val dt = new DateTime()
+      TestEntry(wkt, (100000 + i).toString, dt)
+    }).toList
+  }
+  // load data into the featureCollection
+  def addTestData(points: List[TestEntry]) = {
+    points.foreach { case e: TestEntry =>
+      val sf = AvroSimpleFeatureFactory.buildAvroFeature(sft, List(), e.id)
+      sf.setDefaultGeometry(WKTUtils.read(e.wkt))
+      sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+      featureCollection.add(sf)
+    }
+  }
+  // generates a single SimpleFeature
+  def queryFeature(label: String, lat: Double, lon: Double) = {
+    val sf = AvroSimpleFeatureFactory.buildAvroFeature(sft, List(), label)
+    sf.setDefaultGeometry(WKTUtils.read(f"POINT($lon $lat)"))
+    sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+    sf
+  }
+  // generates a very loose query
+  def wideQuery = {
+    val lat = 38.0
+    val lon = -78.50
+    val siteSize = 5.0
+    val minLat = lat - siteSize
+    val maxLat = lat + siteSize
+    val minLon = lon - siteSize
+    val maxLon = lon + siteSize
+    val queryString = s"BBOX(geom,$minLon, $minLat, $maxLon, $maxLat)"
+    val ecqlFilter = ECQL.toFilter(queryString)
+    //val fs = getTheFeatureSource(tableName, featureName)
+    //new Query(featureName, ecqlFilter, transform)
+    new Query(sftName, ecqlFilter)
+  }
+
+  // begin tests ------------------------------------------------
+
+  "GeoMesaKNearestNeighborSearch" should {
+    "find nothing within 10km of a single query point " in {
+      val inputFeatures = new DefaultFeatureCollection(sftName, sft)
+      inputFeatures.add(queryFeature("fan mountain", 37.878219, -78.692649))
+      val dataFeatures = fs.getFeatures()
+      val knn = new KNearestNeighborSearchProcess
+      knn.execute(inputFeatures, dataFeatures, 5, 500.0, 10000.0).size must equalTo(0)
+    }
+
+    "find 11 points within 400m of a point when k is set to 15 " in {
+      val inputFeatures = new DefaultFeatureCollection(sftName, sft)
+      inputFeatures.add(queryFeature("madison", 38.036871, -78.502720))
+      val dataFeatures = fs.getFeatures()
+      val knn = new KNearestNeighborSearchProcess
+      knn.execute(inputFeatures, dataFeatures, 15, 50.0, 400.0).size should be equalTo 11
+    }
+
+    "handle three query points, one of which will return nothing" in {
+      val inputFeatures = new DefaultFeatureCollection(sftName, sft)
+      inputFeatures.add(queryFeature("madison", 38.036871, -78.502720))
+      inputFeatures.add(queryFeature("fan mountain", 37.878219, -78.692649))
+      inputFeatures.add(queryFeature("blackfriars", 38.149185, -79.070569))
+      val dataFeatures = fs.getFeatures()
+      val knn = new KNearestNeighborSearchProcess
+      knn.execute(inputFeatures, dataFeatures, 5, 500.0, 5000.0).size must greaterThan(0)
+    }
+
+    "handle an empty query point collection" in {
+      val inputFeatures = new DefaultFeatureCollection(sftName, sft)
+      val dataFeatures = fs.getFeatures()
+      val knn = new KNearestNeighborSearchProcess
+      knn.execute(inputFeatures, dataFeatures, 100, 500.0, 5000.0).size must equalTo(0)
+    }
+    "handle non-point geometries in inputFeatures by ignoring them" in {
+      val inputFeatures = new DefaultFeatureCollection(sftName, sft)
+      val lineSF = SimpleFeatureBuilder.build(sft, List(), "route 29")
+      lineSF.setDefaultGeometry(WKTUtils.read(f"LINESTRING(-78.491 38.062, -78.474 38.082)"))
+      lineSF.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+      lineSF
+      inputFeatures.add(lineSF)
+
+      val dataFeatures = fs.getFeatures()
+      val knn = new KNearestNeighborSearchProcess
+      knn.execute(inputFeatures, dataFeatures, 100, 500.0, 5000.0).size must equalTo(0)
+    }
+  }
+
+  "runNewKNNQuery" should {
+    "return a NearestNeighbors object with features around Charlottesville in correct order" in {
+      val orderedFeatureIDs = List("rotunda",
+        "pavilion II",
+        "pavilion I",
+        "pavilion IV",
+        "pavilion III",
+        "pavilion VI",
+        "pavilion V",
+        "pavilion VII",
+        "pavilion VIII",
+        "pavilion IX",
+        "pavilion X",
+        "cabell",
+        "beams",
+        "hep",
+        "mccormick")
+      val knnResults =
+        KNNQuery.runNewKNNQuery(fs, wideQuery, 15, 500.0, 2500.0, queryFeature("madison", 38.036871, -78.502720))
+      // return the ordered neighbors and extract the SimpleFeatures
+      val knnFeatures = knnResults.getK.map { _.sf }
+      val knnIDs = knnFeatures.map { _.getID }
+      knnIDs must equalTo(orderedFeatureIDs)
+    }
+    "return a nearestNeighbors object with features around Staunton in correct order" in {
+      val k = 10
+      val referenceFeature = queryFeature("blackfriars", 38.149185, -79.070569)
+      val knnResults =
+        KNNQuery.runNewKNNQuery(fs, wideQuery, k, 5000.0, 50000.0, referenceFeature)
+      val knnFeatureIDs = knnResults.getK.map { _.sf.getID }
+      val directFeatures = fs.getFeatures().features.toList
+      val sortedByDist = directFeatures.sortBy (
+        a => VincentyModel.getDistanceBetweenTwoPoints(referenceFeature.point, a.point).getDistanceInMeters).take(k)
+      knnFeatureIDs.equals(sortedByDist.map{_.getID}) must beTrue
+    }
+  }
+}

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/process/knn/NearestNeighborsPQTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/process/knn/NearestNeighborsPQTest.scala
@@ -1,0 +1,207 @@
+/*
+* Copyright 2014 Commonwealth Computer Research, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.locationtech.geomesa.core.process.knn
+
+
+import org.geotools.factory.Hints
+import org.geotools.feature.DefaultFeatureCollection
+import org.geotools.feature.simple.SimpleFeatureBuilder
+import org.joda.time.{DateTime, DateTimeZone}
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.core._
+import org.locationtech.geomesa.core.index.Constants
+import org.locationtech.geomesa.utils.geotools.Conversions._
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.text.WKTUtils
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class NearestNeighborsPQTest extends Specification {
+
+  val sftName = "geomesaKNNTestQueryFeature"
+  val sft = SimpleFeatureTypes.createType(sftName, index.spec)
+
+  val equatorSF = SimpleFeatureBuilder.build(sft, List(), "equator")
+  equatorSF.setDefaultGeometry(WKTUtils.read(f"POINT(0.1 0.2)"))
+  equatorSF.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+
+  val midpointSF = SimpleFeatureBuilder.build(sft, List(), "midpoint")
+  midpointSF.setDefaultGeometry(WKTUtils.read(f"POINT(45.1 45.1)"))
+  midpointSF.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+
+  val polarSF = SimpleFeatureBuilder.build(sft, List(), "polar")
+  polarSF.setDefaultGeometry(WKTUtils.read(f"POINT(89.9 89.9)"))
+  polarSF.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+
+  val polarSF2 = SimpleFeatureBuilder.build(sft, List(), "polar2")
+  polarSF2.setDefaultGeometry(WKTUtils.read(f"POINT(0.0001 89.9)"))
+  polarSF2.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+
+  val lineSF = SimpleFeatureBuilder.build(sft, List(), "line")
+  lineSF.setDefaultGeometry(WKTUtils.read(f"LINESTRING(45.0 45.0, 50.0 50.0 )"))
+  lineSF.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+
+  def diagonalFeatureCollection: DefaultFeatureCollection = {
+    val sftName = "geomesaKNNTestDiagonalFeature"
+    val sft = SimpleFeatureTypes.createType(sftName, index.spec)
+    sft.getUserData()(Constants.SF_PROPERTY_START_TIME) = DEFAULT_DTG_PROPERTY_NAME
+
+    val featureCollection = new DefaultFeatureCollection(sftName, sft)
+    val constantDate = new DateTime("2011-01-01T00:00:00Z", DateTimeZone.UTC).toDate
+    // generate a range of Simple Features along a "diagonal"
+    Range(0, 91).foreach { lat =>
+      val sf = SimpleFeatureBuilder.build(sft, List(), lat.toString)
+      sf.setDefaultGeometry(WKTUtils.read(f"POINT($lat%d $lat%d)"))
+      sf.setAttribute(DEFAULT_DTG_PROPERTY_NAME, constantDate)
+      sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+      featureCollection.add(sf)
+    }
+    featureCollection
+  }
+
+  def polarFeatureCollection: DefaultFeatureCollection = {
+    val sftName = "geomesaKNNTestPolarFeature"
+    val sft = SimpleFeatureTypes.createType(sftName, index.spec)
+    sft.getUserData()(Constants.SF_PROPERTY_START_TIME) = DEFAULT_DTG_PROPERTY_NAME
+
+    val featureCollection = new DefaultFeatureCollection(sftName, sft)
+    val constantDate = new DateTime("2011-01-01T00:00:00Z", DateTimeZone.UTC).toDate
+    val polarLat = 89.9
+    // generate a range of Simple Features along a "diagonal"
+    Range(-180, 180).foreach { lon =>
+      val sf = SimpleFeatureBuilder.build(sft, List(), lon.toString)
+      sf.setDefaultGeometry(WKTUtils.read(f"POINT($lon%d $polarLat)"))
+      sf.setAttribute(DEFAULT_DTG_PROPERTY_NAME, constantDate)
+      sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+      featureCollection.add(sf)
+    }
+    featureCollection
+  }
+
+
+  "Geomesa NearestNeighbor PriorityQueue" should {
+    "find things close by the equator" in {
+      val equatorPQ = NearestNeighbors(equatorSF, 10)
+
+      val sfWDC = diagonalFeatureCollection.features.map {
+        sf=> SimpleFeatureWithDistance(sf,equatorPQ.distance(sf))
+      }.toList
+
+      equatorPQ.add(sfWDC)
+
+      equatorPQ.getK.head.sf.getID must equalTo("0")
+    }
+
+    "find things close by Southwest Russia" in {
+      val midpointPQ = NearestNeighbors(midpointSF, 10)
+
+      val sfWDC = diagonalFeatureCollection.features.map {
+        sf=> SimpleFeatureWithDistance(sf,midpointPQ.distance(sf))
+      }.toList
+
+      midpointPQ.add(sfWDC)
+
+      midpointPQ.getK.head.sf.getID must equalTo("45")
+    }
+
+    "find things close by the North Pole" in {
+      val polarPQ = NearestNeighbors(polarSF, 10)
+
+      val sfWDC =  diagonalFeatureCollection.features.map{
+        sf=> SimpleFeatureWithDistance(sf,polarPQ.distance(sf))
+      }.toList
+
+      polarPQ.add(sfWDC)
+
+      polarPQ.getK.head.sf.getID must equalTo("90")
+    }
+
+    "find things in the north polar region" in {
+      val polarPQ = NearestNeighbors(polarSF, 10)
+
+      val sfWDC = polarFeatureCollection.features.map {
+        sf=> SimpleFeatureWithDistance(sf,polarPQ.distance(sf))
+      }.toList
+
+      polarPQ.add(sfWDC)
+
+      polarPQ.getK.head.sf.getID must equalTo("90")
+    }
+
+    "find more things near the north polar region" in {
+      val polarPQ = NearestNeighbors(polarSF2, 10)
+
+      val sfWDC = polarFeatureCollection.features.map {
+        sf => SimpleFeatureWithDistance(sf, polarPQ.distance(sf))
+      }.toList
+
+      polarPQ.add(sfWDC)
+
+      polarPQ.getK.head.sf.getID must equalTo("0")
+    }
+
+    "ignore extra features that are too far away" in {
+      val polarPQ = NearestNeighbors(polarSF2, 10)
+
+      val polarSFWDC = polarFeatureCollection.features.map {
+        sf => SimpleFeatureWithDistance(sf, polarPQ.distance(sf))
+      }.toList
+
+      val dSFWDC = diagonalFeatureCollection.features.map {
+        sf => SimpleFeatureWithDistance(sf, polarPQ.distance(sf))
+      }.toList
+
+      polarPQ.add(polarSFWDC)
+      polarPQ.add(dSFWDC)
+
+      polarPQ.getK.head.sf.getID must equalTo("0")
+    }
+
+    "should produce the same results as its clone" in {
+
+      val polarPQ = NearestNeighbors(polarSF2, 10)
+
+      val sfWDC = polarFeatureCollection.features.map {
+        sf => SimpleFeatureWithDistance(sf, polarPQ.distance(sf))
+      }.toList
+
+      polarPQ.add(sfWDC)
+
+      val clonePQ = polarPQ.clone()
+      polarPQ.getK.map{_.sf.getID} must equalTo(clonePQ.getK.map{_.sf.getID})
+    }
+
+    "should produce the same results as getKNN" in {
+      val polarPQ = NearestNeighbors(polarSF2, 10)
+
+      val sfWDC = polarFeatureCollection.features.map {
+        sf => SimpleFeatureWithDistance(sf, polarPQ.distance(sf))
+      }.toList
+
+      polarPQ.add(sfWDC)
+
+      polarPQ.getK.map{_.sf.getID} must equalTo(polarPQ.getKNN.getK.map{_.sf.getID})
+    }
+
+    "thrown an exception when given non-point geometries" in {
+        NearestNeighbors(lineSF ,10) should throwAn[RuntimeException]
+    }
+  }
+}

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/process/knn/TouchingGeoHashesTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/process/knn/TouchingGeoHashesTest.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.process.knn
+
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.utils.geohash.GeoHash
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TouchingGeoHashesTest extends Specification {
+
+  def generateCvilleGH = {
+    val precision = 30
+    val lat = 38.0752150
+    val lon = -78.4953560
+    GeoHash(lon, lat, precision)
+  }
+
+  def generateSuvaGH = {
+    val precision = 10
+    val lat = -18.140
+    val lon = 178.440
+    GeoHash(lon, lat, precision)
+  }
+
+  def generateMcMurdoGH = {
+    val precision = 5
+    val lat = -77.842
+    val lon = 166.68360
+    GeoHash(lon, lat, precision)
+  }
+
+  "Geomesa TouchingGeoHashes" should {
+
+    "find GeoHashes  around Charlottesville, Virginia" in {
+      val touchingByCalculation = TouchingGeoHashes.touching(generateCvilleGH).map ( _.hash )
+      val touchingByVisualInspection = List(
+        "dqb0te",
+        "dqb0tf",
+        "dqb0td",
+        "dqb0tu",
+        "dqb0ts",
+        "dqb0w5",
+        "dqb0w4",
+        "dqb0wh")
+      touchingByCalculation.forall ( touchingByVisualInspection.contains ) must beTrue
+    }
+
+    "Correctly treat the antimeridian and find GeoHashes around Suva, Fiji" in {
+      val touchingByCalculation = TouchingGeoHashes.touching(generateSuvaGH).map ( _.hash )
+      val touchingByVisualInspection = List(
+        "rv",
+        "rg",
+        "re",
+        "rs",
+        "rt",
+        "2j",
+        "2h",
+        "25")
+      touchingByCalculation.forall ( touchingByVisualInspection.contains ) must beTrue
+    }
+
+    "Correctly treat the polar region and the antimeridian and find GeoHashes around McMurdo Station" in {
+      val touchingByCalculation = TouchingGeoHashes.touching(generateMcMurdoGH).map ( _.hash )
+      val touchingByVisualInspection = List(
+        "h",
+        "j",
+        "n",
+        "0",
+        "1",
+        "4",
+        "5",
+        "2",
+        "r",
+        "q")
+      touchingByCalculation.forall ( touchingByVisualInspection.contains ) must beTrue
+    }
+  }
+}

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/process/ProcessFactory.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/process/ProcessFactory.scala
@@ -19,6 +19,7 @@ package org.locationtech.geomesa.plugin.process
 
 import org.geotools.process.factory.AnnotatedBeanProcessFactory
 import org.geotools.text.Text
+import org.locationtech.geomesa.core.process.knn.KNearestNeighborSearchProcess
 import org.locationtech.geomesa.core.process.proximity.ProximitySearchProcess
 import org.locationtech.geomesa.core.process.query.QueryProcess
 import org.locationtech.geomesa.core.process.tube.TubeSelectProcess
@@ -31,6 +32,8 @@ class ProcessFactory
     classOf[TubeSelectProcess],
     classOf[ProximitySearchProcess],
     classOf[QueryProcess],
+    classOf[KNearestNeighborSearchProcess],
     classOf[DBSCANProcess]
   )
+
 


### PR DESCRIPTION
- Add a K-Nearest Neighbors Search that implements a GeoHash-by-GeoHash query strategy.
- Expose the KNN Search as a WPS process.
- Include an example KNN Search based on the location of the White House.
- Add a bounded PriorityQueue implementation.
- Add a method which, given a GeoHash, retrieves a list of all other GeoHashes in contact with it.
- Using the above method, implement a 'GeoHashSpiral' an Iterator that produces GeoHashes in order of distance from a point.
