### PR TITLE
WIP GEOMESA-638 Expose Available Resolutions in Raster Table

### DIFF
--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/BBOXCombiner.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/BBOXCombiner.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.iterators
+
+import java.util
+
+import com.vividsolutions.jts.geom.Point
+import com.vividsolutions.jts.io.WKTReader
+import org.apache.accumulo.core.data.{Key, Value}
+import org.apache.accumulo.core.iterators.Combiner
+import org.locationtech.geomesa.core.iterators.BBOXCombiner._
+import org.locationtech.geomesa.utils.geohash.BoundingBox
+
+import scala.collection.JavaConversions._
+
+class BBOXCombiner extends Combiner {
+  override def reduce(p1: Key, p2: util.Iterator[Value]): Value = {
+    if(p2.hasNext) {
+      val combinedBbox = p2.map(valueToBbox).reduce( (a, b) => BoundingBox.getCoveringBoundingBox(a, b) )
+      bboxToValue(combinedBbox)
+    } else {
+      new Value()
+    }
+  }
+}
+
+object BBOXCombiner {
+  val wktReader = new ThreadLocal[WKTReader] {
+    override def initialValue = new WKTReader()
+  }
+
+  // These two functions are inverse
+  def bboxToValue(bbox: BoundingBox): Value = {
+    new Value((bbox.ll.toString + ":" + bbox.ur.toString).getBytes)
+  }
+
+  def valueToBbox(value: Value): BoundingBox = {
+    val wkts = value.toString.split(":")
+    BoundingBox(wktReader.get.read(wkts(0)).asInstanceOf[Point], wktReader.get.read(wkts(1)).asInstanceOf[Point])
+  }
+}

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/iterators/BBOXCombinerTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/iterators/BBOXCombinerTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.iterators
+
+import org.apache.accumulo.core.data.Value
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.utils.geohash.BoundingBox
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class BBOXCombinerTest extends Specification {
+  sequential
+
+  "BBOXCombiner" should {
+
+    "covert a BoundingBox to a Value" in {
+      val bbox = BoundingBox(0, 10, 0, 10)
+
+      val value = BBOXCombiner.bboxToValue(bbox)
+
+      value must beAnInstanceOf[Value]
+    }
+
+    "convert a Value into a BoundingBox" in {
+      val value = new Value("POINT (0 0):POINT (10 10)".getBytes())
+
+      val bbox = BBOXCombiner.valueToBbox(value)
+
+      bbox must beAnInstanceOf[BoundingBox]
+    }
+
+    "convert a BoundingBox to a Value and then back again into a BoundingBox" in {
+      val bbox = BoundingBox(0, 10, 0, 10)
+
+      val value = BBOXCombiner.bboxToValue(bbox)
+
+      val resbbox = BBOXCombiner.valueToBbox(value)
+
+      bbox mustEqual(resbbox)
+    }
+
+  }
+
+}

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
@@ -46,14 +46,15 @@ class GeoMesaCoverageReader(val url: String, hints: Hints) extends AbstractGridC
 
   coverageName = table
 
+  val ars = RasterStore(user, password, instanceId, zookeepers, table, auths, "")
+
   // TODO: Either this is needed for rasterToCoverages or remove it.
   this.crs = AbstractGridFormat.getDefaultCRS
-  this.originalEnvelope = new GeneralEnvelope(Array(-180.0, -90.0), Array(180.0, 90.0))
+  this.originalEnvelope = getBounds()
   this.originalEnvelope.setCoordinateReferenceSystem(this.crs)
   this.originalGridRange = new GridEnvelope2D(new Rectangle(0, 0, 1024, 512))
   this.coverageFactory = CoverageFactoryFinder.getGridCoverageFactory(this.hints)
   // TODO: Provide writeVisibilites??  Sort out read visibilites
