### PR TITLE
GEOMESA-725 Add configurable cache and TTL to KafkaDataStore

### DIFF
--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaConsumerFeatureSource.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaConsumerFeatureSource.scala
@@ -74,7 +74,7 @@ class KafkaConsumerFeatureSource(entry: ContentEntry,
       .removalListener(
         new RemovalListener[String, FeatureHolder] {
           def onRemoval(removal: RemovalNotification[String, FeatureHolder]) = {
-            removeFeature(new Delete(removal.getKey))
+            qt.remove(removal.getValue.env, removal.getValue.sf)
           }
         }
       )

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaDataStore.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaDataStore.scala
@@ -42,7 +42,9 @@ class KafkaDataStore(broker: String,
                      zkPath: String,
                      partitions: Int,
                      replication: Int,
-                     isProducer: Boolean) extends ContentDataStore with Logging {
+                     isProducer: Boolean,
+                     expiry: Boolean,
+                     expirationPeriod: Long) extends ContentDataStore with Logging {
 
   import scala.collection.JavaConversions._
 
@@ -123,7 +125,7 @@ class KafkaDataStore(broker: String,
       val decoder = new AvroFeatureDecoder(sft)
       // create a producer that reads from kafka and sends to the event bus
       val producer = new KafkaFeatureConsumer(topic, zookeepers, groupId, decoder, eb)
-      new KafkaConsumerFeatureSource(entry, sft, eb, null)
+      new KafkaConsumerFeatureSource(entry, sft, eb, null, expiry, expirationPeriod)
     } else null
   }
 
@@ -139,6 +141,8 @@ object KafkaDataStoreFactoryParams {
   val TOPIC_PARTITIONS   = new Param("partitions", classOf[Integer], "Number of partitions to use in kafka topics", false)
   val TOPIC_REPLICATION  = new Param("replication", classOf[Integer], "Replication factor to use in kafka topics", false)
   val IS_PRODUCER_PARAM  = new Param("isProducer", classOf[java.lang.Boolean], "Is Producer", false, false)
+  val EXPIRY             = new Param("expiry", classOf[java.lang.Boolean], "Expiry", false, false)
+  val EXPIRATION_PERIOD  = new Param("expirationPeriod", classOf[java.lang.Long], "Expiration Period in milliseconds", false, false)
 }
 
 class KafkaDataStoreFactory extends DataStoreFactorySpi {
@@ -158,10 +162,14 @@ class KafkaDataStoreFactory extends DataStoreFactorySpi {
       if(IS_PRODUCER_PARAM.lookUp(params) == null) java.lang.Boolean.FALSE
       else IS_PRODUCER_PARAM.lookUp(params).asInstanceOf[java.lang.Boolean]
 
-    val partitions  = Option(TOPIC_PARTITIONS.lookUp(params)).map(_.toString.toInt).getOrElse(1)
-    val replication = Option(TOPIC_REPLICATION.lookUp(params)).map(_.toString.toInt).getOrElse(1)
+    val partitions       = Option(TOPIC_PARTITIONS.lookUp(params)).map(_.toString.toInt).getOrElse(1)
+    val replication      = Option(TOPIC_REPLICATION.lookUp(params)).map(_.toString.toInt).getOrElse(1)
+    val expiry =
+      if(EXPIRY.lookUp(params) == null) java.lang.Boolean.FALSE
+      else EXPIRY.lookUp(params).asInstanceOf[java.lang.Boolean]
+    val expirationPeriod = Option(EXPIRATION_PERIOD.lookUp(params)).map(_.toString.toLong).getOrElse(0L)
 
-    new KafkaDataStore(broker, zk, zkPath, partitions, replication, isProducer)
+    new KafkaDataStore(broker, zk, zkPath, partitions, replication, isProducer, expiry, expirationPeriod)
   }
 
   override def createNewDataStore(params: ju.Map[String, Serializable]): DataStore = ???

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaDataStore.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaDataStore.scala
@@ -164,9 +164,7 @@ class KafkaDataStoreFactory extends DataStoreFactorySpi {
 
     val partitions       = Option(TOPIC_PARTITIONS.lookUp(params)).map(_.toString.toInt).getOrElse(1)
     val replication      = Option(TOPIC_REPLICATION.lookUp(params)).map(_.toString.toInt).getOrElse(1)
-    val expiry =
-      if(EXPIRY.lookUp(params) == null) java.lang.Boolean.FALSE
-      else EXPIRY.lookUp(params).asInstanceOf[java.lang.Boolean]
+    val expiry           = Option(EXPIRY.lookUp(params).asInstanceOf[java.lang.Boolean]).getOrElse(java.lang.Boolean.FALSE)
     val expirationPeriod = Option(EXPIRATION_PERIOD.lookUp(params)).map(_.toString.toLong).getOrElse(0L)
 
     new KafkaDataStore(broker, zk, zkPath, partitions, replication, isProducer, expiry, expirationPeriod)

--- a/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/KafkaDataStoreTest.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/KafkaDataStoreTest.scala
@@ -194,7 +194,6 @@ class KafkaDataStoreTest extends Specification with Logging {
       sf.setDefaultGeometry(gf.createPoint(new Coordinate(0.0, 0.0)))
       fw.write()
 
-//      featureCache.cleanUp() //remove stale entries, BUT there shouldn't be anything to remove
       featureCache.size() must eventually(5, 500.millis)(beEqualTo(1))
       Thread.sleep(3005) //sleep enough time to reach the expirationPeriod
 


### PR DESCRIPTION
Added expiry and expirationPeriod options to KafkaDataStore params. If expiry is set to true, then
the queue of features uses a Guava Cache with an expiration period set to the expirationPeriod value in milliseconds.

Signed-off-by: Jake Kenneally <jdk2pq@ccri.com>