### PR TITLE
GEOMESA-787 Adding support for UDP stream sources

### DIFF
--- a/geomesa-stream/README.md
+++ b/geomesa-stream/README.md
@@ -79,6 +79,6 @@ The generic source can be used with UDP as well, although there are some caveats
 * If you are sending text, the source route must include '?textline=true', even though the Camel docs say that only applies to TCP
 * Each UDP packet data must end with a newline character
 * Each UDP packet data must contain exactly one line - everything after the newline will be dropped
-* Packet size can be controlled by the route parameter 'receiveBufferSize' - default is 65536 bytes
-  * If the message is larger than the packet size then the message will be truncated
-* The sender must ensure that the UDP send packet size is sufficient to contain each message
+* Maximun text line size can be controlled by the route parameter 'decoderMaxLineLength' with a maximum value of Integer.MAX_VALUE, which roughly corresponds to 2 KB
+  * If the message is longer than the line size then the message will be dropped
+  * Default maximum text line length is 1024

--- a/geomesa-stream/README.md
+++ b/geomesa-stream/README.md
@@ -79,6 +79,7 @@ The generic source can be used with UDP as well, although there are some caveats
 * If you are sending text, the source route must include '?textline=true', even though the Camel docs say that only applies to TCP
 * Each UDP packet data must end with a newline character
 * Each UDP packet data must contain exactly one line - everything after the newline will be dropped
-* Maximun text line size can be controlled by the route parameter 'decoderMaxLineLength' with a maximum value of Integer.MAX_VALUE, which roughly corresponds to 2 KB
+* Maximun text line size can be controlled by the route parameter 'decoderMaxLineLength' with a maximum value of 2048
   * If the message is longer than the line size then the message will be dropped
   * Default maximum text line length is 1024
+  * Note that technically the line length can be longer, but Camel does not expose the Netty UDP RCVBUF_ALLOCATOR option, which causes messages to be truncated at 2048 bytes.

--- a/geomesa-stream/README.md
+++ b/geomesa-stream/README.md
@@ -71,4 +71,14 @@ val listener =
     def onNext(sf: SimpleFeature) = println(s"Received a new feature: ${sf.getID}")
   }
 ds.asInstanceOf[org.locationtech.geomesa.stream.datastore.StreamDataStore].registerListener(listener)
-```    
+```
+### UDP
+
+The generic source can be used with UDP as well, although there are some caveats:
+
+* If you are sending text, the source route must include '?textline=true', even though the Camel docs say that only applies to TCP
+* Each UDP packet data must end with a newline character
+* Each UDP packet data must contain exactly one line - everything after the newline will be dropped
+* Packet size can be controlled by the route parameter 'receiveBufferSize' - default is 65536 bytes
+  * If the message is larger than the packet size then the message will be truncated
+* The sender must ensure that the UDP send packet size is sufficient to contain each message

