### PR TITLE
GEOMESA-641 Add raster query profiling and dumpQueries geomesa-tools command

### DIFF
--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/stats/RasterQueryStat.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/stats/RasterQueryStat.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.stats
+
+import java.util.Map.Entry
+
+import org.apache.accumulo.core.data.{Key, Mutation, Value}
+import org.calrissian.mango.types.encoders.lexi.LongReverseEncoder
+
+/**
+ * Class for capturing query-related stats
+ */
+case class RasterQueryStat(featureName:   String,
+                           date:          Long,
+                           rasterQuery:   String,
+                           planningTime:  Long,
+                           scanTime:      Long,
+                           mosaicTime:    Long,
+                           numResults:    Int) extends Stat
+
+/**
+ * Maps query stats to accumulo
+ */
+object RasterQueryStatTransform extends StatTransform[RasterQueryStat] {
+
+  private val CQ_QUERY = "rasterQuery"
+  private val CQ_PLANTIME = "timePlanning"
+  private val CQ_SCANTIME = "timeScanning"
+  private val CQ_MOSAICTIME = "timeMosaicing"
+  private val CQ_TIME = "timeTotal"
+  private val CQ_HITS = "hits"
+  val reverseEncoder = new LongReverseEncoder()
+  val NUMBER_OF_CQ_DATA_TYPES = 6
+
+  override def createMutation(stat: Stat) = {
+    new Mutation(s"${stat.featureName}~${reverseEncoder.encode(stat.date)}")
+  }
+
+  override def statToMutation(stat: RasterQueryStat): Mutation = {
+    val mutation = createMutation(stat)
+    val cf = createRandomColumnFamily
+    mutation.put(cf, CQ_QUERY, stat.rasterQuery)
+    mutation.put(cf, CQ_PLANTIME, stat.planningTime + "ms")
+    mutation.put(cf, CQ_SCANTIME, stat.scanTime + "ms")
+    mutation.put(cf, CQ_MOSAICTIME, stat.mosaicTime + "ms")
+    mutation.put(cf, CQ_TIME, (stat.scanTime + stat.planningTime + stat.mosaicTime) + "ms")
+    mutation.put(cf, CQ_HITS, stat.numResults.toString)
+    mutation
+  }
+
+  val ROWID = "(.*)~(.*)".r
+
+  override def rowToStat(entries: Iterable[Entry[Key, Value]]): RasterQueryStat = {
+    if (entries.isEmpty) {
+      return null
+    }
+
+    val ROWID(featureName, dateString) = entries.head.getKey.getRow.toString
+    val date = reverseEncoder.decode(dateString)
+    val values = collection.mutable.Map.empty[String, Any]
+
+    entries.foreach { e =>
+      e.getKey.getColumnQualifier.toString match {
+        case CQ_QUERY => values.put(CQ_QUERY, e.getValue.toString)
+        case CQ_PLANTIME => values.put(CQ_PLANTIME, e.getValue.toString.stripSuffix("ms").toLong)
+        case CQ_SCANTIME => values.put(CQ_SCANTIME, e.getValue.toString.stripSuffix("ms").toLong)
+        case CQ_MOSAICTIME => values.put(CQ_MOSAICTIME, e.getValue.toString.stripSuffix("ms").toLong)
+        case CQ_HITS => values.put(CQ_HITS, e.getValue.toString.toInt)
+        case CQ_TIME => // time is an aggregate, doesn't need to map back to anything
+        case _ => logger.warn(s"Unmapped entry in query stat: ${e.getKey.getColumnQualifier.toString}")
+      }
+    }
+
+    val rasterQuery = values.getOrElse(CQ_QUERY, "").asInstanceOf[String]
+    val planTime = values.getOrElse(CQ_PLANTIME, 0L).asInstanceOf[Long]
+    val scanTime = values.getOrElse(CQ_SCANTIME, 0L).asInstanceOf[Long]
+    val mosaicTime = values.getOrElse(CQ_MOSAICTIME, 0L).asInstanceOf[Long]
+    val hits = values.getOrElse(CQ_HITS, 0).asInstanceOf[Int]
+
+    RasterQueryStat(featureName, date, rasterQuery, planTime, scanTime, mosaicTime, hits)
+  }
+
+  def decodeStat(entry: Entry[Key, Value]): Array[String] = {
+    entry.getKey.getColumnQualifier.toString match {
+      case CQ_QUERY => Array(entry.getKey.toString, entry.getValue.toString)
+      case CQ_PLANTIME => Array(entry.getKey.toString, entry.getValue.toString.stripSuffix("ms"))
+      case CQ_SCANTIME => Array(entry.getKey.toString, entry.getValue.toString.stripSuffix("ms"))
+      case CQ_MOSAICTIME => Array(entry.getKey.toString, entry.getValue.toString.stripSuffix("ms"))
+      case CQ_HITS => Array(entry.getKey.toString, entry.getValue.toString)
+      case CQ_TIME => Array(entry.getKey.toString, entry.getValue.toString)
+      case _ =>
+        logger.warn(s"Unmapped entry in query stat: ${entry.getKey.getColumnQualifier.toString}")
+        Array("", "")
+    }
+  }
+}

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/stats/StatWriter.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/stats/StatWriter.scala
@@ -80,7 +80,9 @@ object StatWriter extends Runnable with Logging {
    * Starts the background thread for writing stats, if it hasn't already been started
    */
   private def startIfNeeded() {
+    logger.debug("Starting StatWriter outside If Statement")
     if (running.compareAndSet(false, true)) {
+      logger.debug("Starting StatWriter inside If Statement")
       // we want to wait between invocations to give more stats a chance to queue up
       executor.scheduleWithFixedDelay(this, writeDelayMillis, writeDelayMillis, TimeUnit.MILLISECONDS)
     }
@@ -107,6 +109,7 @@ object StatWriter extends Runnable with Logging {
       // get the appropriate transform for this type of stat
       val transform = group.clas match {
         case c if c == classOf[QueryStat] => QueryStatTransform.asInstanceOf[StatTransform[Stat]]
+        case r if r == classOf[RasterQueryStat] => RasterQueryStatTransform.asInstanceOf[StatTransform[Stat]]
         case _ => throw new RuntimeException("Not implemented")
       }
       // create the table if necessary

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/stats/StatWriter.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/stats/StatWriter.scala
@@ -80,9 +80,7 @@ object StatWriter extends Runnable with Logging {
    * Starts the background thread for writing stats, if it hasn't already been started
    */
   private def startIfNeeded() {
-    logger.debug("Starting StatWriter outside If Statement")
     if (running.compareAndSet(false, true)) {
-      logger.debug("Starting StatWriter inside If Statement")
       // we want to wait between invocations to give more stats a chance to queue up
       executor.scheduleWithFixedDelay(this, writeDelayMillis, writeDelayMillis, TimeUnit.MILLISECONDS)
     }

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
@@ -25,8 +25,7 @@ import org.geotools.geometry.GeneralEnvelope
 import org.geotools.util.Utilities
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
-import org.locationtech.geomesa.raster.data.{Raster, RasterStore}
-import org.locationtech.geomesa.raster.util.RasterUtils
+import org.locationtech.geomesa.raster.data.{GeoMesaCoverageQueryParams, RasterStore}
 import org.opengis.parameter.GeneralParameterValue
 
 object GeoMesaCoverageReader {
@@ -80,13 +79,7 @@ class GeoMesaCoverageReader(val url: String, hints: Hints) extends AbstractGridC
     logger.debug(s"READ: $parameters")
     val params = new GeoMesaCoverageQueryParams(parameters)
     val rq = params.toRasterQuery
-    rastersToCoverage(ars.getRasters(rq), params)
-  }
-
-  def rastersToCoverage(rasters: Iterator[Raster], params: GeoMesaCoverageQueryParams): GridCoverage2D = {
-    val image = RasterUtils.mosaicRasters(rasters, params.width.toInt, params.height.toInt,
-      params.envelope, params.resX, params.resY)
-    this.coverageFactory.create(coverageName, image, params.envelope)
+    this.coverageFactory.create(coverageName, ars.getMosaicedRaster(rq, params), params.envelope)
   }
 
   def getBounds(): GeneralEnvelope = {

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloBackedRasterOperations.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloBackedRasterOperations.scala
@@ -116,13 +116,14 @@ class AccumuloBackedRasterOperations(val connector: Connector,
 
   def getMosaicedRaster(query: RasterQuery, params: GeoMesaCoverageQueryParams) = {
     val rasters = getRasters(query)
-    val (image, numRasters) = profile("mosaic") {RasterUtils.mosaicRasters(rasters,
-                                                        params.height.toInt,
-                                                        params.width.toInt,
-                                                        params.envelope,
-                                                        params.resX,
-                                                        params.resY)
-                                                }
+    val (image, numRasters) = profile("mosaic") {
+      RasterUtils.mosaicRasters(rasters,
+                                params.height.toInt,
+                                params.width.toInt,
+                                params.envelope,
+                                params.resX,
+                                params.resY)
+    }
     val stat = RasterQueryStat(rasterTable,
       System.currentTimeMillis(),
       query.toString,

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloCoverageStore.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloCoverageStore.scala
@@ -72,7 +72,7 @@ class AccumuloCoverageStore(val rasterStore: RasterStore,
     rasterStore.putRaster(raster)
   }
 
-  def getQueryRecords(numRecords: Int): List[Array[String]]  = rasterStore.getQueryRecords(numRecords)
+  def getQueryRecords(numRecords: Int): Iterator[String]  = rasterStore.getQueryRecords(numRecords)
 
   def registerToGeoserver(raster: Raster) {
     geoserverClientServiceO.foreach { geoserverClientService => {

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloCoverageStore.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloCoverageStore.scala
@@ -72,6 +72,8 @@ class AccumuloCoverageStore(val rasterStore: RasterStore,
     rasterStore.putRaster(raster)
   }
 
+  def getQueryRecords(numRecords: Int): List[Array[String]]  = rasterStore.getQueryRecords(numRecords)
+
   def registerToGeoserver(raster: Raster) {
     geoserverClientServiceO.foreach { geoserverClientService => {
       registerToGeoserver(raster, geoserverClientService)

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/GeoMesaCoverageQueryParams.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/GeoMesaCoverageQueryParams.scala
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package org.locationtech.geomesa.plugin.wcs
+package org.locationtech.geomesa.raster.data
 
 import org.geotools.coverage.grid.GridGeometry2D
 import org.geotools.coverage.grid.io.AbstractGridFormat
 import org.geotools.parameter.Parameter
-import org.locationtech.geomesa.raster.data.RasterQuery
 import org.locationtech.geomesa.raster.util.RasterUtils
 import org.locationtech.geomesa.utils.geohash.{BoundingBox, Bounds}
 import org.opengis.parameter.GeneralParameterValue

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/RasterStore.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/RasterStore.scala
@@ -47,7 +47,7 @@ class RasterStore(val rasterOps: RasterOperations) {
 
   def getRasters(rasterQuery: RasterQuery): Iterator[Raster] = rasterOps.getRasters(rasterQuery)
 
-  def getQueryRecords(numRecords: Int): List[Array[String]] = rasterOps.getQueryRecords(numRecords)
+  def getQueryRecords(numRecords: Int): Iterator[String] = rasterOps.getQueryRecords(numRecords)
 
   def putRaster(raster: Raster) = rasterOps.putRaster(raster)
 

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/RasterStore.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/RasterStore.scala
@@ -16,6 +16,8 @@
 
 package org.locationtech.geomesa.raster.data
 
+import java.awt.image.BufferedImage
+
 import org.geotools.coverage.grid.GridEnvelope2D
 import org.locationtech.geomesa.raster.AccumuloStoreHelper
 import org.locationtech.geomesa.utils.geohash.BoundingBox
@@ -40,7 +42,12 @@ class RasterStore(val rasterOps: RasterOperations) {
 
   def getTable = rasterOps.getTable
 
+  def getMosaicedRaster(rasterQuery: RasterQuery, params: GeoMesaCoverageQueryParams): BufferedImage =
+    rasterOps.getMosaicedRaster(rasterQuery, params)
+
   def getRasters(rasterQuery: RasterQuery): Iterator[Raster] = rasterOps.getRasters(rasterQuery)
+
+  def getQueryRecords(numRecords: Int): List[Array[String]] = rasterOps.getQueryRecords(numRecords)
 
   def putRaster(raster: Raster) = rasterOps.putRaster(raster)
 

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtils.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtils.scala
@@ -12,6 +12,7 @@ import org.joda.time.DateTime
 import org.locationtech.geomesa.core.index.DecodedIndex
 import org.locationtech.geomesa.raster.data.{Raster, RasterQuery, RasterStore}
 import org.locationtech.geomesa.utils.geohash.{BoundingBox, GeoHash}
+import org.locationtech.geomesa.utils.stats.MethodProfiling
 import org.opengis.geometry.Envelope
 
 import scala.reflect.runtime.universe._
@@ -86,9 +87,9 @@ object RasterUtils {
     new BufferedImage(width, height, BufferedImage.TYPE_BYTE_GRAY)
   }
 
-  def mosaicRasters(rasters: Iterator[Raster], width: Int, height: Int, env: Envelope, resX: Double, resY: Double): BufferedImage = {
+  def mosaicRasters(rasters: Iterator[Raster], width: Int, height: Int, env: Envelope, resX: Double, resY: Double): (BufferedImage, Int) = {
     if (rasters.isEmpty) {
-      getEmptyImage(width, height)
+      (getEmptyImage(width, height), 0)
     } else {
       val rescaleX = resX / (env.getSpan(0) / width)
       val rescaleY = resY / (env.getSpan(1) / height)
@@ -97,13 +98,15 @@ object RasterUtils {
       val imageWidth = Math.max(Math.round(scaledWidth), 1).toInt
       val imageHeight = Math.max(Math.round(scaledHeight), 1).toInt
       val firstRaster = rasters.next()
+      var count = 1
       val mosaic = getEmptyMosaic(imageWidth, imageHeight, firstRaster.chunk)
       setMosaicData(mosaic, firstRaster, env, resX, resY)
       while (rasters.hasNext) {
         val raster = rasters.next()
         setMosaicData(mosaic, raster, env, resX, resY)
+        count += 1
       }
-      mosaic
+      (mosaic, count)
     }
   }
 

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/MosaicTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/MosaicTest.scala
@@ -93,7 +93,7 @@ class MosaicTest extends Specification {
                         envelope: ReferencedEnvelope,
                         resX: Double,
                         resY: Double): Array[Byte] = {
-    val image = RasterUtils.mosaicRasters(rasterList, width * 2, height * 2, envelope, resX, resY)
+    val (image, _) = RasterUtils.mosaicRasters(rasterList, width * 2, height * 2, envelope, resX, resY)
     val baos = new ByteArrayOutputStream()
     ImageIO.write(image, "png", baos)
     baos.toByteArray

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/MosaicTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/MosaicTest.scala
@@ -87,16 +87,16 @@ class MosaicTest extends Specification {
     rasterList.toList
   }
 
-  def getImageByteArray(rasterList: Iterator[Raster],
+  def getImageByteArrayAndCount(rasterList: Iterator[Raster],
                         width: Int,
                         height: Int,
                         envelope: ReferencedEnvelope,
                         resX: Double,
-                        resY: Double): Array[Byte] = {
-    val (image, _) = RasterUtils.mosaicRasters(rasterList, width * 2, height * 2, envelope, resX, resY)
+                        resY: Double): (Array[Byte], Int) = {
+    val (image, count) = RasterUtils.mosaicRasters(rasterList, width * 2, height * 2, envelope, resX, resY)
     val baos = new ByteArrayOutputStream()
     ImageIO.write(image, "png", baos)
-    baos.toByteArray
+    (baos.toByteArray, count)
   }
 
   def runAccumuloMosaicTest(width: Int , height: Int, bbox: BoundingBox) = {
@@ -109,8 +109,9 @@ class MosaicTest extends Specification {
     //1.0 is used as a fake resolution for this mock Accumulo test
     val rq = new RasterQuery(BoundingBox(envelope), 1.0, None, None)
     val queryRasters = rs.getRasters(rq)
-    val ingestImageByteArray = getImageByteArray(ingestRastersList.toIterator, width, height, envelope, resX, resY)
-    val queryImageByteArray = getImageByteArray(queryRasters, width, height, envelope, resX, resY)
+    val (ingestImageByteArray, ingestCount) = getImageByteArrayAndCount(ingestRastersList.toIterator, width, height, envelope, resX, resY)
+    val (queryImageByteArray, queryCount) = getImageByteArrayAndCount(queryRasters, width, height, envelope, resX, resY)
+    ingestCount must beEqualTo(queryCount)
     ArrayUtil.equals(ingestImageByteArray, queryImageByteArray) must beTrue
   }
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Runner.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Runner.scala
@@ -37,6 +37,7 @@ object Runner extends Logging {
     val create       = new CreateCommand(jc)
     val explain      = new ExplainCommand(jc)
     val help         = new HelpCommand(jc)
+    val dumpQueries  = new DumpQueriesCommand(jc)
 
     try {
       jc.parse(args.toArray: _*)
@@ -59,6 +60,7 @@ object Runner extends Logging {
         case CreateCommand.Command          => create
         case ExplainCommand.Command         => explain
         case HelpCommand.Command            => help
+        case DumpQueriesCommand.Command     => dumpQueries
         case _                              => new DefaultCommand(jc)
       }
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Runner.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Runner.scala
@@ -37,7 +37,7 @@ object Runner extends Logging {
     val create       = new CreateCommand(jc)
     val explain      = new ExplainCommand(jc)
     val help         = new HelpCommand(jc)
-    val dumpQueries  = new DumpQueriesCommand(jc)
+    val queryStats   = new QueryStatsCommand(jc)
 
     try {
       jc.parse(args.toArray: _*)
@@ -60,7 +60,7 @@ object Runner extends Logging {
         case CreateCommand.Command          => create
         case ExplainCommand.Command         => explain
         case HelpCommand.Command            => help
-        case DumpQueriesCommand.Command     => dumpQueries
+        case QueryStatsCommand.Command      => queryStats
         case _                              => new DefaultCommand(jc)
       }
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/DumpQueriesCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/DumpQueriesCommand.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.locationtech.geomesa.tools.commands
+
+import java.io._
+import java.util.Date
+
+import au.com.bytecode.opencsv.CSVWriter
+import com.beust.jcommander.{JCommander, Parameter, Parameters}
+import org.locationtech.geomesa.core.stats.RasterQueryStatTransform
+import org.locationtech.geomesa.raster.data.AccumuloCoverageStore
+import org.locationtech.geomesa.tools.AccumuloProperties
+import org.locationtech.geomesa.tools.commands.DumpQueriesCommand.{Command, DumpQueriesParameters}
+
+import scala.collection.JavaConverters._
+
+class DumpQueriesCommand(parent: JCommander) extends Command with AccumuloProperties {
+
+  val params = new DumpQueriesParameters()
+  parent.addCommand(Command, params)
+
+  override def execute() = {
+    val queryRecords = createCoverageStore(params).getQueryRecords(params.numRecords * RasterQueryStatTransform.NUMBER_OF_CQ_DATA_TYPES)
+    val fw = getFileWriter
+    val out = new BufferedWriter(fw)
+    val writer = new CSVWriter(out)
+    writer.writeAll(queryRecords.asJava)
+    out.close()
+  }
+
+  def createCoverageStore(config: DumpQueriesParameters): AccumuloCoverageStore = {
+    val password = getPassword(params.password)
+    val auths = Option(params.auths)
+    AccumuloCoverageStore(params.user, password,
+                          params.instance,
+                          params.zookeepers,
+                          params.table,
+                          auths.getOrElse(""),
+                          params.visibilities)
+  }
+
+  def getFileWriter: FileWriter = {
+    val date = new Date().toString.replaceAll(" ", "_")
+    Option(params.file) match {
+      case Some(file) => new FileWriter(file)
+      case None => new FileWriter(s"./queryDump-$date.csv")
+    }
+  }
+}
+
+object DumpQueriesCommand {
+  val Command = "dumpQueries"
+
+  @Parameters(commandDescription = "Dump the last X number of queries and time it took for each into a CSV file.")
+  class DumpQueriesParameters extends RasterParams {
+    @Parameter(names = Array("-num", "--number-of-records"), description = "Number of query records to export from Accumulo")
+    var numRecords: Int = 1000
+
+    @Parameter(names = Array("-o", "--output"), description = "name of the file to output to instead of std out")
+    var file: String = null
+  }
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/MethodProfiling.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/MethodProfiling.scala
@@ -32,11 +32,13 @@ trait MethodProfiling {
     r
   }
 
-  def profile[R](code: => R, identifier: String)(implicit timings: Timings) = {
+  def profile[R](code: => R, identifier: String)(implicit timings: Timings): R = {
     val (startTime, r) = (ctm, code)
     timings.occurrence(identifier, ctm - startTime)
     r
   }
+
+  def profile[R](identifier: String)(code: => R)(implicit timings: Timings): R = profile(code, identifier)
 }
 
 /**


### PR DESCRIPTION
Raster queries are now profiled on the getRasters, Accumulo scanning, and raster mosaicing steps
of returning raster chunks to a client. These are then written to an Accumulo table and can be exported from that table with the "queryStats" geomesa-tools command. This should aid in debugging and configuring environmental setup options.