### PR TITLE
GEOMESA-709 Speeding up delimited exports

### DIFF
--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/FeatureExporter.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/FeatureExporter.scala
@@ -107,118 +107,61 @@ object ShapefileExport {
   }
 }
 
-class DelimitedExport(writer: Writer,
-                      format: String,
-                      attributes: Option[String],
-                      idAttribute: Option[String],
-                      latAttribute: Option[String],
-                      lonAttribute: Option[String],
-                      dtgAttribute: Option[String]) extends FeatureExporter with Logging {
+class DelimitedExport(writer: Writer, format: String, attributes: Option[String])
+    extends FeatureExporter with Logging {
 
   val delimiter = format match {
    case Formats.CSV => ","
    case Formats.TSV => "\t"
   }
 
-  lazy val geometryFactory = JTSFactoryFinder.getGeometryFactory
   lazy val dateFormat = {
     val df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
     df.setTimeZone(TimeZone.getTimeZone("UTC"))
     df
   }
 
-  override def write(features: SimpleFeatureCollection) = {
+  val escape: String => String = format match {
+    case Formats.CSV => StringEscapeUtils.escapeCsv
+    case _           => (s: String) => s
+  }
 
-    val attrArr   = attributes.map(_.split("""(?<!\\),""")).getOrElse(Array.empty[String])
-    val idAttrArr = List(idAttribute).flatten
+  override def write(features: SimpleFeatureCollection): Unit = {
 
-    val attributeTypes = idAttrArr ++ attrArr
-    val idField = attributeTypes.map(_.split(":")(0).split("=").head.trim).headOption
+    val sft = features.getSchema
 
-    val attrNames =
-      if (attributeTypes.nonEmpty) {
-        attributeTypes.map(_.split(":")(0).split("=").head.trim)
-      } else {
-        features.getSchema.getAttributeDescriptors.map(_.getLocalName)
-      }
+    // split apart the optional attributes and then split any derived values to just get the names
+    val names = attributes.map(_.split("""(?<!\\),""").toSeq.map(_.split(":")(0).split("=").head.trim))
+        .getOrElse(sft.getAttributeDescriptors.map(_.getLocalName))
+
+    val indices = names.map(sft.indexOf)
+
+    def findMessage(i: Int) = {
+      val index = indices.indexOf(i)
+      s"Attribute ${names(index)} does not exist in the feature type."
+    }
+
+    indices.foreach(i => assert(i != -1, findMessage(i)))
 
     // write out a header line
-    writer.write(attrNames.mkString(delimiter))
-    writer.write("\n")
+    writer.write(names.mkString("", delimiter, "\n"))
 
     var count = 0
     features.features.foreach { sf =>
-      writeFeature(sf, writer, attrNames, idField)
+      val values = indices.map(i => escape(stringify(sf.getAttribute(i))))
+      writer.write(values.mkString("", delimiter, "\n"))
       count += 1
-      if (count % 10000 == 0) logger.debug("wrote {} features", "" + count)
+      if (count % 10000 == 0) {
+        logger.debug(s"wrote $count features")
+      }
     }
     logger.info(s"Exported $count features")
   }
 
-  val getGeom: SimpleFeature => Option[Geometry] =
-    (sf: SimpleFeature) =>
-      (latAttribute, lonAttribute) match {
-        case (Some(a), Some(b)) =>
-          val lat = sf.getAttribute(latAttribute.get).toString.toDouble
-          val lon = sf.getAttribute(lonAttribute.get).toString.toDouble
-          Some(geometryFactory.createPoint(new Coordinate(lon, lat)))
-        case (Some(lat), _) =>
-          logger.warn("Lattitude attribute provided by no longitude attribute provided...ignoring attribute overrides")
-          None
-        case ( _, Some(lon)) =>
-          logger.warn("Longitude attribute provided by no lattitude attribute provided...ignoring attribute overrides")
-          None
-        case (_, _) => None
-      }
-
-  val getDate: SimpleFeature => Option[Date] =
-    (sf: SimpleFeature) =>
-      dtgAttribute.map { attr =>
-        val date = sf.getAttribute(attr)
-        if (date.isInstanceOf[Date]) {
-          date.asInstanceOf[Date]
-        } else {
-          dateFormat.parse(date.toString)
-        }
-      }
-
-  def writeFeature(sf: SimpleFeature, writer: Writer, attrNames: Seq[String], idField: Option[String]) = {
-    val attrMap = mutable.Map.empty[String, Object]
-
-    // copy attributes into map where we can manipulate them
-    attrNames.foreach(a => Try(attrMap.put(a, sf.getAttribute(a))))
-
-    // check that ID is set in the map
-    if (idField.nonEmpty && attrMap.getOrElse(idField.get, "").toString.isEmpty) attrMap.put(idField.get, sf.getID)
-
-    // update geom and date as needed
-    getGeom(sf).foreach { geom => attrMap("*geom") = geom }
-    getDate(sf).foreach { date => attrMap("dtg") = date }
-
-    // toString, escape, and join with delimiter
-    val escapedStrings = attrNames.map { n => escape(stringify(attrMap.getOrElse(n, null))) }
-    var first = true
-    for (s <- escapedStrings) {
-      if (first) {
-        writer.write(s)
-        first = false
-      } else {
-        writer.write(delimiter)
-        writer.write(s)
-      }
-    }
-    writer.write("\n")
-  }
-
   def stringify(o: Object): String = o match {
-    case null                      => ""
-    case d if d.isInstanceOf[Date] => dateFormat.format(o.asInstanceOf[java.util.Date])
-    case _                         => o.toString
-  }
-
-  val escape: String => String = format match {
-    case Formats.CSV => StringEscapeUtils.escapeCsv
-    case _           => (s: String) => s
+    case null    => ""
+    case d: Date => dateFormat.format(d)
+    case _       => o.toString
   }
 
   override def flush() = writer.flush()
@@ -232,13 +175,7 @@ class DelimitedExport(writer: Writer,
 
 object DelimitedExport {
   def apply(writer: Writer, params: ExportParameters) =
-    new DelimitedExport(writer,
-      params.format.toLowerCase,
-      Option(params.attributes),
-      Option(params.idAttribute),
-      Option(params.latAttribute),
-      Option(params.lonAttribute),
-      Option(params.dateAttribute))
+    new DelimitedExport(writer, params.format.toLowerCase, Option(params.attributes))
 }
 
 object BinFileExport {


### PR DESCRIPTION
In the cloud I was testing, delimited export was much slower than bin export. This was due to the map creation, update, etc for each feature. After this ticket, delimited export was just as fast as bin export, which means the client code was no longer the bottleneck in this particular cloud.
idAttribute, latAttribute, lonAttribute, dtgAttribute are all bin export specific, and don't need to be considered here. As a future ticket, we might want to break apart bin export from other exports so that those arguments aren't confusing.