### PR TITLE
GEOMESA-521 Remove objenesis from main pom

### DIFF
--- a/geomesa-feature/pom.xml
+++ b/geomesa-feature/pom.xml
@@ -35,6 +35,13 @@
             <groupId>com.esotericsoftware</groupId>
             <artifactId>kryo</artifactId>
             <version>3.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <!-- excluded due to license issues -->
+                    <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -607,11 +607,6 @@
                 <version>2.3.0</version>
             </dependency>
             <dependency>
-                <groupId>org.objenesis</groupId>
-                <artifactId>objenesis</artifactId>
-                <version>1.2</version>
-            </dependency>
-            <dependency>
                 <groupId>com.typesafe</groupId>
                 <artifactId>scalalogging-slf4j_2.10</artifactId>
                 <version>${scalalogging.version}</version>


### PR DESCRIPTION
Excluded objenesis from kryo and removed objenesis dependency from main pom. Now is only included as a transitive dependency from specs2