### PR TITLE
GEOMESA-582 Resolve Resolution questions between WCS plugin and SimpleRasterIngest

### DIFF
--- a/geomesa-plugin/src/main/resources/GeoServerApplication.properties
+++ b/geomesa-plugin/src/main/resources/GeoServerApplication.properties
@@ -60,4 +60,3 @@ GeoMesaCoverageStoreEditPanel.zookeepers=Zookeepers String
 GeoMesaCoverageStoreEditPanel.auths=Authorizations
 GeoMesaCoverageStoreEditPanel.visibilities=Visibilities
 GeoMesaCoverageStoreEditPanel.tableName=Accumulo Table Name
-GeoMesaCoverageStoreEditPanel.rasterName=Raster Name

--- a/geomesa-plugin/src/main/resources/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageStoreEditPanel.html
+++ b/geomesa-plugin/src/main/resources/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageStoreEditPanel.html
@@ -41,9 +41,6 @@
             <span wicket:id="tableName"></span>
         </div>
         <div>
-            <span wicket:id="rasterName"></span>
-        </div>
-        <div>
             <span wicket:id="auths"></span>
         </div>
         <div>

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageFormat.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageFormat.scala
@@ -21,15 +21,10 @@ import java.io.File
 import org.geotools.coverage.grid.io.AbstractGridFormat
 import org.geotools.coverage.grid.io.AbstractGridFormat._
 import org.geotools.factory.Hints
-import org.geotools.parameter.{DefaultParameterDescriptor, DefaultParameterDescriptorGroup, ParameterGroup}
-import org.locationtech.geomesa.plugin.wcs.GeoMesaCoverageFormat._
+import org.geotools.parameter.{DefaultParameterDescriptorGroup, ParameterGroup}
 import org.locationtech.geomesa.raster.ingest.GeoserverClientService
 import org.opengis.coverage.grid.Format
 import org.opengis.parameter.GeneralParameterDescriptor
