### PR TITLE
GEOMESA-676 Remove exclude epsg-hsql jar from geomesa-raster and related modules

### DIFF
--- a/geomesa-distributed-runtime/pom.xml
+++ b/geomesa-distributed-runtime/pom.xml
@@ -38,6 +38,12 @@
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-raster-accumulo1.5</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-epsg-hsql</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>

--- a/geomesa-raster/pom.xml
+++ b/geomesa-raster/pom.xml
@@ -59,12 +59,6 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-imageio-ext-gdal</artifactId>
             <version>${gt.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.geotools</groupId>
-                    <artifactId>gt-epsg-hsql</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>

--- a/geomesa-raster/pom.xml
+++ b/geomesa-raster/pom.xml
@@ -59,6 +59,12 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-imageio-ext-gdal</artifactId>
             <version>${gt.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-epsg-hsql</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/Raster.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/Raster.scala
@@ -20,7 +20,7 @@ import java.awt.image.RenderedImage
 import java.util.UUID
 
 import org.geotools.geometry.jts.ReferencedEnvelope
-import org.geotools.referencing.CRS
+import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.joda.time.{DateTime, DateTimeZone}
 import org.locationtech.geomesa.core.index.{DecodedIndex, IndexEntry}
 import org.locationtech.geomesa.raster.util.RasterUtils
@@ -38,7 +38,7 @@ trait Raster {
 
   lazy val minimumBoundingGeoHash = GeohashUtils.getClosestAcceptableGeoHash(metadata.geom.getEnvelopeInternal)
 
-  lazy val referencedEnvelope = new ReferencedEnvelope(metadata.geom.getEnvelopeInternal, CRS.decode("EPSG:4326"))
+  lazy val referencedEnvelope = new ReferencedEnvelope(metadata.geom.getEnvelopeInternal, DefaultGeographicCRS.WGS84 )
 
   def encodeValue = RasterUtils.imageSerialize(chunk)
 }

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtils.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtils.scala
@@ -24,7 +24,7 @@ import javax.media.jai.remote.SerializableRenderedImage
 
 import org.geotools.coverage.grid.GridGeometry2D
 import org.geotools.geometry.jts.ReferencedEnvelope
-import org.geotools.referencing.CRS
+import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.imgscalr.Scalr._
 import org.locationtech.geomesa.raster.data.Raster
 import org.opengis.geometry.Envelope
@@ -191,7 +191,11 @@ object RasterUtils {
   }
 
   def envelopeToReferencedEnvelope(e: Envelope): ReferencedEnvelope = {
-    new ReferencedEnvelope(e.getMinimum(0), e.getMaximum(0), e.getMinimum(1), e.getMaximum(1), CRS.decode("EPSG:4326"))
+    new ReferencedEnvelope(e.getMinimum(0),
+      e.getMaximum(0),
+      e.getMinimum(1),
+      e.getMaximum(1),
+      DefaultGeographicCRS.WGS84)
   }
 
   def getNewImage[T: TypeTag](w: Int, h: Int, fill: Array[T],

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/util/MosaicTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/util/MosaicTest.scala
@@ -19,7 +19,7 @@ package org.locationtech.geomesa.raster.util
 import java.awt.image.{BufferedImage, RenderedImage}
 
 import org.geotools.geometry.jts.ReferencedEnvelope
-import org.geotools.referencing.CRS
+import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.raster.RasterTestsUtils._
 import org.locationtech.geomesa.raster.data.Raster
@@ -43,7 +43,7 @@ class MosaicTest extends Specification {
       val testRaster2 = generateTestRaster(0, 50, 0, 50, color = white)
       val rasterSeq = Seq(testRaster1, testRaster2)
 
-      val queryEnv = new ReferencedEnvelope(-50.0, 50.0, 0.0, 50.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-50.0, 50.0, 0.0, 50.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 512, 256, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -54,7 +54,7 @@ class MosaicTest extends Specification {
     "Mosaic four Rasters together with a Query of larger extent and finer resolution" in {
       val rasterSeq = generateFourAdjacentRaster()
 
-      val queryEnv = new ReferencedEnvelope(-60.0, 60.0, -60.0, 60.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-60.0, 60.0, -60.0, 60.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 800, 800, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -65,7 +65,7 @@ class MosaicTest extends Specification {
     "Mosaic four Rasters together with a Query of larger extent and equal resolution" in {
       val rasterSeq = generateFourAdjacentRaster()
 
-      val queryEnv = new ReferencedEnvelope(-60.0, 60.0, -60.0, 60.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-60.0, 60.0, -60.0, 60.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 614, 614, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -76,7 +76,7 @@ class MosaicTest extends Specification {
     "Mosaic four Rasters together with a Query of larger extent and courser resolution" in {
       val rasterSeq = generateFourAdjacentRaster()
 
-      val queryEnv = new ReferencedEnvelope(-60.0, 60.0, -60.0, 60.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-60.0, 60.0, -60.0, 60.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 307, 307, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -87,7 +87,7 @@ class MosaicTest extends Specification {
     "Mosaic four Rasters together with a Query of equal extent and finer resolution" in {
       val rasterSeq = generateFourAdjacentRaster()
 
-      val queryEnv = new ReferencedEnvelope(-50.0, 50.0, -50.0, 50.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-50.0, 50.0, -50.0, 50.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 800, 800, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -98,7 +98,7 @@ class MosaicTest extends Specification {
     "Mosaic four Rasters together with a Query of equal extent and equal resolution" in {
       val rasterSeq = generateFourAdjacentRaster()
 
-      val queryEnv = new ReferencedEnvelope(-50.0, 50.0, -50.0, 50.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-50.0, 50.0, -50.0, 50.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 512, 512, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -109,7 +109,7 @@ class MosaicTest extends Specification {
     "Mosaic four Rasters together with a Query of equal extent and courser resolution" in {
       val rasterSeq = generateFourAdjacentRaster()
 
-      val queryEnv = new ReferencedEnvelope(-50.0, 50.0, -50.0, 50.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-50.0, 50.0, -50.0, 50.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 64, 64, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -120,7 +120,7 @@ class MosaicTest extends Specification {
     "Mosaic four Rasters together with a Query of smaller extent and finer resolution" in {
       val rasterSeq = generateFourAdjacentRaster()
 
-      val queryEnv = new ReferencedEnvelope(-25.0, 25.0, -25.0, 25.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-25.0, 25.0, -25.0, 25.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 800, 800, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -131,7 +131,7 @@ class MosaicTest extends Specification {
     "Mosaic four Rasters together with a Query of smaller extent and equal resolution" in {
       val rasterSeq = generateFourAdjacentRaster()
 
-      val queryEnv = new ReferencedEnvelope(-25.0, 25.0, -25.0, 25.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-25.0, 25.0, -25.0, 25.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 256, 256, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -142,7 +142,7 @@ class MosaicTest extends Specification {
     "Mosaic four Rasters together with a Query of smaller extent and equal resolution offsetted" in {
       val rasterSeq = generateFourAdjacentRaster()
 
-      val queryEnv = new ReferencedEnvelope(-35.0, 15.0, -25.0, 25.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-35.0, 15.0, -25.0, 25.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 256, 256, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -153,7 +153,7 @@ class MosaicTest extends Specification {
     "Mosaic four Rasters together with a Query of smaller extent and courser resolution" in {
       val rasterSeq = generateFourAdjacentRaster()
 
-      val queryEnv = new ReferencedEnvelope(-25.0, 25.0, -25.0, 25.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-25.0, 25.0, -25.0, 25.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 64, 64, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -164,7 +164,7 @@ class MosaicTest extends Specification {
     "Mosaic several Rasters together with a Rectangular Query of wider extent" in {
       val rasterSeq = generateFourAdjacentRaster()
 
-      val queryEnv = new ReferencedEnvelope(-81.0, 87.0, -60.0, 60.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-81.0, 87.0, -60.0, 60.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 700, 500, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -175,7 +175,7 @@ class MosaicTest extends Specification {
     "Mosaic several Rasters together with a Rectangular Query of taller extent" in {
       val rasterSeq = generateFourAdjacentRaster()
 
-      val queryEnv = new ReferencedEnvelope(-30.0, 30.0, -81.0, 87.0, CRS.decode("EPSG:4326"))
+      val queryEnv = new ReferencedEnvelope(-30.0, 30.0, -81.0, 87.0, DefaultGeographicCRS.WGS84)
       val testMosaic = RasterUtils.mosaicChunks(rasterSeq.iterator, 200, 600, queryEnv)._1
 
       testMosaic must beAnInstanceOf[RenderedImage]
@@ -188,7 +188,7 @@ class MosaicTest extends Specification {
   "cropRaster" should {
 
     "not crop a raster when the cropEnv is identical to raster extent" in {
-      val cropEnv = new ReferencedEnvelope(0.0, 50.0, 0.0, 50.0, CRS.decode("EPSG:4326"))
+      val cropEnv = new ReferencedEnvelope(0.0, 50.0, 0.0, 50.0, DefaultGeographicCRS.WGS84)
       val testRaster = generateTestRaster(0, 50, 0, 50)
 
       val croppedRaster = RasterUtils.cropRaster(testRaster, cropEnv)
@@ -199,7 +199,7 @@ class MosaicTest extends Specification {
     }
 
     "crop a raster into a square quarter" in {
-      val cropEnv = new ReferencedEnvelope(0.0, 25.0, 0.0, 25.0, CRS.decode("EPSG:4326"))
+      val cropEnv = new ReferencedEnvelope(0.0, 25.0, 0.0, 25.0, DefaultGeographicCRS.WGS84)
       val testRaster = generateTestRaster(0, 50, 0, 50)
 
       val croppedRaster = RasterUtils.cropRaster(testRaster, cropEnv)
@@ -210,7 +210,7 @@ class MosaicTest extends Specification {
     }
 
     "crop a raster with a offsetted cropping envelope" in {
-      val cropEnv = new ReferencedEnvelope(-10.0, 10.0, 0.0, 25.0, CRS.decode("EPSG:4326"))
+      val cropEnv = new ReferencedEnvelope(-10.0, 10.0, 0.0, 25.0, DefaultGeographicCRS.WGS84)
       val testRaster = generateTestRaster(0, 50, 0, 50)
 
       val croppedRaster = RasterUtils.cropRaster(testRaster, cropEnv)
@@ -221,7 +221,7 @@ class MosaicTest extends Specification {
     }
 
     "crop a raster into nothing when raster is touching a corner of the cropping envelope" in {
-      val cropEnv = new ReferencedEnvelope(0.0, 50.0, 0.0, 50.0, CRS.decode("EPSG:4326"))
+      val cropEnv = new ReferencedEnvelope(0.0, 50.0, 0.0, 50.0, DefaultGeographicCRS.WGS84)
       val testRaster = generateTestRaster(-50, 0, -50, 0)
 
       val croppedRaster = RasterUtils.cropRaster(testRaster, cropEnv)
@@ -230,7 +230,7 @@ class MosaicTest extends Specification {
     }
 
     "crop a raster into nothing when raster is touching a vertical edge of the cropping envelope" in {
-      val cropEnv = new ReferencedEnvelope(0.0, 50.0, 0.0, 50.0, CRS.decode("EPSG:4326"))
+      val cropEnv = new ReferencedEnvelope(0.0, 50.0, 0.0, 50.0, DefaultGeographicCRS.WGS84)
       val testRaster = generateTestRaster(-50, 0, 0, 50)
 
       val croppedRaster = RasterUtils.cropRaster(testRaster, cropEnv)
@@ -239,7 +239,7 @@ class MosaicTest extends Specification {
     }
 
     "crop a raster into nothing when raster is touching a horizontal edge of the cropping envelope" in {
-      val cropEnv = new ReferencedEnvelope(0.0, 50.0, 0.0, 50.0, CRS.decode("EPSG:4326"))
+      val cropEnv = new ReferencedEnvelope(0.0, 50.0, 0.0, 50.0, DefaultGeographicCRS.WGS84)
       val testRaster = generateTestRaster(0, 50, -50, 0)
 
       val croppedRaster = RasterUtils.cropRaster(testRaster, cropEnv)
@@ -249,7 +249,7 @@ class MosaicTest extends Specification {
 
 
     "crop a raster into nothing when raster is outside cropping envelope" in {
-      val cropEnv = new ReferencedEnvelope(0.0, 50.0, 0.0, 50.0, CRS.decode("EPSG:4326"))
+      val cropEnv = new ReferencedEnvelope(0.0, 50.0, 0.0, 50.0, DefaultGeographicCRS.WGS84)
       val testRaster = generateTestRaster(-150, -100, 0, 50)
 
       val croppedRaster = RasterUtils.cropRaster(testRaster, cropEnv)


### PR DESCRIPTION
This is needed to prevent issues with CRS lookups in the runtime jar. The blanket exclusion may cause trouble with raster ingest so needs to be tested first.