### PR TITLE
GEOMESA-686 DelimitedTextConverter fails to process records bigger than buffer size properly

### DIFF
--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/Transformers.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/Transformers.scala
@@ -104,7 +104,7 @@ object Transformers extends JavaTokenParsers {
 
   class EvaluationContext(fieldNameMap: Map[String, Int], var computedFields: Array[Any]) {
     def indexOf(n: String) = fieldNameMap(n)
-    def lookup(i: Int) = computedFields(i)
+    def lookup(i: Int) = if(i < 0) null else computedFields(i)
   }
 
   sealed trait Expr {

--- a/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
+++ b/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
@@ -100,7 +100,7 @@ class DelimitedTextConverter(format: CSVFormat,
   }
 
   override def close(): Unit = {
-    es.shutdown()
+    es.shutdownNow()
     writer.close()
     reader.close()
   }

--- a/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
+++ b/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
@@ -17,7 +17,9 @@
 package org.locationtech.geomesa.convert.text
 
 import java.io.{PipedReader, PipedWriter}
+import java.util.concurrent.{TimeUnit, Executors}
 
+import com.google.common.collect.Queues
 import com.typesafe.config.Config
 import org.apache.commons.csv.{CSVFormat, QuoteMode}
 import org.locationtech.geomesa.convert.Transformers.Expr
@@ -48,26 +50,45 @@ class DelimitedTextConverterFactory extends SimpleFeatureConverterFactory[String
     }
     val fields    = buildFields(conf.getConfigList("fields"))
     val idBuilder = buildIdBuilder(conf.getString("id-field"))
-    new DelimitedTextConverter(format, targetSFT, idBuilder, fields)
+    val pipeSize  = if(conf.hasPath("pipe-size")) conf.getInt("pipe-size") else 16*1024
+    new DelimitedTextConverter(format, targetSFT, idBuilder, fields, pipeSize)
   }
 }
 
 class DelimitedTextConverter(format: CSVFormat,
                              val targetSFT: SimpleFeatureType,
                              val idBuilder: Expr,
-                             val inputFields: IndexedSeq[Field])
+                             val inputFields: IndexedSeq[Field],
+                             val inputSize: Int = 16*1024)
   extends ToSimpleFeatureConverter[String] {
 
   var curString: String = null
+  val q = Queues.newArrayBlockingQueue[String](32)
+  // if the record to write is bigger than the buffer size of the PipedReader
+  // then the writer will block until the reader reads data off of the pipe.
+  // For this reason, we have to separate the reading and writing into two
+  // threads
   val writer = new PipedWriter()
-  val reader = new PipedReader(writer)
+  val reader = new PipedReader(writer, inputSize) // 16k records
   val parser = format.parse(reader).iterator()
+
+  val es = Executors.newSingleThreadExecutor()
+  es.submit(new Runnable {
+    override def run(): Unit = {
+      while (true) {
+        val s = q.poll(500, TimeUnit.MILLISECONDS)
+        if(s != null) {
+          writer.write(s)
+          writer.write(format.getRecordSeparator)
+        }
+      }
+    }
+  })
 
   def fromInputType(string: String): Array[Any] = {
     import spire.syntax.cfor._
 
-    writer.write(string)
-    writer.write(format.getRecordSeparator)
+    q.put(string)
     val rec = parser.next()
     val len = rec.size()
     val ret = Array.ofDim[Any](len + 1)
@@ -79,6 +100,7 @@ class DelimitedTextConverter(format: CSVFormat,
   }
 
   override def close(): Unit = {
+    es.shutdown()
     writer.close()
     reader.close()
   }


### PR DESCRIPTION
Separate PipedReader and PipedWriter into multiple threads to avoid
blocking when writing records larger than PipedReader's buffer size.