### PR TITLE
GEOMESA-805 Fixing bbox queries without property name

### DIFF
--- a/geomesa-core/src/main/scala/org/locationtech/geomesa/core/filter/package.scala
+++ b/geomesa-core/src/main/scala/org/locationtech/geomesa/core/filter/package.scala
@@ -238,7 +238,8 @@ package object filter {
     val geom = sft.getGeometryDescriptor.getLocalName
     val primary = filter match {
       case f: BinarySpatialOperator =>
-        checkOrder(f.getExpression1, f.getExpression2).exists(_.name == geom)
+        checkOrder(f.getExpression1, f.getExpression2)
+            .exists(p => p.name == null || p.name.isEmpty || p.name == geom)
       case _ => false
     }
     primary && spatialFilters(filter)


### PR DESCRIPTION
This causes wfs requests that use the BBOX parameter to fail.

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>