### PR TITLE
GEOMESA-777 add retyping support to KafkaConsumerFeatureSource

### DIFF
--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaConsumerFeatureSource.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaConsumerFeatureSource.scala
@@ -38,6 +38,7 @@ import org.geotools.geometry.jts.{JTS, ReferencedEnvelope}
 import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.locationtech.geomesa.feature.AvroFeatureDecoder
 import org.locationtech.geomesa.utils.geotools.Conversions._
+import org.locationtech.geomesa.utils.geotools.ContentFeatureSourceReTypingSupport
 import org.locationtech.geomesa.utils.index.SynchronizedQuadtree
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.expression.{Literal, PropertyName}
@@ -53,9 +54,9 @@ class KafkaConsumerFeatureSource(entry: ContentEntry,
                                  query: Query,
                                  expiry: Boolean,
                                  expirationPeriod: Long)
-  extends ContentFeatureStore(entry, query) {
+  extends ContentFeatureStore(entry, query)
+  with ContentFeatureSourceReTypingSupport {
 
-  type FR = FeatureReader[SimpleFeatureType, SimpleFeature]
   var qt = new SynchronizedQuadtree
 
   case class FeatureHolder(sf: SimpleFeature, env: Envelope) {
@@ -120,7 +121,7 @@ class KafkaConsumerFeatureSource(entry: ContentEntry,
   override def getCountInternal(query: Query): Int =
     getReaderInternal(query).getIterator.size
 
-  override def getReaderInternal(query: Query): FR = getReaderForFilter(query.getFilter)
+  override def getReaderInternal(query: Query): FR = addSupport(query, getReaderForFilter(query.getFilter))
 
   def getReaderForFilter(f: Filter): FR =
     f match {

--- a/geomesa-utils/pom.xml
+++ b/geomesa-utils/pom.xml
@@ -72,6 +72,10 @@
             <artifactId>gt-grid</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-data</artifactId>
+        </dependency>
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/ContentFeatureSourceSupport.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/ContentFeatureSourceSupport.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package org.locationtech.geomesa.utils.geotools
+
+import org.geotools.data.store.{ContentFeatureSource, ContentFeatureStore}
+import org.geotools.data.{FeatureReader, Query}
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+
+/** Parent for any trait adding support to a [[ContentFeatureSource]] such as 'retype', 'sort', 'offset',
+  * or 'limit'.
+  *
+  *
+  * Any [[ContentFeatureSource]] with a [[ContentFeatureSourceSupport]] trait should call
+  * ``addSupport(query, reader)`` in their ``getReaderInternal`` implementation.
+  *
+  *
+  * Sub-traits of [[ContentFeatureSource]] should first delegate to ``super.addSupport(query, reader)`` in
+  * their ``addSupport`` implementation so that support can be chained and applied left to right.
+  */
+trait ContentFeatureSourceSupport {
+
+  type FR = FeatureReader[SimpleFeatureType, SimpleFeature]
+
+  /** Adds support to given ``reader``, based on the ``query`` and returns a wrapped [[FR]].  Sub-traits
+    * must override.
+    */
+  def addSupport(query: Query, reader: FR): FR = reader
+}
+
+/** Adds support for retyping to a [[ContentFeatureStore]].  This is necessary because the re-typing
+  * functionality in [[ContentFeatureStore]] does not preserve user data.
+  */
+trait ContentFeatureSourceReTypingSupport extends ContentFeatureSourceSupport {
+  self: ContentFeatureSource =>
+
+  override val canRetype: Boolean = true
+
+  override def addSupport(query: Query, reader: FR): FR = {
+    var result = super.addSupport(query, reader)
+    
+    // logic copied from ContentFeatureSource.getReader() but uses TypeUpdatingFeatureReader instead
+    if (query.getPropertyNames != Query.ALL_NAMES) {
+      val target: SimpleFeatureType = SimpleFeatureTypeBuilder.retype(getSchema, query.getPropertyNames)
+      if (!(target == reader.getFeatureType)) {
+        result = new TypeUpdatingFeatureReader(result, target)
+      }
+    }
+
+    result
+  }
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/TypeUpdatingFeatureReader.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/TypeUpdatingFeatureReader.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.locationtech.geomesa.utils.geotools
+
+import org.geotools.data.{DataUtilities, DelegatingFeatureReader, FeatureReader, ReTypeFeatureReader}
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+
+/** A [[DelegatingFeatureReader]] that re-types simple features.  Unlike [[ReTypeFeatureReader]] this
+  * feature reader will preserve user data.
+  *
+  * @param delegate the delegate reader
+  * @param featureType the projected type
+  */
+class TypeUpdatingFeatureReader(delegate: FeatureReader[SimpleFeatureType, SimpleFeature],
+                                featureType: SimpleFeatureType)
+  extends DelegatingFeatureReader[SimpleFeatureType, SimpleFeature] {
+
+  override val getDelegate: FeatureReader[SimpleFeatureType, SimpleFeature] = delegate
+
+  override def next(): SimpleFeature = {
+    val org = delegate.next()
+    val mod = DataUtilities.reType(featureType, org, false)
+    mod.getUserData.putAll(org.getUserData)
+    mod
+  }
+
+  override def hasNext: Boolean = delegate.hasNext
+  override def getFeatureType: SimpleFeatureType = featureType
+  override def close(): Unit = delegate.close()
+}

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/TypeUpdatingFeatureReaderTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/TypeUpdatingFeatureReaderTest.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2015 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.locationtech.geomesa.utils.geotools
+
+import org.geotools.data.FeatureReader
+import org.geotools.data.collection.DelegateFeatureReader
+import org.geotools.factory.Hints
+import org.geotools.feature.collection.DelegateFeatureIterator
+import org.geotools.feature.simple.{SimpleFeatureBuilder, SimpleFeatureTypeBuilder}
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.utils.geotools.Conversions._
+import org.locationtech.geomesa.utils.text.WKTUtils
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class TypeUpdatingFeatureReaderTest extends Specification with Mockito {
+
+  type FR = FeatureReader[SimpleFeatureType, SimpleFeature]
+  type DFR = DelegateFeatureReader[SimpleFeatureType, SimpleFeature]
+  type DFI = DelegateFeatureIterator[SimpleFeature]
+
+  val sftName = "TypeUpdatingFeatureReaderTest"
+  val sft = SimpleFeatureTypes.createType(sftName, "name:String,*geom:Point,dtg:Date")
+
+  def getDelegate(featureCount: Int): FR = getDelegate(getFeatures(featureCount))
+  def getDelegate(features: Seq[SimpleFeature]): FR = new DFR(sft, new DFI(features.iterator))
+
+  def getFeatures(count: Int) = (0 until count).map { i =>
+    val values = Seq[AnyRef](i.toString, WKTUtils.read("POINT(-110 30)"), "2012-01-02T05:06:07.000Z")
+    val sf = SimpleFeatureBuilder.build(sft, values, i.toString)
+    sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
+    sf.visibility = "USER|ADMIN"
+    sf
+  }
+
+  "TypeUpdatingFeatureReader" should {
+
+    "provide the re-type" >> {
+      val delegateReader = mock[FR]
+      val delegateFT = mock[SimpleFeatureType]
+      delegateReader.getFeatureType returns delegateFT
+
+      val reader = new TypeUpdatingFeatureReader(delegateReader, sft)
+      val result = reader.getFeatureType
+
+      result mustEqual sft
+    }
+
+    "provide the delegate" >> {
+      val delegateReader = mock[FR]
+
+      val reader = new TypeUpdatingFeatureReader(delegateReader, sft)
+      val result = reader.getDelegate
+
+      result mustEqual delegateReader
+    }
+
+    "delegate hasNext" >> {
+      val delegateReader = getDelegate(2)
+      val reader = new TypeUpdatingFeatureReader(delegateReader, sft)
+
+      reader.hasNext must beTrue
+      reader.next()
+      reader.hasNext must beTrue
+      reader.next()
+      reader.hasNext must beFalse
+    }
+
+    "delegate close" >> {
+      val delegate = mock[FR]
+
+      val reader = new TypeUpdatingFeatureReader(delegate, sft)
+      reader.close()
+
+      there was one(delegate).close
+    }
+
+    "next must re-type and preserve user data" >> {
+      val features = getFeatures(1)
+      val expected = features.head
+
+      "with a single attribute" >> {
+        val delegateReader = getDelegate(features)
+        val targetType = SimpleFeatureTypeBuilder.retype(sft, Seq("geom"))
+
+        val reader = new TypeUpdatingFeatureReader(delegateReader, targetType)
+        val result = reader.next()
+
+        result must not(beNull)
+        result.getAttributeCount mustEqual 1
+        result.getAttribute(0) mustEqual expected.getAttribute("geom")
+        result.getAttribute("geom") mustEqual expected.getAttribute("geom")
+        result.getUserData mustEqual expected.getUserData
+      }
+
+      "with multiple attributes" >> {
+        val delegateReader = getDelegate(features)
+        val targetType = SimpleFeatureTypeBuilder.retype(sft, Seq("geom", "dtg"))
+
+        val reader = new TypeUpdatingFeatureReader(delegateReader, targetType)
+        val result = reader.next()
+
+        result must not(beNull)
+        result.getAttributeCount mustEqual 2
+
+        result.getAttribute(0) mustEqual expected.getAttribute("geom")
+        result.getAttribute("geom") mustEqual expected.getAttribute("geom")
+
+        result.getAttribute(1) mustEqual expected.getAttribute("dtg")
+        result.getAttribute("dtg") mustEqual expected.getAttribute("dtg")
+
+        result.getUserData mustEqual expected.getUserData
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
KafkaConsumerFeatureSource now canRetype.

Signed-off-by: Michael Matz <mmatz@ccri.com>