### PR TITLE
GEOMESA-625 Remove org.jaitools jt-zonalstats and jt-utils from jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,16 @@
                         <groupId>javax.media</groupId>
                         <artifactId>jai_core</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>org.jaitools</groupId>
+                        <artifactId>jt-zonalstats</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>org.jaitools</groupId>
+                        <artifactId>jt-utils</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
jt-zonalstats and jt-utils are excluded from gt-coverage.