-
-object GeoMesaCoverageFormat {
-  val RESOLUTION = new DefaultParameterDescriptor[String]("RESOLUTION", classOf[String], null, "1.0")
-}
 
 class GeoMesaCoverageFormat extends AbstractGridFormat() with Format {
   mInfo = new java.util.HashMap[String, String]()
@@ -39,7 +34,7 @@ class GeoMesaCoverageFormat extends AbstractGridFormat() with Format {
   mInfo.put("docURL", "http://www.geomesa.org")
   mInfo.put("version", "1.0")
 
-  val parameterDescriptors = Array[GeneralParameterDescriptor](READ_GRIDGEOMETRY2D, RESOLUTION)
+  val parameterDescriptors = Array[GeneralParameterDescriptor](READ_GRIDGEOMETRY2D)
   val defaultParameterGroup = new DefaultParameterDescriptorGroup(mInfo, parameterDescriptors)
 
   readParameters = new ParameterGroup(defaultParameterGroup)

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageQueryParams.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageQueryParams.scala
@@ -20,6 +20,7 @@ import org.geotools.coverage.grid.GridGeometry2D
 import org.geotools.coverage.grid.io.AbstractGridFormat
 import org.geotools.parameter.Parameter
 import org.locationtech.geomesa.raster.data.RasterQuery
+import org.locationtech.geomesa.raster.util.RasterUtils
 import org.locationtech.geomesa.utils.geohash.{BoundingBox, Bounds}
 import org.opengis.parameter.GeneralParameterValue
 
@@ -35,16 +36,17 @@ class GeoMesaCoverageQueryParams(parameters: Array[GeneralParameterValue]) {
                      .asInstanceOf[Parameter[GridGeometry2D]].getValue
   val envelope = gridGeometry.getEnvelope
   val dim = gridGeometry.getGridRange2D.getBounds
-  val width = gridGeometry.getGridRange2D.getWidth
-  val height = gridGeometry.getGridRange2D.getHeight
-  val resX = (envelope.getMaximum(0) - envelope.getMinimum(0)) / width
-  val resY = (envelope.getMaximum(1) - envelope.getMinimum(1)) / height
-  val accResolution = math.min(resX, resY)
+  val rasterParams = RasterUtils.sharedRasterParams(gridGeometry, envelope)
+  val width = rasterParams.width
+  val height = rasterParams.height
+  val resX = rasterParams.resX
+  val resY = rasterParams.resY
+  val accumuloResolution = rasterParams.accumuloResolution
   val min = Array(Math.max(envelope.getMinimum(0), -180) + .00000001,
                   Math.max(envelope.getMinimum(1), -90) + .00000001)
   val max = Array(Math.min(envelope.getMaximum(0), 180) - .00000001,
                   Math.min(envelope.getMaximum(1), 90) - .00000001)
   val bbox = BoundingBox(Bounds(min(0), max(0)), Bounds(min(1), max(1)))
 
-  def toRasterQuery: RasterQuery = RasterQuery(bbox, accResolution, None, None)
+  def toRasterQuery: RasterQuery = RasterQuery(bbox, accumuloResolution, None, None)
 }

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageQueryParams.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageQueryParams.scala
@@ -39,9 +39,7 @@ class GeoMesaCoverageQueryParams(parameters: Array[GeneralParameterValue]) {
   val height = gridGeometry.getGridRange2D.getHeight
   val resX = (envelope.getMaximum(0) - envelope.getMinimum(0)) / width
   val resY = (envelope.getMaximum(1) - envelope.getMinimum(1)) / height
-  val accResolution = Option(paramsMap(GeoMesaCoverageFormat.RESOLUTION.getName.toString))
-                      .getOrElse(GeoMesaCoverageFormat.RESOLUTION.getDefaultValue)
-                      .asInstanceOf[Parameter[String]].getValue.toDouble
+  val accResolution = math.min(resX, resY)
   val min = Array(Math.max(envelope.getMinimum(0), -180) + .00000001,
                   Math.max(envelope.getMinimum(1), -90) + .00000001)
   val max = Array(Math.min(envelope.getMaximum(0), 180) - .00000001,

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
@@ -34,23 +34,17 @@ import org.opengis.parameter.GeneralParameterValue
 object GeoMesaCoverageReader {
   val GeoServerDateFormat = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   val DefaultDateString = GeoServerDateFormat.print(new DateTime(DateTimeZone.forID("UTC")))
-  val FORMAT = """accumulo://(.*):(.*)@(.*)/(.*)#rasterName=(.*)#zookeepers=([^#]*)(?:#auths=)?([^#]*)(?:#visibilities=)?([^#]*)$""".r
+  val FORMAT = """accumulo://(.*):(.*)@(.*)/(.*)#zookeepers=([^#]*)(?:#auths=)?([^#]*)(?:#visibilities=)?([^#]*)$""".r
 }
 
 import org.locationtech.geomesa.plugin.wcs.GeoMesaCoverageReader._
 
 class GeoMesaCoverageReader(val url: String, hints: Hints) extends AbstractGridCoverage2DReader() with Logging {
-
-  //TODO: WCS: Implement function/class for parsing our "new" url
-  // right now we want to extract the table name and magnification like this "dataSource_mag"
-  // later, if the magnification is not provided in the URL, we should estimate it later in the read() method
-
-  // JNH: This todo is for Jake.
   logger.debug(s"""creating coverage reader for url "${url.replaceAll(":.*@", ":********@").replaceAll("#auths=.*","#auths=********")}"""")
-  val FORMAT(user, password, instanceId, table, rasterName, zookeepers, auths, visibilities) = url
+  val FORMAT(user, password, instanceId, table, zookeepers, auths, visibilities) = url
   logger.debug(s"extracted user $user, password ********, instance id $instanceId, table $table, zookeepers $zookeepers, auths ********")
 
-  coverageName = table + ":" + rasterName
+  coverageName = table
 
   // TODO: Either this is needed for rasterToCoverages or remove it.
   this.crs = AbstractGridFormat.getDefaultCRS

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
@@ -85,7 +85,8 @@ class GeoMesaCoverageReader(val url: String, hints: Hints) extends AbstractGridC
   }
 
   def rastersToCoverage(rasters: Iterator[Raster], params: GeoMesaCoverageQueryParams): GridCoverage2D = {
-    val image = RasterUtils.mosaicRasters(rasters, params.width.toInt, params.height.toInt, params.envelope, params.resX, params.resY)
+    val image = RasterUtils.mosaicRasters(rasters, params.width.toInt, params.height.toInt,
+      params.envelope, params.resX, params.resY)
     this.coverageFactory.create(coverageName, image, params.envelope)
   }
 }

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageStoreEditPanel.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageStoreEditPanel.scala
@@ -41,9 +41,8 @@ class GeoMesaCoverageStoreEditPanel(componentId: String, storeEditForm: Form[_])
   val auths = addTextPanel(paramsModel, new Param("auths", classOf[String], "Authorizations", false))
   val visibilities = addTextPanel(paramsModel, new Param("visibilities", classOf[String], "Visibilities", false))
   val tableName = addTextPanel(paramsModel, new Param("tableName", classOf[String], "The Accumulo Table Name", true))
-  val rasterName = addTextPanel(paramsModel, new Param("rasterName", classOf[String], "Raster Name", true))
 
-  val dependentFormComponents = Array[FormComponent[_]](instanceId, zookeepers, user, password, auths, visibilities, tableName, rasterName)
+  val dependentFormComponents = Array[FormComponent[_]](instanceId, zookeepers, user, password, auths, visibilities, tableName)
   dependentFormComponents.map(_.setOutputMarkupId(true))
 
   storeEditForm.add(new IFormValidator() {
@@ -56,7 +55,6 @@ class GeoMesaCoverageStoreEditPanel(componentId: String, storeEditForm: Form[_])
         .append(":").append(password.getValue)
         .append("@").append(instanceId.getValue)
         .append("/").append(tableName.getValue)
-        .append("#rasterName=").append(rasterName.getValue)
         .append("#zookeepers=").append(zookeepers.getValue)
         .append("#auths=").append(auths.getValue)
         .append("#visibilities=").append(visibilities.getValue)
@@ -68,12 +66,11 @@ class GeoMesaCoverageStoreEditPanel(componentId: String, storeEditForm: Form[_])
   def parseConnectionParametersFromURL(url: String): JMap[String, String] = {
     val params = new JMap[String, String]
     if (url != null && url.startsWith("accumulo:")) {
-      val FORMAT(user, password, instanceId, table, rasterName, zookeepers, auths, visibilities) = url
+      val FORMAT(user, password, instanceId, table, zookeepers, auths, visibilities) = url
       params.put("user", user)
       params.put("password", password)
       params.put("instanceId", instanceId)
       params.put("tableName", table)
-      params.put("rasterName", rasterName)
       params.put("zookeepers", zookeepers)
       params.put("auths", auths)
       params.put("visibilities", visibilities)

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloBackedRasterOperations.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloBackedRasterOperations.scala
@@ -100,10 +100,10 @@ class AccumuloBackedRasterOperations(val connector: Connector,
     val batchScanner = connector.createBatchScanner(rasterTable, authorizationsProvider.getAuthorizations, numQThreads)
     val plan = queryPlanner.getQueryPlan(rasterQuery)
     configureBatchScanner(batchScanner, plan)
-    adaptIterator(batchScanner.iterator, rasterQuery.resolution)
+    adaptIterator(batchScanner.iterator)
   }
 
-  def adaptIterator(iter: java.util.Iterator[Entry[Key, Value]], res: Double): Iterator[Raster] = {
+  def adaptIterator(iter: java.util.Iterator[Entry[Key, Value]]): Iterator[Raster] = {
     iter.map { entry => schema.decode((entry.getKey, entry.getValue)) }
   }
 

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloCoverageStore.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloCoverageStore.scala
@@ -81,12 +81,7 @@ class AccumuloCoverageStore(val rasterStore: RasterStore,
 
   private def registerToGeoserver(raster: Raster, geoserverClientService: GeoserverClientService) {
     geoserverClientService.registerRasterStyles()
-    geoserverClientService.registerRaster(raster.id,
-                                          raster.id,
-                                          raster.id,
-                                          "Raster data",
-                                          raster.resolution,
-                                          None)
+    geoserverClientService.registerRaster(raster.id, raster.id, "Raster data", None)
   }
 }
 

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterQueryPlanner.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterQueryPlanner.scala
@@ -13,7 +13,7 @@ import org.locationtech.geomesa.core.iterators._
 import org.locationtech.geomesa.raster._
 import org.locationtech.geomesa.raster.index.RasterIndexSchema
 import org.locationtech.geomesa.raster.iterators.RasterFilteringIterator
-import org.locationtech.geomesa.utils.geohash.BoundingBox
+import org.locationtech.geomesa.utils.geohash.{BoundingBox, GeoHash, GeohashUtils}
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
@@ -28,7 +28,8 @@ case class AccumuloRasterQueryPlanner(schema: RasterIndexSchema) extends Logging
     // ticket is GEOMESA-560
     // note that this will only go DOWN in GeoHash resolution -- the enumeration will miss any GeoHashes
     // that perfectly match the bbox or ones that fully contain it.
-    val hashes = BoundingBox.getGeoHashesFromBoundingBox(rq.bbox)
+    val closestAcceptableGeoHash = GeohashUtils.getClosestAcceptableGeoHash(rq.bbox).getOrElse(GeoHash("")).hash
+    val hashes = BoundingBox.getGeoHashesFromBoundingBox(rq.bbox) :+ closestAcceptableGeoHash
     val res = lexiEncodeDoubleToString(rq.resolution)
     logger.debug(s"Planner: BBox: ${rq.bbox} has geohashes: $hashes, and has encoded Resolution: $res")
 

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterQueryPlanner.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterQueryPlanner.scala
@@ -29,7 +29,7 @@ case class AccumuloRasterQueryPlanner(schema: RasterIndexSchema) extends Logging
     // note that this will only go DOWN in GeoHash resolution -- the enumeration will miss any GeoHashes
     // that perfectly match the bbox or ones that fully contain it.
     val closestAcceptableGeoHash = GeohashUtils.getClosestAcceptableGeoHash(rq.bbox).getOrElse(GeoHash("")).hash
-    val hashes = BoundingBox.getGeoHashesFromBoundingBox(rq.bbox) :+ closestAcceptableGeoHash
+    val hashes = (BoundingBox.getGeoHashesFromBoundingBox(rq.bbox) :+ closestAcceptableGeoHash).toSet.toList
     val res = lexiEncodeDoubleToString(rq.resolution)
     logger.debug(s"Planner: BBox: ${rq.bbox} has geohashes: $hashes, and has encoded Resolution: $res")
 

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/index/RasterIndexEntry.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/index/RasterIndexEntry.scala
@@ -136,6 +136,7 @@ case class RasterIndexEntryDecoder() {
   def decode(entry: KeyValuePair) = {
     val renderedImage: RenderedImage = rasterImageDeserialize(entry._2.get)
     val metadata: DecodedIndex = RasterIndexEntry.decodeIndexCQMetadata(entry._1)
+    //TODO: move this to RasterIndexSchema
     val res = raster.lexiDecodeStringToDouble(new String(entry._1.getRowData.toArray).split("~")
       .toList.get(1))
     Raster(renderedImage, metadata, res)

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/index/RasterIndexEntry.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/index/RasterIndexEntry.scala
@@ -27,6 +27,7 @@ import org.apache.hadoop.io.Text
 import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.joda.time.DateTime
 import org.locationtech.geomesa.core.index._
+import org.locationtech.geomesa.raster
 import org.locationtech.geomesa.raster.data.Raster
 import org.locationtech.geomesa.utils.text.WKBUtils
 
@@ -135,7 +136,8 @@ case class RasterIndexEntryDecoder() {
   def decode(entry: KeyValuePair) = {
     val renderedImage: RenderedImage = rasterImageDeserialize(entry._2.get)
     val metadata: DecodedIndex = RasterIndexEntry.decodeIndexCQMetadata(entry._1)
-    val res = 0.0 // TODO: WCS get the resolution from the row
-    Raster(renderedImage, metadata, 0.0)
+    val res = raster.lexiDecodeStringToDouble(new String(entry._1.getRowData.toArray).split("~")
+      .toList.get(1))
+    Raster(renderedImage, metadata, res)
   }
 }

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/package.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/package.scala
@@ -18,12 +18,37 @@ package org.locationtech.geomesa
 
 import org.calrissian.mango.types.LexiTypeEncoders
 
+/**
+ * In these lexiEncode and -Decode functions, a double is encoded or decoded into a lexical
+ * representation to be used in the rowID in the Accumulo key.
+ *
+ * In the lexiEncodeDoubleToString function, the double is rounded off to seven significant digits,
+ * giving a scientific notation of #.###E0. This is to ensure that there is flexibility in the
+ * precision of the bounding box given when querying for chunks. Prior to rounding the resolution,
+ * it was found that even that slightest change in bounding box caused the resolution to be calculated
+ * differently many digits after the decimal point, leading to a different lexical representation of the
+ * resolution. This meant that no chunks would be returned out of Accumulo, since they did not match
+ * the resolution calculated upon ingest.
+ *
+ * Now, there is greater flexibility in specifying a bounding box and calculating a resolution because
+ * we save only seven digits after the decimal point.
+ */
 package object raster {
+  /**
+   * The double, number, is rounded off to seven significant digits and then lexiEncoded into
+   * a string representations.
+   * @param number, the Double to be lexiEncoded
+   */
   def lexiEncodeDoubleToString(number: Double): String = {
     val truncatedRes = BigDecimal(number).setScale(7, BigDecimal.RoundingMode.HALF_UP).toDouble
     LexiTypeEncoders.LEXI_TYPES.encode(truncatedRes)
   }
 
+  /**
+   * The string representation of a double, str, is decoded to its original Double representation
+   * and then rounded to seven significant digits to remain consistent with the lexiEncode function.
+   * @param str, the String representation of the Double
+   */
   def lexiDecodeStringToDouble(str: String): Double = {
     val number = LexiTypeEncoders.LEXI_TYPES.decode("double", str).asInstanceOf[Double]
     BigDecimal(number).setScale(7, BigDecimal.RoundingMode.HALF_UP).toDouble

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/package.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/package.scala
@@ -19,7 +19,13 @@ package org.locationtech.geomesa
 import org.calrissian.mango.types.LexiTypeEncoders
 
 package object raster {
-  def lexiEncodeDoubleToString(number: Double): String = LexiTypeEncoders.LEXI_TYPES.encode(number)
+  def lexiEncodeDoubleToString(number: Double): String = {
+    val truncatedRes = BigDecimal(number).setScale(7, BigDecimal.RoundingMode.HALF_UP).toDouble
+    LexiTypeEncoders.LEXI_TYPES.encode(truncatedRes)
+  }
 
-  def lexiDecodeStringToDouble(str: String): Double = LexiTypeEncoders.LEXI_TYPES.decode("double", str).asInstanceOf[Double]
+  def lexiDecodeStringToDouble(str: String): Double = {
+    val number = LexiTypeEncoders.LEXI_TYPES.decode("double", str).asInstanceOf[Double]
+    BigDecimal(number).setScale(7, BigDecimal.RoundingMode.HALF_UP).toDouble
+  }
 }

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtil.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtil.scala
@@ -1,11 +1,11 @@
 package org.locationtech.geomesa.raster.util
 
-import java.awt.image.{BufferedImage, RenderedImage, WritableRaster, Raster => JRaster}
+import java.awt.image.{BufferedImage, Raster => JRaster, RenderedImage, WritableRaster}
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 import java.util.{Hashtable => JHashtable}
 import javax.media.jai.remote.SerializableRenderedImage
 
-import org.geotools.coverage.grid.{GridCoverage2D, GridCoverageFactory}
+import org.geotools.coverage.grid.{GridCoverage2D, GridCoverageFactory, GridGeometry2D}
 import org.geotools.geometry.jts.ReferencedEnvelope
 import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.joda.time.DateTime
@@ -30,7 +30,6 @@ object RasterUtils {
     val FORMAT              = "geomesa-tools.ingestraster.format"
     val TIME                = "geomesa-tools.ingestraster.time"
     val GEOSERVER_REG       = "geomesa-tools.ingestraster.geoserver.reg"
-    val RASTER_NAME         = "geomesa-tools.ingestraster.name"
     val TABLE               = "geomesa-tools.ingestraster.table"
     val PARLEVEL            = "geomesa-tools.ingestraster.parallel.level"
   }
@@ -160,6 +159,14 @@ object RasterUtils {
 
   def generateTestRasterFromGeoHash(gh: GeoHash, w: Int = 256, h: Int = 256, res: Double = 10.0): Raster = {
     generateTestRasterFromBoundingBox(gh.bbox, w, h, res)
+  }
+
+  case class sharedRasterParams(gg: GridGeometry2D, envelope: Envelope) {
+    val width = gg.getGridRange2D.getWidth
+    val height = gg.getGridRange2D.getHeight
+    val resX = (envelope.getMaximum(0) - envelope.getMinimum(0)) / width
+    val resY = (envelope.getMaximum(1) - envelope.getMinimum(1)) / height
+    val accumuloResolution = math.min(resX, resY)
   }
 }
 

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/RasterStoreQueryIntegratedTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/RasterStoreQueryIntegratedTest.scala
@@ -17,7 +17,6 @@
 package org.locationtech.geomesa.raster.data
 
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.raster.data.Raster
 import org.locationtech.geomesa.raster.util.RasterUtils
 import org.locationtech.geomesa.utils.geohash.GeoHash
 import org.specs2.mutable.Specification
@@ -113,7 +112,7 @@ class RasterStoreQueryIntegratedTest extends Specification {
 
       rasterStore must beAnInstanceOf[RasterStore]
       val theResults = rasterStore.getRasters(query).toList
-      theResults.length must beEqualTo(2)
+      theResults.length must beEqualTo(1)
     }
 
     "Properly filter in a raster conforming to GeoHashes via a query bbox and resolution" in {
@@ -129,7 +128,7 @@ class RasterStoreQueryIntegratedTest extends Specification {
 
       rasterStore must beAnInstanceOf[RasterStore]
       val theResults = rasterStore.getRasters(query).toList
-      theResults.length must beEqualTo(2)
+      theResults.length must beEqualTo(1)
     }
 
     "Properly return a raster slightly smaller than a GeoHash via a query bbox" in {
@@ -148,7 +147,7 @@ class RasterStoreQueryIntegratedTest extends Specification {
 
       rasterStore must beAnInstanceOf[RasterStore]
       val theResults = rasterStore.getRasters(query).toList
-      theResults.length must beEqualTo(2)
+      theResults.length must beEqualTo(1)
     }
 
     "Properly return a raster slightly larger than a GeoHash via a query bbox" in {
@@ -167,7 +166,7 @@ class RasterStoreQueryIntegratedTest extends Specification {
 
       rasterStore must beAnInstanceOf[RasterStore]
       val theResults = rasterStore.getRasters(query).toList
-      theResults.length must beEqualTo(2)
+      theResults.length must beEqualTo(1)
     }
 
     "Properly filter out a raster conforming to GeoHashes via a query bbox and resolution" in {

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/RasterStoreQueryIntegratedTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/RasterStoreQueryIntegratedTest.scala
@@ -113,7 +113,7 @@ class RasterStoreQueryIntegratedTest extends Specification {
 
       rasterStore must beAnInstanceOf[RasterStore]
       val theResults = rasterStore.getRasters(query).toList
-      theResults.length must beEqualTo(1)
+      theResults.length must beEqualTo(2)
     }
 
     "Properly filter in a raster conforming to GeoHashes via a query bbox and resolution" in {
@@ -129,7 +129,7 @@ class RasterStoreQueryIntegratedTest extends Specification {
 
       rasterStore must beAnInstanceOf[RasterStore]
       val theResults = rasterStore.getRasters(query).toList
-      theResults.length must beEqualTo(1)
+      theResults.length must beEqualTo(2)
     }
 
     "Properly return a raster slightly smaller than a GeoHash via a query bbox" in {
@@ -148,7 +148,7 @@ class RasterStoreQueryIntegratedTest extends Specification {
 
       rasterStore must beAnInstanceOf[RasterStore]
       val theResults = rasterStore.getRasters(query).toList
-      theResults.length must beEqualTo(1)
+      theResults.length must beEqualTo(2)
     }
 
     "Properly return a raster slightly larger than a GeoHash via a query bbox" in {
@@ -167,7 +167,7 @@ class RasterStoreQueryIntegratedTest extends Specification {
 
       rasterStore must beAnInstanceOf[RasterStore]
       val theResults = rasterStore.getRasters(query).toList
-      theResults.length must beEqualTo(1)
+      theResults.length must beEqualTo(2)
     }
 
     "Properly filter out a raster conforming to GeoHashes via a query bbox and resolution" in {

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/AccumuloParams.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/AccumuloParams.scala
@@ -75,9 +75,6 @@ class CreateFeatureParams extends FeatureParams {
 }
 
 class RasterParams extends AccumuloParams {
-  @Parameter(names = Array("-r", "--raster-name"), description = "Raster name on which to operate", required = true)
-  var rasterName: String = null
-
   @Parameter(names = Array("-t", "--raster-table"), description = "Accumulo table for storing raster data", required = true)
   var table: String = null
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestRasterCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestRasterCommand.scala
@@ -51,6 +51,7 @@ class IngestRasterCommand(parent: JCommander) extends Command with AccumuloPrope
     val args: Map[String, Option[String]] = Map(
       IngestRasterParams.FILE_PATH -> Some(params.file),
       IngestRasterParams.FORMAT -> Some(Option(params.format).getOrElse(getFileExtension(params.file))),
+      IngestRasterParams.TABLE -> Option(params.table),
       IngestRasterParams.TIME -> Option(params.timeStamp),
       IngestRasterParams.PARLEVEL -> Option(params.parLevel.toString)
     )

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestRasterCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestRasterCommand.scala
@@ -51,7 +51,6 @@ class IngestRasterCommand(parent: JCommander) extends Command with AccumuloPrope
     val args: Map[String, Option[String]] = Map(
       IngestRasterParams.FILE_PATH -> Some(params.file),
       IngestRasterParams.FORMAT -> Some(Option(params.format).getOrElse(getFileExtension(params.file))),
-      IngestRasterParams.RASTER_NAME -> Some(params.rasterName),
       IngestRasterParams.TIME -> Option(params.timeStamp),
       IngestRasterParams.PARLEVEL -> Option(params.parLevel.toString)
     )
@@ -64,12 +63,6 @@ class IngestRasterCommand(parent: JCommander) extends Command with AccumuloPrope
   }
 
   def createCoverageStore(config: IngestRasterParameters): AccumuloCoverageStore = {
-    if (config.rasterName == null || config.rasterName.isEmpty) {
-      logger.error("No raster name specified for raster feature ingest." +
-        " Please check that all arguments are correct in the previous command. ")
-      sys.exit()
-    }
-
     val password = getPassword(params.password)
     val csConfig: JMap[String, Serializable] = getAccumuloCoverageStoreConf(config, password)
 


### PR DESCRIPTION
Upon ingest, resolution is calculated with the BBOX, width, and height of the data. Then in lexi-encode and -decode methods, the calculated resolution is truncated to gain a little flexibility in querying for tiles. Additionally, the closest acceptable GeoHash is added to the enumerated GeoHashes to query with.