### PR TITLE
GEOMESA-342 - Updated geomesa-tools log4j properties to stop making .log file 1.5

### DIFF
--- a/geomesa-tools/src/main/resources/log4j.properties
+++ b/geomesa-tools/src/main/resources/log4j.properties
@@ -14,7 +14,7 @@
 #  limitations under the License.
 #
 
-log4j.rootLogger=info, stdout, file
+log4j.rootLogger=info, stdout
 
 log4j.logger.geomesa=debug
 log4j.logger.org.apache.zookeeper=warn
@@ -23,10 +23,3 @@ log4j.logger.hsqldb.db=warn
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 #log4j.appender.stdout.layout.ConversionPattern= %-5p %c - %m%n
-
-log4j.appender.file=org.apache.log4j.RollingFileAppender
-log4j.appender.file.File=geomesa-tools.log
-log4j.appender.file.MaxFileSize=1000KB
-log4j.appender.file.MaxBackupIndex=4
-log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d [%t] %-5p %c - %m%n


### PR DESCRIPTION
This is a fairly small update to the log4.properties file so that we are not creating a log file.  If there are other suggestions/ features needed to be added to the log4j properties now would be a good time to add them.
