### PR TITLE
GEOMESA-774,775 Fix CAGH and Return null for invalid Mosaic

### DIFF
--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/wcs/GeoMesaCoverageReader.scala
@@ -85,9 +85,12 @@ class GeoMesaCoverageReader(val url: String, hints: Hints) extends AbstractGridC
     val rq = params.toRasterQuery
     logger.info(s"In rastersToCoverage: width: ${params.width.toInt} height: ${params.height.toInt} resX: ${params.resX} resY: ${params.resY} env: ${params.envelope}")
     val mosaic = ars.getMosaicedRaster(rq, params)
-    val coverage = this.coverageFactory.create(coverageName, mosaic, params.envelope)
-    mosaic.flush()
-    coverage
+    if (mosaic == null) null
+    else {
+      val coverage = this.coverageFactory.create(coverageName, mosaic, params.envelope)
+      mosaic.flush()
+      coverage
+    }
   }
 
   def getBounds(): GeneralEnvelope = {

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtils.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/util/RasterUtils.scala
@@ -37,8 +37,6 @@ import scala.reflect.runtime.universe._
 
 object RasterUtils {
 
-  val nullImage = new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_GRAY)
-
   object IngestRasterParams {
     val ACCUMULO_INSTANCE   = "geomesa-tools.ingestraster.instance"
     val ZOOKEEPERS          = "geomesa-tools.ingestraster.zookeepers"
@@ -131,13 +129,13 @@ object RasterUtils {
 
   def mosaicChunks(chunks: Iterator[Raster], queryWidth: Int, queryHeight: Int, queryEnv: Envelope): (BufferedImage, Int) = {
     if (chunks.isEmpty) {
-      (nullImage, 0)
+      (null, 0)
     } else {
       val firstRaster = chunks.next()
       if (!chunks.hasNext) {
         val croppedRaster = cropRaster(firstRaster, queryEnv)
         croppedRaster match {
-          case None      => (nullImage, 1)
+          case None      => (null, 1)
           case Some(buf) => (scaleBufferedImage(queryWidth, queryHeight, buf), 1)
         }
       } else {
@@ -147,7 +145,7 @@ object RasterUtils {
         val mosaicX = Math.round(queryEnv.getSpan(0) / accumuloRasterXRes).toInt
         val mosaicY = Math.round(queryEnv.getSpan(1) / accumuloRasterYRes).toInt
         if (mosaicX <= 0 || mosaicY <= 0) {
-          (nullImage, 1)
+          (null, 1)
         } else {
           var count = 1
           val mosaic = allocateBufferedImage(mosaicX, mosaicY, firstRaster.chunk)
@@ -166,7 +164,7 @@ object RasterUtils {
     if (image.getWidth == newWidth && image.getHeight == newHeight) {
       image
     } else {
-      if (newWidth < 1 || newHeight < 1) nullImage
+      if (newWidth < 1 || newHeight < 1) null
       else {
         val result = allocateBufferedImage(newWidth, newHeight, image)
         val resGraphics = result.createGraphics()

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/AccumuloRasterQueryPlannerTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/AccumuloRasterQueryPlannerTest.scala
@@ -53,7 +53,7 @@ class AccumuloRasterQueryPlannerTest extends Specification {
 
   def runTest(size: Int, expectedResolution: Double): MatchResult[Double] = {
     val q1 = generateQuery(0, 45, 0, 45, 45.0/size)
-    val qp = arqp.getQueryPlan(q1, dataMap)
+    val qp = arqp.getQueryPlan(q1, dataMap).get
 
     val rangeString = qp.ranges.head.getStartKey.getRow.toString
     val encodedDouble = rangeString.split("~")(1)

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/ClosestAcceptableGeoHashTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/ClosestAcceptableGeoHashTest.scala
@@ -55,6 +55,20 @@ class ClosestAcceptableGeoHashTest extends Specification {
       result.get.hash must beEqualTo("d")
     }
 
+    "Given bounds outside the world, return None" in {
+      val bbox = BoundingBox(0, 180, 90, 90)
+
+      val result = GeohashUtils.getClosestAcceptableGeoHash(bbox)
+      result must beNone
+    }
+
+    "Given bounds outside the world again, return None" in {
+      val bbox = BoundingBox(-180, 0, 90, 90)
+
+      val result = GeohashUtils.getClosestAcceptableGeoHash(bbox)
+      result must beNone
+    }
+
     "Given a QLevel 1 BoundingBox '-90.0, -67.5, 22.5, 45.0', the closest acceptable GeoHash must be 'd' " in {
       testClosestAcceptableGeoHash(-90.0, -67.5, 22.5, 45.0, "d") must beTrue
     }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geohash/GeohashUtils.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geohash/GeohashUtils.scala
@@ -404,12 +404,16 @@ object GeohashUtils
    */
   def getClosestAcceptableGeoHash(bbox: BoundingBox): Option[GeoHash] = {
     val prec = calculatePrecision(bbox)
-    // The GeoHash precision must be some multiple of 5 to be correctly represented via the 32-bit GeoHash encoding
-    val gh  = getClosestAcceptableGeoHash(bbox, prec)
-    prec % 5 match {
-      case 0               => Some(gh)
-      case _ if (prec > 5) => Some(GeoHash(gh.hash.dropRight(1)))
-      case _               => None
+    if (prec >= 0 ) {
+      // The GeoHash precision must be some multiple of 5 to be correctly represented via the 32-bit GeoHash encoding
+      val gh = getClosestAcceptableGeoHash(bbox, prec)
+      prec % 5 match {
+        case 0               => Some(gh)
+        case _ if (prec > 5) => Some(GeoHash(gh.hash.dropRight(1)))
+        case _               => None
+      }
+    } else {
+      None
     }
   }
 


### PR DESCRIPTION
* Made getQueryPlan return a Option[QueryPlan] to deal with invalid queries.
* Fixed closest acceptable geohash to return None when given a bad GeoHash.
* The GeoMesaCoverageReader now returns nulls coverages when mosaic could not be constructed.

Signed-off-by: Andrew Annex <aannex@ccri.com>