### PR TITLE
GEOMESA-356 adding label for binary format in layer previews

### DIFF
--- a/geomesa-plugin/src/main/resources/GeoServerApplication.properties
+++ b/geomesa-plugin/src/main/resources/GeoServerApplication.properties
@@ -48,3 +48,7 @@ HadoopStatusPage.title=Hadoop Cluster Status
 HadoopStatusPage.description=
 
 HadoopStatusPage.label.main=Hadoop Cluster
+
+# binary viewer format labels
+format.wfs.application/vnd.binary-viewer=Binary Viewer
+format.wfs.bin=Binary Viewer


### PR DESCRIPTION
fixes warning logged in the geoserver layer preview page.