-  val ars: RasterStore = RasterStore(user, password, instanceId, zookeepers, table, auths, "")
 
   /**
    * Default implementation does not allow a non-default coverage name
@@ -64,6 +65,8 @@ class GeoMesaCoverageReader(val url: String, hints: Hints) extends AbstractGridC
     Utilities.ensureNonNull("coverageName", coverageName)
     true
   }
+
+  override def getOriginalEnvelope = this.getOriginalEnvelope
 
   override def getCoordinateReferenceSystem = this.crs
 
@@ -82,5 +85,10 @@ class GeoMesaCoverageReader(val url: String, hints: Hints) extends AbstractGridC
     val image = RasterUtils.mosaicRasters(rasters, params.width.toInt, params.height.toInt,
       params.envelope, params.resX, params.resY)
     this.coverageFactory.create(coverageName, image, params.envelope)
+  }
+
+  def getBounds(): GeneralEnvelope = {
+    val bbox = ars.getBounds()
+    new GeneralEnvelope(Array(bbox.minLon, bbox.minLat), Array(bbox.maxLon, bbox.maxLat))
   }
 }

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloBackedRasterOperations.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloBackedRasterOperations.scala
@@ -19,24 +19,28 @@ package org.locationtech.geomesa.raster.data
 import java.util.Map.Entry
 
 import org.apache.accumulo.core.client.{BatchWriterConfig, Connector, TableExistsException}
-import org.apache.accumulo.core.data.{Key, Mutation, Value}
+import org.apache.accumulo.core.data.{Range, Key, Mutation, Value}
 import org.apache.accumulo.core.security.{Authorizations, TablePermission}
 import org.joda.time.DateTime
 import org.locationtech.geomesa.core.index._
+import org.locationtech.geomesa.core.iterators.BBOXCombiner
 import org.locationtech.geomesa.core.security.AuthorizationsProvider
 import org.locationtech.geomesa.core.stats.StatWriter
 import org.locationtech.geomesa.raster.index.RasterIndexSchema
+import org.locationtech.geomesa.utils.geohash.BoundingBox
 
 import scala.collection.JavaConversions._
 
 trait RasterOperations extends StrategyHelpers {
   def getTable(): String
   def ensureTableExists(): Unit
+  def ensureBoundsTableExists(): Unit
   def getAuths(): Authorizations
   def getVisibility(): String
   def getConnector(): Connector
   def getRasters(rasterQuery: RasterQuery): Iterator[Raster]
   def putRaster(raster: Raster): Unit
+  def getBounds(): BoundingBox
 }
 
 /**
@@ -72,6 +76,8 @@ class AccumuloBackedRasterOperations(val connector: Connector,
 
   lazy val queryPlanner: AccumuloRasterQueryPlanner = new AccumuloRasterQueryPlanner(schema)
 
+  lazy val boundsPlanner: AccumuloRasterBoundsPlanner = new AccumuloRasterBoundsPlanner(rasterTable)
+
   private val tableOps = connector.tableOperations()
   private val securityOps = connector.securityOperations
 
@@ -86,12 +92,15 @@ class AccumuloBackedRasterOperations(val connector: Connector,
 
   def getTable() = rasterTable
 
+  private def getBoundsRowID = rasterTable + "_bounds"
+
   def putRasters(rasters: Seq[Raster]) {
     rasters.foreach { putRaster(_) }
   }
 
   def putRaster(raster: Raster) {
-    writeMutations(createMutation(raster))
+    writeMutations(rasterTable, createMutation(raster))
+    writeMutations(GEOMESA_RASTER_BOUNDS_TABLE, createBoundsMutation(raster))
   }
 
   def getRasters(rasterQuery: RasterQuery): Iterator[Raster] = {
@@ -103,13 +112,44 @@ class AccumuloBackedRasterOperations(val connector: Connector,
     adaptIterator(batchScanner.iterator)
   }
 
+  def getBounds(): BoundingBox = {
+    ensureTableExists(GEOMESA_RASTER_BOUNDS_TABLE)
+    val scanner = connector.createScanner(GEOMESA_RASTER_BOUNDS_TABLE, authorizationsProvider.getAuthorizations)
+    scanner.setRange(new Range(getBoundsRowID))
+    val resultingBounds = scanner.iterator.toList
+    if (resultingBounds.length > 0) {
+      //TODO: add fix for stuff crossing anti-meridian, may not be an issue...
+      BBOXCombiner.valueToBbox(resultingBounds.head.getValue)
+    } else {
+      BoundingBox(-180, 180, -90, 90)
+    }
+  }
+
   def adaptIterator(iter: java.util.Iterator[Entry[Key, Value]]): Iterator[Raster] = {
     iter.map { entry => schema.decode((entry.getKey, entry.getValue)) }
   }
 
-  def ensureTableExists() = ensureTableExists(rasterTable)
+  def ensureTableExists() = {
+    ensureTableExists(rasterTable)
+    ensureBoundsTableExists()
+  }
+
+  def ensureBoundsTableExists() = {
+    ensureTableExists(GEOMESA_RASTER_BOUNDS_TABLE)
+    if (!tableOps.listIterators(GEOMESA_RASTER_BOUNDS_TABLE).containsKey("GEOMESA_BBOX_COMBINER")) {
+      val bboxcombinercfg = boundsPlanner.getBoundsScannerCfg()
+      tableOps.attachIterator(GEOMESA_RASTER_BOUNDS_TABLE, bboxcombinercfg)
+    }
+  }
 
   private def dateToAccTimestamp(dt: DateTime): Long =  dt.getMillis / 1000
+
+  private def createBoundsMutation(raster: Raster): Mutation = {
+    val mutation = new Mutation(getBoundsRowID)
+    val value = BBOXCombiner.bboxToValue(BoundingBox(raster.metadata.geom.getEnvelopeInternal))
+    mutation.put("", "", value)
+    mutation
+  }
 
   /**
    * Create Mutation instance from input Raster instance
@@ -135,8 +175,8 @@ class AccumuloBackedRasterOperations(val connector: Connector,
    *
    * @param mutations
    */
