### PR TITLE
GEOMESA-527 Add skipheader flag for csv/tsv ingest

### DIFF
--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestCommand.scala
@@ -79,7 +79,7 @@ object IngestCommand {
       "to override file extension recognition")
     var format: String = null
 
-    @Parameter(names = Array("-skH", "--skip-header"), description = "flag to skip the first line (header) of a csv/tsv data file")
+    @Parameter(names = Array("--skip-header"), description = "flag to skip the first line (header) of a csv/tsv data file")
     var skipHeader: Boolean = false
 
     @Parameter(names = Array("-ld", "--list-delimiter"), description = "character(s) to delimit list features")

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestCommand.scala
@@ -79,6 +79,9 @@ object IngestCommand {
       "to override file extension recognition")
     var format: String = null
 
+    @Parameter(names = Array("-skH", "--skip-header"), description = "flag to skip the first line (header) of a csv/tsv data file")
+    var skipHeader: Boolean = false
+
     @Parameter(names = Array("-ld", "--list-delimiter"), description = "character(s) to delimit list features")
     var listDelimiter: String = ","
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/DelimitedIngest.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/DelimitedIngest.scala
@@ -116,6 +116,7 @@ class DelimitedIngest(params: IngestParameters) extends AccumuloProperties {
         IngestParams.DT_FORMAT         -> Option(params.dtFormat),
         IngestParams.ID_FIELDS         -> Option(params.idFields),
         IngestParams.DT_FIELD          -> Option(params.dtgField),
+        IngestParams.SKIP_HEADER       -> Option(params.skipHeader),
         IngestParams.LON_ATTRIBUTE     -> Option(params.lon),
         IngestParams.LAT_ATTRIBUTE     -> Option(params.lat),
         IngestParams.AUTHORIZATIONS    -> Option(params.auths),

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/ScaldingDelimitedIngestJob.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/ScaldingDelimitedIngestJob.scala
@@ -53,6 +53,7 @@ class ScaldingDelimitedIngestJob(args: Args) extends Job(args) with Logging {
   lazy val idFields         = args.optional(IngestParams.ID_FIELDS).orNull
   lazy val pathList         = DelimitedIngest.decodeFileList(args(IngestParams.FILE_PATH))
   lazy val sftSpec          = URLDecoder.decode(args(IngestParams.SFT_SPEC), "UTF-8")
+  lazy val skipHeader       = args.optional(IngestParams.SKIP_HEADER).map(_.toBoolean).getOrElse(false)
   lazy val colList          = args.optional(IngestParams.COLS).map(ColsParser.build)
   lazy val dtgField         = args.optional(IngestParams.DT_FIELD)
   lazy val dtgFmt           = args.optional(IngestParams.DT_FORMAT)
@@ -127,7 +128,7 @@ class ScaldingDelimitedIngestJob(args: Args) extends Job(args) with Logging {
   // Check to see if this an actual ingest job or just a test.
   if (!isTestRun) {
     new MultipleUsefulTextLineFiles(pathList: _*).using(new Resources)
-      .foreach('line) { (cres: Resources, line: String) => lineNumber += 1; ingestLine(cres.fw, line) }
+      .foreach('line) { (cres: Resources, line: String) => lineNumber += 1; ingestLine(cres.fw, line, skipHeader) }
   }
 
   // TODO unit test class without having an internal helper method
@@ -142,7 +143,7 @@ class ScaldingDelimitedIngestJob(args: Args) extends Job(args) with Logging {
     }
   }
 
-  def ingestLine(fw: FeatureWriter[SimpleFeatureType, SimpleFeature], line: String): Unit =
+  def ingestLine(fw: FeatureWriter[SimpleFeatureType, SimpleFeature], line: String, skipHeader: Boolean = false): Unit =
     Try {
       ingestDataToFeature(line, fw.next())
       fw.write()
@@ -153,8 +154,17 @@ class ScaldingDelimitedIngestJob(args: Args) extends Job(args) with Logging {
           logger.info(getStatInfo(successes, failures, s"Ingest proceeding $line, on line number:"))
 
       case Failure(ex) =>
-        failures += 1
-        logger.warn(s"Cannot ingest feature on line number: $lineNumber: ${ex.getMessage}", ex)
+        if (lineNumber == 1) {
+          if (!skipHeader) {
+            // log a warning and suggest command line arg
+            logger.warn(s"Cannot ingest feature on line number $lineNumber")
+            logger.warn(s"If this line contains column headers, consider using the command line option --skip-header")
+          }
+          // else we're fine, continue/skip, no messages needed
+        } else {
+          failures += 1
+          logger.warn(s"Cannot ingest feature on line number: $lineNumber: ${ex.getMessage}", ex)
+        }
     }
 
   // Populate the fields of a SimpleFeature with a line of CSV

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/ScaldingDelimitedIngestJob.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/ScaldingDelimitedIngestJob.scala
@@ -130,8 +130,9 @@ class ScaldingDelimitedIngestJob(args: Args) extends Job(args) with Logging {
     new MultipleUsefulTextLineFiles(pathList: _*).using(new Resources)
       .foreach('line) { (cres: Resources, line: String) =>
           lineNumber += 1
-          if (lineNumber > 1 || !skipHeader)
-            ingestLine(cres.fw, line) }
+          if (lineNumber > 1 || !skipHeader) {
+            ingestLine(cres.fw, line)
+          }}
   }
 
   // TODO unit test class without having an internal helper method


### PR DESCRIPTION
Add the --skip-header command line flag for ingest
If there is an error ingesting the first line,
 this flag is checked. If yes, no error is output,
 and ingesting continues.
This option defaults to false.

Squashed commit of the following:

commit 13be7fb5d21af507d685ae0133465adbdb44d3cc
Merge: 774edd5 2d95a75
Author: Michael Matthews <mmatthews@ccri.com>
Date:   Thu Jan 22 15:23:09 2015 -0500

    Merge branch 'accumulo1.5.x/1.x' into f_skipHeaderOption

commit 774edd593263910bbf73c912ca5457ba2204cc7c
Author: Michael Matthews <mmatthews@ccri.com>
Date:   Thu Jan 15 16:15:34 2015 -0500

    Added command line option for skipHeader

    skipHeader is handled in ScaldingDelimitedIngestJob # ingestLine
    This places it next to the old error handling when failing to ingest, which seems nice
    Does add another parameter to ingestLine, but a default value should minimize impact