### PR TITLE
GEOMESA-584 Refactor Geoserver registration code to add "resolution" coverage parameter to layer

### DIFF
--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageQueryParams.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageQueryParams.scala
@@ -17,7 +17,7 @@
 package org.locationtech.geomesa.plugin.wcs
 
 import org.geotools.coverage.grid.GridGeometry2D
-import org.geotools.coverage.grid.io.{AbstractGridFormat, OverviewPolicy}
+import org.geotools.coverage.grid.io.AbstractGridFormat
 import org.geotools.parameter.Parameter
 import org.locationtech.geomesa.utils.geohash.{BoundingBox, Bounds}
 import org.opengis.parameter.GeneralParameterValue
@@ -38,7 +38,8 @@ class GeoMesaCoverageQueryParams(parameters: Array[GeneralParameterValue]) {
   val height = gridGeometry.getGridRange2D.getHeight
   val resX = (envelope.getMaximum(0) - envelope.getMinimum(0)) / width
   val resY = (envelope.getMaximum(1) - envelope.getMinimum(1)) / height
-  val accResolution = paramsMap(GeoMesaCoverageFormat.RESOLUTION.getName.toString)
+  val accResolution = Option(paramsMap(GeoMesaCoverageFormat.RESOLUTION.getName.toString))
+                      .getOrElse(GeoMesaCoverageFormat.RESOLUTION.getDefaultValue)
                       .asInstanceOf[Parameter[String]].getValue.toDouble
   val min = Array(Math.max(envelope.getMinimum(0), -180) + .00000001,
                   Math.max(envelope.getMinimum(1), -90) + .00000001)

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/ingest/GeoserverClientService.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/ingest/GeoserverClientService.scala
@@ -335,6 +335,7 @@ class GeoserverClientService(config: Map[String, String]) extends Logging {
       <abstract>{ description }</abstract>
       <name>{ name }</name>
       <srs>{ srs }</srs>
+      <nativeFormat> { GeoserverClientService.coverageFormatName }</nativeFormat>
       <nativeBoundingBox>
         <minx>{ nativeBoundingBox.minx }</minx>
         <maxx>{ nativeBoundingBox.maxx }</maxx>
@@ -359,6 +360,12 @@ class GeoserverClientService(config: Map[String, String]) extends Logging {
         </entry>
         <entry key="cachingEnabled">false</entry>
       </metadata>
+      <parameters>
+        <entry>
+          <string>RESOLUTION</string>
+          <string>1.0</string>
+        </entry>
+      </parameters>
     </coverage>.toString()
 
   def modifyDefaultStyle(name: String, style: String) {


### PR DESCRIPTION
When making the POST to the GeoServer rest client, a resolution coverage parameter is added with
a default value of 1.0. This fixes a NullPointerException that was sometimes encountered when registering
a layer with Raster ingest code.