--- a/geomesa-stream/geomesa-stream-generic/pom.xml
+++ b/geomesa-stream/geomesa-stream-generic/pom.xml
@@ -53,6 +53,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-netty4</artifactId>
+            <version>${camel.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
             <scope>test</scope>
@@ -63,9 +69,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-netty4</artifactId>
-            <version>${camel.version}</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-stream/geomesa-stream-generic/src/test/resources/log4j.xml
+++ b/geomesa-stream/geomesa-stream-generic/src/test/resources/log4j.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Apache License, Version 2.0 which
+  ~ accompanies this distribution and is available at
+  ~ http://www.opensource.org/licenses/apache2.0.php.
+  -->
+
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="[%d] %5p %c: %m%n"/>
+        </layout>
+    </appender>
+
+    <category name="org.apache.zookeeper">
+        <priority value="warn"/>
+    </category>
+    <category name="org.apache.accumulo">
+        <priority value="warn"/>
+    </category>
+    <category name="org.apache.hadoop">
+        <priority value="warn"/>
+    </category>
+    <category name="hsqldb">
+        <priority value="warn"/>
+    </category>
+
+    <!-- un-comment the following line to enable verbose log messages
+         from the index query-planner; this can be helpful in debugging
+         query plans -->
+    <!--
+    <category name="org.locationtech.geomesa.core.index.IndexQueryPlanner">
+        <priority value="trace"/>
+    </category>
+    -->
+
+    <root>
+        <priority value="warn"/>
+        <appender-ref ref="CONSOLE" />
+    </root>
+</log4j:configuration>
+

--- a/geomesa-stream/geomesa-stream-generic/src/test/scala/org/locationtech/geomesa/stream/generic/GenericSimpleFeatureStreamSourceTest.scala
+++ b/geomesa-stream/geomesa-stream-generic/src/test/scala/org/locationtech/geomesa/stream/generic/GenericSimpleFeatureStreamSourceTest.scala
@@ -85,6 +85,7 @@ class GenericSimpleFeatureStreamSourceTest extends Specification  {
     "work with udp" >> {
       val port = 5898
       val udpConf = confString.replace("tcp", "udp").replace("5899", port.toString)
+          .replace("textline=true", "textline=true&decoderMaxLineLength=" + Int.MaxValue)
       val source = SimpleFeatureStreamSource.buildSource(ConfigFactory.parseString(udpConf))
       source.init()
       source must not beNull

--- a/geomesa-stream/geomesa-stream-generic/src/test/scala/org/locationtech/geomesa/stream/generic/GenericSimpleFeatureStreamSourceTest.scala
+++ b/geomesa-stream/geomesa-stream-generic/src/test/scala/org/locationtech/geomesa/stream/generic/GenericSimpleFeatureStreamSourceTest.scala
@@ -1,11 +1,12 @@
 package org.locationtech.geomesa.stream.generic
 
+import java.net.{DatagramPacket, InetAddress}
 import java.nio.charset.StandardCharsets
 
 import com.google.common.io.Resources
 import com.typesafe.config.ConfigFactory
 import org.apache.commons.io.IOUtils
-import org.apache.commons.net.DefaultSocketFactory
+import org.apache.commons.net.{DefaultDatagramSocketFactory, DefaultSocketFactory}
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.stream.SimpleFeatureStreamSource
 import org.opengis.feature.simple.SimpleFeature
@@ -20,7 +21,7 @@ class GenericSimpleFeatureStreamSourceTest extends Specification  {
 
   "GenericSimpleFeatureStreamSource" should {
 
-    val conf = ConfigFactory.parseString(
+    val confString =
       """
         |{
         |  type         = "generic"
@@ -46,10 +47,9 @@ class GenericSimpleFeatureStreamSourceTest extends Specification  {
         |                 }
         |}
       """.stripMargin
-    )
 
     "be built from a conf" >> {
-      val source = SimpleFeatureStreamSource.buildSource(conf)
+      val source = SimpleFeatureStreamSource.buildSource(ConfigFactory.parseString(confString))
       source.init()
       source must not beNull
 
@@ -75,6 +75,47 @@ class GenericSimpleFeatureStreamSourceTest extends Specification  {
             ret = source.next
           }
           i+=1
+          ret
+        }
+      }
+      val result = iter.take(lines.length).toList
+      result.length must be equalTo lines.length
+    }
+
+    "work with udp" >> {
+      val port = 5898
+      val udpConf = confString.replace("tcp", "udp").replace("5899", port.toString)
+      val source = SimpleFeatureStreamSource.buildSource(ConfigFactory.parseString(udpConf))
+      source.init()
+      source must not beNull
+
+      val url = Resources.getResource("testdata.tsv")
+      val lines = Resources.readLines(url, StandardCharsets.UTF_8)
+      val socketFactory = new DefaultDatagramSocketFactory
+      Future {
+        val address = InetAddress.getByName("localhost")
+        val socket = socketFactory.createDatagramSocket()
+        socket.connect(address, port)
+
+        lines.foreach { line =>
+          val bytes = (line + "\n").getBytes("UTF-8")
+          if (bytes.length > socket.getSendBufferSize) {
+            println("Error in buffer size with line \n" + line)
+          }
+          val packet = new DatagramPacket(bytes, bytes.length, address, port)
+          socket.send(packet)
+        }
+        socket.disconnect()
+      }
+
+      val iter = new Iterator[SimpleFeature] {
+        override def hasNext: Boolean = true
+        override def next() = {
+          var ret: SimpleFeature = null
+          while (ret == null) {
+            Thread.sleep(10)
+            ret = source.next
+          }
           ret
         }
       }


### PR DESCRIPTION
* Source route must be in the form 'netty4:udp://\<host\>:\<port\>?textline=true'
* Each message must end with a newline character
* Each message must contain exactly one line - extra lines will be dropped
* Packet size can be controlled by the route parameter 'receiveBufferSize'
  * If the message is larger than the packet size then the message will be truncated

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>