### PR TITLE
GEOMESA-479 - adding covering indices for attributes

### DIFF
--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/core.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/core.scala
@@ -42,6 +42,7 @@ package object core {
   val GEOMESA_ITERATORS_SFT_NAME            = "geomesa.iterators.sft-name"
   val GEOMESA_ITERATORS_SFT_INDEX_VALUE     = "geomesa.iterators.sft.index-value-schema"
   val GEOMESA_ITERATORS_ATTRIBUTE_NAME      = "geomesa.iterators.attribute.name"
+  val GEOMESA_ITERATORS_ATTRIBUTE_COVERAGE  = "geomesa.iterators.attribute.coverage"
   val GEOMESA_ITERATORS_ECQL_FILTER         = "geomesa.iterators.ecql-filter"
   val GEOMESA_ITERATORS_TRANSFORM           = "geomesa.iterators.transform"
   val GEOMESA_ITERATORS_TRANSFORM_SCHEMA    = "geomesa.iterators.transform.schema"

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/core.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/core.scala
@@ -42,7 +42,7 @@ package object core {
   val GEOMESA_ITERATORS_SFT_NAME            = "geomesa.iterators.sft-name"
   val GEOMESA_ITERATORS_SFT_INDEX_VALUE     = "geomesa.iterators.sft.index-value-schema"
   val GEOMESA_ITERATORS_ATTRIBUTE_NAME      = "geomesa.iterators.attribute.name"
-  val GEOMESA_ITERATORS_ATTRIBUTE_COVERAGE  = "geomesa.iterators.attribute.coverage"
+  val GEOMESA_ITERATORS_ATTRIBUTE_COVERED   = "geomesa.iterators.attribute.covered"
   val GEOMESA_ITERATORS_ECQL_FILTER         = "geomesa.iterators.ecql-filter"
   val GEOMESA_ITERATORS_TRANSFORM           = "geomesa.iterators.transform"
   val GEOMESA_ITERATORS_TRANSFORM_SCHEMA    = "geomesa.iterators.transform.schema"

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloFeatureWriter.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloFeatureWriter.scala
@@ -93,7 +93,8 @@ abstract class AccumuloFeatureWriter(featureType: SimpleFeatureType,
         val attrWriter = multiBWWriter.getBatchWriter(ds.getAttrIdxTableName(featureType))
         val recWriter = multiBWWriter.getBatchWriter(ds.getRecordTableForType(featureType))
         val rowIdPrefix = org.locationtech.geomesa.core.index.getTableSharingPrefix(featureType)
-        List(AttributeTable.attrWriter(attrWriter, featureType, indexedAttributes, rowIdPrefix),
+        val encoding = encoder.encoding
+        List(AttributeTable.attrWriter(attrWriter, featureType, encoding, indexedAttributes, rowIdPrefix),
              RecordTable.recordWriter(recWriter, encoder, rowIdPrefix))
       }
 

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/AttributeIdxStrategy.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/AttributeIdxStrategy.scala
@@ -552,5 +552,5 @@ object AttributeIndexStrategy {
     cfg.addOption(GEOMESA_ITERATORS_ATTRIBUTE_NAME, attributeName)
 
   def configureIndexCoverage(cfg: IteratorSetting, coverage: IndexCoverage) =
-    cfg.addOption(GEOMESA_ITERATORS_ATTRIBUTE_COVERAGE, coverage.toString)
+    cfg.addOption(GEOMESA_ITERATORS_ATTRIBUTE_COVERED, coverage.toString)
 }

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/STIdxStrategy.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/STIdxStrategy.scala
@@ -266,7 +266,7 @@ class STIdxStrategy extends Strategy with Logging with IndexFilterHelpers {
 object STIdxStrategy {
 
   import org.locationtech.geomesa.core.filter.spatialFilters
-  import org.locationtech.geomesa.utils.geotools.Conversions._
+  import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 
   def getSTIdxStrategy(filter: Filter, sft: SimpleFeatureType): Option[Strategy] =
     if(!spatialFilters(filter)) None

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/Strategy.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/Strategy.scala
@@ -73,9 +73,6 @@ trait Strategy {
     cfg.addOption(GEOMESA_ITERATORS_SFT_INDEX_VALUE, encodedSimpleFeatureType)
   }
 
-  def configureAttributeName(cfg: IteratorSetting, attributeName: String) =
-    cfg.addOption(GEOMESA_ITERATORS_ATTRIBUTE_NAME, attributeName)
-
   def configureEcqlFilter(cfg: IteratorSetting, ecql: Option[String]) =
     ecql.foreach(filter => cfg.addOption(GEOMESA_ITERATORS_ECQL_FILTER, filter))
 

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/StrategyHints.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/StrategyHints.scala
@@ -16,7 +16,6 @@
 
 package org.locationtech.geomesa.core.index
 
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.stats.Cardinality.Cardinality
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType
@@ -53,5 +52,8 @@ trait StrategyHints {
  * Implementation of hints that uses user data stored in the attribute descriptor
  */
 class UserDataStrategyHints extends StrategyHints {
-  override def cardinality(ad: AttributeDescriptor) = SimpleFeatureTypes.getCardinality(ad)
+
+  import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
+
+  override def cardinality(ad: AttributeDescriptor) = ad.getCardinality()
 }

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/AttributeIndexIterator.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/AttributeIndexIterator.scala
@@ -65,7 +65,7 @@ class AttributeIndexIterator
     attributeType = Option(options.get(GEOMESA_ITERATORS_ATTRIBUTE_NAME))
         .flatMap(n => Option(featureType.getDescriptor(n)))
     dtgIndex = index.getDtgFieldName(featureType).map(featureType.indexOf(_))
-    val coverage = Option(options.get(GEOMESA_ITERATORS_ATTRIBUTE_COVERAGE)).map(IndexCoverage.withName)
+    val coverage = Option(options.get(GEOMESA_ITERATORS_ATTRIBUTE_COVERED)).map(IndexCoverage.withName)
         .getOrElse(IndexCoverage.JOIN)
     setTopFunction = coverage match {
       case IndexCoverage.FULL => setTopFullCoverage

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/IteratorTrigger.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/IteratorTrigger.scala
@@ -97,7 +97,7 @@ object IteratorTrigger extends Logging {
                            query: Query,
                            sft: SimpleFeatureType,
                            indexedAttribute: Option[String] = None): Boolean = {
-    if (useDensityIterator(query: Query)) {
+    if (useDensityIterator(query)) {
       // the Density Iterator is run in place of the SFFI. If it is requested we keep the SFFI
       // config in the stack, and do NOT run the IndexIterator.
       return false

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/IteratorTrigger.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/iterators/IteratorTrigger.scala
@@ -26,7 +26,8 @@ import org.locationtech.geomesa.core._
 import org.locationtech.geomesa.core.data._
 import org.locationtech.geomesa.core.index.QueryHints._
 import org.locationtech.geomesa.core.index._
-import org.locationtech.geomesa.utils.geotools.Conversions.RichAttributeDescriptor
+import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
+import org.locationtech.geomesa.utils.stats.IndexCoverage
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 import org.opengis.filter.expression.{Function, PropertyName}
@@ -94,25 +95,32 @@ object IteratorTrigger extends Logging {
    */
   def useIndexOnlyIterator(ecqlPredicate: Option[Filter],
                            query: Query,
-                           sourceSFT: SimpleFeatureType,
+                           sft: SimpleFeatureType,
                            indexedAttribute: Option[String] = None): Boolean = {
+    if (useDensityIterator(query: Query)) {
+      // the Density Iterator is run in place of the SFFI. If it is requested we keep the SFFI
+      // config in the stack, and do NOT run the IndexIterator.
+      return false
+    }
+
+    if (indexedAttribute.exists(a => sft.getDescriptor(a).getIndexCoverage() == IndexCoverage.FULL)) {
+      // the attribute index is a covering index, so we can use the index iterator regardless
+      return true
+    }
+
     // get transforms if they exist
     val transformDefs = Option(query.getHints.get(TRANSFORMS)).map(_.asInstanceOf[String])
 
     // if the transforms exist, check if the transform is simple enough to be handled by the IndexIterator
     // if it does not exist, then set this variable to false
     val isIndexTransform = transformDefs
-        .map(tDef => isOneToOneIndexTransformation(tDef, sourceSFT, indexedAttribute))
+        .map(tDef => isOneToOneIndexTransformation(tDef, sft, indexedAttribute))
         .orElse(Some(false))
     // if the ecql predicate exists, check that it is a trivial filter that does nothing
     val isPassThroughFilter = ecqlPredicate.map { ecql => passThroughFilter(ecql)}
 
-    // the Density Iterator is run in place of the SFFI. If it is requested we keep the SFFI config in the stack,
-    // and do NOT run the IndexIterator. Wrap in an Option to keep clean logic below
-    val notDensity = Some(!useDensityIterator(query: Query))
-
     // require both to be true
-    (isIndexTransform ++ isPassThroughFilter ++ notDensity).forall {_ == true}
+    (isIndexTransform ++ isPassThroughFilter).forall(_ == true)
   }
 
   /**
@@ -200,7 +208,11 @@ object IteratorTrigger extends Logging {
     // if the transforms cover the filtered attributes, we can decode into the transformed feature
     // otherwise, we need to decode into the original feature, apply the filter, and then transform
     if (useIndexOnlyIterator(ecqlPredicate, query, sourceSFT, Some(indexedAttribute))) {
-      IteratorConfig(IndexOnlyIterator, false, doTransformsCoverFilters(query))
+      val needsTransform = sourceSFT.getDescriptor(indexedAttribute).getIndexCoverage() match {
+        case IndexCoverage.FULL => true // in this case, we want to decode the original simple feature
+        case _                  => doTransformsCoverFilters(query)
+      }
+      IteratorConfig(IndexOnlyIterator, false, needsTransform)
     } else {
       val hasEcqlOrTransform = useSimpleFeatureFilteringIterator(ecqlPredicate, query)
       val transformsCoverFilter = if (hasEcqlOrTransform) doTransformsCoverFilters(query) else true

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/process/unique/UniqueProcess.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/process/unique/UniqueProcess.scala
@@ -29,7 +29,7 @@ import org.geotools.process.vector.VectorProcess
 import org.locationtech.geomesa.core.data.GEOMESA_UNIQUE
 import org.locationtech.geomesa.core.data.tables.AttributeTable
 import org.locationtech.geomesa.core.util.SelfClosingIterator
-import org.locationtech.geomesa.utils.geotools.Conversions.RichAttributeDescriptor
+import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 import org.opengis.feature.Feature
 import org.opengis.feature.simple.SimpleFeature
 import org.opengis.filter.Filter

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/TestWithDataStore.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/TestWithDataStore.scala
@@ -18,7 +18,7 @@ package org.locationtech.geomesa.core
 
 import org.apache.accumulo.core.client.mock.MockInstance
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
-import org.geotools.data.DataStoreFinder
+import org.geotools.data.{Query, DataStoreFinder}
 import org.geotools.feature.DefaultFeatureCollection
 import org.locationtech.geomesa.core.data.{AccumuloDataStore, AccumuloFeatureStore}
 import org.locationtech.geomesa.core.index._
@@ -74,5 +74,11 @@ trait TestWithDataStore {
     getTestFeatures().foreach(featureCollection.add)
     // write the feature to the store
     fs.addFeatures(featureCollection)
+  }
+
+  def explain(query: Query): String = {
+    val o = new ExplainString
+    ds.getFeatureReader(sftName, query).explainQuery(o)
+    o.toString()
   }
 }

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/data/AccumuloDataStoreTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/data/AccumuloDataStoreTest.scala
@@ -310,7 +310,7 @@ class AccumuloDataStoreTest extends Specification {
 
       "with the correct schema" >> {
         SimpleFeatureTypes.encodeType(results.getSchema) mustEqual
-            s"name:String,*geom:Point:srid=4326:index=true:$OPT_INDEX_VALUE=true,derived:String"
+            s"name:String,*geom:Point:srid=4326:$OPT_INDEX=full:$OPT_INDEX_VALUE=true,derived:String"
       }
       "with the correct results" >> {
         val features = results.features
@@ -370,7 +370,7 @@ class AccumuloDataStoreTest extends Specification {
 
       "with the correct schema" >> {
         SimpleFeatureTypes.encodeType(results.getSchema) mustEqual
-            s"name:String,*geom:Point:srid=4326:index=true:$OPT_INDEX_VALUE=true,derived:String"
+            s"name:String,*geom:Point:srid=4326:$OPT_INDEX=full:$OPT_INDEX_VALUE=true,derived:String"
       }
 
       "with the correct results" >> {
@@ -394,7 +394,7 @@ class AccumuloDataStoreTest extends Specification {
 
       "with the correct schema" >> {
         SimpleFeatureTypes.encodeType(results.getSchema) mustEqual
-            s"name:String,*geom:Point:srid=4326:index=true:$OPT_INDEX_VALUE=true"
+            s"name:String,*geom:Point:srid=4326:$OPT_INDEX=full:$OPT_INDEX_VALUE=true"
       }
       "with the correct results" >> {
         val features = results.features
@@ -939,8 +939,8 @@ class AccumuloDataStoreTest extends Specification {
 
     "update metadata for indexed attributes" in {
       val sftName = "updateMetadataTest"
-      val originalSchema = s"name:String,dtg:Date,*geom:Point:srid=4326:index=true:$OPT_INDEX_VALUE=true"
-      val updatedSchema = s"name:String:index=true,dtg:Date,*geom:Point:srid=4326:index=true:$OPT_INDEX_VALUE=true"
+      val originalSchema = s"name:String,dtg:Date,*geom:Point:srid=4326:$OPT_INDEX=full:$OPT_INDEX_VALUE=true"
+      val updatedSchema = s"name:String:$OPT_INDEX=join,dtg:Date,*geom:Point:srid=4326:$OPT_INDEX=full:$OPT_INDEX_VALUE=true"
 
       val sft = createSchema(sftName, originalSchema)
       ds.updateIndexedAttributes(sftName, updatedSchema)
@@ -950,7 +950,7 @@ class AccumuloDataStoreTest extends Specification {
 
     "prevent changing schema types" in {
       val sftName = "preventSchemaChangeTest"
-      val originalSchema = s"name:String,dtg:Date,*geom:Point:srid=4326:index=true:$OPT_INDEX_VALUE=true"
+      val originalSchema = s"name:String,dtg:Date,*geom:Point:srid=4326:$OPT_INDEX=full:$OPT_INDEX_VALUE=true"
       val sft = createSchema(sftName, originalSchema)
 
       "prevent changing default geometry" in {
@@ -1241,7 +1241,7 @@ class AccumuloDataStoreTest extends Specification {
 
       val result = AccumuloFeatureStore.computeSchema(origSFT, definitions.toSeq)
       SimpleFeatureTypes.encodeType(result) mustEqual
-        "name:String,helloName:String,*geom:Point:srid=4326:index-value=true"
+        s"name:String,helloName:String,*geom:Point:srid=4326:$OPT_INDEX=full:index-value=true"
     }
 
     "support sorting and handle time bounds" in {

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/index/AttributeTableTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/index/AttributeTableTest.scala
@@ -19,9 +19,11 @@ package org.locationtech.geomesa.core.index
 import org.apache.accumulo.core.security.ColumnVisibility
 import org.geotools.factory.Hints
 import org.junit.runner.RunWith
+import org.locationtech.geomesa.core.data.DEFAULT_ENCODING
 import org.locationtech.geomesa.core.data.tables.{AttributeIndexRow, AttributeTable}
 import org.locationtech.geomesa.feature.AvroSimpleFeatureFactory
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes._
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -32,9 +34,9 @@ import scala.util.Success
 @RunWith(classOf[JUnitRunner])
 class AttributeTableTest extends Specification {
 
-  val geotimeAttributes = org.locationtech.geomesa.core.index.spec
   val sftName = "mutableType"
-  val sft = SimpleFeatureTypes.createType(sftName, s"name:String,age:Integer,$geotimeAttributes")
+  val spec = s"name:String:$OPT_INDEX=true,age:Integer:$OPT_INDEX=true,*geom:Geometry:srid=4326,dtg:Date:$OPT_INDEX=true"
+  val sft = SimpleFeatureTypes.createType(sftName, spec)
   sft.getUserData.put(SF_PROPERTY_START_TIME, "dtg")
 
     "AttributeTable" should {
@@ -49,7 +51,7 @@ class AttributeTableTest extends Specification {
         feature.setAttribute("age",50.asInstanceOf[Any])
         feature.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
 
-        val mutations = AttributeTable.getAttributeIndexMutations(feature, descriptors, new ColumnVisibility(), "")
+        val mutations = AttributeTable.getAttributeIndexMutations(feature, DEFAULT_ENCODING, descriptors, new ColumnVisibility(), "")
         mutations.size mustEqual descriptors.length
         mutations.map(_.getUpdates.size()) must contain(beEqualTo(1)).foreach
         mutations.map(_.getUpdates.get(0).isDeleted) must contain(beEqualTo(false)).foreach
@@ -65,7 +67,7 @@ class AttributeTableTest extends Specification {
         feature.setAttribute("age",50.asInstanceOf[Any])
         feature.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
 
-        val mutations = AttributeTable.getAttributeIndexMutations(feature, descriptors, new ColumnVisibility(), "", delete = true)
+        val mutations = AttributeTable.getAttributeIndexMutations(feature, DEFAULT_ENCODING, descriptors, new ColumnVisibility(), "", delete = true)
         mutations.size mustEqual descriptors.length
         mutations.map(_.getUpdates.size()) must contain(beEqualTo(1)).foreach
         mutations.map(_.getUpdates.get(0).isDeleted) must contain(beEqualTo(true)).foreach

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/index/CoveringAttributeIndexTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/index/CoveringAttributeIndexTest.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2015 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.core.index
+
+import org.apache.accumulo.core.data.{Range => AccRange}
+import org.geotools.data._
+import org.geotools.filter.text.ecql.ECQL
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.core.TestWithDataStore
+import org.locationtech.geomesa.core.util.SelfClosingIterator
+import org.locationtech.geomesa.feature.ScalaSimpleFeatureFactory
+import org.locationtech.geomesa.utils.text.WKTUtils
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class CoveringAttributeIndexTest extends Specification with TestWithDataStore {
+
+  sequential
+
+  override val spec = "name:String:index=full,age:Integer:index=join,weight:Double:index=true," +
+      "height:Double,dtg:Date,*geom:Geometry:srid=4326"
+
+  val geom = WKTUtils.read("POINT(45.0 49.0)")
+
+  override def getTestFeatures() = {
+    (0 until 10).map { i =>
+      val dtg = s"2014-01-1${i}T12:00:00.000Z"
+      val attrs = Array(s"${i}name$i", s"$i", s"${i * 2.0}", s"${i * 3.0}", dtg, geom)
+      ScalaSimpleFeatureFactory.buildFeature(sft, attrs, i.toString)
+    }
+  }
+
+  populateFeatures
+
+  "AttributeIndexStrategy" should {
+
+    "support full coverage of attributes" in {
+      val query = new Query(sftName, ECQL.toFilter("name = '3name3'"))
+      explain(query).indexOf("Using record join iterator") mustEqual(-1)
+
+      val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
+
+      features must haveSize(1)
+      features(0).getAttribute("name") mustEqual("3name3")
+      features(0).getAttribute("age") mustEqual(3)
+      features(0).getAttribute("weight") mustEqual(6.0)
+      features(0).getAttribute("height") mustEqual(9.0)
+      features(0).getAttribute("dtg").toString must contain("Jan 13")
+    }
+
+    "support transforms in fully covered indices" in {
+      val query = new Query(sftName, ECQL.toFilter("name = '3name3'"), Array("name", "age", "dtg", "geom"))
+      explain(query).indexOf("Using record join iterator") mustEqual(-1)
+
+      val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
+
+      features must haveSize(1)
+      features(0).getAttribute("name") mustEqual("3name3")
+      features(0).getAttribute("age") mustEqual(3)
+      features(0).getAttribute("weight") must beNull
+      features(0).getAttribute("height") must beNull
+      features(0).getAttribute("dtg").toString must contain("Jan 13")
+    }
+
+    "support ecql filters in fully covered indices" in {
+      val query = new Query(sftName, ECQL.toFilter("name >= '3name3' AND height = '9.0'"))
+      explain(query).indexOf("Using record join iterator") mustEqual(-1)
+
+      val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
+
+      features must haveSize(1)
+      features(0).getAttribute("name") mustEqual("3name3")
+      features(0).getAttribute("age") mustEqual(3)
+      features(0).getAttribute("weight") mustEqual(6.0)
+      features(0).getAttribute("height") mustEqual(9.0)
+      features(0).getAttribute("dtg").toString must contain("Jan 13")
+    }
+
+    "support ecql filters and covering transforms in fully covered indices" in {
+      val query = new Query(sftName, ECQL.toFilter("name >= '3name3' AND height = '9.0'"),
+        Array("name", "height", "dtg", "geom"))
+      explain(query).indexOf("Using record join iterator") mustEqual(-1)
+
+      val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
+
+      features must haveSize(1)
+      features(0).getAttribute("name") mustEqual("3name3")
+      features(0).getAttribute("age") must beNull
+      features(0).getAttribute("weight") must beNull
+      features(0).getAttribute("height") mustEqual(9.0)
+      features(0).getAttribute("dtg").toString must contain("Jan 13")
+    }
+
+    "support ecql filters and non-covering transforms in fully covered indices" in {
+      val query = new Query(sftName, ECQL.toFilter("name >= '3name3' AND height = '9.0'"),
+        Array("name", "age", "dtg", "geom"))
+      explain(query).indexOf("Using record join iterator") mustEqual(-1)
+
+      val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
+
+      features must haveSize(1)
+      features(0).getAttribute("name") mustEqual("3name3")
+      features(0).getAttribute("age") mustEqual(3)
+      features(0).getAttribute("weight") must beNull
+      features(0).getAttribute("height") must beNull
+      features(0).getAttribute("dtg").toString must contain("Jan 13")
+    }
+
+    "support join coverage of attributes" in {
+      val query = new Query(sftName, ECQL.toFilter("age = '5'"))
+      explain(query).indexOf("Using record join iterator") must beGreaterThan(-1)
+
+      val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
+
+      features must haveSize(1)
+      features(0).getAttribute("name") mustEqual("5name5")
+      features(0).getAttribute("age") mustEqual(5)
+      features(0).getAttribute("weight") mustEqual(10.0)
+      features(0).getAttribute("height") mustEqual(15.0)
+      features(0).getAttribute("dtg").toString must contain("Jan 15")
+    }
+
+    "be backwards compatible with index spec" in {
+      val query = new Query(sftName, ECQL.toFilter("weight = '4.0'"))
+      explain(query).indexOf("Using record join iterator") must beGreaterThan(-1)
+
+      val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
+
+      features must haveSize(1)
+      features(0).getAttribute("name") mustEqual("2name2")
+      features(0).getAttribute("age") mustEqual(2)
+      features(0).getAttribute("weight") mustEqual(4.0)
+      features(0).getAttribute("height") mustEqual(6.0)
+      features(0).getAttribute("dtg").toString must contain("Jan 12")
+    }
+  }
+}

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/iterators/AttributeIndexIteratorTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/iterators/AttributeIndexIteratorTest.scala
@@ -29,6 +29,7 @@ import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.core._
+import org.locationtech.geomesa.core.data.DEFAULT_ENCODING
 import org.locationtech.geomesa.core.data.tables.AttributeTable
 import org.locationtech.geomesa.core.index._
 import org.locationtech.geomesa.core.util.SelfClosingIterator
@@ -78,6 +79,7 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
       val attributes = (0 until sft.getAttributeCount).zip(sft.getAttributeDescriptors)
       getTestFeatures().foreach { feature =>
         val muts = AttributeTable.getAttributeIndexMutations(feature,
+                                                             DEFAULT_ENCODING,
                                                              attributes,
                                                              new ColumnVisibility(), "")
         bw.addMutations(muts)

--- a/geomesa-feature/src/main/scala/org/locationtech/geomesa/feature/AvroSimpleFeatureUtils.scala
+++ b/geomesa-feature/src/main/scala/org/locationtech/geomesa/feature/AvroSimpleFeatureUtils.scala
@@ -25,7 +25,7 @@ import com.vividsolutions.jts.io.WKBWriter
 import org.apache.avro.{Schema, SchemaBuilder}
 import org.apache.commons.codec.binary.Hex
 import org.geotools.util.Converters
-import org.locationtech.geomesa.utils.geotools.Conversions.RichAttributeDescriptor
+import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes._
 import org.opengis.feature.simple.SimpleFeatureType
 

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/index/AttributeIndexJob.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/index/AttributeIndexJob.scala
@@ -129,6 +129,7 @@ object AttributeIndexJob {
 
     AttributeTable.getAttributeIndexMutations(
       feature,
+      r.decoder.encoding,
       r.attributeDescriptors,
       new ColumnVisibility(r.visibilities),
       prefix

--- a/geomesa-jobs/src/test/scala/org/locationtech/geomesa/jobs/index/AttributeIndexJobTest.scala
+++ b/geomesa-jobs/src/test/scala/org/locationtech/geomesa/jobs/index/AttributeIndexJobTest.scala
@@ -16,26 +16,20 @@
 
 package org.locationtech.geomesa.jobs.index
 
-import java.util
-
 import org.apache.accumulo.core.client.mock.MockInstance
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
-import org.apache.accumulo.core.data.{Key, Mutation, Value}
 import org.apache.accumulo.core.security.ColumnVisibility
 import org.geotools.data.DataStoreFinder
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.core.data.AccumuloDataStore
+import org.locationtech.geomesa.core.data.{AccumuloDataStore, DEFAULT_ENCODING}
 import org.locationtech.geomesa.core.data.tables.AttributeTable
 import org.locationtech.geomesa.core.iterators.TestData
 import org.locationtech.geomesa.core.iterators.TestData._
-import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
 import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 @RunWith(classOf[JUnitRunner])
 class AttributeIndexJobTest extends Specification {
@@ -49,8 +43,7 @@ class AttributeIndexJobTest extends Specification {
     "password"          -> "mypassword",
     "auths"             -> "A,B,C",
     "tableName"         -> tableName,
-    "useMock"           -> "true",
-    "featureEncoding"   -> "avro")
+    "useMock"           -> "true")
 
   val ds = DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
 
@@ -81,7 +74,7 @@ class AttributeIndexJobTest extends Specification {
     val attrList = Seq((sft.indexOf(descriptor.getName), descriptor))
     val prefix = org.locationtech.geomesa.core.index.getTableSharingPrefix(sft)
     val tableMutations1 = feats.flatMap { sf =>
-      AttributeTable.getAttributeIndexMutations(sf, attrList, new ColumnVisibility(ds.writeVisibilities), prefix)
+      AttributeTable.getAttributeIndexMutations(sf, DEFAULT_ENCODING, attrList, new ColumnVisibility(ds.writeVisibilities), prefix)
     }
     forall(tableMutations1) { mut => jobMutations1.exists(mut.equals) }
   }

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/ui/GeoMesaFeaturePage.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/ui/GeoMesaFeaturePage.scala
@@ -36,6 +36,7 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.locationtech.geomesa.core.data.AccumuloDataStore
 import org.locationtech.geomesa.jobs.index.AttributeIndexJob
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.stats.IndexCoverage
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -149,7 +150,7 @@ class GeoMesaFeaturePage(parameters: PageParameters) extends GeoMesaBasePage wit
                       .map { case (a, _) => a }
         if (!changed.isEmpty) {
           val (ds, sft) = loadStore().get
-          val added = changed.filter(a => a.index).map(a => a.name)
+          val added = changed.filter(_.index != IndexCoverage.NONE).map(_.name)
           val run =
             if (added.isEmpty) {
               Success(true)

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/ScaldingDelimitedIngestJob.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/ScaldingDelimitedIngestJob.scala
@@ -294,13 +294,15 @@ class ScaldingDelimitedIngestJob(args: Args) extends Job(args) with Logging {
 
 object ScaldingDelimitedIngestJob {
   import scala.collection.JavaConverters._
+  import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 
   def isList(ad: AttributeDescriptor) = classOf[java.util.List[_]].isAssignableFrom(ad.getType.getBinding)
 
   def toList(s: String, delim: Char,  ad: AttributeDescriptor): JList[_] = {
-    val clazz = SimpleFeatureTypes.getCollectionType(ad).get
-    if (s.isEmpty) List().asJava
-    else {
+    if (s.isEmpty) {
+      List().asJava
+    } else {
+      val clazz = ad.getCollectionType().get
       s.split(delim).map(_.trim).map { value =>
         Converters.convert(value, clazz).asInstanceOf[AnyRef]
       }.toList.asJava
@@ -313,9 +315,10 @@ object ScaldingDelimitedIngestJob {
             delimBetweenKeysAndValues: Char,
             delimBetweenKeyValuePairs: Char,
             ad: AttributeDescriptor): JMap[_,_] = {
-    val (keyClass, valueClass) = SimpleFeatureTypes.getMapTypes(ad).get
-    if (s.isEmpty) Map().asJava
-    else {
+    if (s.isEmpty) {
+      Map().asJava
+    } else {
+      val (keyClass, valueClass) = ad.getMapTypes().get
       s.split(delimBetweenKeyValuePairs)
         .map(_.split(delimBetweenKeysAndValues).map(_.trim))
         .map { case Array(key, value) =>

--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/ScaldingDelimitedIngestJobTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/ScaldingDelimitedIngestJobTest.scala
@@ -41,7 +41,7 @@ import scala.util.Try
 
 @RunWith(classOf[JUnitRunner])
 class ScaldingDelimitedIngestJobTest extends Specification{
-  isolated
+  sequential
 
   var id = 0
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GenerateFeatureWrappers.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GenerateFeatureWrappers.scala
@@ -31,12 +31,12 @@ case class AttributeDetails(unsafeName: String, index: Int, clazz: String) {
 }
 
 object AttributeDetails {
-  import org.locationtech.geomesa.utils.geotools.Conversions.RichAttributeDescriptor
+  import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors._
 
   def apply(ad: AttributeDescriptor, sft: SimpleFeatureType): AttributeDetails = {
     val majorBinding = classToString(Some(ad.getType.getBinding))
     val binding = if (ad.isCollection) {
-      val subtype = classToString(SimpleFeatureTypes.getCollectionType(ad))
+      val subtype = classToString(ad.getCollectionType())
       s"$majorBinding[$subtype]"
     } else if (ad.isMap) {
       val keyType = classToString(Option(ad.getUserData.get("keyclass").asInstanceOf[Class[_]]))

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
@@ -146,11 +146,11 @@ object SimpleFeatureTypes {
         )
 
       case t if t.getBinding.equals(classOf[java.util.Map[_, _]]) =>
-        val mapTypes = ad.getMapTypes().get
+        val Some((keyType, valueType)) = ad.getMapTypes()
         MapAttributeSpec(
           ad.getLocalName,
-          mapTypes._1,
-          mapTypes._2,
+          keyType,
+          valueType,
           ad.getIndexCoverage(),
           ad.getCardinality()
         )

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/IndexCoverage.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/IndexCoverage.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.locationtech.geomesa.utils.stats
+
+object IndexCoverage extends Enumeration {
+  type IndexCoverage = Value
+  val FULL = Value("full")
+  val JOIN = Value("join")
+  val NONE = Value("none")
+}


### PR DESCRIPTION
A 'covering' index means that we store the entire simple feature in the index, and thus we won't do a join against the record table.
You can now indicate covered indices in the SFT spec by using the notation:
'attr:String:index=full'
options are:
full -> fully covering index
join -> partial index, most queries will require a join on the record table
none -> not attribute indexed
true/false -> legacy fallbacks equivalent to join/none