### PR TITLE
WIP: Remove gt-epsg-hsql from the geomesa-raster jar

### DIFF
--- a/geomesa-raster/pom.xml
+++ b/geomesa-raster/pom.xml
@@ -59,6 +59,12 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-imageio-ext-gdal</artifactId>
             <version>${gt.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-epsg-hsql</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>


### PR DESCRIPTION
This is needed to prevent issues with CRS lookups in the runtime jar. The blanket exclusion may cause trouble with raster ingest so needs to be tested first. 