### PR TITLE
GEOMESA-551 removing extraneous flush from modify feature writer

### DIFF
--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloFeatureWriter.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloFeatureWriter.scala
@@ -195,8 +195,7 @@ class ModifyAccumuloFeatureWriter(featureType: SimpleFeatureType,
 
   override def remove() =
     if (original != null) {
-      removers.foreach { r => r(original)}
-      multiBWWriter.flush()
+      removers.foreach { r => r(original) }
     }
 
   override def hasNext = reader.hasNext

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/data/AccumuloDataStoreTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/data/AccumuloDataStoreTest.scala
@@ -1074,10 +1074,22 @@ class AccumuloDataStoreTest extends Specification {
 
       val filter = ff.id(ff.featureId("2"))
       val writer = ds.getFeatureWriter(sftName, filter, Transaction.AUTO_COMMIT)
-      writer must beAnInstanceOf[ModifyAccumuloFeatureWriter]
       writer.hasNext must beTrue
-      writer.next.getID mustEqual "2"
+      val feat = writer.next
+      feat.getID mustEqual "2"
+      feat.getAttribute("name") mustEqual "2"
+      feat.setAttribute("name", "2-updated")
+      writer.write()
       writer.hasNext must beFalse
+      writer.close()
+
+      val reader = ds.getFeatureReader(new Query(sftName, filter), Transaction.AUTO_COMMIT)
+      reader.hasNext must beTrue
+      val updated = reader.next()
+      reader.hasNext must beFalse
+      reader.close()
+      updated.getID mustEqual("2")
+      updated.getAttribute("name") mustEqual "2-updated"
     }
   }
 


### PR DESCRIPTION
I believe this was left over from back when we were setting explicit timestamps and not using logical time. It greatly improves performance to not flush on every feature.
