### PR TITLE
GEOMESA-779 Bump Kafka version to 0.8.2.1

### DIFF
--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverterFactory.scala
@@ -149,7 +149,7 @@ trait ToSimpleFeatureConverter[I] extends SimpleFeatureConverter[I] with Logging
     Try { convert(fromInputType(i), reuse) } match {
       case Success(s) => Some(s)
       case Failure(t) =>
-        logger.debug("Failed to parse input", t)
+        logger.warn("Failed to parse input", t)
         None
     }
   }

--- a/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/KafkaDataStoreTest.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/KafkaDataStoreTest.scala
@@ -56,13 +56,6 @@ class KafkaDataStoreTest extends Specification with Logging {
     "zkPath"     -> "/geomesa/kafka/testds",
     "isProducer" -> false)
 
-  val cachedConsumerParams = Map(
-    "brokers"          -> s"$host:$port",
-    "zookeepers"       -> zkConnect,
-    "zkPath"           -> "/geomesa/kafka/testds",
-    "isProducer"       -> false,
-    "expiry"           -> true,
-    "expirationPeriod" -> 2000L)
 
   val producerParams = Map(
     "brokers"    -> s"$host:$port",
@@ -187,6 +180,20 @@ class KafkaDataStoreTest extends Specification with Logging {
 
   "KafkaDataStore with cachedConsumer" should {
     "expire messages correctly when expirationPeriod is set" >> {
+      val cachedConsumerParams = Map(
+        "brokers"          -> s"$host:$port",
+        "zookeepers"       -> zkConnect,
+        "zkPath"           -> "/geomesa/kafka/cachedtestds",
+        "isProducer"       -> false,
+        "expiry"           -> true,
+        "expirationPeriod" -> 2000L)
+
+      val producerParams = Map(
+        "brokers"    -> s"$host:$port",
+        "zookeepers" -> zkConnect,
+        "zkPath"     -> "/geomesa/kafka/cachedtestds",
+        "isProducer" -> true)
+
       //Setup datastores and schema
       val cachedConsumerDS = DataStoreFinder.getDataStore(cachedConsumerParams)
       val producerDS = DataStoreFinder.getDataStore(producerParams)

--- a/geomesa-kafka/pom.xml
+++ b/geomesa-kafka/pom.xml
@@ -16,7 +16,7 @@
     </modules>
 
     <properties>
-        <kafka.version>0.8.1.1</kafka.version>
+        <kafka.version>0.8.2.1</kafka.version>
         <commons-lang3.version>3.3.2</commons-lang3.version>
     </properties>
 


### PR DESCRIPTION
* Bumped Kafka version to 0.8.2.1
* Changed conversion parse error logging to warn instead of debug

Signed-off-by: Anthony Fox <anthony.fox@ccri.com>