### PR TITLE
GEOMESA-750 Making default index schema use hour precision

### DIFF
--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloDataStore.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloDataStore.scala
@@ -97,14 +97,14 @@ class AccumuloDataStore(val connector: Connector,
   // floor on the number of query threads, even if the number of shards is 1
   private val MIN_QUERY_THREADS = 5
 
-  // equivalent to: s"%~#s%$maxShard#r%${name}#cstr%0,3#gh%yyyyMMdd#d::%~#s%3,2#gh::%~#s%#id"
+  // equivalent to: s"%~#s%$maxShard#r%${name}#cstr%0,3#gh%yyyyMMddHH#d::%~#s%3,2#gh::%~#s%#id"
   def buildDefaultSpatioTemporalSchema(name: String, maxShard: Int = DEFAULT_MAX_SHARD): String =
     new IndexSchemaBuilder("~")
       .randomNumber(maxShard)
       .indexOrDataFlag()
       .constant(name)
       .geoHash(0, 3)
-      .date("yyyyMMdd")
+      .date("yyyyMMddHH")
       .nextPart()
       .geoHash(3, 2)
       .nextPart()


### PR DESCRIPTION
Putting the hour in the default index schema dramatically speeds up queries that span less than a day, and doesn't seem to negatively impact larger queries (which might be assumed, as we will create more rows)
Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>