### PR TITLE
GEOMESA-488, 492 Understand and remove use of jai_core, CoverageReader's VersioningIterator's random name string isn't created properly

### DIFF
--- a/geomesa-plugin/pom.xml
+++ b/geomesa-plugin/pom.xml
@@ -30,23 +30,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.geotools</groupId>
-                <artifactId>gt-process</artifactId>
-                <version>${gt.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.geotools</groupId>
-                <artifactId>gt-coverage</artifactId>
-                <version>${gt.version}</version>
-                <scope>provided</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
@@ -132,6 +115,18 @@
             <groupId>org.geotools.ogc</groupId>
             <artifactId>net.opengis.wfs</artifactId>
             <version>${gt.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- excluded due to license issues -->
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-coverage</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wms/CoverageReader.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wms/CoverageReader.scala
@@ -156,7 +156,7 @@ class CoverageReader(val url: String) extends AbstractGridCoverage2DReader() wit
         val endDate = dateRange.getMaxValue
         TimestampRangeIterator.setupIterator(scanner, startDate, endDate)
       case None =>
-        val name = "version-" + Random.alphanumeric.take(5)
+        val name = "version-" + Random.alphanumeric.take(5).mkString
         val cfg = new IteratorSetting(2, name, classOf[VersioningIterator])
         VersioningIterator.setMaxVersions(cfg, 1)
         scanner.addScanIterator(cfg)

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wms/ImageUtils.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wms/ImageUtils.scala
@@ -16,9 +16,9 @@
 
 package org.locationtech.geomesa.plugin.wms
 
-import java.awt.Point
+import java.awt.color.ColorSpace
 import java.awt.image._
-import javax.media.jai.{PlanarImage, RasterFactory}
+import java.awt.{Point, Transparency}
 
 import org.locationtech.geomesa.utils.geohash.{GeoHash, TwoGeoHashBoundingBox}
 
@@ -84,14 +84,19 @@ object ImageUtils {
 
   def drawImage(buffer: Array[Array[Byte]], xdim: Int, ydim: Int): BufferedImage = {
     val dbuffer: DataBufferByte = new DataBufferByte(buffer, xdim * ydim)
-    val sampleModel: SampleModel = RasterFactory.createBandedSampleModel(DataBuffer.TYPE_BYTE,
-                                                                         xdim,
-                                                                         ydim,
-                                                                         1)
-    val colorModel: ColorModel = PlanarImage.createColorModel(sampleModel)
-    val raster: WritableRaster = RasterFactory.createWritableRaster(sampleModel,
-                                                                    dbuffer,
-                                                                    new Point(0, 0))
+    val sampleModel = new BandedSampleModel(DataBuffer.TYPE_BYTE,
+                                            xdim,
+                                            ydim,
+                                            1)
+    val colorModel = new ComponentColorModel(ColorSpace.getInstance(ColorSpace.CS_GRAY),
+                                             null,
+                                             false,
+                                             false,
+                                             Transparency.OPAQUE,
+                                             DataBuffer.TYPE_BYTE)
+    val raster = Raster.createWritableRaster(sampleModel,
+                                             dbuffer,
+                                             new Point(0, 0))
     new BufferedImage(colorModel, raster, false, null)
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,13 @@
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-main</artifactId>
                 <version>${gt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
@@ -155,21 +162,49 @@
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-opengis</artifactId>
                 <version>${gt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-cql</artifactId>
                 <version>${gt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-metadata</artifactId>
                 <version>${gt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-data</artifactId>
                 <version>${gt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
@@ -186,6 +221,11 @@
                         <artifactId>jgridshift</artifactId>
                         <groupId>jgridshift</groupId>
                      </exclusion>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -204,11 +244,25 @@
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-api</artifactId>
                 <version>${gt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-geojson</artifactId>
                 <version>${gt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
@@ -219,6 +273,11 @@
                     <groupId>commons-jxpath</groupId>
                     <artifactId>commons-jxpath</artifactId>
                   </exclusion>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -236,6 +295,11 @@
                         <groupId>javax.media</groupId>
                         <artifactId>jai_imageio</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -252,17 +316,36 @@
 	                    <artifactId>imageio-ext-tiff</artifactId>
 	                    <groupId>it.geosolutions.imageio-ext</groupId>
 	                </exclusion>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
 	            </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-transform</artifactId>
                 <version>${gt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-grid</artifactId>
                 <version>${gt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>commons-pool</groupId>
@@ -412,6 +495,13 @@
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-geometry</artifactId>
                 <version>${gt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.spark</groupId>
@@ -568,36 +658,78 @@
                 <artifactId>gs-main</artifactId>
                 <version>${geoserver.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geoserver.web</groupId>
                 <artifactId>gs-web-core</artifactId>
                 <version>${geoserver.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geoserver.extension</groupId>
                 <artifactId>gs-wps-core</artifactId>
                 <version>${geoserver.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geoserver</groupId>
                 <artifactId>gs-ows</artifactId>
                 <version>${geoserver.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geoserver</groupId>
                 <artifactId>gs-platform</artifactId>
                 <version>${geoserver.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geoserver</groupId>
                 <artifactId>gs-wfs</artifactId>
                 <version>${geoserver.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.wicket</groupId>


### PR DESCRIPTION
Excluded jai_core and removed usages of jai_core functionality from geomesa-plugin. Also
fixed an issue with a random name not being properly generated for VersioningIterator
in CoverageReader
