### PR TITLE
GEOMESA-453 ClosableIterator flatMap may end prematurely

### DIFF
--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/util/CloseableIteratorTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/util/CloseableIteratorTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.util
+
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class CloseableIteratorTest extends Specification {
+
+  "CloseableIterator" should {
+    "not smash the stack in ciFlatMap" >> {
+      val f: Int => CloseableIterator[Int] = n =>
+        if (n < 50000) CloseableIterator.empty
+        else CloseableIterator(List(n).iterator)
+      val ci = CloseableIterator((1 to 50000).iterator)
+      ci.ciFlatMap(f).length should be equalTo 1
+    }
+  }
+}


### PR DESCRIPTION
refactored ciFlatMap method to use an internal tail-recursive helper, and added a test that smashes the stack with the old code.
