### PR TITLE
GEOMESA-424 cql 'OR' filter query does not deduplicate

### DIFF
--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/QueryPlanner.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/QueryPlanner.scala
@@ -98,7 +98,7 @@ case class QueryPlanner(schema: String,
     if(isDensity) {
       val env = query.getHints.get(BBOX_KEY).asInstanceOf[ReferencedEnvelope]
       val q1 = new Query(featureType.getTypeName, ff.bbox(ff.property(featureType.getGeometryDescriptor.getLocalName), env))
-      val mixedQuery = DataUtilities.mixQueries(q1, query, "geomesa.mixed.query"))
+      val mixedQuery = DataUtilities.mixQueries(q1, query, "geomesa.mixed.query")
       if (duplicatableData) {
         deduplicate(Seq(mixedQuery))
       } else {


### PR DESCRIPTION
moved deduplication code into QueryPlanner.getIterator method and used it for both duplicatable data and OR queries
