### PR TITLE
GEOMESA-742 add a visibility filter as a security extension to GeoServer

### DIFF
--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaConsumerFeatureSource.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaConsumerFeatureSource.scala
@@ -29,7 +29,7 @@ import kafka.producer.KeyedMessage
 import kafka.serializer.DefaultDecoder
 import org.geotools.data.collection.DelegateFeatureReader
 import org.geotools.data.store.{ContentEntry, ContentFeatureStore}
-import org.geotools.data.{FeatureReader, FilteringFeatureReader, Query}
+import org.geotools.data.{FilteringFeatureReader, Query}
 import org.geotools.factory.CommonFactoryFinder
 import org.geotools.feature.collection.DelegateFeatureIterator
 import org.geotools.filter.FidFilterImpl
@@ -38,7 +38,7 @@ import org.geotools.geometry.jts.{JTS, ReferencedEnvelope}
 import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.locationtech.geomesa.feature.AvroFeatureDecoder
 import org.locationtech.geomesa.utils.geotools.Conversions._
-import org.locationtech.geomesa.utils.geotools.ContentFeatureSourceReTypingSupport
+import org.locationtech.geomesa.utils.geotools.{ContentFeatureSourceSecuritySupport, ContentFeatureSourceReTypingSupport}
 import org.locationtech.geomesa.utils.index.SynchronizedQuadtree
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.expression.{Literal, PropertyName}
@@ -55,6 +55,7 @@ class KafkaConsumerFeatureSource(entry: ContentEntry,
                                  expiry: Boolean,
                                  expirationPeriod: Long)
   extends ContentFeatureStore(entry, query)
