### PR TITLE
GEOMESA-619,637,638,639 Ensure WCS DescribeCoverage Returns all useful information.

### DIFF
--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/BBOXCombiner.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/BBOXCombiner.scala
@@ -53,6 +53,7 @@ object BBOXCombiner {
 
   def valueToBbox(value: Value): BoundingBox = {
     val wkts = value.toString.split(":")
-    BoundingBox(wktReader.get.read(wkts(0)).asInstanceOf[Point], wktReader.get.read(wkts(1)).asInstanceOf[Point])
+    val localReader = wktReader.get
+    BoundingBox(localReader.read(wkts(0)).asInstanceOf[Point], localReader.read(wkts(1)).asInstanceOf[Point])
   }
 }

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/BBOXCombiner.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/BBOXCombiner.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.iterators
+
+import java.util
+
+import com.vividsolutions.jts.geom.Point
+import com.vividsolutions.jts.io.WKTReader
+import org.apache.accumulo.core.data.{Key, Value}
+import org.apache.accumulo.core.iterators.Combiner
+import org.locationtech.geomesa.core.iterators.BBOXCombiner._
+import org.locationtech.geomesa.utils.geohash.BoundingBox
+
+import scala.collection.JavaConversions._
+
+class BBOXCombiner extends Combiner {
+  override def reduce(p1: Key, p2: util.Iterator[Value]): Value = {
+    if(p2.hasNext) {
+      bboxToValue(reduceValuesToBoundingBox(p2))
+    } else {
+      new Value()
+    }
+  }
+}
+
+object BBOXCombiner {
+  val wktReader = new ThreadLocal[WKTReader] {
+    override def initialValue = new WKTReader()
+  }
+
+  def reduceValuesToBoundingBox(values: util.Iterator[Value]): BoundingBox = {
+    values.map(valueToBbox).reduce( (a, b) => BoundingBox.getCoveringBoundingBox(a, b) )
+  }
+
+  // These two functions are inverse
+  def bboxToValue(bbox: BoundingBox): Value = {
+    new Value((bbox.ll.toString + ":" + bbox.ur.toString).getBytes)
+  }
+
+  def valueToBbox(value: Value): BoundingBox = {
+    val wkts = value.toString.split(":")
+    BoundingBox(wktReader.get.read(wkts(0)).asInstanceOf[Point], wktReader.get.read(wkts(1)).asInstanceOf[Point])
+  }
+}

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/util/CloseableIterator.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/util/CloseableIterator.scala
@@ -106,3 +106,8 @@ object SelfClosingIterator {
 object SelfClosingBatchScanner {
   def apply(bs: BatchScanner): SelfClosingIterator[Entry[Key, Value]] = SelfClosingIterator(bs.iterator, () => bs.close())
 }
+
+// This object provides a standard way to wrap Scanners in a self-closing and closeable iterator.
+object SelfClosingScanner {
+  def apply(bs: Scanner): SelfClosingIterator[Entry[Key, Value]] = SelfClosingIterator(bs.iterator, () => bs.close())
+}

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/iterators/BBOXCombinerTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/iterators/BBOXCombinerTest.scala
@@ -29,7 +29,6 @@ class BBOXCombinerTest extends Specification {
   def givenValue(v: Value): Value = BBOXCombiner.bboxToValue(BBOXCombiner.valueToBbox(v))
 
   "BBOXCombiner" should {
-
     "covert a number of BoundingBoxes to Values and back again" in {
       val bbox1 = BoundingBox(0, 10, 0, 10)
       val bbox2 = BoundingBox(0, 10, -10, 0)
@@ -53,8 +52,5 @@ class BBOXCombinerTest extends Specification {
       value3 must beEqualTo(givenValue(value3))
       value4 must beEqualTo(givenValue(value4))
     }
-
-
   }
-
 }

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/iterators/BBOXCombinerTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/iterators/BBOXCombinerTest.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.iterators
+
+import org.apache.accumulo.core.data.Value
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.utils.geohash.BoundingBox
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class BBOXCombinerTest extends Specification {
+
+  def givenBBox(bbox: BoundingBox): BoundingBox = BBOXCombiner.valueToBbox(BBOXCombiner.bboxToValue(bbox))
+  def givenValue(v: Value): Value = BBOXCombiner.bboxToValue(BBOXCombiner.valueToBbox(v))
+
+  "BBOXCombiner" should {
+
+    "covert a number of BoundingBoxes to Values and back again" in {
+      val bbox1 = BoundingBox(0, 10, 0, 10)
+      val bbox2 = BoundingBox(0, 10, -10, 0)
+      val bbox3 = BoundingBox(-10, 0, 0, 10)
+      val bbox4 = BoundingBox(-10, 0, -10, 0)
+
+      bbox1 must beEqualTo(givenBBox(bbox1))
+      bbox2 must beEqualTo(givenBBox(bbox2))
+      bbox3 must beEqualTo(givenBBox(bbox3))
+      bbox4 must beEqualTo(givenBBox(bbox4))
+    }
+
+    "covert a number of Values to BoundingBoxes and back again" in {
+      val value1 = new Value("POINT (0 0):POINT (10 10)".getBytes())
+      val value2 = new Value("POINT (-10 -10):POINT (0 0)".getBytes())
+      val value3 = new Value("POINT (-10 0):POINT (0 10)".getBytes())
+      val value4 = new Value("POINT (0 -10):POINT (10 0)".getBytes())
+
+      value1 must beEqualTo(givenValue(value1))
+      value2 must beEqualTo(givenValue(value2))
+      value3 must beEqualTo(givenValue(value3))
+      value4 must beEqualTo(givenValue(value4))
+    }
+
+
+  }
+
+}

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageQueryParams.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageQueryParams.scala
@@ -42,11 +42,18 @@ class GeoMesaCoverageQueryParams(parameters: Array[GeneralParameterValue]) {
   val resX = rasterParams.resX
   val resY = rasterParams.resY
   val accumuloResolution = rasterParams.accumuloResolution
-  val min = Array(Math.max(envelope.getMinimum(0), -180) + .00000001,
-                  Math.max(envelope.getMinimum(1), -90) + .00000001)
-  val max = Array(Math.min(envelope.getMaximum(0), 180) - .00000001,
-                  Math.min(envelope.getMaximum(1), 90) - .00000001)
+  val min = Array(correctedMinLongitude, correctedMinLatitude)
+  val max = Array(correctedMaxLongitude, correctedMaxLatitude)
   val bbox = BoundingBox(Bounds(min(0), max(0)), Bounds(min(1), max(1)))
 
   def toRasterQuery: RasterQuery = RasterQuery(bbox, accumuloResolution, None, None)
+
+  def correctedMaxLongitude(): Double = Math.max(Math.min(envelope.getMaximum(0), 180) - .00000001, -179.99999999)
+
+  def correctedMinLongitude(): Double = Math.min(Math.max(envelope.getMinimum(0), -180) + .00000001, 179.99999999)
+
+  def correctedMaxLatitude(): Double = Math.max(Math.min(envelope.getMaximum(1), 90) - .00000001, -89.99999999)
+
+  def correctedMinLatitude(): Double = Math.min(Math.max(envelope.getMinimum(1), -90) + .00000001, 89.99999999)
+
 }

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
@@ -74,7 +74,7 @@ class GeoMesaCoverageReader(val url: String, hints: Hints) extends AbstractGridC
 
   override def getOriginalGridRange() = this.originalGridRange
 
-  override def getOriginalGridRange(coverageName: String) = getOriginalGridRange()
+  override def getOriginalGridRange(coverageName: String) = this.originalGridRange
 
   def read(parameters: Array[GeneralParameterValue]): GridCoverage2D = {
     logger.debug(s"READ: $parameters")

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
@@ -16,8 +16,6 @@
 
 package org.locationtech.geomesa.plugin.wcs
 
-import java.awt.Rectangle
-
 import com.typesafe.scalalogging.slf4j.Logging
 import org.geotools.coverage.CoverageFactoryFinder
 import org.geotools.coverage.grid.io.{AbstractGridCoverage2DReader, AbstractGridFormat}
@@ -46,14 +44,15 @@ class GeoMesaCoverageReader(val url: String, hints: Hints) extends AbstractGridC
 
   coverageName = table
 
+  val ars = RasterStore(user, password, instanceId, zookeepers, table, auths, "")
+
   // TODO: Either this is needed for rasterToCoverages or remove it.
   this.crs = AbstractGridFormat.getDefaultCRS
-  this.originalEnvelope = new GeneralEnvelope(Array(-180.0, -90.0), Array(180.0, 90.0))
+  this.originalEnvelope = getBounds()
   this.originalEnvelope.setCoordinateReferenceSystem(this.crs)
-  this.originalGridRange = new GridEnvelope2D(new Rectangle(0, 0, 1024, 512))
+  this.originalGridRange = getGridRange()
   this.coverageFactory = CoverageFactoryFinder.getGridCoverageFactory(this.hints)
   // TODO: Provide writeVisibilites??  Sort out read visibilites
-  val ars: RasterStore = RasterStore(user, password, instanceId, zookeepers, table, auths, "")
 
   /**
    * Default implementation does not allow a non-default coverage name
@@ -65,11 +64,17 @@ class GeoMesaCoverageReader(val url: String, hints: Hints) extends AbstractGridC
     true
   }
 
+  override def getOriginalEnvelope = this.getOriginalEnvelope
+
   override def getCoordinateReferenceSystem = this.crs
 
   override def getCoordinateReferenceSystem(coverageName: String) = this.getCoordinateReferenceSystem
 
   override def getFormat = new GeoMesaCoverageFormat
+
+  override def getOriginalGridRange() = this.originalGridRange
+
+  override def getOriginalGridRange(coverageName: String) = getOriginalGridRange()
 
   def read(parameters: Array[GeneralParameterValue]): GridCoverage2D = {
     logger.debug(s"READ: $parameters")
@@ -82,5 +87,14 @@ class GeoMesaCoverageReader(val url: String, hints: Hints) extends AbstractGridC
     val image = RasterUtils.mosaicRasters(rasters, params.width.toInt, params.height.toInt,
       params.envelope, params.resX, params.resY)
     this.coverageFactory.create(coverageName, image, params.envelope)
+  }
+
+  def getBounds(): GeneralEnvelope = {
+    val bbox = ars.getBounds()
+    new GeneralEnvelope(Array(bbox.minLon, bbox.minLat), Array(bbox.maxLon, bbox.maxLat))
+  }
+
+  def getGridRange(): GridEnvelope2D = {
+    ars.getGridRange()
   }
 }

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloBackedRasterOperations.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloBackedRasterOperations.scala
@@ -19,24 +19,33 @@ package org.locationtech.geomesa.raster.data
 import java.util.Map.Entry
 
 import org.apache.accumulo.core.client.{BatchWriterConfig, Connector, TableExistsException}
-import org.apache.accumulo.core.data.{Key, Mutation, Value}
+import org.apache.accumulo.core.data.{Range, Key, Mutation, Value}
 import org.apache.accumulo.core.security.{Authorizations, TablePermission}
+import org.geotools.coverage.grid.GridEnvelope2D
 import org.joda.time.DateTime
 import org.locationtech.geomesa.core.index._
+import org.locationtech.geomesa.core.iterators.BBOXCombiner._
 import org.locationtech.geomesa.core.security.AuthorizationsProvider
 import org.locationtech.geomesa.core.stats.StatWriter
+import org.locationtech.geomesa.raster._
 import org.locationtech.geomesa.raster.index.RasterIndexSchema
+import org.locationtech.geomesa.utils.geohash.BoundingBox
 
 import scala.collection.JavaConversions._
 
 trait RasterOperations extends StrategyHelpers {
   def getTable(): String
   def ensureTableExists(): Unit
+  def ensureBoundsTableExists(): Unit
+  def createTableStructure(): Unit
   def getAuths(): Authorizations
   def getVisibility(): String
   def getConnector(): Connector
   def getRasters(rasterQuery: RasterQuery): Iterator[Raster]
   def putRaster(raster: Raster): Unit
+  def getBounds(): BoundingBox
+  def getAvailableResolutions(): Set[Double]
+  def getGridRange(): GridEnvelope2D
 }
 
 /**
@@ -86,12 +95,15 @@ class AccumuloBackedRasterOperations(val connector: Connector,
 
   def getTable() = rasterTable
 
+  private def getBoundsRowID = rasterTable + "_bounds"
+
   def putRasters(rasters: Seq[Raster]) {
     rasters.foreach { putRaster(_) }
   }
 
   def putRaster(raster: Raster) {
-    writeMutations(createMutation(raster))
+    writeMutations(rasterTable, createMutation(raster))
+    writeMutations(GEOMESA_RASTER_BOUNDS_TABLE, createBoundsMutation(raster))
   }
 
   def getRasters(rasterQuery: RasterQuery): Iterator[Raster] = {
@@ -103,13 +115,73 @@ class AccumuloBackedRasterOperations(val connector: Connector,
     adaptIterator(batchScanner.iterator)
   }
 
+  def getBounds(): BoundingBox = {
+    ensureTableExists(GEOMESA_RASTER_BOUNDS_TABLE)
+    val scanner = connector.createScanner(GEOMESA_RASTER_BOUNDS_TABLE, authorizationsProvider.getAuthorizations)
+    scanner.setRange(new Range(getBoundsRowID))
+    val resultingBounds = scanner.iterator()
+    if (resultingBounds.isEmpty) {
+      BoundingBox(-180, 180, -90, 90)
+    } else {
+      //TODO: add fix for stuff crossing anti-meridian, may not be an issue...
+      reduceValuesToBoundingBox(resultingBounds.map(_.getValue))
+    }
+  }
+
+  def getAvailableResolutions(): Set[Double] = {
+    ensureTableExists(GEOMESA_RASTER_BOUNDS_TABLE)
+    val scanner = connector.createScanner(GEOMESA_RASTER_BOUNDS_TABLE, getAuths())
+    scanner.setRange(new Range(getBoundsRowID))
+    val scanResultingCQs = scanner.iterator.toList.map(_.getKey.getColumnQualifier.toString)
+    val resultingResolutions = scanResultingCQs.length match {
+      case 0 => Set[Double]()
+      case _ => scanResultingCQs.map(lexiDecodeStringToDouble).toSet[Double]
+    }
+    resultingResolutions
+  }
+
+  def getGridRange(): GridEnvelope2D = {
+    val bounds = getBounds()
+    val resolutions = getAvailableResolutions().toSeq
+    val resolution = resolutions match {
+      case Nil => 1.0
+      case _   => resolutions.min
+    }
+    val width  = Math.abs(bounds.getWidth / resolution).toInt
+    val height = Math.abs(bounds.getHeight / resolution).toInt
+
+    new GridEnvelope2D(0, 0, width, height)
+  }
+
   def adaptIterator(iter: java.util.Iterator[Entry[Key, Value]]): Iterator[Raster] = {
     iter.map { entry => schema.decode((entry.getKey, entry.getValue)) }
   }
 
-  def ensureTableExists() = ensureTableExists(rasterTable)
+  def createTableStructure() = {
+    ensureTableExists()
+  }
+
+  def ensureTableExists() = {
+    ensureTableExists(rasterTable)
+    ensureBoundsTableExists()
+  }
+
+  def ensureBoundsTableExists() = {
+    ensureTableExists(GEOMESA_RASTER_BOUNDS_TABLE)
+    if (!tableOps.listIterators(GEOMESA_RASTER_BOUNDS_TABLE).containsKey("GEOMESA_BBOX_COMBINER")) {
+      val bboxcombinercfg =  AccumuloRasterBoundsPlanner.getBoundsScannerCfg(rasterTable)
+      tableOps.attachIterator(GEOMESA_RASTER_BOUNDS_TABLE, bboxcombinercfg)
+    }
+  }
 
   private def dateToAccTimestamp(dt: DateTime): Long =  dt.getMillis / 1000
+
+  private def createBoundsMutation(raster: Raster): Mutation = {
+    val mutation = new Mutation(getBoundsRowID)
+    val value = bboxToValue(BoundingBox(raster.metadata.geom.getEnvelopeInternal))
+    mutation.put("", lexiEncodeDoubleToString(raster.resolution), value)
+    mutation
+  }
 
   /**
    * Create Mutation instance from input Raster instance
@@ -135,8 +207,8 @@ class AccumuloBackedRasterOperations(val connector: Connector,
    *
    * @param mutations
    */
-  private def writeMutations(mutations: Mutation*) {
-    val writer = connector.createBatchWriter(rasterTable, bwConfig)
+  private def writeMutations(tableName: String, mutations: Mutation*) {
+    val writer = connector.createBatchWriter(tableName, bwConfig)
     mutations.foreach { m => writer.addMutation(m) }
     writer.flush()
     writer.close()

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloCoverageStore.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloCoverageStore.scala
@@ -55,8 +55,8 @@ class AccumuloCoverageStore(val rasterStore: RasterStore,
   extends CoverageStore with Logging {
 
   Hints.putSystemDefault(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, true)
-  //TODO: WCS: remove if no longer needed
-  rasterStore.ensureTableExists()
+  // Ensure the Table and Bounds Table both exist
+  rasterStore.createTableStructure()
 
   def getAuths = rasterStore.getAuths
 
@@ -133,6 +133,9 @@ object AccumuloCoverageStore extends Logging {
                                      writeThreadsConfig,
                                      queryThreadsConfig,
                                      collectStats)
+
+    // Create Bounds Store, this is required for combiners to function
+    rasterOps.ensureBoundsTableExists()
 
     val dsConnectConfig: Map[String, String] = Map(
       IngestRasterParams.ACCUMULO_INSTANCE -> instanceIdParam.lookUp(config).asInstanceOf[String],

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterBoundsPlanner.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterBoundsPlanner.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.locationtech.geomesa.raster.data
+
+import com.typesafe.scalalogging.slf4j.Logging
+import org.apache.accumulo.core.client.IteratorSetting
+import org.locationtech.geomesa.core.iterators.BBOXCombiner
+
+object AccumuloRasterBoundsPlanner extends Logging {
+
+  def getBoundsScannerCfg(tableName: String): IteratorSetting = {
+    logger.debug(s"Raster Bounds Planner for table: $tableName")
+    val cfg = new IteratorSetting(10, "GEOMESA_BBOX_COMBINER", classOf[BBOXCombiner])
+    cfg.addOption("all", "true")
+    cfg
+  }
+
+}

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterQueryPlanner.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterQueryPlanner.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package org.locationtech.geomesa.raster.data
 
 import com.typesafe.scalalogging.slf4j.Logging

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/RasterStore.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/RasterStore.scala
@@ -16,8 +16,9 @@
 
 package org.locationtech.geomesa.raster.data
 
+import org.geotools.coverage.grid.GridEnvelope2D
 import org.locationtech.geomesa.raster.AccumuloStoreHelper
-import org.locationtech.geomesa.raster.data.Raster
+import org.locationtech.geomesa.utils.geohash.BoundingBox
 
 /**
  * This class defines basic operations on Raster, including saving/retrieving
@@ -28,6 +29,10 @@ import org.locationtech.geomesa.raster.data.Raster
 class RasterStore(val rasterOps: RasterOperations) {
 
   def ensureTableExists() = rasterOps.ensureTableExists()
+
+  def ensureBoundsTableExists() = rasterOps.ensureBoundsTableExists()
+
+  def createTableStructure() = rasterOps.createTableStructure()
 
   def getAuths = rasterOps.getAuths()
 
@@ -40,6 +45,12 @@ class RasterStore(val rasterOps: RasterOperations) {
   def getRasters(rasterQuery: RasterQuery): Iterator[Raster] = rasterOps.getRasters(rasterQuery)
 
   def putRaster(raster: Raster) = rasterOps.putRaster(raster)
+
+  def getBounds(): BoundingBox = rasterOps.getBounds()
+
+  def getAvailableResolutions(): Set[Double] = rasterOps.getAvailableResolutions()
+
+  def getGridRange(): GridEnvelope2D = rasterOps.getGridRange()
 }
 
 object RasterStore {
@@ -58,7 +69,7 @@ object RasterStore {
 
     val rasterOps = new AccumuloBackedRasterOperations(conn, tableName, authorizationsProvider, writeVisibilities)
     // this will actually create the Accumulo Table
-    rasterOps.ensureTableExists()
+    rasterOps.createTableStructure()
     // TODO: WCS: Configure the shards/writeMemory/writeThreads/queryThreadsParams
     // GEOMESA-568
     new RasterStore(rasterOps)

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/RasterStore.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/RasterStore.scala
@@ -28,8 +28,6 @@ import org.locationtech.geomesa.utils.geohash.BoundingBox
  */
 class RasterStore(val rasterOps: RasterOperations) {
 
-  def ensureTableExists() = rasterOps.ensureTableExists()
-
   def ensureBoundsTableExists() = rasterOps.ensureBoundsTableExists()
 
   def createTableStructure() = rasterOps.createTableStructure()
@@ -48,7 +46,7 @@ class RasterStore(val rasterOps: RasterOperations) {
 
   def getBounds(): BoundingBox = rasterOps.getBounds()
 
-  def getAvailableResolutions(): Set[Double] = rasterOps.getAvailableResolutions()
+  def getAvailableResolutions(): Seq[Double] = rasterOps.getAvailableResolutions()
 
   def getGridRange(): GridEnvelope2D = rasterOps.getGridRange()
 }

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/package.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/package.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.locationtech.geomesa.raster
+
+package object data {
+  val GEOMESA_RASTER_BOUNDS_TABLE = "GEOMESA_RASTER_BOUNDS"
+}

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/MosaicTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/MosaicTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.locationtech.geomesa.raster.data
 
 import java.awt.image._

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/RasterBoundsTableTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/RasterBoundsTableTest.scala
@@ -152,7 +152,7 @@ class RasterBoundsTableTest extends Specification{
       // get bounds
       val theResolutions = theStore.getAvailableResolutions()
 
-      theResolutions must beEmpty[Set[Double]]
+      theResolutions must beEmpty[Seq[Double]]
     }
 
     "Return a set of one resolution for a table with one raster ingested" in {
@@ -166,9 +166,9 @@ class RasterBoundsTableTest extends Specification{
       // get bounds
       val theResolutions = theStore.getAvailableResolutions()
 
-      theResolutions must not(beEmpty[Set[Double]])
+      theResolutions must not(beEmpty[Seq[Double]])
       theResolutions.size must beEqualTo(1)
-      theResolutions must beEqualTo(Set(10.0))
+      theResolutions must beEqualTo(Seq(10.0))
     }
 
     "Return a set of one resolution for a table with duplicated rasters ingested" in {
@@ -184,9 +184,9 @@ class RasterBoundsTableTest extends Specification{
       // get bounds
       val theResolutions = theStore.getAvailableResolutions()
 
-      theResolutions must not(beEmpty[Set[Double]])
+      theResolutions must not(beEmpty[Seq[Double]])
       theResolutions.size must beEqualTo(1)
-      theResolutions must beEqualTo(Set(10.0))
+      theResolutions must beEqualTo(Seq(10.0))
     }
 
     "Return a set of one resolution for a table with multiple similar rasters ingested" in {
@@ -206,9 +206,9 @@ class RasterBoundsTableTest extends Specification{
       // get bounds
       val theResolutions = theStore.getAvailableResolutions()
 
-      theResolutions must not(beEmpty[Set[Double]])
+      theResolutions must not(beEmpty[Seq[Double]])
       theResolutions.size must beEqualTo(1)
-      theResolutions must beEqualTo(Set(10.0))
+      theResolutions must beEqualTo(Seq(10.0))
     }
 
     "Return a set of many resolutions for a table with multiple rasters ingested" in {
@@ -230,9 +230,9 @@ class RasterBoundsTableTest extends Specification{
       // get bounds
       val theResolutions = theStore.getAvailableResolutions()
 
-      theResolutions must not(beEmpty[Set[Double]])
+      theResolutions must not(beEmpty[Seq[Double]])
       theResolutions.size must beEqualTo(5)
-      theResolutions must beEqualTo(Set(6.0, 7.0, 8.0, 9.0, 10.0))
+      theResolutions must beEqualTo(Seq(6.0, 7.0, 8.0, 9.0, 10.0))
     }
 
     "Return the default GridRange for an empty table" in {

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/RasterBoundsTableTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/RasterBoundsTableTest.scala
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.raster.data
+
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.raster.util.RasterUtils
+import org.locationtech.geomesa.utils.geohash.BoundingBox
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class RasterBoundsTableTest extends Specification{
+  sequential
+
+  var testIteration = 0
+
+  val wholeWorld = BoundingBox(-180.0, 180.0, -90.0, 90.0)
+
+  def getNewIteration() = {
+    testIteration += 1
+    s"testRBTT_Table_$testIteration"
+  }
+
+  "RasterStore" should {
+    "return the bounds of a empty table as the whole world" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // get bounds
+      val theBounds = theStore.getBounds()
+
+      theBounds must beAnInstanceOf[BoundingBox]
+      theBounds must beEqualTo(wholeWorld)
+    }
+
+    "return the bounds of a table with a single raster" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate store
+      val testRaster = RasterUtils.generateTestRaster(0, 50, 0, 50)
+      theStore.putRaster(testRaster)
+
+      // get bounds
+      val theBounds = theStore.getBounds()
+
+      theBounds must beAnInstanceOf[BoundingBox]
+      theBounds.maxLon must beEqualTo(50.0)
+      theBounds.maxLat must beEqualTo(50.0)
+      theBounds.minLon must beEqualTo(0.0)
+      theBounds.minLat must beEqualTo(0.0)
+    }
+
+    "return the bounds of a table with two identical rasters" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate store
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(0, 50, 0, 50)
+      theStore.putRaster(testRaster2)
+
+      // get bounds
+      val theBounds = theStore.getBounds()
+
+      theBounds must beAnInstanceOf[BoundingBox]
+      theBounds.maxLon must beEqualTo(50.0)
+      theBounds.maxLat must beEqualTo(50.0)
+      theBounds.minLon must beEqualTo(0.0)
+      theBounds.minLat must beEqualTo(0.0)
+    }
+
+    "return the bounds of a table with two adjacent rasters" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate store
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(-50, 0, 0, 50)
+      theStore.putRaster(testRaster2)
+
+      // get bounds
+      val theBounds = theStore.getBounds()
+
+      theBounds must beAnInstanceOf[BoundingBox]
+      theBounds.maxLon must beEqualTo(50.0)
+      theBounds.maxLat must beEqualTo(50.0)
+      theBounds.minLon must beEqualTo(-50.0)
+      theBounds.minLat must beEqualTo(0.0)
+    }
+
+    "return the bounds of a table with two adjacent rasters at different resolutions" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate store
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 1.0)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(-50, 0, 0, 50, res = 2.0)
+      theStore.putRaster(testRaster2)
+
+      // get bounds
+      val theBounds = theStore.getBounds()
+
+      theBounds must beAnInstanceOf[BoundingBox]
+      theBounds.maxLon must beEqualTo(50.0)
+      theBounds.maxLat must beEqualTo(50.0)
+      theBounds.minLon must beEqualTo(-50.0)
+      theBounds.minLat must beEqualTo(0.0)
+    }
+
+    "return the bounds of a table with two non-adjacent rasters" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate store
+      val testRaster1 = RasterUtils.generateTestRaster(-180, -170, -90, -80)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(170, 180, 80, 90)
+      theStore.putRaster(testRaster2)
+
+      // get bounds
+      val theBounds = theStore.getBounds()
+
+      theBounds must beAnInstanceOf[BoundingBox]
+      theBounds.maxLon must beEqualTo(180.0)
+      theBounds.maxLat must beEqualTo(90.0)
+      theBounds.minLon must beEqualTo(-180.0)
+      theBounds.minLat must beEqualTo(-90.0)
+    }
+
+    "Return an empty set of resolutions for an empty table" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // get bounds
+      val theResolutions = theStore.getAvailableResolutions()
+
+      theResolutions must beEmpty[Set[Double]]
+    }
+
+    "Return a set of one resolution for a table with one raster ingested" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate the table
+      val testRaster = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 10.0)
+      theStore.putRaster(testRaster)
+
+      // get bounds
+      val theResolutions = theStore.getAvailableResolutions()
+
+      theResolutions must not(beEmpty[Set[Double]])
+      theResolutions.size must beEqualTo(1)
+      theResolutions must beEqualTo(Set(10.0))
+    }
+
+    "Return a set of one resolution for a table with duplicated rasters ingested" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate the table
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 10.0)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 10.0)
+      theStore.putRaster(testRaster2)
+
+      // get bounds
+      val theResolutions = theStore.getAvailableResolutions()
+
+      theResolutions must not(beEmpty[Set[Double]])
+      theResolutions.size must beEqualTo(1)
+      theResolutions must beEqualTo(Set(10.0))
+    }
+
+    "Return a set of one resolution for a table with multiple similar rasters ingested" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate the table
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 10.0)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(0, -50, 0, 50, res = 10.0)
+      theStore.putRaster(testRaster2)
+      val testRaster3 = RasterUtils.generateTestRaster(0, -50, 0, -50, res = 10.0)
+      theStore.putRaster(testRaster3)
+      val testRaster4 = RasterUtils.generateTestRaster(0, 50, 0, -50, res = 10.0)
+      theStore.putRaster(testRaster4)
+
+      // get bounds
+      val theResolutions = theStore.getAvailableResolutions()
+
+      theResolutions must not(beEmpty[Set[Double]])
+      theResolutions.size must beEqualTo(1)
+      theResolutions must beEqualTo(Set(10.0))
+    }
+
+    "Return a set of many resolutions for a table with multiple rasters ingested" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate the table
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 6.0)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(0, 40, 0, 40, res = 7.0)
+      theStore.putRaster(testRaster2)
+      val testRaster3 = RasterUtils.generateTestRaster(0, 30, 0, 30, res = 8.0)
+      theStore.putRaster(testRaster3)
+      val testRaster4 = RasterUtils.generateTestRaster(0, 20, 0, 20, res = 9.0)
+      theStore.putRaster(testRaster4)
+      val testRaster5 = RasterUtils.generateTestRaster(0, 10, 0, 10, res = 10.0)
+      theStore.putRaster(testRaster5)
+
+      // get bounds
+      val theResolutions = theStore.getAvailableResolutions()
+
+      theResolutions must not(beEmpty[Set[Double]])
+      theResolutions.size must beEqualTo(5)
+      theResolutions must beEqualTo(Set(6.0, 7.0, 8.0, 9.0, 10.0))
+    }
+
+    "Return the default GridRange for an empty table" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // get GridRange
+      val theGridRange = theStore.getGridRange()
+
+      theGridRange.width must beEqualTo(360)
+      theGridRange.height must beEqualTo(180)
+    }
+
+    "Return the correct GridRange for a table with one Raster with specific resolution" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate the table
+      val testRaster = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 1.0)
+      theStore.putRaster(testRaster)
+
+      // get GridRange
+      val theGridRange = theStore.getGridRange()
+
+      theGridRange.width must beEqualTo(50)
+      theGridRange.height must beEqualTo(50)
+    }
+
+    "Return the correct GridRange for a table with four Rasters with specific resolution" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate the table
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 1.0)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(0, -50, 0, 50, res = 1.0)
+      theStore.putRaster(testRaster2)
+      val testRaster3 = RasterUtils.generateTestRaster(0, -50, 0, -50, res = 1.0)
+      theStore.putRaster(testRaster3)
+      val testRaster4 = RasterUtils.generateTestRaster(0, 50, 0, -50, res = 1.0)
+      theStore.putRaster(testRaster4)
+
+      // get GridRange
+      val theGridRange = theStore.getGridRange()
+
+      theGridRange.width must beEqualTo(100)
+      theGridRange.height must beEqualTo(100)
+    }
+
+    "Return the correct GridRange for a table of an image pyramid, defaulting to highest resolution" in {
+      val tableName = getNewIteration()
+      val theStore = RasterUtils.createRasterStore(tableName)
+
+      // populate the table
+      val testRaster1 = RasterUtils.generateTestRaster(0, 50, 0, 50, res = 50.0 / 256)
+      theStore.putRaster(testRaster1)
+      val testRaster2 = RasterUtils.generateTestRaster(0, 40, 0, 40, res = 40.0 / 256)
+      theStore.putRaster(testRaster2)
+      val testRaster3 = RasterUtils.generateTestRaster(0, 30, 0, 30, res = 30.0 / 256)
+      theStore.putRaster(testRaster3)
+      val testRaster4 = RasterUtils.generateTestRaster(0, 20, 0, 20, res = 20.0 / 256)
+      theStore.putRaster(testRaster4)
+      val testRaster5 = RasterUtils.generateTestRaster(0, 10, 0, 10, res = 10.0 / 256)
+      theStore.putRaster(testRaster5)
+
+      // get GridRange
+      val theGridRange = theStore.getGridRange()
+
+      theGridRange.width must beEqualTo(1280)
+      theGridRange.height must beEqualTo(1280)
+    }
+
+  }
+}


### PR DESCRIPTION
* DescribeCoverage now returns useful information about each raster table
* WCS DescribeCoverage Returns Bounds of Table
** DescribeCoverage now returns valid bounds
** Added BBOXCombiner to core iterators
** Added unit tests for BBOXCombiner
** Added unit tests for getBounds call in RasterStore
* RasterStore Returns Available Resolutions in Table
** RasterStore now exposes sets of Available Resolutions in Table
** Added unit tests for getAvailableResolutions
* WCS DescribeCoverage Returns GridRange of Table
** RasterStore now exposes GridRange of data in Table
** Added unit tests for getGridRange