### PR TITLE
GEOMESA-617 WCS mosaiced image's imageType is hardcoded

### DIFF
--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtil.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtil.scala
@@ -1,12 +1,10 @@
 package org.locationtech.geomesa.raster.util
 
-import java.awt.Graphics2D
 import java.awt.image.{BufferedImage, RenderedImage, WritableRaster, Raster => JRaster}
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 import java.util.{Hashtable => JHashtable}
 import javax.media.jai.remote.SerializableRenderedImage
 
-import org.geotools.coverage.grid.io.AbstractGridFormat
 import org.geotools.coverage.grid.{GridCoverage2D, GridCoverageFactory}
 import org.geotools.geometry.jts.ReferencedEnvelope
 import org.geotools.referencing.crs.DefaultGeographicCRS

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtil.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtil.scala
@@ -73,14 +73,7 @@ object RasterUtils {
     val alphaPremultiplied = colorModel.isAlphaPremultiplied
     val sampleModel = chunk.getSampleModel.createCompatibleSampleModel(width, height)
     val emptyRaster = JRaster.createWritableRaster(sampleModel, null)
-    val defaultColor = AbstractGridFormat.BACKGROUND_COLOR.getDefaultValue
-    val image = new BufferedImage(colorModel, emptyRaster, alphaPremultiplied, properties)
-    val g2D = image.getGraphics.asInstanceOf[Graphics2D]
-    val originalColor = g2D.getColor
-    g2D.setColor(defaultColor)
-    g2D.fillRect(0, 0, image.getWidth, image.getHeight)
-    g2D.setColor(originalColor)
-    image
+    new BufferedImage(colorModel, emptyRaster, alphaPremultiplied, properties)
   }
 
   def setMosaicData(mosaic: BufferedImage, raster: Raster, env: Envelope, resX: Double, resY: Double) = {

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtil.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtil.scala
@@ -82,22 +82,31 @@ object RasterUtils {
     mosaic.getRaster.setRect(dx, dy, chunk.getData)
   }
 
-  def mosaicRasters(rasters: Iterator[Raster], width: Int, height: Int, env: Envelope, resX: Double, resY: Double): BufferedImage = {
-    val rescaleX = resX / (env.getSpan(0) / width)
-    val rescaleY = resY / (env.getSpan(1) / height)
-    val scaledWidth = width / rescaleX
-    val scaledHeight = height / rescaleY
-    val imageWidth = Math.max(Math.round(scaledWidth), 1).toInt
-    val imageHeight = Math.max(Math.round(scaledHeight), 1).toInt
-    val firstRaster = rasters.next()
-    val mosaic = getEmptyMosaic(imageWidth, imageHeight, firstRaster.chunk)
-    setMosaicData(mosaic, firstRaster, env, resX, resY)
-    while(rasters.hasNext) {
-      val raster = rasters.next()
-      setMosaicData(mosaic, raster, env, resX, resY)
-    }
-    mosaic
+  def getEmptyImage(width: Int, height: Int): BufferedImage = {
+    new BufferedImage(width, height, BufferedImage.TYPE_BYTE_GRAY)
   }
+
+  def mosaicRasters(rasters: Iterator[Raster], width: Int, height: Int, env: Envelope, resX: Double, resY: Double): BufferedImage = {
+    if (rasters.isEmpty) {
+      getEmptyImage(width, height)
+    } else {
+      val rescaleX = resX / (env.getSpan(0) / width)
+      val rescaleY = resY / (env.getSpan(1) / height)
+      val scaledWidth = width / rescaleX
+      val scaledHeight = height / rescaleY
+      val imageWidth = Math.max(Math.round(scaledWidth), 1).toInt
+      val imageHeight = Math.max(Math.round(scaledHeight), 1).toInt
+      val firstRaster = rasters.next()
+      val mosaic = getEmptyMosaic(imageWidth, imageHeight, firstRaster.chunk)
+      setMosaicData(mosaic, firstRaster, env, resX, resY)
+      while (rasters.hasNext) {
+        val raster = rasters.next()
+        setMosaicData(mosaic, raster, env, resX, resY)
+      }
+      mosaic
+    }
+  }
+
   //TODO: WCS: Split off functions useful for just tests into a separate object, which includes classes from here on down
   val white = Array[Int] (255, 255, 255)
   val black = Array[Int] (0, 0, 0)


### PR DESCRIPTION
Refactored mosaic code in the way a new, empty image is retrieved. Instead of harcoding the imageType, it depends on the colorModel and sampleModel from
the first raster chunk in the raster iterator and then continues mosaicing as it had before. Tested on GeoServer to return the exact image ingested.