### PR TITLE
GEOMESA-679 Converter should allow literal strings and composite convert...

### DIFF
--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/CompositeConverter.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/CompositeConverter.scala
@@ -21,6 +21,7 @@ import org.locationtech.geomesa.convert.Transformers.{EvaluationContext, Predica
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.JavaConversions._
+import scala.util.Try
 
 class CompositeConverterFactory[I] extends SimpleFeatureConverterFactory[I] {
   override def canProcess(conf: Config): Boolean = canProcessType(conf, "composite-converter")
@@ -51,7 +52,7 @@ class CompositeConverter[I](val targetSFT: SimpleFeatureType,
 
   implicit val ec = new EvaluationContext(Map(), Array())
   def processIfValid(input: I, pred: Predicate, conv: SimpleFeatureConverter[I]) =
-    if(pred.eval(input)) conv.processSingleInput(input) else None
+    Try { pred.eval(input) }.toOption.flatMap { v => if(v) conv.processSingleInput(input) else None }
 }
 
 

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/Transformers.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/Transformers.scala
@@ -43,7 +43,7 @@ object Transformers extends JavaTokenParsers {
     private val OPEN_PAREN  = "("
     private val CLOSE_PAREN = ")"
 
-    def string      = "'" ~> "[^']+".r <~ "'".r ^^ { s => LitString(s) }
+    def string      = "'" ~> "[^']*".r <~ "'".r ^^ { s => LitString(s) }
     def int         = wholeNumber ^^   { i => LitInt(i.toInt) }
     def double      = decimalNumber ^^ { d => LitDouble(d.toDouble) }
     def long        = wholeNumber ^^   { l => LitLong(l.toLong) }
@@ -81,7 +81,12 @@ object Transformers extends JavaTokenParsers {
     def dGTEq     = numericPredicate("dGTEq", DGTEQ)
     def dGT       = numericPredicate("dGT", DGT)
 
-    def binaryPred  = strEq | intEq | intLTEq | intLT | intGTEq | intGT | dEq | dLTEq | dLT | dGTEq | dGT
+    def binaryPred  =
+      strEq |
+        intEq  | intLTEq  | intLT  | intGTEq  | intGT  |
+        dEq    | dLTEq    | dLT    | dGTEq    | dGT    |
+        longEq | longLTEq | longLT | longGTEq | longGT
+
     def andPred     = ("and" ~ OPEN_PAREN) ~> (pred ~ "," ~ pred) <~ CLOSE_PAREN ^^ {
       case l ~ "," ~ r => And(l, r)
     }

--- a/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert/common/TransformersTest.scala
+++ b/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert/common/TransformersTest.scala
@@ -39,6 +39,16 @@ class TransformersTest extends Specification {
     "handle transformations" >> {
       "handle string transformations" >> {
 
+        "allow literal strings" >> {
+          val exp = Transformers.parseTransform("'hello'")
+          exp.eval(null) must be equalTo "hello"
+        }
+
+        "allow empty literal strings" >> {
+          val exp = Transformers.parseTransform("''")
+          exp.eval(null) must be equalTo ""
+        }
+
         "trim" >> {
           val exp = Transformers.parseTransform("trim($1)")
           exp.eval("", "foo ", "bar") must be equalTo "foo"

--- a/geomesa-convert/geomesa-convert-text/src/test/resources/sft_testsft.conf
+++ b/geomesa-convert/geomesa-convert-text/src/test/resources/sft_testsft.conf
@@ -5,6 +5,7 @@
     { name = "phrase",   type = "String", index = false },
     { name = "lat",      type = "Double", index = false },
     { name = "lon",      type = "Double", index = false },
+    { name = "lit",      type = "String", index = false },
     { name = "geom",     type = "Point",  index = true, srid = 4326, default = true }
   ]
 }

--- a/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/CompositeTextConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/CompositeTextConverterTest.scala
@@ -28,9 +28,10 @@ class CompositeTextConverterTest extends Specification {
 
   val data =
     """
-      |1,hello,45.0,45.0
+      |1  ,hello,45.0,45.0
       |asfastofail,f
-      |2,world,90.0,90.0
+      |3
+      |2  ,world,90.0,90.0
     """.stripMargin
 
   val conf = ConfigFactory.parseString(
@@ -38,14 +39,14 @@ class CompositeTextConverterTest extends Specification {
       | converter = {
       |   type         = "composite-converter",
       |   converters = [
-      |     { converter = "first",   predicate = "strEq('1', substr($0, 0, 1))" },
-      |     { converter = "second",  predicate = "strEq('2',  substr($0, 0, 1))" }
+      |     { converter = "first",   predicate = "strEq('1', trim(substr($0, 0, 2)))" },
+      |     { converter = "second",  predicate = "strEq('2', trim(substr($0, 0, 2)))" }
       |   ]
       |   first = {
       |     converter = {
       |       type         = "delimited-text",
       |       format       = "DEFAULT",
-      |       id-field     = "concat('first', $1)",
+      |       id-field     = "concat('first', trim($1))",
       |       fields = [
       |         { name = "phrase", transform = "concat($1, $2)" },
       |         { name = "lat",    transform = "$3::double" },
@@ -59,7 +60,7 @@ class CompositeTextConverterTest extends Specification {
       |     converter = {
       |       type         = "delimited-text",
       |       format       = "DEFAULT",
-      |       id-field     = "concat('second', $1)",
+      |       id-field     = "concat('second', trim($1))",
       |       fields = [
       |         { name = "phrase", transform = "concat($1, $2)" },
       |         { name = "lat",    transform = "$3::double" },

--- a/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterTest.scala
@@ -49,6 +49,7 @@ class DelimitedTextConverterTest extends Specification {
         |     { name = "phrase", transform = "concat($1, $2)" },
         |     { name = "lat",    transform = "$3::double" },
         |     { name = "lon",    transform = "$4::double" },
+        |     { name = "lit",    transform = "'hello'" },
         |     { name = "geom",   transform = "point($lat, $lon)" }
         |   ]
         | }


### PR DESCRIPTION
...er should be more robust

Literal strings and literal empty strings are now allowed in transformations.

CompositeConverter now handles the case where predicates can fail.