### PR TITLE
GEOMESA-788 Add Proper Partitioning Control To GeoSpark

### DIFF
--- a/geomesa-compute/pom.xml
+++ b/geomesa-compute/pom.xml
@@ -41,6 +41,10 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-jobs-accumulo1.5</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-start</artifactId>
             <scope>compile</scope>

--- a/geomesa-compute/pom.xml
+++ b/geomesa-compute/pom.xml
@@ -43,6 +43,12 @@
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-jobs-accumulo1.5</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-feature-accumulo1.5</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>

--- a/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
+++ b/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
@@ -60,10 +60,10 @@ object GeoMesaSpark extends Logging {
 
     override def getSplits(context: JobContext) : java.util.List[InputSplit] = {
       init(context.getConfiguration)
+      val desiredSplits = context.getConfiguration.getInt("SplitsDesired", 10*numShards)
       val accumuloSplits = delegate.getSplits(context)
       // try to create 2 mappers per node - account for case where there are less splits than shards
-      val desiredSplits = context.getConfiguration.getInt("SplitsDesired", numShards)
-      val groupSize = Math.max(desiredSplits * 2, accumuloSplits.length / (desiredSplits * 2))
+      val groupSize = Math.max(1, accumuloSplits.length / desiredSplits)
       logger.error("I am being used....")
       // We know each range will only have a single location because of autoAdjustRanges
       val splits = accumuloSplits.groupBy(_.getLocations()(0)).flatMap { case (location, splits) =>
@@ -74,7 +74,10 @@ object GeoMesaSpark extends Logging {
           split
         }
       }
-      logger.error(s"Got ${splits.toList.length} splits using desired=${desiredSplits} and asking for ${groupSize} from ${accumuloSplits.length}")
+      //we've dumped all ranges into groups by location, and tried to get enough splits by breaking up those groups.
+      //we may eventually need to go ahead and do some pretty grim mojo to break each split down small enough
+      //so that we don't blow executor's memory pools. Right now, that's not happening, so I'm not going to push it.
+      logger.error(s"Got ${splits.toList.length} splits using desired=${desiredSplits} from ${accumuloSplits.length}")
       splits.toList
 
     }
@@ -97,7 +100,7 @@ object GeoMesaSpark extends Logging {
   @deprecated("Relies on incidental functional parity across classes, effectively an implicit and unexpressed dependency on non-guaranteed behavior", "Apr2015")
   def rddPartPerExec(conf: Configuration, sc: SparkContext, dsParams: Map[String, String], query: Query, partsPerExec: Int): RDD[SimpleFeature] = {
     val filter = ECQL.toCQL(query.getFilter)
-    conf.setInt("SplitsDesired", sc.getExecutorStorageStatus.length * partsPerExec / 2)
+    conf.setInt("SplitsDesired", partsPerExec * sc.getExecutorStorageStatus.length) // sc.get[...]status.length returns a much smaller value than I expected.
     val job = Job.getInstance(conf, "GeoMesa Spark")
     GeoMesaInputFormat.configure(job, dsParams, query.getTypeName, Some(filter)) // this appears to be mutator for job
     sc.newAPIHadoopRDD(job.getConfiguration(), classOf[GeoSparkInputFormat], classOf[Text], classOf[SimpleFeature]).map{ case (t, sf) => sf}

--- a/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
+++ b/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
@@ -64,7 +64,6 @@ object GeoMesaSpark extends Logging {
       val accumuloSplits = delegate.getSplits(context)
       // try to create 2 mappers per node - account for case where there are less splits than shards
       val groupSize = Math.max(1, accumuloSplits.length / desiredSplits)
-      logger.error("I am being used....")
       // We know each range will only have a single location because of autoAdjustRanges
       val splits = accumuloSplits.groupBy(_.getLocations()(0)).flatMap { case (location, splits) =>
         splits.grouped(groupSize).map { group =>
@@ -77,7 +76,7 @@ object GeoMesaSpark extends Logging {
       //we've dumped all ranges into groups by location, and tried to get enough splits by breaking up those groups.
       //we may eventually need to go ahead and do some pretty grim mojo to break each split down small enough
       //so that we don't blow executor's memory pools. Right now, that's not happening, so I'm not going to push it.
-      logger.error(s"Got ${splits.toList.length} splits using desired=${desiredSplits} from ${accumuloSplits.length}")
+      logger.info(s"Got ${splits.toList.length} splits using desired=${desiredSplits} from ${accumuloSplits.length}")
       splits.toList
 
     }

--- a/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
+++ b/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
@@ -150,8 +150,8 @@ object GeoMesaSpark extends Logging {
       ConfiguratorBase.setMockInstance(classOf[AccumuloInputFormat],
         conf,
         ds.connector.getInstance().getInstanceName)
-    }else
-    {ConfiguratorBase.setZooKeeperInstance(classOf[AccumuloInputFormat],
+    } else {
+      ConfiguratorBase.setZooKeeperInstance(classOf[AccumuloInputFormat],
       conf,
       ds.connector.getInstance().getInstanceName,
       ds.connector.getInstance().getZooKeepers)

--- a/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
+++ b/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
@@ -22,25 +22,61 @@ import java.util.UUID
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.google.common.cache.{CacheBuilder, CacheLoader}
-import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat
+import org.apache.accumulo.core.client.mapreduce.{RangeInputSplit, AccumuloInputFormat}
 import org.apache.accumulo.core.client.mapreduce.lib.util.{ConfiguratorBase, InputConfigurator}
 import org.apache.accumulo.core.data.{Key, Value}
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.mapreduce.{InputSplit, JobContext, Job}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.KryoRegistrator
 import org.apache.spark.{SparkConf, SparkContext}
 import org.geotools.data.{DataStore, DataStoreFinder, DefaultTransaction, Query}
 import org.geotools.factory.CommonFactoryFinder
+import org.geotools.filter.text.ecql.ECQL
 import org.locationtech.geomesa.core.data._
-import org.locationtech.geomesa.core.index.{ExplainPrintln, STIdxStrategy, _}
+import org.locationtech.geomesa.core.index._
 import org.locationtech.geomesa.feature._
 import org.locationtech.geomesa.feature.kryo.{KryoFeatureSerializer, SimpleFeatureSerializer}
+import org.locationtech.geomesa.jobs.GeoMesaConfigurator
+import org.locationtech.geomesa.jobs.mapreduce.{GroupedSplit, GeoMesaInputFormat}
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.JavaConversions._
 
 object GeoMesaSpark {
+
+  class GeoSparkInputFormat extends GeoMesaInputFormat
+  {
+    private def init(conf: Configuration): Unit = if (sft == null) {
+      val params = GeoMesaConfigurator.getDataStoreInParams(conf)
+      val ds = DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
+      sft = ds.getSchema(GeoMesaConfigurator.getFeatureType(conf))
+      encoding = ds.getFeatureEncoding(sft)
+      numShards = IndexSchema.maxShard(ds.getIndexSchemaFmt(sft.getTypeName))
+     }
+
+    override def getSplits(context: JobContext) : java.util.List[InputSplit] = {
+      init(context.getConfiguration)
+      val accumuloSplits = delegate.getSplits(context)
+      // try to create 2 mappers per node - account for case where there are less splits than shards
+      val desiredSplits = context.getConfiguration.getInt("SplitsDesired", numShards)
+      val groupSize = Math.max(desiredSplits * 2, accumuloSplits.length / (desiredSplits * 2))
+
+      // We know each range will only have a single location because of autoAdjustRanges
+      val splits = accumuloSplits.groupBy(_.getLocations()(0)).flatMap { case (location, splits) =>
+        splits.grouped(groupSize).map { group =>
+          val split = new GroupedSplit()
+          split.location = location
+          split.splits.append(group.map(_.asInstanceOf[RangeInputSplit]): _*)
+          split
+        }
+      }
+      splits.toList
+    }
+
+  }
 
   def init(conf: SparkConf, ds: DataStore): SparkConf = {
     val typeOptions = ds.getTypeNames.map { t => (t, SimpleFeatureTypes.encodeType(ds.getSchema(t))) }
@@ -54,6 +90,20 @@ object GeoMesaSpark {
 
   def typeProp(typeName: String) = s"geomesa.types.$typeName"
   def jOpt(typeName: String, spec: String) = s"-D${typeProp(typeName)}=$spec"
+
+  def rddPartPerExec(conf: Configuration, sc: SparkContext, dsParams: Map[String, String], query: Query, partsPerExec: Int): RDD[SimpleFeature] = {
+    val filter = ECQL.toCQL(query.getFilter)
+    conf.setInt("SplitsDesired", sc.getExecutorStorageStatus.length * partsPerExec)
+    val job = Job.getInstance(conf, "GeoMesa Spark")
+    GeoMesaInputFormat.configure(job, dsParams, query, Some(filter)) // this appears to be mutator for job
+    val rdd = sc.newAPIHadoopRDD(job.getConfiguration(), classOf[GeoSparkInputFormat], classOf[Text], classOf[SimpleFeature])
+
+/*    rdd.mapPartitions { iter =>
+      val sft = SimpleFeatureTypes.createType(typeName, spec)
+      val decoder = SimpleFeatureDecoder(sft, featureEncoding)
+      iter.map { case (k: Key, v: Value) => decoder.decode(v.get()) }
+    }*/
+  }
 
   def rdd(conf: Configuration, sc: SparkContext, ds: AccumuloDataStore, query: Query, useMock: Boolean = false): RDD[SimpleFeature] = {
     val typeName = query.getTypeName
@@ -75,6 +125,8 @@ object GeoMesaSpark {
     InputConfigurator.setRanges(classOf[AccumuloInputFormat], conf, qp.ranges)
     qp.iterators.foreach { is => InputConfigurator.addIterator(classOf[AccumuloInputFormat], conf, is) }
 
+    val job = Job.getInstance(conf, "GeoMesa Spark") // this line, I don't totally grok.
+    GeoMesaInputFormat.configure(job, )
     val rdd = sc.newAPIHadoopRDD(conf, classOf[AccumuloInputFormat], classOf[Key], classOf[Value])
 
     rdd.mapPartitions { iter =>


### PR DESCRIPTION
This is a messy mid-term solution to the over-partitioning issue. It does not resolve the under-partitioning issue, which would require finagling the actual ranges. I didn't feel comfortable enough with the deadlines or the codebases to pursue that, but we do need to discuss it.

Coding style's a little rough, but I've tried to be mostly conformant. The added API function is deprecated, as it will be merged into the main API function down the road, once we solve the under-partitioning problem.