### PR TITLE
GEOMESA-362 Ingest fails to convert Float to Double

### DIFF
--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/ScaldingDelimitedIngestJob.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/ScaldingDelimitedIngestJob.scala
@@ -208,7 +208,7 @@ class ScaldingDelimitedIngestJob(args: Args) extends Job(args) with Logging {
         logger.info(s"Using lon/lat from simple feature fields $lon/$lat")
         (_: Seq[String], sf: SimpleFeature) => {
           import org.locationtech.geomesa.utils.geotools.Conversions.RichSimpleFeature
-          val g = geomFactory.createPoint(new Coordinate(sf.get[Double](lon), sf.get[Double](lat)))
+          val g = geomFactory.createPoint(new Coordinate(sf.getDouble(lon), sf.getDouble(lat)))
           sf.setDefaultGeometry(g)
         }
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -81,6 +81,17 @@ object Conversions {
 
     def get[T](i: Int) = sf.getAttribute(i).asInstanceOf[T]
     def get[T](name: String) = sf.getAttribute(name).asInstanceOf[T]
+
+    def getDouble(str: String): Double = {
+
+      val ret = sf.getAttribute(str)
+      ret match {
+        case d: java.lang.Double  => d
+        case f: java.lang.Float   => f.toDouble
+        case i: java.lang.Integer => i.toDouble
+        case _                    => throw new Exception(s"Input $ret is not a numeric type.")
+      }
+    }
   }
 
   import scala.collection.JavaConversions._


### PR DESCRIPTION
When retrieving the lat/lon, we explicitly request a Double
This adds a method that enables converting of Floats and Ints to Double,
  which is used instead of the generic retrieval method

Squashed commit of the following:

commit c1122e01dd75d5440a82934f82c2edff8c16f306
Author: Michael Matthews <mmatthews@ccri.com>
Date:   Tue Feb 3 14:55:05 2015 -0500

    Removed leftover comments

commit 10ab470ca03883d3ed187d611e3c50cc6873bb60
Author: Michael Matthews <mmatthews@ccri.com>
Date:   Mon Jan 26 09:41:16 2015 -0500

    first pass at converting lat/long to desired double. needs clean-up