-  private def writeMutations(mutations: Mutation*) {
-    val writer = connector.createBatchWriter(rasterTable, bwConfig)
+  private def writeMutations(tableName: String, mutations: Mutation*) {
+    val writer = connector.createBatchWriter(tableName, bwConfig)
     mutations.foreach { m => writer.addMutation(m) }
     writer.flush()
     writer.close()

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloCoverageStore.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloCoverageStore.scala
@@ -55,8 +55,10 @@ class AccumuloCoverageStore(val rasterStore: RasterStore,
   extends CoverageStore with Logging {
 
   Hints.putSystemDefault(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, true)
-  //TODO: WCS: remove if no longer needed
+  // Ensure the Table Exists
   rasterStore.ensureTableExists()
+  // Ensure the Bounds Table Exists
+  rasterStore.ensureBoundsTableExists()
 
   def getAuths = rasterStore.getAuths
 
@@ -133,6 +135,9 @@ object AccumuloCoverageStore extends Logging {
                                      writeThreadsConfig,
                                      queryThreadsConfig,
                                      collectStats)
+
+    // Create Bounds Store
+    rasterOps.ensureBoundsTableExists()
 
     val dsConnectConfig: Map[String, String] = Map(
       IngestRasterParams.ACCUMULO_INSTANCE -> instanceIdParam.lookUp(config).asInstanceOf[String],

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterBoundsPlanner.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterBoundsPlanner.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.locationtech.geomesa.raster.data
+
+import com.typesafe.scalalogging.slf4j.Logging
+import org.apache.accumulo.core.client.IteratorSetting
+import org.locationtech.geomesa.core.iterators.BBOXCombiner
+
+case class AccumuloRasterBoundsPlanner(tableName: String) extends Logging {
+
+  def getBoundsScannerCfg(): IteratorSetting = {
+    logger.debug(s"Raster Bounds Planner for table: $tableName")
+    val cfg = new IteratorSetting(10, "GEOMESA_BBOX_COMBINER", classOf[BBOXCombiner])
+    cfg.addOption("all", "true")
+    cfg
+  }
+
+}

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterQueryPlanner.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterQueryPlanner.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package org.locationtech.geomesa.raster.data
 
 import com.typesafe.scalalogging.slf4j.Logging

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/RasterStore.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/RasterStore.scala
@@ -43,6 +43,8 @@ class RasterStore(val rasterOps: RasterOperations) {
   def putRaster(raster: Raster) = rasterOps.putRaster(raster)
 
   def getBounds() = rasterOps.getBounds()
+
+  def getAvailableResolutions() = rasterOps.getAvailableResolutions()
 }
 
 object RasterStore {

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/RasterStore.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/RasterStore.scala
@@ -17,7 +17,6 @@
 package org.locationtech.geomesa.raster.data
 
 import org.locationtech.geomesa.raster.AccumuloStoreHelper
-import org.locationtech.geomesa.raster.data.Raster
 
 /**
  * This class defines basic operations on Raster, including saving/retrieving
@@ -28,6 +27,8 @@ import org.locationtech.geomesa.raster.data.Raster
 class RasterStore(val rasterOps: RasterOperations) {
 
   def ensureTableExists() = rasterOps.ensureTableExists()
+
+  def ensureBoundsTableExists() = rasterOps.ensureBoundsTableExists()
 
   def getAuths = rasterOps.getAuths()
 
@@ -40,6 +41,8 @@ class RasterStore(val rasterOps: RasterOperations) {
   def getRasters(rasterQuery: RasterQuery): Iterator[Raster] = rasterOps.getRasters(rasterQuery)
 
   def putRaster(raster: Raster) = rasterOps.putRaster(raster)
+
+  def getBounds() = rasterOps.getBounds()
 }
 
 object RasterStore {
@@ -59,6 +62,8 @@ object RasterStore {
     val rasterOps = new AccumuloBackedRasterOperations(conn, tableName, authorizationsProvider, writeVisibilities)
     // this will actually create the Accumulo Table
     rasterOps.ensureTableExists()
+    // This will create the Bounds Table if not present.
+    rasterOps.ensureBoundsTableExists()
     // TODO: WCS: Configure the shards/writeMemory/writeThreads/queryThreadsParams
     // GEOMESA-568
     new RasterStore(rasterOps)

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/package.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/package.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.locationtech.geomesa.raster
+
+package object data {
+  val GEOMESA_RASTER_BOUNDS_TABLE = "GEOMESA_RASTER_BOUNDS"
+}

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/MosaicTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/MosaicTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.locationtech.geomesa.raster.data
 
 import java.awt.image._

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/RasterBoundsTableTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/RasterBoundsTableTest.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.raster.data
+
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.raster.util.RasterUtils
+import org.locationtech.geomesa.utils.geohash.BoundingBox
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class RasterBoundsTableTest extends Specification{
+  sequential
+
+  var testIteration = 0
+
+  val wholeWorld = BoundingBox(-180.0, 180.0, -90.0, 90.0)
+
+  def getNewIteration() = {
+    testIteration += 1
+    s"testRBTT_Table_$testIteration"
+  }
+
+  "RasterStore" should {
+    "return the bounds of a empty table as the whole world" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // get bounds
+      val theBounds = theStore.getBounds()
+
+      theBounds must beAnInstanceOf[BoundingBox]
+      theBounds must beEqualTo(wholeWorld)
+    }
+
+    "return the bounds of a table with a single raster" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate store
+      val testRaster = RasterUtils.generateTestRaster(0, 50, 0, 50)
+      theStore.putRaster(testRaster)
+
+      // get bounds
+      val theBounds = theStore.getBounds()
+
+      theBounds must beAnInstanceOf[BoundingBox]
+      theBounds.maxLon must beEqualTo(50.0)
+      theBounds.maxLat must beEqualTo(50.0)
+      theBounds.minLon must beEqualTo(0.0)
+      theBounds.minLat must beEqualTo(0.0)
+    }
+
+    "return the bounds of a table with two identical rasters" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate store
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(0, 50, 0, 50)
+      theStore.putRaster(testRaster2)
+
+      // get bounds
+      val theBounds = theStore.getBounds()
+
+      theBounds must beAnInstanceOf[BoundingBox]
+      theBounds.maxLon must beEqualTo(50.0)
+      theBounds.maxLat must beEqualTo(50.0)
+      theBounds.minLon must beEqualTo(0.0)
+      theBounds.minLat must beEqualTo(0.0)
+    }
+
+    "return the bounds of a table with two adjacent rasters" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate store
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(-50, 0, 0, 50)
+      theStore.putRaster(testRaster2)
+
+      // get bounds
+      val theBounds = theStore.getBounds()
+
+      theBounds must beAnInstanceOf[BoundingBox]
+      theBounds.maxLon must beEqualTo(50.0)
+      theBounds.maxLat must beEqualTo(50.0)
+      theBounds.minLon must beEqualTo(-50.0)
+      theBounds.minLat must beEqualTo(0.0)
+    }
+
+    "return the bounds of a table with two non-adjacent rasters" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate store
+      val testRaster1 = RasterUtils.generateTestRaster(-180, -170, -90, -80)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(170, 180, 80, 90)
+      theStore.putRaster(testRaster2)
+
+      // get bounds
+      val theBounds = theStore.getBounds()
+
+      theBounds must beAnInstanceOf[BoundingBox]
+      theBounds.maxLon must beEqualTo(180.0)
+      theBounds.maxLat must beEqualTo(90.0)
+      theBounds.minLon must beEqualTo(-180.0)
+      theBounds.minLat must beEqualTo(-90.0)
+    }
+
+  }
+}

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/RasterBoundsTableTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/RasterBoundsTableTest.scala
@@ -125,5 +125,95 @@ class RasterBoundsTableTest extends Specification{
       theBounds.minLat must beEqualTo(-90.0)
     }
 
+    "Return an empty set of resolutions for an empty table" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // get bounds
+      val theResolutions = theStore.getAvailableResolutions()
+
+      theResolutions must beEmpty[Set[Double]]
+    }
+
+    "Return a set of one resolution for a table with one raster ingested" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate the table
+      val testRaster = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 10.0)
+      theStore.putRaster(testRaster)
+
+      // get bounds
+      val theResolutions = theStore.getAvailableResolutions()
+
+      theResolutions must not(beEmpty[Set[Double]])
+      theResolutions.size must beEqualTo(1)
+      theResolutions must beEqualTo(Set(10.0))
+    }
+
+    "Return a set of one resolution for a table with duplicated rasters ingested" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate the table
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 10.0)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 10.0)
+      theStore.putRaster(testRaster2)
+
+      // get bounds
+      val theResolutions = theStore.getAvailableResolutions()
+
+      theResolutions must not(beEmpty[Set[Double]])
+      theResolutions.size must beEqualTo(1)
+      theResolutions must beEqualTo(Set(10.0))
+    }
+
+    "Return a set of one resolution for a table with multiple similar rasters ingested" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate the table
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 10.0)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(0, -50, 0, 50, res = 10.0)
+      theStore.putRaster(testRaster2)
+      val testRaster3 = RasterUtils.generateTestRaster(0, -50, 0, -50, res = 10.0)
+      theStore.putRaster(testRaster3)
+      val testRaster4 = RasterUtils.generateTestRaster(0, 50, 0, -50, res = 10.0)
+      theStore.putRaster(testRaster4)
+
+      // get bounds
+      val theResolutions = theStore.getAvailableResolutions()
+
+      theResolutions must not(beEmpty[Set[Double]])
+      theResolutions.size must beEqualTo(1)
+      theResolutions must beEqualTo(Set(10.0))
+    }
+
+    "Return a set of many resolutions for a table with multiple rasters ingested" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate the table
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 6.0)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(0, 40, 0, 40, res = 7.0)
+      theStore.putRaster(testRaster2)
+      val testRaster3 = RasterUtils.generateTestRaster(0, 30, 0, 30, res = 8.0)
+      theStore.putRaster(testRaster3)
+      val testRaster4 = RasterUtils.generateTestRaster(0, 20, 0, 20, res = 9.0)
+      theStore.putRaster(testRaster4)
+      val testRaster5 = RasterUtils.generateTestRaster(0, 10, 0, 10, res = 10.0)
+      theStore.putRaster(testRaster5)
+
+      // get bounds
+      val theResolutions = theStore.getAvailableResolutions()
+
+      theResolutions must not(beEmpty[Set[Double]])
+      theResolutions.size must beEqualTo(5)
+      theResolutions must beEqualTo(Set(6.0, 7.0, 8.0, 9.0, 10.0))
+    }
+
   }
 }


### PR DESCRIPTION
This is a WIP PR for comments only. 638 is a sub task of 619, and 638 is a prerequisite as it utilizes the Bounds table for aggregating resolution information. Once #431 has been commented on, those changes will be incorporated into this branch, the idea being at the end there will be one large commit spanning a few tickets.

* RasterStore now exposes sets of Available Resolutions in Table
* Added unit tests for getAvailableResolutions