### PR TITLE
GEOMESA-668 Delimited converter uses the wrong number of fields on the i...

### DIFF
--- a/geomesa-convert/geomesa-convert-text/src/test/resources/sft_testsft.conf
+++ b/geomesa-convert/geomesa-convert-text/src/test/resources/sft_testsft.conf
@@ -1,7 +1,10 @@
 {
   type-name = "testsft"
   attributes = [
-    { name = "phrase",   type = "String", index = "false" },
-    { name = "geom",     type = "Point",  index = "true", srid = 4326, default = true }
+    { name = "oneup",    type = "String", index = false },
+    { name = "phrase",   type = "String", index = false },
+    { name = "lat",      type = "Double", index = false },
+    { name = "lon",      type = "Double", index = false },
+    { name = "geom",     type = "Point",  index = true, srid = 4326, default = true }
   ]
 }

--- a/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterTest.scala
@@ -45,6 +45,7 @@ class DelimitedTextConverterTest extends Specification {
         |   format       = "DEFAULT",
         |   id-field     = "md5(string2bytes($0))",
         |   fields = [
+        |     { name = "oneup",  transform = "$1" },
         |     { name = "phrase", transform = "concat($1, $2)" },
         |     { name = "lat",    transform = "$3::double" },
         |     { name = "lon",    transform = "$4::double" },
@@ -58,12 +59,17 @@ class DelimitedTextConverterTest extends Specification {
       val converter = SimpleFeatureConverters.build[String](sft, conf)
       converter must not beNull
 
+      val res = converter.processInput(data.split("\n").toIterator.filterNot( s => "^\\s*$".r.findFirstIn(s).size > 0)).toList
+      converter.close()
+
       "and process some data" >> {
-        val res = converter.processInput(data.split("\n").toIterator.filterNot( s => "^\\s*$".r.findFirstIn(s).size > 0)).toList
         res.size must be equalTo 2
-        converter.close()
         res(0).getAttribute("phrase").asInstanceOf[String] must be equalTo "1hello"
         res(1).getAttribute("phrase").asInstanceOf[String] must be equalTo "2world"
+      }
+
+      "handle more derived fields than input fields" >> {
+        res(0).getAttribute("oneup").asInstanceOf[String] must be equalTo "1"
       }
     }
 


### PR DESCRIPTION
...nput data

Use the incoming number of fields rather than the SFT fields
when processing the input data.  Also included some performance
enhancements.