+  with ContentFeatureSourceSecuritySupport
   with ContentFeatureSourceReTypingSupport {
 
   var qt = new SynchronizedQuadtree

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/ContentFeatureSourceSupport.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/ContentFeatureSourceSupport.scala
@@ -18,6 +18,7 @@ package org.locationtech.geomesa.utils.geotools
 import org.geotools.data.store.{ContentFeatureSource, ContentFeatureStore}
 import org.geotools.data.{FeatureReader, Query}
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder
+import org.locationtech.geomesa.utils.security.DataStoreSecurityService
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 /** Parent for any trait adding support to a [[ContentFeatureSource]] such as 'retype', 'sort', 'offset',
@@ -62,4 +63,12 @@ trait ContentFeatureSourceReTypingSupport extends ContentFeatureSourceSupport {
 
     result
   }
+}
+
+/** Adds security to a [[FeatureReader]] if a DataStoreSecurityProvider has been registered.
+  */
+trait ContentFeatureSourceSecuritySupport extends ContentFeatureSourceSupport {
+
+  override def addSupport(query: Query, reader: FR): FR =
+    DataStoreSecurityService.provider.secure(super.addSupport(query, reader))
 }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/security/DataStoreSecurityService.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/security/DataStoreSecurityService.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package org.locationtech.geomesa.utils.security
+
+import java.util.ServiceLoader
+
+import com.typesafe.scalalogging.slf4j.Logging
+import org.geotools.data.{FeatureSource, FeatureReader}
+import org.geotools.feature.FeatureCollection
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+
+/** A service for adding to security to feature readers.
+ */
+object DataStoreSecurityService extends Logging {
+
+  lazy val provider: DataStoreSecurityProvider = {
+    val providers = ServiceLoader.load(classOf[DataStoreSecurityProvider]).iterator()
+    
+    if (providers.hasNext) {
+      val first = providers.next()
+      if (providers.hasNext) {
+        logger.warn(s"Multiple security providers found.  Using the first: '$first'")
+      }
+      first
+    } else {
+      logger.info(s"No security provider found.  No security will be provided.")
+      NoSecurityProvider
+    }
+  }
+}
+
+trait DataStoreSecurityProvider {
+
+  /**
+   * @param fs the feature source to be secured
+   * @return a security decorator wrapping ``fs`` or ``fs`` if there is no registered security provider or if
+   *         [[FeatureReader[SimpleFeatureType, FeatureType]]s cannot be secured
+   */
+  def secure(fs: FeatureSource[SimpleFeatureType, SimpleFeature]): FeatureSource[SimpleFeatureType, SimpleFeature]
+
+  /**
+    * @param fr the feature reader to be secured
+    * @return a security decorator wrapping ``fr`` or ``fr`` if there is no registered security provider or if
+    *         [[FeatureReader[SimpleFeatureType, FeatureType]]s cannot be secured
+    */
+  def secure(fr: FeatureReader[SimpleFeatureType, SimpleFeature]): FeatureReader[SimpleFeatureType, SimpleFeature]
+
+  /**
+   * @param fc the feature collection to be secured
+   * @return a security decorator wrapping ``fc`` or ``fc`` if there is no registered security provider or if
+   *         [[FeatureReader[SimpleFeatureType, FeatureType]]s cannot be secured
+   */
+  def secure(fc: FeatureCollection[SimpleFeatureType, SimpleFeature]): FeatureCollection[SimpleFeatureType, SimpleFeature]
+}
+
+/** Default implementation provides no security.
+  */
+object NoSecurityProvider extends DataStoreSecurityProvider {
+
+  override def secure(fs: FeatureSource[SimpleFeatureType, SimpleFeature]) = fs
+
+  override def secure(fc: FeatureCollection[SimpleFeatureType, SimpleFeature]) = fc
+
+  override def secure(fr: FeatureReader[SimpleFeatureType, SimpleFeature]) = fr
+}

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/security/DataStoreSecurityServiceTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/security/DataStoreSecurityServiceTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.locationtech.geomesa.utils.security
+
+import org.geotools.data.{FeatureSource, FeatureReader}
+import org.geotools.feature.FeatureCollection
+import org.junit.runner.RunWith
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class DataStoreSecurityServiceTest extends Specification with Mockito {
+
+  sequential
+
+  "DataStoreSecurityService" should {
+
+    "use default, no security, provider when no provider is registered" >> {
+      
+      "for a FeatureReader" >> {
+        val fr = mock[FeatureReader[SimpleFeatureType, SimpleFeature]]
+        val result = DataStoreSecurityService.provider.secure(fr)
+        result mustEqual fr
+      }
+      
+      "for a FeatureCollection" >> {
+        val fc = mock[FeatureCollection[SimpleFeatureType, SimpleFeature]]
+        val result = DataStoreSecurityService.provider.secure(fc)
+        result mustEqual fc        
+      }
+
+      "for a FeatureSource" >> {
+        val fs = mock[FeatureSource[SimpleFeatureType, SimpleFeature]]
+        val result = DataStoreSecurityService.provider.secure(fs)
+        result mustEqual fs
+      }
+    }
+  }
+}

--- a/geomesa-web/geomesa-web-security/README.md
+++ b/geomesa-web/geomesa-web-security/README.md
@@ -1,0 +1,35 @@
+## GeoMesa Web Security
+
+GeoMesa Web Security provides Accumulo security to data stores within GeoServer, particularly the
+KafkaDataStore but it works for any data store using the
+``org.locationtech.geomesa.utils.security.DataStoreSecurityService``.  The easiest way for a data store to use
+this service is to modify the ``FeatureSource`` to extend
+``org.locationtech.geomesa.utils.geotools.ContentFeatureSourceSecuritySupport``.  Alternatively, the data
+store may call ``org.locationtech.geomesa.utils.security.DataStoreSecurityService.provider.secure(obj)`` which
+will provide a security wrapper around ``obj`` where ``obj`` may be a ``FeatureSource``, ``FeatureReader``,
+or a ``FeatureCollection``.
+
+
+To deploy the module, copy the ```geomesa-web-security-$VERSION.jar``` and dependencies to 
+```$GEOSERVER_WEB_APP_HOME/WEB-INF/lib``` and restart GeoServer.  Any data store using the
+``DataStoreSecurityService`` will then have an Accumulo visibility filter applied to SimpleFeatures.  The
+visibility property in the simple feature ```user data``` will be compared to the current user's
+authorizations to determine if the user has access to the simple feature or not.  Any simple feature with no
+visibility will be inaccessable to all users.  This behavior differs from Accumulo where entries without a
+visibility marking are accessible to all users.
+
+
+The ``DataStoreSecurityService`` provides read security.  The data store should be additionally configured in
+GeoServer to be read-only.  To configure read only access, log into GeoServer using administrator credentials.
+Then select "Data" under "Security" on the left side menu.  Set the "Catalog Mode" to "Hide".  Next, click
+the default "*.*.w" rule and add the roles "ADMIN" and optionally "GROUP_ADMIN".  Without this all users will
+have write access by default.  Finally, create a new rule for the workspace and layer that you want to control
+access to.  Set the access mode to "Read" and add all roles (i.e. visibility lables) that exist in the datset.
+Don't forget to click "Save" on the main "Data Security" page when you're done.
+
+
+To add additional users and roles select "User, Groups, Roles" under "Security" on the left side menu.
+
+
+See ```org.locationtech.geomesa.utils.security.SecurityUtils``` for more details on how to get and set
+visibilities on a SimpleFeature

--- a/geomesa-web/geomesa-web-security/pom.xml
+++ b/geomesa-web/geomesa-web-security/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>geomesa-web-accumulo1.5</artifactId>
+        <groupId>org.locationtech.geomesa</groupId>
+        <version>1.0.0-rc.6-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-web-security-accumulo1.5</artifactId>
+    <name>GeoMesa Web Security - [Accumulo 1.5.x]</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver</groupId>
+            <artifactId>gs-main</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.accumulo</groupId>
+            <artifactId>accumulo-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-core-accumulo1.5</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2_2.10</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/geomesa-web/geomesa-web-security/src/main/resources/META-INF/services/org.locationtech.geomesa.utils.security.DataStoreSecurityProvider
+++ b/geomesa-web/geomesa-web-security/src/main/resources/META-INF/services/org.locationtech.geomesa.utils.security.DataStoreSecurityProvider
@@ -1,0 +1,1 @@
+org.locationtech.geomesa.web.security.DataStoreSecurityProviderImpl

--- a/geomesa-web/geomesa-web-security/src/main/scala/org/locationtech/geomesa/web/security/DataStoreSecurityProviderImpl.scala
+++ b/geomesa-web/geomesa-web-security/src/main/scala/org/locationtech/geomesa/web/security/DataStoreSecurityProviderImpl.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2015 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.locationtech.geomesa.web.security
+
+import com.typesafe.scalalogging.slf4j.Logging
+import org.apache.accumulo.core.security.{Authorizations, ColumnVisibility, VisibilityEvaluator}
+import org.geoserver.security.decorators.{DecoratingDataAccess, DecoratingDataStore, DecoratingSimpleFeatureSource}
+import org.geotools.data._
+import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
+import org.geotools.feature.FeatureCollection
+import org.geotools.feature.collection.FilteringSimpleFeatureCollection
+import org.locationtech.geomesa.utils.security.DataStoreSecurityProvider
+import org.locationtech.geomesa.web.security.DataStoreSecurityProviderImpl.{DA, FC, FR, FS}
+import org.opengis.feature.`type`.Name
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import org.opengis.filter.{Filter, FilterVisitor}
+import org.springframework.security.core.context.SecurityContextHolder
+
+import scala.collection.mutable
+
+/** Implementation of [[DataStoreSecurityProvider]] using the spring security context to access the
+  * user's authorizations.
+  */
+class DataStoreSecurityProviderImpl extends DataStoreSecurityProvider with Logging {
+
+  override def secure(fs: FS): FS = GMSecureFeatureSource(fs)
+
+  override def secure(fr: FR): FR = GMSecureFeatureReader(fr)
+
+  override def secure(fc: FC): FC = GMSecureFeatureCollection(fc)
+}
+
+object DataStoreSecurityProviderImpl {
+  type DA = DataAccess[SimpleFeatureType, SimpleFeature]
+  type FS = FeatureSource[SimpleFeatureType, SimpleFeature]
+  type FR = FeatureReader[SimpleFeatureType, SimpleFeature]
+  type FC = FeatureCollection[SimpleFeatureType, SimpleFeature]
+}
+
+class GMSecureDataAccess(delegate: DA)
+  extends DecoratingDataAccess[SimpleFeatureType, SimpleFeature](delegate)
+  with Logging {
+
+  logger.info("Secured Data Access '{}'", delegate)
+
+  override def getFeatureSource(typeName: Name): SimpleFeatureSource =
+    GMSecureFeatureSource(super.getFeatureSource(typeName), this)
+}
+
+class GMSecureDataStore(delegate: DataStore) extends DecoratingDataStore(delegate) with Logging {
+  
+  logger.info("Secured Data Store '{}'", delegate)
+
+  override def getFeatureSource(typeName: Name): SimpleFeatureSource =
+    new GMSecureFeatureSource(super.getFeatureSource(typeName), this)
+
+  override def getFeatureSource(typeName: String): SimpleFeatureSource =
+    new GMSecureFeatureSource(super.getFeatureSource(typeName), this)
+
+  override def getFeatureReader(query: Query, transaction: Transaction): FR =
+    GMSecureFeatureReader(super.getFeatureReader(query, transaction))
+}
+
+class GMSecureFeatureSource(delegate: SimpleFeatureSource, secureDataStore: DA)
+  extends DecoratingSimpleFeatureSource(delegate)
+  with Logging {
+
+  logger.info("Secured Feature Source '{}'", delegate)
+
+  override val getDataStore: DA =
+    secureDataStore
+
+  override def getFeatures: SimpleFeatureCollection =
+    GMSecureFeatureCollection(super.getFeatures)
+
+  override def getFeatures(filter: Filter): SimpleFeatureCollection =
+    GMSecureFeatureCollection(super.getFeatures(filter))
+
+  override def getFeatures(query: Query): SimpleFeatureCollection =
+    GMSecureFeatureCollection(super.getFeatures(query))
+}
+
+object GMSecureFeatureSource {
+
+  def apply(delegate: FS, secureDataAccess: GMSecureDataAccess): GMSecureFeatureSource =
+    new GMSecureFeatureSource(DataUtilities.simple(delegate), secureDataAccess)
+
+  def apply(delegate: FS): GMSecureFeatureSource = {
+    val secureDataAccess = delegate.getDataStore match {
+      case ds: DataStore => new GMSecureDataStore(ds)
+      case da => new GMSecureDataAccess(da)
+    }
+    new GMSecureFeatureSource(DataUtilities.simple(delegate), secureDataAccess)
+  }
+}
+
+object GMSecureFeatureCollection extends Logging {
+
+  def apply(fc: FC): SimpleFeatureCollection = {
+    logger.info("Secured Feature Collection '{}'", fc)
+
+    val filter = VisibilityFilter()
+    new FilteringSimpleFeatureCollection(fc, filter)
+  }
+}
+
+object GMSecureFeatureReader extends Logging {
+
+  def apply(fr: FR): FR = {
+    logger.info("Secured Feature Reader '{}'", fr)
+
+    val filter = VisibilityFilter()
+    new FilteringFeatureReader[SimpleFeatureType, SimpleFeature](fr, filter)
+  }
+}
+
+class VisibilityFilter(ve: VisibilityEvaluator) extends Filter {
+  import org.locationtech.geomesa.utils.geotools.Conversions._
+
+  private val vizCache = new mutable.HashMap[String, Boolean]()
+
+  override def evaluate(o: Any): Boolean = {
+    val viz = o.asInstanceOf[SimpleFeature].visibility
+    viz.exists(v =>
+      vizCache.getOrElseUpdate(v, ve.evaluate(new ColumnVisibility(v))))
+  }
+
+  override def accept(filterVisitor: FilterVisitor, o: AnyRef): AnyRef = o
+}
+
+object VisibilityFilter {
+  import scala.collection.JavaConversions._
+
+  def apply(): VisibilityFilter = new VisibilityFilter(buildVisibilityEvaluator())
+
+  def getAuthorizations: Authorizations = {
+     val auths = SecurityContextHolder.getContext.getAuthentication.getAuthorities.map(_.getAuthority).toList
+     new Authorizations(auths: _*)
+  }
+
+  def buildVisibilityEvaluator(): VisibilityEvaluator =
+    new VisibilityEvaluator(getAuthorizations)
+}

--- a/geomesa-web/geomesa-web-security/src/test/scala/org/locationtech/geomesa/web/security/DataStoreSecurityProviderImplTest.scala
+++ b/geomesa-web/geomesa-web-security/src/test/scala/org/locationtech/geomesa/web/security/DataStoreSecurityProviderImplTest.scala
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2015 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.locationtech.geomesa.web.security
+
+import org.geotools.data.collection.DelegateFeatureReader
+import org.geotools.data.simple.{SimpleFeatureReader, SimpleFeatureStore, SimpleFeatureSource}
+import org.geotools.data._
+import org.geotools.feature.collection.DelegateFeatureIterator
+import org.geotools.feature.{DefaultFeatureCollection, FeatureCollection}
+import org.geotools.filter.identity.FeatureIdImpl
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.feature.AvroSimpleFeature
+import org.locationtech.geomesa.utils.geotools.Conversions._
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.feature.`type`.Name
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import org.opengis.filter.Filter
+import org.specs2.matcher.MatchResult
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class DataStoreSecurityProviderImplTest extends Specification with Mockito {
+
+  sequential
+
+  val testSFT = SimpleFeatureTypes.createType("test", "name:String,*geom:Point:srid=4326")
+
+  "DataStoreSecurityProviderImpl" should {
+
+    val ctx = SecurityContextHolder.createEmptyContext()
+    ctx.setAuthentication(new TestingAuthenticationToken(null, null, "USER"))
+    SecurityContextHolder.setContext(ctx)
+
+    val features: Seq[SimpleFeature] = Seq(null, "USER", "ADMIN", "USER&ADMIN", "USER|ADMIN").zipWithIndex.map { case (vis, i) =>
+      val sf = new AvroSimpleFeature(new FeatureIdImpl(i.toString), testSFT)
+      sf.visibility = vis
+      sf
+    }
+
+    val provider = new DataStoreSecurityProviderImpl
+
+    "be able to secure a feature reader " >> {
+
+      val fr = new DelegateFeatureReader[SimpleFeatureType, SimpleFeature](testSFT, new DelegateFeatureIterator[SimpleFeature](features.iterator))
+      
+      val secureFr = provider.secure(fr)
+
+      secureFr.hasNext must beTrue
+      secureFr.next mustEqual features(1)
+
+      secureFr.hasNext must beTrue
+      secureFr.next mustEqual features(4)
+
+      secureFr.hasNext must beFalse
+    }
+
+    "be able to secure a feature collection" >> {
+
+      val fc = new DefaultFeatureCollection(null, testSFT)
+      fc.addAll(features)
+
+      validate(provider.secure(fc))
+    }
+
+    "be able to secure a feature source" >> {
+
+      val fc = new DefaultFeatureCollection(null, testSFT)
+      fc.addAll(features)
+
+      val ds = mock[DataStore]
+
+      val fs = mock[SimpleFeatureSource]
+      fs.getDataStore returns ds
+
+      val secureFs = provider.secure(fs)
+
+      "when getting all features" >> {
+        fs.getFeatures returns fc
+
+        validate(secureFs.getFeatures)
+      }
+
+      "when using a query" >> {
+        val query = mock[Query]
+        fs.getFeatures(query) returns fc
+
+        validate(secureFs.getFeatures(query))
+      }
+
+      "when using a filter" >> {
+        val filter = mock[Filter]
+        fs.getFeatures(filter) returns fc
+
+        validate(secureFs.getFeatures(filter))
+      }
+    }
+
+    def validate(secureFc: FeatureCollection[SimpleFeatureType, SimpleFeature]): MatchResult[Boolean] = {
+      val iter = secureFc.features()
+
+      iter.hasNext must beTrue
+      iter.next mustEqual features(1)
+
+      iter.hasNext must beTrue
+      iter.next mustEqual features(4)
+
+      iter.hasNext must beFalse
+    }
+  }
+
+  "GMSecureFeatureSource" should {
+
+    "return the secure" >> {
+      "DataStore" >> {
+        val sfs = mock[SimpleFeatureSource]
+        sfs.getSchema returns testSFT
+
+        val secureDS = mock[GMSecureDataStore]
+
+        val secureSource = new GMSecureFeatureSource(sfs, secureDS)
+        secureSource.getDataStore mustEqual secureDS
+      }
+
+      "DataAccess" >> {
+        val fs = mock[FeatureSource[SimpleFeatureType, SimpleFeature]]
+        fs.getSchema returns testSFT
+
+        val secureDA = mock[GMSecureDataAccess]
+
+        val secureSource = GMSecureFeatureSource(fs, secureDA)
+        secureSource.getDataStore mustEqual secureDA
+      }
+    }
+
+    "or create a secure" >> {
+      "DataStore" >> {
+        val ds = mock[DataStore]
+        val fs = mock[SimpleFeatureStore]
+        fs.getSchema returns testSFT
+        fs.getDataStore returns ds
+
+        val secureFs = GMSecureFeatureSource(fs)
+        secureFs.getDataStore.isInstanceOf[GMSecureDataStore] must beTrue
+      }
+
+      "DataAccess" >> {
+        val da = mock[DataAccess[SimpleFeatureType, SimpleFeature]]
+        val fs = mock[FeatureSource[SimpleFeatureType, SimpleFeature]]
+        fs.getSchema returns testSFT
+        fs.getDataStore returns da
+
+        val secureFs = GMSecureFeatureSource(fs)
+        secureFs.getDataStore.isInstanceOf[GMSecureDataAccess] must beTrue
+      }
+    }
+  }
+
+  "GMSecureDataAccess" should {
+
+    "provide a secure feature source" >> {
+      val name = mock[Name]
+      val fs = mock[SimpleFeatureStore]
+
+      val da = mock[DataAccess[SimpleFeatureType, SimpleFeature]]
+      da.getFeatureSource(name) returns fs
+
+      val secureDa = new GMSecureDataAccess(da)
+
+      val result = secureDa.getFeatureSource(name)
+      result.isInstanceOf[GMSecureFeatureSource] must beTrue
+      result.getDataStore mustEqual secureDa
+    }
+  }
+
+  "GMSecureDataStore" should {
+
+    val fs = mock[SimpleFeatureStore]
+    val fr = mock[SimpleFeatureReader]
+
+    val ds = mock[DataStore]
+    val secureDs = new GMSecureDataStore(ds)
+
+    "provide a secure feature source by Name" >> {
+      val name = mock[Name]
+      ds.getFeatureSource(name) returns fs
+
+      val result = secureDs.getFeatureSource(name)
+      result.isInstanceOf[GMSecureFeatureSource] must beTrue
+      result.getDataStore mustEqual secureDs
+    }
+
+    "provide a secure feature source by String" >> {
+      val name = "test"
+      ds.getFeatureSource(name) returns fs
+
+      val result = secureDs.getFeatureSource(name)
+      result.isInstanceOf[GMSecureFeatureSource] must beTrue
+      result.getDataStore mustEqual secureDs
+    }
+
+    "provide a secure feature reader" >> {
+      val query = mock[Query]
+      val txn = mock[Transaction]
+      ds.getFeatureReader(query, txn) returns fr
+
+      val result = secureDs.getFeatureReader(query, txn)
+      result.isInstanceOf[FilteringFeatureReader[SimpleFeatureType, SimpleFeature]] must beTrue
+      result.asInstanceOf[FilteringFeatureReader[SimpleFeatureType, SimpleFeature]].getDelegate mustEqual fr
+    }
+  }
+}

--- a/geomesa-web/geomesa-web-security/src/test/scala/org/locationtech/geomesa/web/security/VisibilityFilterTest.scala
+++ b/geomesa-web/geomesa-web-security/src/test/scala/org/locationtech/geomesa/web/security/VisibilityFilterTest.scala
@@ -1,0 +1,71 @@
+package org.locationtech.geomesa.web.security
+
+import org.geotools.filter.identity.FeatureIdImpl
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.feature.AvroSimpleFeature
+import org.locationtech.geomesa.utils.geotools.Conversions._
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+
+@RunWith(classOf[JUnitRunner])
+class VisibilityFilterTest extends Specification {
+
+  sequential
+
+  val testSFT = SimpleFeatureTypes.createType("test", "name:String,*geom:Point:srid=4326")
+
+  "VisibilityFilter" should {
+
+    "work with simple viz" in {
+
+      val f = new AvroSimpleFeature(new FeatureIdImpl(""), testSFT)
+      f.visibility = "ADMIN&USER"
+
+      val ctx = SecurityContextHolder.createEmptyContext()
+      ctx.setAuthentication(new TestingAuthenticationToken(null, null, "ADMIN", "USER"))
+      SecurityContextHolder.setContext(ctx)
+
+      val vizFilter = VisibilityFilter()
+      vizFilter.evaluate(f) must beTrue
+    }
+
+    "work with no viz on the feature" in {
+      val f = new AvroSimpleFeature(new FeatureIdImpl(""), testSFT)
+
+      val ctx = SecurityContextHolder.createEmptyContext()
+      ctx.setAuthentication(new TestingAuthenticationToken(null, null, "ADMIN", "USER"))
+      SecurityContextHolder.setContext(ctx)
+
+      val vizFilter = VisibilityFilter()
+      vizFilter.evaluate(f) must beFalse
+    }
+
+    "return false when user does not have the right auths" in {
+      val f = new AvroSimpleFeature(new FeatureIdImpl(""), testSFT)
+      f.visibility = "ADMIN&USER"
+
+      val ctx = SecurityContextHolder.createEmptyContext()
+      ctx.setAuthentication(new TestingAuthenticationToken(null, null, "ADMIN"))
+      SecurityContextHolder.setContext(ctx)
+
+      val vizFilter = VisibilityFilter()
+      vizFilter.evaluate(f) must beFalse
+    }
+
+    "return true when dealing with expressions" in {
+      val f = new AvroSimpleFeature(new FeatureIdImpl(""), testSFT)
+      f.visibility = "ADMIN|USER"
+
+      val ctx = SecurityContextHolder.createEmptyContext()
+      ctx.setAuthentication(new TestingAuthenticationToken(null, null, "USER"))
+      SecurityContextHolder.setContext(ctx)
+
+      val vizFilter = VisibilityFilter()
+      vizFilter.evaluate(f) must beTrue
+    }
+
+  }
+}

--- a/geomesa-web/pom.xml
+++ b/geomesa-web/pom.xml
@@ -56,6 +56,7 @@
         <module>geomesa-web-core</module>
         <module>geomesa-web-csv</module>
         <module>geomesa-web-data</module>
+        <module>geomesa-web-security</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Visibility filtering can be applied using combination of the DataStoreSecurityService by the data store, the geomesa-web-security plugin, and GeoServer configuration.  See README.md for more details.