### PR TITLE
GEOMESA-522 - Either depend on xml-apis 1.3.04 or exclude sun files from...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -609,6 +609,12 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
+            <dependency>
+                <!-- transitive dependency versioned due to license issues -->
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>1.3.04</version>
+            </dependency>
 
             <!-- provided dependencies -->
             <dependency>


### PR DESCRIPTION
... 1.0.b2

Added a dependency on xml-apis 1.3.04 to override transitive
depencies on xml-apis 1.0.b2.
This conforms with a requirement to remove licensed Sun files.