### PR TITLE
GEOMESA-687 adding cardinality hints to attributes for query planning

### DIFF
--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloDataStore.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloDataStore.scala
@@ -659,7 +659,7 @@ class AccumuloDataStore(val connector: Connector,
    */
   def getFeatureEncoding(sft: SimpleFeatureType): FeatureEncoding = {
     metadata.read(sft.getTypeName, FEATURE_ENCODING_KEY)
-      .map(FeatureEncoding.withName(_)).getOrElse(FeatureEncoding.TEXT)
+      .map(FeatureEncoding.withName).getOrElse(FeatureEncoding.TEXT)
   }
 
   // We assume that they want the bounds for everything.

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloDataStore.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloDataStore.scala
@@ -78,7 +78,7 @@ class AccumuloDataStore(val connector: Connector,
                         val writeThreadsConfig: Option[Int] = None,
                         val cachingConfig: Boolean = false,
                         val featureEncoding: FeatureEncoding = FeatureEncoding.AVRO)
-    extends AbstractDataStore(true) with AccumuloConnectorCreator with Logging {
+    extends AbstractDataStore(true) with AccumuloConnectorCreator with StrategyHintsProvider with Logging {
 
   // having at least as many shards as tservers provides optimal parallelism in queries
   protected [core] val DEFAULT_MAX_SHARD = connector.instanceOperations().getTabletServers.size()
@@ -652,16 +652,14 @@ class AccumuloDataStore(val connector: Connector,
    * @param featureName
    * @return
    */
-  private def getAttributes(featureName: String) =
-    metadata.read(featureName, ATTRIBUTES_KEY)
+  private def getAttributes(featureName: String) = metadata.read(featureName, ATTRIBUTES_KEY)
 
   /**
    * Reads the feature encoding from the metadata. Defaults to TEXT if there is no metadata.
    */
   def getFeatureEncoding(sft: SimpleFeatureType): FeatureEncoding = {
-    val encodingString = metadata.read(sft.getTypeName, FEATURE_ENCODING_KEY)
-                         .getOrElse(FeatureEncoding.TEXT.toString)
-    FeatureEncoding.withName(encodingString)
+    metadata.read(sft.getTypeName, FEATURE_ENCODING_KEY)
+      .map(FeatureEncoding.withName(_)).getOrElse(FeatureEncoding.TEXT)
   }
 
   // We assume that they want the bounds for everything.
@@ -878,6 +876,8 @@ class AccumuloDataStore(val connector: Connector,
    * @return
    */
   private def getFeatureName(featureType: SimpleFeatureType) = featureType.getName.getLocalPart
+
+  override def strategyHints(sft: SimpleFeatureType) = new UserDataStrategyHints()
 }
 
 object AccumuloDataStore {

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloFeatureReader.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloFeatureReader.scala
@@ -19,6 +19,7 @@ package org.locationtech.geomesa.core.data
 import org.geotools.data.{FeatureReader, Query}
 import org.locationtech.geomesa.core.index._
 import org.locationtech.geomesa.core.stats._
+import org.locationtech.geomesa.core.util.ExplainingConnectorCreator
 import org.locationtech.geomesa.feature.SimpleFeatureEncoder
 import org.locationtech.geomesa.utils.stats.{MethodProfiling, TimingsImpl}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -34,13 +35,17 @@ class AccumuloFeatureReader(dataStore: AccumuloDataStore,
 
   private val indexSchema = IndexSchema(indexSchemaFmt, sft, featureEncoder)
   private val queryPlanner = indexSchema.planner
+  private lazy val strategyHints = dataStore.strategyHints(sft)
 
-  def explainQuery(q: Query = query, o: ExplainerOutputType = ExplainPrintln) = {
-    profile(indexSchema.explainQuery(q, o), "explain")
+  def explainQuery(o: ExplainerOutputType = ExplainPrintln) = {
+    profile({
+      val cc = new ExplainingConnectorCreator(o)
+      queryPlanner.getIterator(cc, sft, query, strategyHints, o)
+    }, "explain")
     o(s"Query Planning took ${timings.time("explain")} milliseconds.")
   }
 
-  private lazy val iter = profile(queryPlanner.query(query, dataStore), "planning")
+  private lazy val iter = profile(queryPlanner.query(query, dataStore, strategyHints), "planning")
 
   override def getFeatureType = sft
 

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/AttributeIdxStrategy.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/AttributeIdxStrategy.scala
@@ -335,44 +335,22 @@ trait AttributeIdxStrategy extends Strategy with Logging {
 
 class AttributeIdxEqualsStrategy extends AttributeIdxStrategy {
 
+  import org.locationtech.geomesa.core.index.AttributeIndexStrategy._
+
   override def execute(acc: AccumuloConnectorCreator,
                        iqp: QueryPlanner,
                        sft: SimpleFeatureType,
                        query: Query,
                        output: ExplainerOutputType): SelfClosingIterator[Entry[Key, Value]] = {
     val (strippedQuery, filter) = partitionFilter(query, sft)
-    val (prop, range) =
-      filter match {
-        case f: PropertyIsEqualTo =>
-          val (prop, lit, _) = checkOrder(f.getExpression1, f.getExpression2)
-          (prop, AccRange.exact(getEncodedAttrIdxRow(sft, prop, lit)))
-
-        case f: TEquals =>
-          val (prop, lit, _) = checkOrder(f.getExpression1, f.getExpression2)
-          (prop, AccRange.exact(getEncodedAttrIdxRow(sft, prop, lit)))
-
-        case f: PropertyIsNil =>
-          val prop = f.getExpression.asInstanceOf[PropertyName].getPropertyName
-          val rowIdPrefix = org.locationtech.geomesa.core.index.getTableSharingPrefix(sft)
-          val exact = AttributeTable.getAttributeIndexRows(rowIdPrefix, sft.getDescriptor(prop), None).head
-          (prop, AccRange.exact(exact))
-
-        case f: PropertyIsNull =>
-          val prop = f.getExpression.asInstanceOf[PropertyName].getPropertyName
-          val rowIdPrefix = org.locationtech.geomesa.core.index.getTableSharingPrefix(sft)
-          val exact = AttributeTable.getAttributeIndexRows(rowIdPrefix, sft.getDescriptor(prop), None).head
-          (prop, AccRange.exact(exact))
-
-        case _ =>
-          val msg = s"Unhandled filter type in equals strategy: ${filter.getClass.getName}"
-          throw new RuntimeException(msg)
-      }
-
+    val (prop, range) = getPropertyAndRange(filter, sft)
     attrIdxQuery(acc, strippedQuery, iqp, sft, prop, range, output)
   }
 }
 
 class AttributeIdxRangeStrategy extends AttributeIdxStrategy {
+
+  import org.locationtech.geomesa.core.index.AttributeIndexStrategy._
 
   override def execute(acc: AccumuloConnectorCreator,
                        iqp: QueryPlanner,
@@ -380,107 +358,14 @@ class AttributeIdxRangeStrategy extends AttributeIdxStrategy {
                        query: Query,
                        output: ExplainerOutputType): SelfClosingIterator[Entry[Key, Value]] = {
     val (strippedQuery, filter) = partitionFilter(query, featureType)
-    val (prop, range) =
-      filter match {
-        case f: PropertyIsBetween =>
-          val prop = f.getExpression.asInstanceOf[PropertyName].getPropertyName
-          val lower = f.getLowerBoundary.asInstanceOf[Literal].getValue
-          val upper = f.getUpperBoundary.asInstanceOf[Literal].getValue
-          val lowerBound = getEncodedAttrIdxRow(featureType, prop, lower)
-          val upperBound = getEncodedAttrIdxRow(featureType, prop, upper)
-          (prop, new AccRange(lowerBound, true, upperBound, true))
-
-        case f: PropertyIsGreaterThan =>
-          val (prop, lit, flipped) = checkOrder(f.getExpression1, f.getExpression2)
-          if (flipped) {
-            (prop, lessThanRange(featureType, prop, lit))
-          } else {
-            (prop, greaterThanRange(featureType, prop, lit))
-          }
-        case f: PropertyIsGreaterThanOrEqualTo =>
-          val (prop, lit, flipped) = checkOrder(f.getExpression1, f.getExpression2)
-          if (flipped) {
-            (prop, lessThanOrEqualRange(featureType, prop, lit))
-          } else {
-            (prop, greaterThanOrEqualRange(featureType, prop, lit))
-          }
-        case f: PropertyIsLessThan =>
-          val (prop, lit, flipped) = checkOrder(f.getExpression1, f.getExpression2)
-          if (flipped) {
-            (prop, greaterThanRange(featureType, prop, lit))
-          } else {
-            (prop, lessThanRange(featureType, prop, lit))
-          }
-        case f: PropertyIsLessThanOrEqualTo =>
-          val (prop, lit, flipped) = checkOrder(f.getExpression1, f.getExpression2)
-          if (flipped) {
-            (prop, greaterThanOrEqualRange(featureType, prop, lit))
-          } else {
-            (prop, lessThanOrEqualRange(featureType, prop, lit))
-          }
-        case f: Before =>
-          val (prop, lit, flipped) = checkOrder(f.getExpression1, f.getExpression2)
-          if (flipped) {
-            (prop, greaterThanRange(featureType, prop, lit))
-          } else {
-            (prop, lessThanRange(featureType, prop, lit))
-          }
-        case f: After =>
-          val (prop, lit, flipped) = checkOrder(f.getExpression1, f.getExpression2)
-          if (flipped) {
-            (prop, lessThanRange(featureType, prop, lit))
-          } else {
-            (prop, greaterThanRange(featureType, prop, lit))
-          }
-        case f: During =>
-          val (prop, lit, _) = checkOrder(f.getExpression1, f.getExpression2)
-          val during = lit.asInstanceOf[DefaultPeriod]
-          val lower = during.getBeginning.getPosition.getDate
-          val upper = during.getEnding.getPosition.getDate
-          val lowerBound = getEncodedAttrIdxRow(featureType, prop, lower)
-          val upperBound = getEncodedAttrIdxRow(featureType, prop, upper)
-          (prop, new AccRange(lowerBound, true, upperBound, true))
-
-        case _ =>
-          val msg = s"Unhandled filter type in range strategy: ${filter.getClass.getName}"
-          throw new RuntimeException(msg)
-      }
-
+    val (prop, range) = getPropertyAndRange(filter, featureType)
     attrIdxQuery(acc, strippedQuery, iqp, featureType, prop, range, output)
-  }
-
-  private def greaterThanRange(sft: SimpleFeatureType, prop: String, lit: AnyRef): AccRange = {
-    val rowIdPrefix = getTableSharingPrefix(sft)
-    val start = new Text(getEncodedAttrIdxRow(sft, prop, lit))
-    val endPrefix = AttributeTable.getAttributeIndexRowPrefix(rowIdPrefix, sft.getDescriptor(prop))
-    val end = AccRange.followingPrefix(new Text(endPrefix))
-    new AccRange(start, false, end, false)
-  }
-
-  private def greaterThanOrEqualRange(sft: SimpleFeatureType, prop: String, lit: AnyRef): AccRange = {
-    val rowIdPrefix = getTableSharingPrefix(sft)
-    val start = new Text(getEncodedAttrIdxRow(sft, prop, lit))
-    val endPrefix = AttributeTable.getAttributeIndexRowPrefix(rowIdPrefix, sft.getDescriptor(prop))
-    val end = AccRange.followingPrefix(new Text(endPrefix))
-    new AccRange(start, true, end, false)
-  }
-
-  private def lessThanRange(sft: SimpleFeatureType, prop: String, lit: AnyRef): AccRange = {
-    val rowIdPrefix = getTableSharingPrefix(sft)
-    val start = AttributeTable.getAttributeIndexRowPrefix(rowIdPrefix, sft.getDescriptor(prop))
-    val end = getEncodedAttrIdxRow(sft, prop, lit)
-    new AccRange(start, false, end, false)
-  }
-
-  private def lessThanOrEqualRange(sft: SimpleFeatureType, prop: String, lit: AnyRef): AccRange = {
-    val rowIdPrefix = getTableSharingPrefix(sft)
-    val start = AttributeTable.getAttributeIndexRowPrefix(rowIdPrefix, sft.getDescriptor(prop))
-    val end = getEncodedAttrIdxRow(sft, prop, lit)
-    new AccRange(start, false, end, true)
   }
 }
 
 class AttributeIdxLikeStrategy extends AttributeIdxStrategy {
+
+  import org.locationtech.geomesa.core.index.AttributeIndexStrategy._
 
   override def execute(acc: AccumuloConnectorCreator,
                        iqp: QueryPlanner,
@@ -488,22 +373,7 @@ class AttributeIdxLikeStrategy extends AttributeIdxStrategy {
                        query: Query,
                        output: ExplainerOutputType): SelfClosingIterator[Entry[Key, Value]] = {
     val (strippedQuery, extractedFilter) = partitionFilter(query, featureType)
-    val filter = extractedFilter.asInstanceOf[PropertyIsLike]
-    val expr = filter.getExpression
-    val prop = expr match {
-      case p: PropertyName => p.getPropertyName
-    }
-
-    // Remove the trailing wildcard and create a range prefix
-    val literal = filter.getLiteral
-    val value =
-      if(literal.endsWith(QueryStrategyDecider.MULTICHAR_WILDCARD))
-        literal.substring(0, literal.length - QueryStrategyDecider.MULTICHAR_WILDCARD.length)
-      else
-        literal
-
-    val range = AccRange.prefix(getEncodedAttrIdxRow(featureType, prop, value))
-
+    val (prop, range) = getPropertyAndRange(extractedFilter, featureType)
     attrIdxQuery(acc, strippedQuery, iqp, featureType, prop, range, output)
   }
 }
@@ -591,4 +461,214 @@ object AttributeIndexStrategy {
       lits.forall(_.isInstanceOf[Literal])
   }
 
+  /**
+   * Checks the order of properties and literals in the expression
+   *
+   * @param one
+   * @param two
+   * @return (prop, literal, whether the order was flipped)
+   */
+  def checkOrder(one: Expression, two: Expression): (String, AnyRef, Boolean) =
+    (one, two) match {
+      case (p: PropertyName, l: Literal) => (p.getPropertyName, l.getValue, false)
+      case (l: Literal, p: PropertyName) => (p.getPropertyName, l.getValue, true)
+      case _ =>
+        val msg = "Unhandled properties in attribute index strategy: " +
+            s"${one.getClass.getName}, ${two.getClass.getName}"
+        throw new RuntimeException(msg)
+    }
+
+  /**
+   * Gets a row key that can used as a range for an attribute query.
+   * The attribute index encodes the type of the attribute as part of the row. This checks for
+   * query literals that don't match the expected type and tries to convert them.
+   *
+   * @param sft
+   * @param prop
+   * @param value
+   * @return
+   */
+  def getEncodedAttrIdxRow(sft: SimpleFeatureType, prop: String, value: Any): String = {
+    val descriptor = sft.getDescriptor(prop)
+    // the class type as defined in the SFT
+    val expectedBinding = descriptor.getType.getBinding
+    // the class type of the literal pulled from the query
+    val actualBinding = value.getClass
+    val typedValue =
+      if (expectedBinding == actualBinding) {
+        value
+      } else if (descriptor.isCollection) {
+        // we need to encode with the collection type
+        SimpleFeatureTypes.getCollectionType(descriptor) match {
+          case Some(collectionType) if collectionType == actualBinding => Seq(value).asJava
+          case Some(collectionType) if collectionType != actualBinding =>
+            Seq(AttributeTable.convertType(value, actualBinding, collectionType)).asJava
+        }
+      } else if (descriptor.isMap) {
+        // TODO GEOMESA-454 - support querying against map attributes
+        Map.empty.asJava
+      } else {
+        // type mismatch, encoding won't work b/c value is wrong class
+        // try to convert to the appropriate class
+        AttributeTable.convertType(value, actualBinding, expectedBinding)
+      }
+
+    val rowIdPrefix = org.locationtech.geomesa.core.index.getTableSharingPrefix(sft)
+    // grab the first encoded row - right now there will only ever be a single item in the seq
+    // eventually we may support searching a whole collection at once
+    AttributeTable.getAttributeIndexRows(rowIdPrefix, descriptor, Some(typedValue)).head
+  }
+
+  def getPropertyAndRange(filter: Filter, sft: SimpleFeatureType): (String, AccRange) =
+    filter match {
+      case f: PropertyIsBetween =>
+        val prop = f.getExpression.asInstanceOf[PropertyName].getPropertyName
+        val lower = f.getLowerBoundary.asInstanceOf[Literal].getValue
+        val upper = f.getUpperBoundary.asInstanceOf[Literal].getValue
+        val lowerBound = getEncodedAttrIdxRow(sft, prop, lower)
+        val upperBound = getEncodedAttrIdxRow(sft, prop, upper)
+        (prop, new AccRange(lowerBound, true, upperBound, true))
+
+      case f: PropertyIsGreaterThan =>
+        val (prop, lit, flipped) = checkOrder(f.getExpression1, f.getExpression2)
+        if (flipped) {
+          (prop, lessThanRange(sft, prop, lit))
+        } else {
+          (prop, greaterThanRange(sft, prop, lit))
+        }
+      case f: PropertyIsGreaterThanOrEqualTo =>
+        val (prop, lit, flipped) = checkOrder(f.getExpression1, f.getExpression2)
+        if (flipped) {
+          (prop, lessThanOrEqualRange(sft, prop, lit))
+        } else {
+          (prop, greaterThanOrEqualRange(sft, prop, lit))
+        }
+      case f: PropertyIsLessThan =>
+        val (prop, lit, flipped) = checkOrder(f.getExpression1, f.getExpression2)
+        if (flipped) {
+          (prop, greaterThanRange(sft, prop, lit))
+        } else {
+          (prop, lessThanRange(sft, prop, lit))
+        }
+      case f: PropertyIsLessThanOrEqualTo =>
+        val (prop, lit, flipped) = checkOrder(f.getExpression1, f.getExpression2)
+        if (flipped) {
+          (prop, greaterThanOrEqualRange(sft, prop, lit))
+        } else {
+          (prop, lessThanOrEqualRange(sft, prop, lit))
+        }
+      case f: Before =>
+        val (prop, lit, flipped) = checkOrder(f.getExpression1, f.getExpression2)
+        if (flipped) {
+          (prop, greaterThanRange(sft, prop, lit))
+        } else {
+          (prop, lessThanRange(sft, prop, lit))
+        }
+      case f: After =>
+        val (prop, lit, flipped) = checkOrder(f.getExpression1, f.getExpression2)
+        if (flipped) {
+          (prop, lessThanRange(sft, prop, lit))
+        } else {
+          (prop, greaterThanRange(sft, prop, lit))
+        }
+      case f: During =>
+        val (prop, lit, _) = checkOrder(f.getExpression1, f.getExpression2)
+        val during = lit.asInstanceOf[DefaultPeriod]
+        val lower = during.getBeginning.getPosition.getDate
+        val upper = during.getEnding.getPosition.getDate
+        val lowerBound = getEncodedAttrIdxRow(sft, prop, lower)
+        val upperBound = getEncodedAttrIdxRow(sft, prop, upper)
+        (prop, new AccRange(lowerBound, true, upperBound, true))
+
+      case f: PropertyIsEqualTo =>
+        val (prop, lit, _) = checkOrder(f.getExpression1, f.getExpression2)
+        (prop, AccRange.exact(getEncodedAttrIdxRow(sft, prop, lit)))
+
+      case f: TEquals =>
+        val (prop, lit, _) = checkOrder(f.getExpression1, f.getExpression2)
+        (prop, AccRange.exact(getEncodedAttrIdxRow(sft, prop, lit)))
+
+      case f: PropertyIsNil =>
+        val prop = f.getExpression.asInstanceOf[PropertyName].getPropertyName
+        val rowIdPrefix = org.locationtech.geomesa.core.index.getTableSharingPrefix(sft)
+        val exact = AttributeTable.getAttributeIndexRows(rowIdPrefix, sft.getDescriptor(prop), None).head
+        (prop, AccRange.exact(exact))
+
+      case f: PropertyIsNull =>
+        val prop = f.getExpression.asInstanceOf[PropertyName].getPropertyName
+        val rowIdPrefix = org.locationtech.geomesa.core.index.getTableSharingPrefix(sft)
+        val exact = AttributeTable.getAttributeIndexRows(rowIdPrefix, sft.getDescriptor(prop), None).head
+        (prop, AccRange.exact(exact))
+
+      case f: PropertyIsLike =>
+        val prop = f.getExpression.asInstanceOf[PropertyName].getPropertyName
+        // Remove the trailing wildcard and create a range prefix
+        val literal = f.getLiteral
+        val value = if (literal.endsWith(QueryStrategyDecider.MULTICHAR_WILDCARD)) {
+          literal.substring(0, literal.length - QueryStrategyDecider.MULTICHAR_WILDCARD.length)
+        } else {
+          literal
+        }
+        (prop, AccRange.prefix(getEncodedAttrIdxRow(sft, prop, value)))
+
+      case _ =>
+        val msg = s"Unhandled filter type in attribute strategy: ${filter.getClass.getName}"
+        throw new RuntimeException(msg)
+    }
+
+  private def greaterThanRange(sft: SimpleFeatureType, prop: String, lit: AnyRef): AccRange = {
+    val rowIdPrefix = getTableSharingPrefix(sft)
+    val start = new Text(getEncodedAttrIdxRow(sft, prop, lit))
+    val endPrefix = AttributeTable.getAttributeIndexRowPrefix(rowIdPrefix, sft.getDescriptor(prop))
+    val end = AccRange.followingPrefix(new Text(endPrefix))
+    new AccRange(start, false, end, false)
+  }
+
+  private def greaterThanOrEqualRange(sft: SimpleFeatureType, prop: String, lit: AnyRef): AccRange = {
+    val rowIdPrefix = getTableSharingPrefix(sft)
+    val start = new Text(getEncodedAttrIdxRow(sft, prop, lit))
+    val endPrefix = AttributeTable.getAttributeIndexRowPrefix(rowIdPrefix, sft.getDescriptor(prop))
+    val end = AccRange.followingPrefix(new Text(endPrefix))
+    new AccRange(start, true, end, false)
+  }
+
+  private def lessThanRange(sft: SimpleFeatureType, prop: String, lit: AnyRef): AccRange = {
+    val rowIdPrefix = getTableSharingPrefix(sft)
+    val start = AttributeTable.getAttributeIndexRowPrefix(rowIdPrefix, sft.getDescriptor(prop))
+    val end = getEncodedAttrIdxRow(sft, prop, lit)
+    new AccRange(start, false, end, false)
+  }
+
+  private def lessThanOrEqualRange(sft: SimpleFeatureType, prop: String, lit: AnyRef): AccRange = {
+    val rowIdPrefix = getTableSharingPrefix(sft)
+    val start = AttributeTable.getAttributeIndexRowPrefix(rowIdPrefix, sft.getDescriptor(prop))
+    val end = getEncodedAttrIdxRow(sft, prop, lit)
+    new AccRange(start, false, end, true)
+  }
+
+  // This function assumes that the query's filter object is or has an attribute-idx-satisfiable
+  //  filter.  If not, you will get a None.get exception.
+  def partitionFilter(query: Query, sft: SimpleFeatureType): (Query, Filter) = {
+
+    val filter = query.getFilter
+
+    val (indexFilter: Option[Filter], cqlFilter) = filter match {
+      case and: And =>
+        findFirst(AttributeIndexStrategy.getAttributeIndexStrategy(_, sft).isDefined)(and.getChildren)
+      case f: Filter =>
+        (Some(f), Seq())
+    }
+
+    val nonIndexFilters = filterListAsAnd(cqlFilter).getOrElse(Filter.INCLUDE)
+
+    val newQuery = new Query(query)
+    newQuery.setFilter(nonIndexFilters)
+
+    if (indexFilter.isEmpty) {
+      throw new Exception(s"Partition Filter was called on $query for filter $filter. " +
+          "The AttributeIdxStrategy did not find a compatible sub-filter.")
+    }
+
+    (newQuery, indexFilter.get)
+  }
 }

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/IndexSchema.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/IndexSchema.scala
@@ -82,11 +82,6 @@ case class IndexSchema(encoder: IndexEntryEncoder,
       case CompositeTextFormatter(Seq(PartitionTextFormatter(numPartitions), xs@_*), sep) => numPartitions
       case _ => 1  // couldn't find a matching partitioner
     }
-
-  // Writes out an explanation of how a query would be run.
-  def explainQuery(q: Query, output: ExplainerOutputType = log) = {
-     planner.getIterator(new ExplainingConnectorCreator(output), featureType, q, output)
-  }
 }
 
 object IndexSchema extends RegexParsers with Logging {

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/QueryStrategyDecider.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/QueryStrategyDecider.scala
@@ -86,12 +86,14 @@ object QueryStrategyDecider {
     // scan the query and identify the type of predicates present
 
     // record strategy takes priority
-    val recordStrategies = filters.toStream.flatMap(f => getRecordIdxStrategy(f, sft).map(StrategyAndFilter(_, f)))
+    val recordStrategies =
+      filters.toStream.flatMap(f => getRecordIdxStrategy(f, sft).map(StrategyAndFilter(_, f)))
     if (!recordStrategies.isEmpty) {
       return recordStrategies(0).strategy
     }
 
-    val attributeStrategies = filters.flatMap(f => getAttributeIndexStrategy(f, sft).map(StrategyAndFilter(_, f)))
+    val attributeStrategies =
+      filters.flatMap(f => getAttributeIndexStrategy(f, sft).map(StrategyAndFilter(_, f)))
     // if no attribute or record strategies, use ST
     if (attributeStrategies.isEmpty) {
       return new STIdxStrategy

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/QueryStrategyDecider.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/QueryStrategyDecider.scala
@@ -29,6 +29,7 @@ import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.{And, Filter, Id, PropertyIsLike}
 
 import scala.collection.JavaConversions._
+import scala.collection.mutable
 
 object QueryStrategyDecider {
 
@@ -59,49 +60,69 @@ object QueryStrategyDecider {
     }
   }
 
-  private def processAnd(and: And, sft: SimpleFeatureType, hints: StrategyHints): Strategy = {
-    val children: util.List[Filter] = decomposeAnd(and)
+  case class StrategyAndFilter(strategy: Strategy, filter: Filter)
 
-    def determineStrategy(attr: Filter, st: Filter): Strategy = {
-      val (prop, _) = AttributeIndexStrategy.getPropertyAndRange(attr, sft)
-      // check cardinality hints for attribute
-      hints.cardinality(sft.getDescriptor(prop)) match {
-        case Cardinality.LOW  => new STIdxStrategy
-        case Cardinality.HIGH => getAttributeIndexStrategy(attr, sft).get
-        // if no cardinality, use order of query
-        case _ if (children.indexOf(attr) < children.indexOf(st)) => getAttributeIndexStrategy(attr, sft).get
-        case _ => new STIdxStrategy
-      }
+  /**
+   * Choose the query strategy to be employed here. This is the priority
+   *   * If an ID predicate is present, it is assumed that only a small number of IDs are requested
+   *            --> The Record Index is scanned, and the other ECQL filters, if any, are then applied
+   *
+   *   * If attribute filters and ST filters are present, use the cardinality + ordering to choose
+   *     the correct strategy
+   *
+   *   * If attribute filters are present, then select the correct type of AttributeIdx Strategy
+   *            --> The Attribute Indices are scanned, and the other ECQL filters, if any, are then applied
+   *
+   *   * If ST filters are present, use the STIdxStrategy
+   *            --> The ST Index is scanned, and the other ECQL filters, if any are then applied
+   *
+   *   * If filters are not identified, use the STIdxStrategy
+   *            --> The ST Index is scanned (likely a full table scan) and the ECQL filters are applied
+   */
+  private def processAnd(and: And, sft: SimpleFeatureType, hints: StrategyHints): Strategy = {
+
+    val filters: util.List[Filter] = decomposeAnd(and)
+
+    // scan the query and identify the type of predicates present
+
+    // record strategy takes priority
+    val recordStrategies = filters.toStream.flatMap(f => getRecordIdxStrategy(f, sft).map(StrategyAndFilter(_, f)))
+    if (!recordStrategies.isEmpty) {
+      return recordStrategies(0).strategy
     }
 
-    // first scan the query and identify the type of predicates present
-    val strats = (children.find(c => getAttributeIndexStrategy(c, sft).isDefined),
-                  children.find(c => getSTIdxStrategy(c, sft).isDefined),
-                  children.find(c => getRecordIdxStrategy(c, sft).isDefined))
+    val attributeStrategies = filters.flatMap(f => getAttributeIndexStrategy(f, sft).map(StrategyAndFilter(_, f)))
+    // if no attribute or record strategies, use ST
+    if (attributeStrategies.isEmpty) {
+      return new STIdxStrategy
+    }
 
-    /**
-     * Choose the query strategy to be employed here. This is the priority
-     *   * If an ID predicate is present, it is assumed that only a small number of IDs are requested
-     *            --> The Record Index is scanned, and the other ECQL filters, if any, are then applied
-     *
-     *   * If attribute filters and ST filters are present, use the cardinality + ordering to choose
-     *     the correct strategy
-     *
-     *   * If attribute filters are present, then select the correct type of AttributeIdx Strategy
-     *            --> The Attribute Indices are scanned, and the other ECQL filters, if any, are then applied
-     *
-     *   * If ST filters are present, use the STIdxStrategy
-     *            --> The ST Index is scanned, and the other ECQL filters, if any are then applied
-     *
-     *   * If filters are not identified, use the STIdxStrategy
-     *            --> The ST Index is scanned (likely a full table scan) and the ECQL filters are applied
-     */
-    strats match {
-      case (               _,              _, Some(idFilter))  => new RecordIdxStrategy
-      case (Some(attrFilter), Some(stFilter),           None)  => determineStrategy(attrFilter, stFilter)
-      case (Some(attrFilter),           None,           None)  => getAttributeIndexStrategy(attrFilter, sft).get
-      case (            None, Some(stFilter),           None)  => new STIdxStrategy
-      case (            None,           None,           None)  => new STIdxStrategy
+    // next look for high-cardinality attribute filters
+    val highCardinalityStrategy = attributeStrategies.find { case StrategyAndFilter(strategy, filter) =>
+      val (prop, _) = AttributeIndexStrategy.getPropertyAndRange(filter, sft)
+      hints.cardinality(sft.getDescriptor(prop)) == Cardinality.HIGH
+    }
+    if (highCardinalityStrategy.isDefined) {
+      return highCardinalityStrategy.get.strategy
+    }
+
+    // finally, compare spatial and attribute filters based on order
+    val stStrategy = filters.flatMap(f => getSTIdxStrategy(f, sft).map(StrategyAndFilter(_, f))).headOption
+    val attrStrategy = attributeStrategies.find { case StrategyAndFilter(strategy, filter) =>
+      val (prop, _) = AttributeIndexStrategy.getPropertyAndRange(filter, sft)
+      hints.cardinality(sft.getDescriptor(prop)) != Cardinality.LOW
+    }
+
+    (stStrategy, attrStrategy) match {
+      case (None, None)           => new STIdxStrategy
+      case (Some(st), None)       => st.strategy
+      case (None, Some(attr))     => attr.strategy
+      case (Some(st), Some(attr)) =>
+        if (filters.indexOf(st.filter) < filters.indexOf(attr.filter)) {
+          st.strategy
+        } else {
+          attr.strategy
+        }
     }
   }
 

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/QueryStrategyDecider.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/QueryStrategyDecider.scala
@@ -24,6 +24,7 @@ import org.locationtech.geomesa.core.index.FilterHelper._
 import org.locationtech.geomesa.core.index.QueryHints._
 import org.locationtech.geomesa.core.index.RecordIdxStrategy.getRecordIdxStrategy
 import org.locationtech.geomesa.core.index.STIdxStrategy.getSTIdxStrategy
+import org.locationtech.geomesa.utils.stats.Cardinality
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.{And, Filter, Id, PropertyIsLike}
 
@@ -33,36 +34,44 @@ object QueryStrategyDecider {
 
   def chooseStrategy(isCatalogTableFormat: Boolean,
                      sft: SimpleFeatureType,
-                     query: Query): Strategy =
-    // if datastore doesn't support attr index use spatiotemporal only
-    if (isCatalogTableFormat) chooseNewStrategy(sft, query) else new STIdxStrategy
+                     query: Query,
+                     hints: StrategyHints): Strategy = {
+    if (!isCatalogTableFormat) {
+      // if datastore doesn't support attr index use spatiotemporal only
+      return new STIdxStrategy
+    }
 
-  def chooseNewStrategy(sft: SimpleFeatureType, query: Query): Strategy = {
-    val filter = query.getFilter
-    val isADensity = query.getHints.containsKey(BBOX_KEY) || query.getHints.contains(TIME_BUCKETS_KEY)
-
-    if (isADensity) {
+    val isDensity = query.getHints.containsKey(BBOX_KEY) || query.getHints.contains(TIME_BUCKETS_KEY)
+    if (isDensity) {
       // TODO GEOMESA-322 use other strategies with density iterator
-      new STIdxStrategy
-    } else {
-      // check if we can use the attribute index first
-      val attributeStrategy = getAttributeIndexStrategy(filter, sft)
-      attributeStrategy.getOrElse {
-        filter match {
-          case idFilter: Id => new RecordIdxStrategy
-          case and: And => processAnd(isADensity, sft, and)
-          case cql          => new STIdxStrategy
-        }
+      return new STIdxStrategy
+    }
+
+    val filter = query.getFilter
+    // check if we can use the attribute index first
+    val attributeStrategy = getAttributeIndexStrategy(filter, sft)
+    attributeStrategy.getOrElse {
+      filter match {
+        case idFilter: Id => new RecordIdxStrategy
+        case and: And     => processAnd(and, sft, hints)
+        case cql          => new STIdxStrategy
       }
     }
   }
 
-  private def processAnd(isADensity: Boolean, sft: SimpleFeatureType, and: And): Strategy = {
+  private def processAnd(and: And, sft: SimpleFeatureType, hints: StrategyHints): Strategy = {
     val children: util.List[Filter] = decomposeAnd(and)
 
     def determineStrategy(attr: Filter, st: Filter): Strategy = {
-      if (children.indexOf(attr) < children.indexOf(st)) { getAttributeIndexStrategy(attr, sft).get }
-      else { new STIdxStrategy }
+      val (prop, _) = AttributeIndexStrategy.getPropertyAndRange(attr, sft)
+      // check cardinality hints for attribute
+      hints.cardinality(sft.getDescriptor(prop)) match {
+        case Cardinality.LOW  => new STIdxStrategy
+        case Cardinality.HIGH => getAttributeIndexStrategy(attr, sft).get
+        // if no cardinality, use order of query
+        case _ if (children.indexOf(attr) < children.indexOf(st)) => getAttributeIndexStrategy(attr, sft).get
+        case _ => new STIdxStrategy
+      }
     }
 
     // first scan the query and identify the type of predicates present
@@ -75,7 +84,8 @@ object QueryStrategyDecider {
      *   * If an ID predicate is present, it is assumed that only a small number of IDs are requested
      *            --> The Record Index is scanned, and the other ECQL filters, if any, are then applied
      *
-     *   * If attribute filters and ST filters are present, use the ordering to choose the correct strategy
+     *   * If attribute filters and ST filters are present, use the cardinality + ordering to choose
+     *     the correct strategy
      *
      *   * If attribute filters are present, then select the correct type of AttributeIdx Strategy
      *            --> The Attribute Indices are scanned, and the other ECQL filters, if any, are then applied

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/StrategyHints.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/StrategyHints.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.index
+
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.stats.Cardinality.Cardinality
+import org.opengis.feature.`type`.AttributeDescriptor
+import org.opengis.feature.simple.SimpleFeatureType
+
+/**
+ * Provides hints for a simple feature type
+ */
+trait StrategyHintsProvider {
+
+  /**
+   * Get a hint implementation based on the feature type
+   *
+   * @param sft
+   * @return
+   */
+  def strategyHints(sft: SimpleFeatureType): StrategyHints
+}
+
+/**
+ * Provides hints for determining query strategies
+ */
+trait StrategyHints {
+
+  /**
+   * Returns the cardinality for an attribute
+   *
+   * @param ad
+   * @return
+   */
+  def cardinality(ad: AttributeDescriptor): Cardinality
+}
+
+/**
+ * Implementation of hints that uses user data stored in the attribute descriptor
+ */
+class UserDataStrategyHints extends StrategyHints {
+  override def cardinality(ad: AttributeDescriptor) = SimpleFeatureTypes.getCardinality(ad)
+}

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/util/SftBuilder.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/util/SftBuilder.scala
@@ -22,6 +22,8 @@ import org.locationtech.geomesa.core.util.SftBuilder._
 import org.locationtech.geomesa.data.TableSplitter
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.{Splitter, _}
+import org.locationtech.geomesa.utils.stats.Cardinality
+import org.locationtech.geomesa.utils.stats.Cardinality.Cardinality
 
 import scala.collection.mutable.ListBuffer
 import scala.reflect.runtime.universe.{Type => UType, _}
@@ -33,48 +35,85 @@ class SftBuilder {
   private var splitterOpt: Option[Splitter] = None
   private var dtgFieldOpt: Option[String] = None
 
+  // Primitives - back compatible
+  def stringType(name: String, index: Boolean): SftBuilder =
+    stringType(name, Opts(index = index))
+  def stringType(name: String, index: Boolean, stIndex: Boolean): SftBuilder =
+    stringType(name, Opts(index = index, stIndex = stIndex))
+  def intType(name: String, index: Boolean): SftBuilder =
+    intType(name, Opts(index = index))
+  def intType(name: String, index: Boolean, stIndex: Boolean): SftBuilder =
+    intType(name, Opts(index = index, stIndex = stIndex))
+  def longType(name: String, index: Boolean): SftBuilder =
+    longType(name, Opts(index = index))
+  def longType(name: String, index: Boolean, stIndex: Boolean): SftBuilder =
+    longType(name, Opts(index = index, stIndex = stIndex))
+  def floatType(name: String, index: Boolean): SftBuilder =
+    floatType(name, Opts(index = index))
+  def floatType(name: String, index: Boolean, stIndex: Boolean): SftBuilder =
+    floatType(name, Opts(index = index, stIndex = stIndex))
+  def doubleType(name: String, index: Boolean): SftBuilder =
+    doubleType(name, Opts(index = index))
+  def doubleType(name: String, index: Boolean, stIndex: Boolean): SftBuilder =
+    doubleType(name, Opts(index = index, stIndex = stIndex))
+  def booleanType(name: String, index: Boolean): SftBuilder =
+    booleanType(name, Opts(index = index))
+  def booleanType(name: String, index: Boolean, stIndex: Boolean): SftBuilder =
+    booleanType(name, Opts(index = index, stIndex = stIndex))
+
   // Primitives
-  def stringType(name: String, index: Boolean = false, stIndex: Boolean = false) =
-    append(name, index, stIndex, "String")
-  def intType(name: String, index: Boolean = false, stIndex: Boolean = false) =
-    append(name, index, stIndex, "Integer")
-  def longType(name: String, index: Boolean = false, stIndex: Boolean = false) =
-    append(name, index, stIndex, "Long")
-  def floatType(name: String, index: Boolean = false, stIndex: Boolean = false) =
-    append(name, index, stIndex, "Float")
-  def doubleType(name: String, index: Boolean = false, stIndex: Boolean = false) =
-    append(name, index, stIndex, "Double")
-  def booleanType(name: String, index: Boolean = false, stIndex: Boolean = false) =
-    append(name, index, stIndex, "Boolean")
+  def stringType (name: String, opts: Opts = Opts()) = append(name, opts, "String")
+  def intType    (name: String, opts: Opts = Opts()) = append(name, opts, "Integer")
+  def longType   (name: String, opts: Opts = Opts()) = append(name, opts, "Long")
+  def floatType  (name: String, opts: Opts = Opts()) = append(name, opts, "Float")
+  def doubleType (name: String, opts: Opts = Opts()) = append(name, opts, "Double")
+  def booleanType(name: String, opts: Opts = Opts()) = append(name, opts, "Boolean")
+
+  // Helpful Types - back compatible
+  def date(name: String, default: Boolean): SftBuilder =
+    date(name, Opts(default = default))
+  def date(name: String, index: Boolean, default: Boolean): SftBuilder =
+    date(name, Opts(index = index, default = default))
+  def date(name: String, index: Boolean, stIndex: Boolean, default: Boolean): SftBuilder =
+    date(name, Opts(index = index, stIndex = stIndex, default = default))
+  def uuid(name: String, index: Boolean): SftBuilder =
+    uuid(name, Opts(index = index))
+  def uuid(name: String, index: Boolean, stIndex: Boolean): SftBuilder =
+    uuid(name, Opts(index = index, stIndex = stIndex))
 
   // Helpful Types
-  def date(name: String, index: Boolean = false, stIndex: Boolean = false, default: Boolean = false) = {
-    if (default) {
+  def date(name: String, opts: Opts = Opts()) = {
+    if (opts.default) {
       withDefaultDtg(name)
     }
-    append(name, index, stIndex, "Date")
+    append(name, opts, "Date")
   }
-  def uuid(name: String, index: Boolean = false, stIndex: Boolean = false) =
-    append(name, index, stIndex, "UUID")
+  def uuid(name: String, opts: Opts = Opts()) = append(name, opts, "UUID")
 
   // Single Geometries
-  def point(name: String, default: Boolean = false) = appendGeom(name, default, "Point")
+  def point     (name: String, default: Boolean = false) = appendGeom(name, default, "Point")
   def lineString(name: String, default: Boolean = false) = appendGeom(name, default, "LineString")
-  def polygon(name: String, default: Boolean = false) = appendGeom(name, default, "Polygon")
-  def geometry(name: String, default: Boolean = false) = appendGeom(name, default, "Geometry")
+  def polygon   (name: String, default: Boolean = false) = appendGeom(name, default, "Polygon")
+  def geometry  (name: String, default: Boolean = false) = appendGeom(name, default, "Geometry")
 
   // Multi Geometries
-  def multiPoint(name: String, default: Boolean = false) = appendGeom(name, default, "MultiPoint")
+  def multiPoint     (name: String, default: Boolean = false) = appendGeom(name, default, "MultiPoint")
   def multiLineString(name: String, default: Boolean = false) = appendGeom(name, default, "MultiLineString")
-  def multiPolygon(name: String, default: Boolean = false) = appendGeom(name, default, "MultiPolygon")
+  def multiPolygon   (name: String, default: Boolean = false) = appendGeom(name, default, "MultiPolygon")
   def geometryCollection(name: String, default: Boolean = false) =
     appendGeom(name, default, "GeometryCollection")
 
+  // List and Map Types - back compatible
+  def mapType[K: TypeTag, V: TypeTag](name: String, index: Boolean): SftBuilder =
+    mapType[K, V](name, Opts(index = index))
+  def listType[T: TypeTag](name: String, index: Boolean): SftBuilder =
+    listType[T](name, Opts(index = index))
+
   // List and Map Types
-  def mapType[K: TypeTag, V: TypeTag](name: String, index: Boolean = false) =
-    append(name, index, stIndex = false, s"Map[${resolve(typeOf[K])},${resolve(typeOf[V])}]")
-  def listType[T: TypeTag](name: String, index: Boolean = false) =
-    append(name, index, stIndex = false, s"List[${resolve(typeOf[T])}]")
+  def mapType[K: TypeTag, V: TypeTag](name: String, opts: Opts = Opts()) =
+    append(name, opts.copy(stIndex = false), s"Map[${resolve(typeOf[K])},${resolve(typeOf[V])}]")
+  def listType[T: TypeTag](name: String, opts: Opts = Opts()) =
+    append(name, opts.copy(stIndex = false), s"List[${resolve(typeOf[T])}]")
 
   def recordSplitter(clazz: String, splitOptions: Map[String,String]) = {
     this.splitterOpt = Some(Splitter(clazz, splitOptions))
@@ -101,8 +140,9 @@ class SftBuilder {
       case t if tt == typeOf[UUID]          => "UUID"
     }
 
-  private def append(name: String, index: Boolean, stIndex: Boolean = false, typeStr: String) = {
-    val parts = List(name, typeStr) ++ indexPart(index) ++ stIndexPart(stIndex)
+  private def append(name: String, opts: Opts, typeStr: String) = {
+    val parts = List(name, typeStr) ++ indexPart(opts.index) ++ stIndexPart(opts.stIndex) ++
+        cardinalityPart(opts.cardinality)
     entries += parts.mkString(SepPart)
     this
   }
@@ -118,6 +158,10 @@ class SftBuilder {
 
   private def indexPart(index: Boolean) = if (index) Seq(s"$OPT_INDEX=true") else Seq.empty
   private def stIndexPart(index: Boolean) = if (index) Seq(s"$OPT_INDEX_VALUE=true") else Seq.empty
+  private def cardinalityPart(cardinality: Cardinality) = cardinality match {
+    case Cardinality.LOW | Cardinality.HIGH => Seq(s"$OPT_CARDINALITY=${cardinality.toString}")
+    case _ => Seq.empty
+  }
 
   // note that SimpleFeatureTypes requires that splitter and splitter opts be ordered properly
   private def splitPart = splitterOpt.map { s =>
@@ -145,6 +189,11 @@ class SftBuilder {
 }
 
 object SftBuilder {
+
+  case class Opts(index: Boolean = false,
+                  stIndex: Boolean = false,
+                  default: Boolean = false,
+                  cardinality: Cardinality = Cardinality.UNKNOWN)
 
   // Note: not for general use - only for use with SimpleFeatureTypes parsing (doesn't escape separator characters)
   def encodeMap(opts: Map[String,String], kvSep: String, entrySep: String) =

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/data/AccumuloDataStoreTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/data/AccumuloDataStoreTest.scala
@@ -751,8 +751,8 @@ class AccumuloDataStoreTest extends Specification {
       val sftName = "schematest"
 
       val query = new Query(sftName, Filter.INCLUDE)
-      val fr = ds.getFeatureReader(sftName)
-      fr.explainQuery(query)
+      val fr = ds.getFeatureReader(sftName, query)
+      fr.explainQuery()
       fr should not be null
     }
 

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/data/AccumuloFeatureReaderTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/data/AccumuloFeatureReaderTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.data
+
+import org.geotools.data.Query
+import org.geotools.filter.text.ecql.ECQL
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.core._
+import org.locationtech.geomesa.core.index.ExplainString
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class AccumuloFeatureReaderTest extends Specification with TestWithDataStore {
+
+  override def spec = s"foo:String,baz:Date,dtg:Date,*geom:Geometry"
+  override def getTestFeatures() = Seq.empty
+
+  "AccumuloFeatureReader" should {
+
+    "be able to run explainQuery" in {
+      val query = new Query()
+      val fs = "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
+      val f = ECQL.toFilter(fs)
+      query.setFilter(f)
+
+      val out = new ExplainString()
+      val reader = ds.getFeatureReader(sftName, query)
+      reader.explainQuery(out)
+
+      val explanation = out.toString()
+      explanation must not be null
+    }
+  }
+}

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/data/FeatureWritersTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/data/FeatureWritersTest.scala
@@ -398,8 +398,9 @@ class FeatureWritersTest extends Specification {
 
         val deleteFilter = CQL.toFilter("name = 'will'")
 
+        val hints = ds.strategyHints(sft)
         val q = new Query(sft.getTypeName, deleteFilter)
-        QueryStrategyDecider.chooseStrategy(true, sft, q) must beAnInstanceOf[AttributeIdxEqualsStrategy]
+        QueryStrategyDecider.chooseStrategy(true, sft, q, hints) must beAnInstanceOf[AttributeIdxEqualsStrategy]
 
         import org.locationtech.geomesa.utils.geotools.Conversions._
 

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/index/AttributeIndexStrategyTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/index/AttributeIndexStrategyTest.scala
@@ -127,44 +127,40 @@ class AttributeIndexStrategyTest extends Specification {
     }
 
     "use first indexable attribute if equals" in {
-      val strategy = new AttributeIdxEqualsStrategy
       val filter = ECQL.toFilter("age=21 AND count<5")
       val query = new Query(sft.getTypeName, filter)
-      val (strippedQuery, extractedFilter) = strategy.partitionFilter(query, sft)
+      val (strippedQuery, extractedFilter) = AttributeIndexStrategy.partitionFilter(query, sft)
       AttributeIndexStrategy.getAttributeIndexStrategy(extractedFilter, sft).get must beAnInstanceOf[AttributeIdxEqualsStrategy]
-      val (secondStripped, secondExtractedFilter) = strategy.partitionFilter(strippedQuery, sft)
+      val (secondStripped, secondExtractedFilter) = AttributeIndexStrategy.partitionFilter(strippedQuery, sft)
       AttributeIndexStrategy.getAttributeIndexStrategy(secondExtractedFilter, sft).get must beAnInstanceOf[AttributeIdxRangeStrategy]
     }
 
     "use first indexable attribute if range" in {
-      val strategy = new AttributeIdxEqualsStrategy
       val filter = ECQL.toFilter("count<5 AND age=21")
       val query = new Query(sft.getTypeName, filter)
-      val (strippedQuery, extractedFilter) = strategy.partitionFilter(query, sft)
+      val (strippedQuery, extractedFilter) = AttributeIndexStrategy.partitionFilter(query, sft)
       AttributeIndexStrategy.getAttributeIndexStrategy(extractedFilter, sft).get must beAnInstanceOf[AttributeIdxRangeStrategy]
-      val (secondStripped, secondExtractedFilter) = strategy.partitionFilter(strippedQuery, sft)
+      val (secondStripped, secondExtractedFilter) = AttributeIndexStrategy.partitionFilter(strippedQuery, sft)
       AttributeIndexStrategy.getAttributeIndexStrategy(secondExtractedFilter, sft).get must beAnInstanceOf[AttributeIdxEqualsStrategy]
     }
 
     "use first indexable attribute if like" in {
-      val strategy = new AttributeIdxEqualsStrategy
       val filter = ECQL.toFilter("name LIKE 'baddy' AND age=21")
       val query = new Query(sft.getTypeName, filter)
-      val (strippedQuery, extractedFilter) = strategy.partitionFilter(query, sft)
+      val (strippedQuery, extractedFilter) = AttributeIndexStrategy.partitionFilter(query, sft)
       AttributeIndexStrategy.getAttributeIndexStrategy(extractedFilter, sft).get must beAnInstanceOf[AttributeIdxLikeStrategy]
-      val (secondStripped, secondExtractedFilter) = strategy.partitionFilter(strippedQuery, sft)
+      val (secondStripped, secondExtractedFilter) = AttributeIndexStrategy.partitionFilter(strippedQuery, sft)
       AttributeIndexStrategy.getAttributeIndexStrategy(secondExtractedFilter, sft).get must beAnInstanceOf[AttributeIdxEqualsStrategy]
     }
 
     "use first indexable attribute if like and retain all children for > 2 filters" in {
-      val strategy = new AttributeIdxEqualsStrategy
       val filter = FilterHelper.filterListAsAnd(Seq(ECQL.toFilter("name LIKE 'baddy'"), ECQL.toFilter("age=21"), ECQL.toFilter("count<5"))).get
       val query = new Query(sft.getTypeName, filter)
-      val (strippedQuery, extractedFilter) = strategy.partitionFilter(query, sft)
+      val (strippedQuery, extractedFilter) = AttributeIndexStrategy.partitionFilter(query, sft)
       AttributeIndexStrategy.getAttributeIndexStrategy(extractedFilter, sft).get must beAnInstanceOf[AttributeIdxLikeStrategy]
-      val (secondStripped, secondExtractedFilter) = strategy.partitionFilter(strippedQuery, sft)
+      val (secondStripped, secondExtractedFilter) = AttributeIndexStrategy.partitionFilter(strippedQuery, sft)
       AttributeIndexStrategy.getAttributeIndexStrategy(secondExtractedFilter, sft).get must beAnInstanceOf[AttributeIdxEqualsStrategy]
-      val (thirdStripped, thirdExtractedFilter) = strategy.partitionFilter(secondStripped, sft)
+      val (thirdStripped, thirdExtractedFilter) = AttributeIndexStrategy.partitionFilter(secondStripped, sft)
       AttributeIndexStrategy.getAttributeIndexStrategy(thirdExtractedFilter, sft).get must beAnInstanceOf[AttributeIdxRangeStrategy]
     }
 

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/index/IndexSchemaTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/index/IndexSchemaTest.scala
@@ -157,24 +157,6 @@ class IndexSchemaTest extends Specification {
     }
   }
 
-  "IndexSchema " should {
-    "be able to run explainQuery" in {
-
-      val schema = IndexSchema("%~#s%foo#cstr%99#r::%~#s%0,4#gh::%~#s%4,3#gh%15#id",
-        dummyType, dummyEncoder)
-      val q = new Query()
-      val fs = s"INTERSECTS(${dummyType.getGeometryDescriptor.getLocalName}, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
-      val f = ECQL.toFilter(fs)
-      q.setFilter(f)
-
-      val queue = scala.collection.mutable.Queue[String]()
-      schema.explainQuery(q, s => queue.enqueue(Seq(s) : _*))
-
-      val explanation = queue.mkString(",\n")
-      explanation must not be null
-    }
-  }
-
   "IndexSchemaBuilder" should {
     "be able to create index schemas" in {
       val maxShard = 31

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/index/QueryStrategyDeciderTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/index/QueryStrategyDeciderTest.scala
@@ -249,5 +249,17 @@ class QueryStrategyDeciderTest extends Specification {
       getStrategy(s"$attr AND $geom") must beAnInstanceOf[STIdxStrategy]
       getStrategy(s"$geom AND $attr") must beAnInstanceOf[STIdxStrategy]
     }
+
+    "respect cardinality with multiple attributes" in {
+      val attr1 = "low = 'test'"
+      val attr2 = "high = 'test'"
+      val geom = "BBOX(geom, -10,-10,10,10)"
+      getStrategy(s"$geom AND $attr1 AND $attr2") must beAnInstanceOf[AttributeIdxEqualsStrategy]
+      getStrategy(s"$geom AND $attr2 AND $attr1") must beAnInstanceOf[AttributeIdxEqualsStrategy]
+      getStrategy(s"$attr1 AND $attr2 AND $geom") must beAnInstanceOf[AttributeIdxEqualsStrategy]
+      getStrategy(s"$attr2 AND $attr1 AND $geom") must beAnInstanceOf[AttributeIdxEqualsStrategy]
+      getStrategy(s"$attr1 AND $geom AND $attr2") must beAnInstanceOf[AttributeIdxEqualsStrategy]
+      getStrategy(s"$attr2 AND $geom AND $attr1") must beAnInstanceOf[AttributeIdxEqualsStrategy]
+    }
   }
 }

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/index/QueryStrategyDeciderTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/index/QueryStrategyDeciderTest.scala
@@ -19,8 +19,11 @@ package org.locationtech.geomesa.core.index
 import org.geotools.data.Query
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
+import org.locationtech.geomesa.core.data
 import org.locationtech.geomesa.core.filter.TestFilters._
 import org.locationtech.geomesa.core.util.SftBuilder
+import org.locationtech.geomesa.core.util.SftBuilder.Opts
+import org.locationtech.geomesa.utils.stats.Cardinality
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -37,6 +40,8 @@ class QueryStrategyDeciderTest extends Specification {
     .date("dtg", default = true)
     .stringType("attr1")
     .stringType("attr2", index = true)
+    .stringType("high", Opts(index = true, cardinality = Cardinality.HIGH))
+    .stringType("low", Opts(index = true, cardinality = Cardinality.LOW))
     .date("dtgNonIdx")
     .build("feature")
 
@@ -51,9 +56,10 @@ class QueryStrategyDeciderTest extends Specification {
   def getStrategy(filterString: String, isCatalogTable: Boolean = true): Strategy = {
     val sft = if (isCatalogTable) sftIndex else sftNonIndex
     val filter = ECQL.toFilter(filterString)
+    val hints = new UserDataStrategyHints()
     val query = new Query(sft.getTypeName)
     query.setFilter(filter)
-    QueryStrategyDecider.chooseStrategy(isCatalogTable, sft, query)
+    QueryStrategyDecider.chooseStrategy(isCatalogTable, sft, query, hints)
   }
 
   def getStrategyT[T <: Strategy](filterString: String, ct: ClassTag[T]) =
@@ -217,7 +223,6 @@ class QueryStrategyDeciderTest extends Specification {
     }
   }
 
-
   "Anded Attribute filters" should {
     "get the STIdx strategy with stIdxStrategyPredicates" in {
       forall(stIdxStrategyPredicates) { getStStrategy }
@@ -229,6 +234,20 @@ class QueryStrategyDeciderTest extends Specification {
 
     "get the attribute strategy with attrIdxStrategyPredicates" in {
       forall(attrIdxStrategyPredicates) { getAttributeIdxStrategy }
+    }
+
+    "respect high cardinality attributes regardless of order" in {
+      val attr = "high = 'test'"
+      val geom = "BBOX(geom, -10,-10,10,10)"
+      getStrategy(s"$attr AND $geom") must beAnInstanceOf[AttributeIdxEqualsStrategy]
+      getStrategy(s"$geom AND $attr") must beAnInstanceOf[AttributeIdxEqualsStrategy]
+    }
+
+    "respect low cardinality attributes regardless of order" in {
+      val attr = "low = 'test'"
+      val geom = "BBOX(geom, -10,-10,10,10)"
+      getStrategy(s"$attr AND $geom") must beAnInstanceOf[STIdxStrategy]
+      getStrategy(s"$geom AND $attr") must beAnInstanceOf[STIdxStrategy]
     }
   }
 }

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/util/SftBuilderTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/util/SftBuilderTest.scala
@@ -20,6 +20,7 @@ import java.util.{Date, UUID}
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.core.data.DigitSplitter
 import org.locationtech.geomesa.core.index._
+import org.locationtech.geomesa.core.util.SftBuilder.Opts
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes._
 import org.opengis.feature.simple.SimpleFeatureType
@@ -51,7 +52,7 @@ class SftBuilderTest extends Specification {
         .floatType("f",  index = true)
         .doubleType("d", index = true)
         .stringType("s", index = true)
-        .date("dt",      index = true)
+        .date("dt",      Opts(index = true))
         .uuid("u",       index = true)
         .getSpec
       val expected = "i:Integer,l:Long,f:Float,d:Double,s:String,dt:Date,u:UUID".split(",").map(_+":index=true").mkString(",")

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/ExplainCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/ExplainCommand.scala
@@ -30,7 +30,7 @@ class ExplainCommand(parent: JCommander) extends CommandWithCatalog(parent) with
     try {
       val q = new Query(params.featureName, ECQL.toFilter(params.cqlFilter))
       val afr = ds.getFeatureReader(q, Transaction.AUTO_COMMIT).asInstanceOf[AccumuloFeatureReader]
-      afr.explainQuery(q)
+      afr.explainQuery()
     } catch {
       case e: Exception =>
         logger.error(s"Error: Could not explain the query (${params.cqlFilter}): ${e.getMessage}", e)

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
@@ -16,7 +16,7 @@
 
 package org.locationtech.geomesa.utils.geotools
 
-import java.util.{Date, UUID}
+import java.util.{Locale, Date, UUID}
 
 import com.typesafe.config.{Config, ConfigFactory}
 import com.vividsolutions.jts.geom._
@@ -25,6 +25,8 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.geotools.referencing.CRS
 import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.SpecParser.{ListAttributeType, MapAttributeType, SimpleAttributeType}
+import org.locationtech.geomesa.utils.stats.Cardinality
+import org.locationtech.geomesa.utils.stats.Cardinality.Cardinality
 import org.opengis.feature.`type`.{AttributeDescriptor, GeometryDescriptor}
 import org.opengis.feature.simple.SimpleFeatureType
 
@@ -40,6 +42,7 @@ object SimpleFeatureTypes {
 
   val OPT_INDEX_VALUE        = "index-value"
   val OPT_INDEX              = "index"
+  val OPT_CARDINALITY        = "cardinality"
 
   // use the epsg jar if it's available (e.g. in geoserver), otherwise use the less-rich constant
   val CRS_EPSG_4326          = Try(CRS.decode("EPSG:4326")).getOrElse(DefaultGeographicCRS.WGS84)
@@ -108,6 +111,13 @@ object SimpleFeatureTypes {
   def getCollectionType(ad: AttributeDescriptor): Option[Class[_]] =
     Option(ad.getUserData.get("subtype")).map(_.asInstanceOf[Class[_]])
 
+  def setCardinality(ad: AttributeDescriptor, cardinality: Cardinality): Unit =
+    ad.getUserData.put(OPT_CARDINALITY, cardinality.toString)
+
+  def getCardinality(ad: AttributeDescriptor): Cardinality =
+    Option(ad.getUserData.get(OPT_CARDINALITY).asInstanceOf[String])
+        .flatMap(c => Try(Cardinality.withName(c)).toOption).getOrElse(Cardinality.UNKNOWN)
+
   def encodeType(sft: SimpleFeatureType): String =
     sft.getAttributeDescriptors.map { ad => AttributeSpecFactory.fromAttributeDescriptor(sft, ad).toSpec }.mkString(",")
 
@@ -123,7 +133,8 @@ object SimpleFeatureTypes {
           ad.getLocalName,
           ad.getType.getBinding,
           ad.getUserData.getOrElse(OPT_INDEX, false).asInstanceOf[Boolean],
-          ad.getUserData.getOrElse(OPT_INDEX_VALUE, false).asInstanceOf[Boolean]
+          ad.getUserData.getOrElse(OPT_INDEX_VALUE, false).asInstanceOf[Boolean],
+          getCardinality(ad)
         )
 
       case t if geometryTypeMap.contains(t.getBinding.getSimpleName) =>
@@ -140,14 +151,17 @@ object SimpleFeatureTypes {
         ListAttributeSpec(
           ad.getLocalName,
           ad.getUserData.get("subtype").asInstanceOf[Class[_]],
-          ad.getUserData.getOrElse(OPT_INDEX, false).asInstanceOf[Boolean]
+          ad.getUserData.getOrElse(OPT_INDEX, false).asInstanceOf[Boolean],
+          getCardinality(ad)
         )
 
       case t if t.getBinding.equals(classOf[java.util.Map[_, _]]) =>
         MapAttributeSpec(ad.getLocalName,
           ad.getUserData.get("keyclass").asInstanceOf[Class[_]],
           ad.getUserData.get("valueclass").asInstanceOf[Class[_]],
-          ad.getUserData.getOrElse(OPT_INDEX, false).asInstanceOf[Boolean])
+          ad.getUserData.getOrElse(OPT_INDEX, false).asInstanceOf[Boolean],
+          getCardinality(ad)
+        )
     }
   }
 
@@ -160,14 +174,24 @@ object SimpleFeatureTypes {
 
     def indexValue: Boolean
 
+    def cardinality: Cardinality
+
     def toAttribute: AttributeDescriptor
 
     def toSpec: String
 
     protected def getIndexSpec = {
-      val idx = if (index) s":$OPT_INDEX=$index" else ""
-      val idxValue = if (indexValue) s":$OPT_INDEX_VALUE=$indexValue" else ""
-      idx + idxValue
+      val builder = new StringBuilder()
+      if (index) {
+        builder.append(s":$OPT_INDEX=$index")
+      }
+      if (indexValue) {
+        builder.append(s":$OPT_INDEX_VALUE=$indexValue")
+      }
+      if (cardinality == Cardinality.LOW || cardinality == Cardinality.HIGH) {
+        builder.append(s":$OPT_CARDINALITY=$cardinality")
+      }
+      builder.toString()
     }
   }
 
@@ -180,51 +204,65 @@ object SimpleFeatureTypes {
     }
   }
 
+  object AttributeSpec {
+    import java.lang.Boolean.FALSE
+    val defaults = Map[String, AnyRef](
+      OPT_INDEX       -> FALSE,
+      OPT_INDEX_VALUE -> FALSE,
+      OPT_CARDINALITY -> Cardinality.UNKNOWN.toString,
+      "srid"          -> Integer.valueOf(4326),
+      "default"       -> FALSE
+    )
+    val fallback = ConfigFactory.parseMap(defaults)
+  }
+
   sealed trait NonGeomAttributeSpec extends AttributeSpec
 
   object SimpleAttributeSpec {
-    import java.lang.{Boolean => JBool}
-
-    private val fallback = ConfigFactory.parseMap(Map[String, AnyRef]("index" -> JBool.FALSE, "indexValue" -> JBool.FALSE))
-
     def apply(in: Config): SimpleAttributeSpec = {
-      val conf = in.withFallback(fallback)
+      val conf = in.withFallback(AttributeSpec.fallback)
 
-      val name       = conf.getString("name")
-      val attrType   = conf.getString("type")
-      val index      = conf.getBoolean("index")
-      val indexValue = conf.getBoolean("index")
-      SimpleAttributeSpec(name, simpleTypeMap(attrType), index, indexValue)
+      val name        = conf.getString("name")
+      val attrType    = conf.getString("type")
+      val index       = conf.getBoolean(OPT_INDEX)
+      val indexValue  = conf.getBoolean(OPT_INDEX_VALUE)
+      val cardinality = Cardinality.withName(conf.getString(OPT_CARDINALITY).toLowerCase(Locale.US))
+      SimpleAttributeSpec(name, simpleTypeMap(attrType), index, indexValue, cardinality)
     }
   }
 
-  case class SimpleAttributeSpec(name: String, clazz: Class[_], index: Boolean, indexValue: Boolean)
-      extends NonGeomAttributeSpec {
-    override def toAttribute: AttributeDescriptor = {
+  case class SimpleAttributeSpec(name: String,
+                                 clazz: Class[_],
+                                 index: Boolean,
+                                 indexValue: Boolean,
+                                 cardinality: Cardinality) extends NonGeomAttributeSpec {
+
+    override def toAttribute: AttributeDescriptor =
       new AttributeTypeBuilder()
           .binding(clazz)
           .userData(OPT_INDEX, index)
           .userData(OPT_INDEX_VALUE, indexValue)
+          .userData(OPT_CARDINALITY, cardinality.toString)
           .buildDescriptor(name)
-    }
 
     override def toSpec = s"$name:${typeEncode(clazz)}$getIndexSpec"
   }
 
   object ListAttributeSpec {
-    import java.lang.{Boolean => JBool}
-    private val fallback = ConfigFactory.parseMap(Map[String, AnyRef]("index" -> JBool.FALSE, "indexValue" -> JBool.FALSE))
     private val specParser = new SpecParser
     def apply(in: Config): ListAttributeSpec = {
-      val conf          = in.withFallback(fallback)
+      val conf          = in.withFallback(AttributeSpec.fallback)
       val name          = conf.getString("name")
       val attributeType = specParser.parse(specParser.listType, conf.getString("type")).getOrElse(ListAttributeType(SimpleAttributeType("string")))
-      val index         = conf.getBoolean("index")
-      ListAttributeSpec(name, simpleTypeMap(attributeType.p.t), index)
+      val index         = conf.getBoolean(OPT_INDEX)
+      val cardinality   = Cardinality.withName(conf.getString(OPT_CARDINALITY).toLowerCase(Locale.US))
+      ListAttributeSpec(name, simpleTypeMap(attributeType.p.t), index, cardinality)
     }
   }
 
-  case class ListAttributeSpec(name: String, subClass: Class[_], index: Boolean) extends NonGeomAttributeSpec {
+  case class ListAttributeSpec(name: String, subClass: Class[_], index: Boolean, cardinality: Cardinality)
+      extends NonGeomAttributeSpec {
+
     val clazz = classOf[java.util.List[_]]
     // currently we only allow simple types in the ST IDX for simplicity - revisit if it becomes a use-case
     val indexValue = false
@@ -234,6 +272,7 @@ object SimpleFeatureTypes {
           .binding(clazz)
           .userData(OPT_INDEX, index)
           .userData(OPT_INDEX_VALUE, indexValue)
+          .userData(OPT_CARDINALITY, cardinality.toString)
           .userData("subtype", subClass)
           .buildDescriptor(name)
     }
@@ -244,21 +283,23 @@ object SimpleFeatureTypes {
   }
 
   object MapAttributeSpec {
-    import java.lang.{Boolean => JBool}
-    private val fallback = ConfigFactory.parseMap(Map[String, AnyRef]("index" -> JBool.FALSE, "indexValue" -> JBool.FALSE))
     private val specParser = new SpecParser
     private val defaultType = MapAttributeType(SimpleAttributeType("string"), SimpleAttributeType("string"))
     def apply(in: Config): MapAttributeSpec = {
-      val conf          = in.withFallback(fallback)
+      val conf          = in.withFallback(AttributeSpec.fallback)
       val name          = conf.getString("name")
       val attributeType = specParser.parse(specParser.mapType, conf.getString("type")).getOrElse(defaultType)
-      val index         = conf.getBoolean("index")
-      MapAttributeSpec(name, simpleTypeMap(attributeType.kt.t), simpleTypeMap(attributeType.vt.t), index)
+      val index         = conf.getBoolean(OPT_INDEX)
+      val cardinality   = Cardinality.withName(conf.getString(OPT_CARDINALITY).toLowerCase(Locale.US))
+      MapAttributeSpec(name, simpleTypeMap(attributeType.kt.t), simpleTypeMap(attributeType.vt.t), index, cardinality)
     }
   }
 
-  case class MapAttributeSpec(name: String, keyClass: Class[_], valueClass: Class[_], index: Boolean)
-      extends NonGeomAttributeSpec {
+  case class MapAttributeSpec(name: String,
+                              keyClass: Class[_],
+                              valueClass: Class[_],
+                              index: Boolean,
+                              cardinality: Cardinality) extends NonGeomAttributeSpec {
     val clazz = classOf[java.util.Map[_, _]]
     // currently we only allow simple types in the ST IDX for simplicity - revisit if it becomes a use-case
     val indexValue = false
@@ -268,6 +309,7 @@ object SimpleFeatureTypes {
           .binding(clazz)
           .userData(OPT_INDEX, index)
           .userData(OPT_INDEX_VALUE, indexValue)
+          .userData(OPT_CARDINALITY, cardinality.toString)
           .userData("keyclass", keyClass)
           .userData("valueclass", valueClass)
           .buildDescriptor(name)
@@ -278,13 +320,8 @@ object SimpleFeatureTypes {
   }
 
   object GeomAttributeSpec {
-    import java.lang.{Boolean => JBool}
-
-    private val fallback = ConfigFactory.parseMap(
-      Map[String, AnyRef]("index" -> JBool.FALSE, "indexValue" -> JBool.FALSE, "srid" -> Integer.valueOf(4326), "default" -> JBool.FALSE))
-
     def apply(in: Config): GeomAttributeSpec = {
-      val conf = in.withFallback(fallback)
+      val conf = in.withFallback(AttributeSpec.fallback)
 
       val name       = conf.getString("name")
       val attrType   = conf.getString("type")
@@ -298,6 +335,7 @@ object SimpleFeatureTypes {
   case class GeomAttributeSpec(name: String, clazz: Class[_], index: Boolean, srid: Int, default: Boolean)
       extends AttributeSpec {
     val indexValue = default
+    val cardinality = Cardinality.UNKNOWN
 
     override def toAttribute: AttributeDescriptor = {
       if (!(srid == 4326 || srid == -1)) {
@@ -307,6 +345,7 @@ object SimpleFeatureTypes {
       b.binding(clazz)
           .userData(OPT_INDEX, index)
           .userData(OPT_INDEX_VALUE, indexValue)
+          .userData(OPT_CARDINALITY, cardinality)
           .crs(CRS_EPSG_4326)
           .buildDescriptor(name)
     }
@@ -400,6 +439,10 @@ object SimpleFeatureTypes {
     case class SimpleAttributeType(t: String) extends AttributeType
     case class ListAttributeType(p: SimpleAttributeType) extends AttributeType
     case class MapAttributeType(kt: SimpleAttributeType, vt: SimpleAttributeType) extends AttributeType
+    def optionToCardinality(options: Map[String, String]) =
+      options.get(OPT_CARDINALITY)
+        .flatMap(c => Try(Cardinality.withName(c.toLowerCase(Locale.US))).toOption)
+        .getOrElse(Cardinality.UNKNOWN)
   }
   private class SpecParser extends JavaTokenParsers {
     import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.SpecParser._
@@ -487,18 +530,21 @@ object SimpleFeatureTypes {
       case Name(n, default) ~ SEP ~ SimpleAttributeType(t) ~ options =>
         val indexed = options.getOrElse(OPT_INDEX, "false").toBoolean
         val stIndexed = options.getOrElse(OPT_INDEX_VALUE, "false").toBoolean
-        SimpleAttributeSpec(n, simpleTypeMap(t), indexed, stIndexed)
+        val cardinality = optionToCardinality(options)
+        SimpleAttributeSpec(n, simpleTypeMap(t), indexed, stIndexed, cardinality)
     }
 
     // builds a NonGeomAttributeSpec for complex types
     def complexAttribute      = (name ~ SEP ~ complexType ~ optionsOrEmptyMap) ^^ {
       case Name(n, default) ~ SEP ~ ListAttributeType(SimpleAttributeType(t)) ~ options =>
         val indexed = options.getOrElse(OPT_INDEX, "false").toBoolean
-        ListAttributeSpec(n, simpleTypeMap(t), indexed)
+        val cardinality = optionToCardinality(options)
+        ListAttributeSpec(n, simpleTypeMap(t), indexed, cardinality)
 
       case Name(n, default) ~ SEP ~ MapAttributeType(SimpleAttributeType(kt), SimpleAttributeType(vt)) ~ options =>
         val indexed = options.getOrElse(OPT_INDEX, "false").toBoolean
-        MapAttributeSpec(n, simpleTypeMap(kt), simpleTypeMap(vt), indexed)
+        val cardinality = optionToCardinality(options)
+        MapAttributeSpec(n, simpleTypeMap(kt), simpleTypeMap(vt), indexed, cardinality)
     }
 
     // any attribute

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/Cardinality.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/Cardinality.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.utils.stats
+
+object Cardinality  extends Enumeration {
+  type Cardinality = Value
+  val HIGH    = Value("high")
+  val LOW     = Value("low")
+  val UNKNOWN = Value("unknown")
+}


### PR DESCRIPTION
* Query planning uses a cardinality hint when determining attribute queries
* Valid values are 'high', 'low' or 'unknown'
* Current impl uses user data for cardinality hints
** In SimpleFeatureTypes, you can specify 'attr1:index=true:cardinality=high'
** In SftBuilder, you can use: stringType("attr1", Opts(index = true, cardinality = Cardinality.HIGH))
** Manually, you can use:'attributeDescriptor.getUserData.put("cardinality", "high")