### PR TITLE
GEOMESA-341 Confirm that export-to-Shapefile works as expected

### DIFF
--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Export.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Export.scala
@@ -116,7 +116,7 @@ class Export(config: ExportArguments, password: String) extends Logging with Acc
 
     q.setMaxFeatures(config.maxFeatures.getOrElse(Query.DEFAULT_MAX))
     if (overrideAttributes.isDefined) { q.setPropertyNames(overrideAttributes.get.split(',')) }
-    else if (config.attributes.isDefined) { q.setPropertyNames(overrideAttributes.get.split(',')) }
+    else if (config.attributes.isDefined) { q.setPropertyNames(config.attributes.get.split(',')) }
 
     // get the feature store used to query the GeoMesa data
     val fs = ds.getFeatureSource(config.featureName).asInstanceOf[AccumuloFeatureStore]


### PR DESCRIPTION
Shapefiles were being written without geometry information. This is because Geotools requires that
the geometry attribute be named the_geom. The geometry attribute now gets renamed for shapefile export only.
