### PR TITLE
GEOMESA-722 Ordering of Point Pairs

### DIFF
--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
@@ -20,6 +20,7 @@ import java.util.{Date, Locale, UUID}
 
 import com.typesafe.config.{Config, ConfigFactory}
 import com.vividsolutions.jts.geom._
+import org.geotools.factory.Hints
 import org.geotools.feature.AttributeTypeBuilder
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.geotools.referencing.CRS
@@ -50,6 +51,8 @@ object SimpleFeatureTypes {
   val USER_DATA_LIST_TYPE      = "subtype"
   val USER_DATA_MAP_KEY_TYPE   = "keyclass"
   val USER_DATA_MAP_VALUE_TYPE = "valueclass"
+
+  Hints.putSystemDefault(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, true);
 
   def createType(conf: Config): SimpleFeatureType = {
     val nameSpec = conf.getString("type-name")


### PR DESCRIPTION
Add a Hint to force Longitude to be first,
 as expected by downstream processes.

Signed-off-by: Michael Matthews <mmatthews@ccri.com>