### PR TITLE
GEOMESA-802 Allow for short circuiting getCount

### DIFF
--- a/geomesa-core/pom.xml
+++ b/geomesa-core/pom.xml
@@ -115,6 +115,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>
+            <artifactId>accumulo-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-start</artifactId>
         </dependency>
         <dependency>

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloDataStore.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloDataStore.scala
@@ -712,6 +712,10 @@ class AccumuloDataStore(val connector: Connector,
       .getOrElse(ALL_TIME_BOUNDS)
   }
 
+  def getRecordTableSize(featureName: String): Long = {
+    metadata.getTableSize(getRecordTable(featureName))
+  }
+
   def stringToTimeBounds(value: String): Interval = {
     val longs = value.split(":").map(java.lang.Long.parseLong)
     require(longs(0) <= longs(1))

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloFeatureSource.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/data/AccumuloFeatureSource.scala
@@ -53,7 +53,29 @@ trait AccumuloAbstractFeatureSource extends AbstractFeatureSource with Logging w
 
   def getDataStore: AccumuloDataStore = dataStore
 
-  override def getCount(query: Query) = getFeaturesNoCache(query).features().size
+  def longCount = dataStore.getRecordTableSize(featureName.getLocalPart)
+
+  // The default behavior for getCount is to use Accumulo to look up the number of entries in
+  //  the record table for a feature.
+  //  This approach gives a rough upper count for the size of the query results.
+  //  For Filter.INCLUDE, this is likely pretty close; other all others, it is a lie.
+
+  // Since users may want *actual* counts, there are two ways to force exact counts.
+  //  First, one can set the System property "geomesa.force.count".
+  //  Second, there is an EXACT_COUNT query hint.
+  override def getCount(query: Query) = {
+    val exactCount = query.getHints.get(EXACT_COUNT) == java.lang.Boolean.TRUE ||
+                     System.getProperty("geomesa.force.count") == "true"
+
+    if (exactCount || longCount == -1) {
+      getFeaturesNoCache(query).features().size
+    } else {
+      longCount match {
+        case _ if longCount > Int.MaxValue      => Int.MaxValue
+        case _                                  => longCount.toInt
+      }
+    }
+  }
 
   override def getQueryCapabilities =
     new QueryCapabilities() {

--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/index.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/index/index.scala
@@ -194,6 +194,8 @@ package object index {
     val RETURN_ENCODED       = new ClassKey(classOf[java.lang.Boolean])
 
     val MAP_AGGREGATION_KEY  = new ClassKey(classOf[java.lang.String])
+
+    val EXACT_COUNT          = new ClassKey(classOf[java.lang.Boolean])
   }
 
   type ExplainerOutputType = ( => String) => Unit

--- a/geomesa-core/src/test/scala/org/locationtech/geomesa/core/data/AccumuloFeatureStoreTest.scala
+++ b/geomesa-core/src/test/scala/org/locationtech/geomesa/core/data/AccumuloFeatureStoreTest.scala
@@ -8,6 +8,7 @@ import org.geotools.data.simple.SimpleFeatureStore
 import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.joda.time.DateTime
 import org.junit.runner.RunWith
+import org.locationtech.geomesa.core.index._
 import org.locationtech.geomesa.utils.geotools.Conversions._
 import org.opengis.filter.Filter
 import org.opengis.filter.sort.{SortBy, SortOrder}
@@ -204,6 +205,17 @@ class AccumuloFeatureStoreTest extends Specification with AccumuloDataStoreDefau
         res.size must beEqualTo(featList.size)
         res.reverse must beSorted
         res.head must beGreaterThan(res(1))
+      }
+
+      // This test case to show how the EXACT_COUNT Query Hint can be used.
+      // Since we can't get table sizes for MockAccumulo, we can't test both directions.
+      "also accept counting hints" >> {
+        val exactCountQuery = new Query("test", Filter.INCLUDE)
+        val sizeByQuery = fs.getFeatures(exactCountQuery).features.toList.size
+
+        exactCountQuery.getHints.put(QueryHints.EXACT_COUNT, java.lang.Boolean.TRUE)
+
+        fs.getCount(exactCountQuery) must equalTo(sizeByQuery)
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -638,6 +638,12 @@
                 <groupId>org.apache.accumulo</groupId>
                 <artifactId>accumulo-server</artifactId>
                 <version>${accumulo.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.accumulo</groupId>
+                <artifactId>accumulo-server</artifactId>
+                <version>${accumulo.version}</version>
                 <classifier>source</classifier>
                 <scope>provided</scope>
             </dependency>


### PR DESCRIPTION
* By default FeatureStore.getCount will return the associated record table size.
 This is done to return quickly.
 Limitations:
  The query/filter is ignored.
  If several features are sharing a table, the record table size will be larger than any one feature.

Since clients may want getCount to return correctly rather than quickly, there are two override methods.

* First, a Java System property, "geomesa.force.count" can be set to "true".
* Second a GeoTools query hint (QueryHints.EXACT_COUNT) can be set to java.lang.Boolean.TRUE.

(If either are true, then getCount will iterate through the result set.)

Signed-off-by: Jim Hughes <jnh5y@ccri.com>