### PR TITLE
GEOMESA-518,519 Refactoring of RasterIndexEntry and added Test

### DIFF
--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/Decoders.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/Decoders.scala
@@ -16,16 +16,18 @@
 
 package org.locationtech.geomesa.core.index
 
+import com.vividsolutions.jts.geom.Geometry
 import org.apache.accumulo.core.data.Key
 import org.joda.time.{DateTime, DateTimeZone}
 import org.locationtech.geomesa.utils.geohash.GeoHash
+import org.locationtech.geomesa.utils.text.WKBUtils
 
 trait Decoder[T] {
   def decode(key: Key): T
 }
 
 abstract class ExtractingDecoder[T] extends Decoder[T] {
-  def seqExtract(seq: Seq[TextExtractor], key: Key): String =
+  def seqExtract[T <: TextExtractor](seq: Seq[T], key: Key): String =
     seq.map { _.extract(key) }.mkString
 }
 
@@ -34,7 +36,7 @@ case class GeohashDecoder(orderedSeq: Seq[TextExtractor]) extends ExtractingDeco
     GeoHash(seqExtract(orderedSeq, key).takeWhile(c => c != '.'))
 }
 
-case class DateDecoder(orderSeq: Seq[TextExtractor], fs: String) extends ExtractingDecoder[DateTime] {
+case class DateDecoder[T <: TextExtractor](orderSeq: Seq[T], fs: String) extends ExtractingDecoder[DateTime] {
   DateTimeZone.setDefault(DateTimeZone.forID("UTC"))
   val parser = org.joda.time.format.DateTimeFormat.forPattern(fs)
   def decode(key: Key): DateTime = parser.parseDateTime(seqExtract(orderSeq, key))
@@ -42,6 +44,11 @@ case class DateDecoder(orderSeq: Seq[TextExtractor], fs: String) extends Extract
 
 case class IdDecoder(orderedSeq: Seq[TextExtractor]) extends ExtractingDecoder[String] {
   def decode(key: Key): String = seqExtract(orderedSeq, key).replaceAll("_+$", "")
+}
+
+case class GeometryDecoder(orderedSeq: Seq[ColumnQualifierExtractor]) extends ExtractingDecoder[Geometry] {
+  def decode(key: Key): Geometry =
+    WKBUtils.read(seqExtract(orderedSeq, key).takeWhile(c => c != '.'))
 }
 
 case class ScientificNotationDecoder(orderSeq: Seq[TextExtractor]) extends ExtractingDecoder[Double] {

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/IndexSchema.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/IndexSchema.scala
@@ -24,8 +24,6 @@ import org.locationtech.geomesa.core.data._
 import org.locationtech.geomesa.core.util._
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
-import scala.util.parsing.combinator.RegexParsers
-
 // A secondary index consists of interleaved elements of a composite key stored in
 // Accumulo's key (row, column family, and column qualifier)
 //
@@ -139,7 +137,7 @@ object IndexSchema extends SchemaHelpers with Logging {
       }
   }}
 
-  def buildDateDecoder(s: String): Option[DateDecoder] = parse(dateDecoderParser, s).get
+  def buildDateDecoder(s: String): Option[DateDecoder[AbstractExtractor]] = parse(dateDecoderParser, s).get
 
   // builds a geohash decoder to extract the entire geohash from the parts of the index key
   def ghDecoderParser = keypart ~ PART_DELIMITER ~ keypart ~ PART_DELIMITER ~ cqpart ^^ {

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/AttributeIndexFilteringIterator.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/AttributeIndexFilteringIterator.scala
@@ -25,7 +25,7 @@ import org.apache.accumulo.core.iterators.{Filter, IteratorEnvironment, SortedKe
 import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.geotools.filter.text.ecql.ECQL
 import org.locationtech.geomesa.core._
-import org.locationtech.geomesa.core.index.IndexEntry.DecodedIndexValue
+import org.locationtech.geomesa.core.index.IndexEntry.DecodedIndex
 import org.locationtech.geomesa.core.index._
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.SimpleFeature
@@ -81,7 +81,7 @@ class AttributeIndexFilteringIterator extends Filter with Logging {
   }
 
   override def accept(k: Key, v: Value): Boolean = {
-    val DecodedIndexValue(_, geom, dtgOpt) = IndexEntry.decodeIndexValue(v)
+    val DecodedIndex(_, geom, dtgOpt) = IndexEntry.decodeIndexValue(v)
     wrappedSTFilter(geom, dtgOpt)
   }
 }

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/IndexIterator.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/IndexIterator.scala
@@ -92,7 +92,7 @@ class IndexIterator extends SpatioTemporalIntersectingIterator with SortedKeyVal
    * converted key value.  This is *IMPORTANT*, as otherwise we do not emit rows
    * that honor the SortedKeyValueIterator expectation, and Bad Things Happen.
    */
-  override def seekData(decodedValue: IndexEntry.DecodedIndexValue) {
+  override def seekData(decodedValue: IndexEntry.DecodedIndex) {
     // now increment the value of nextKey, copy because reusing it is UNSAFE
     nextKey = new Key(indexSource.getTopKey)
     // using the already decoded index value, generate a SimpleFeature and set as the Value

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/SpatioTemporalIntersectingIterator.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/SpatioTemporalIntersectingIterator.scala
@@ -242,7 +242,7 @@ class SpatioTemporalIntersectingIterator
    * data-iterator.  This is *IMPORTANT*, as otherwise we do not emit rows
    * that honor the SortedKeyValueIterator expectation, and Bad Things Happen.
    */
-  def seekData(indexValue: IndexEntry.DecodedIndexValue) {
+  def seekData(indexValue: IndexEntry.DecodedIndex) {
     val nextId = indexValue.id
     curId = new Text(nextId)
     val indexSourceTopKey = indexSource.getTopKey

--- a/geomesa-raster/pom.xml
+++ b/geomesa-raster/pom.xml
@@ -103,6 +103,22 @@
             <artifactId>gt-epsg-hsql</artifactId>
             <version>${gt.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2_2.10</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/iterators/RasterFilteringIterator.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/iterators/RasterFilteringIterator.scala
@@ -28,7 +28,7 @@ import org.locationtech.geomesa.core._
 import org.locationtech.geomesa.core.index._
 import org.locationtech.geomesa.core.iterators.IteratorHelpers
 import org.locationtech.geomesa.raster.index.RasterIndexEntry
-import org.locationtech.geomesa.raster.index.RasterIndexEntry.DecodedCQMetadata
+import org.locationtech.geomesa.raster.index.RasterIndexEntry.DecodedIndex
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.SimpleFeature
 
@@ -86,7 +86,7 @@ class RasterFilteringIterator extends Filter with Logging {
   }
 
   override def accept(k: Key, v: Value): Boolean = {
-    val DecodedCQMetadata(_, geom, dtgOpt) = RasterIndexEntry.decodeIndexCQMetadata(k)
+    val DecodedIndex(_, geom, dtgOpt) = RasterIndexEntry.decodeIndexCQMetadata(k)
     wrappedSTFilter(geom, dtgOpt)
   }
 

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/index/RasterIndexEntryTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/index/RasterIndexEntryTest.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.raster.index
+
+import org.apache.accumulo.core.data.Key
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.utils.text.WKTUtils
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class RasterIndexEntryTest extends Specification {
+
+  sequential
+
+  val now = new DateTime().toDateTime
+  val emptyByte = Array.empty[Byte]
+
+  def makeKey(cq: Array[Byte]): Key = new Key(emptyByte, emptyByte, cq, emptyByte, Long.MaxValue)
+
+  "RasterIndexEntry" should {
+
+    "encode and decode Raster meta-data properly" in {
+      val wkt = "POLYGON ((10 0, 10 10, 0 10, 0 0, 10 0))"
+      val id = "Feature0123456789"
+      val geom = WKTUtils.read(wkt)
+      val dt = now
+
+      // output encoded meta data
+      val cqMetaData = RasterIndexEntry.encodeIndexCQMetadata(id, geom, Some(dt))
+
+      // convert CQ Array[Byte] to Key (a key with everything as a null except CQ)
+      val keyWithCq = makeKey(cqMetaData)
+
+      // decode metadata from key
+      val decoded = RasterIndexEntry.decodeIndexCQMetadata(keyWithCq)
+
+      // requirements
+      decoded must not equalTo null
+      decoded.id must be equalTo id
+      WKTUtils.write(decoded.geom) must be equalTo wkt
+      dt must be equalTo now
+    }
+
+    "encode and decode Raster meta-data properly when there is no datetime" in {
+      val wkt = "POLYGON ((10 0, 10 10, 0 10, 0 0, 10 0))"
+      val id = "Feature0123456789"
+      val geom = WKTUtils.read(wkt)
+      val dt: Option[DateTime] = None
+
+      // output encoded meta data
+      val cqMetaData = RasterIndexEntry.encodeIndexCQMetadata(id, geom, dt)
+
+      // convert CQ Array[Byte] to Key (a key with everything as a null except CQ)
+      val keyWithCq = makeKey(cqMetaData)
+
+      // decode metadata from key
+      val decoded = RasterIndexEntry.decodeIndexCQMetadata(keyWithCq)
+
+      // requirements
+      decoded must not equalTo null
+      decoded.id must be equalTo id
+      WKTUtils.write(decoded.geom) must be equalTo wkt
+      dt.isDefined must beFalse
+    }
+
+  }
+
+}


### PR DESCRIPTION
- RasterIndexEntry now properly encodes and decodes id, geom, time into the CQ of the key
- Added unittests for RasterIndexEntry, testing time optionally.
- Added new GeometryDecoder for decoding geometry from the CQ.
- Now using context bounds for some decoders, reduced some code duplication between IndexEntry and RasterIndexEntry.
