### PR TITLE
GEOMESA-788 Down-ported New Partitioning Logic Into GeoMesaInputFormat

### DIFF
--- a/geomesa-compute/pom.xml
+++ b/geomesa-compute/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>geomesa-core-accumulo1.5</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-jobs-accumulo1.5</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-core</artifactId>
             <scope>compile</scope>

--- a/geomesa-compute/scripts/test/scala/localtest.scala
+++ b/geomesa-compute/scripts/test/scala/localtest.scala
@@ -51,7 +51,7 @@ val sconf = GeoMesaSpark.init(new SparkConf(true).setAppName("localtest").setMas
 val sc = new SparkContext(sconf)
 
 // Create an RDD from a query
-val queryRDD = org.locationtech.geomesa.compute.spark.GeoMesaSpark.rdd(conf, sc, ds, q)
+val queryRDD = org.locationtech.geomesa.compute.spark.GeoMesaSpark.rdd(conf, sc, params, q)
 
 // Convert RDD[SimpleFeature] to RDD[(String, SimpleFeature)] where the first
 // element of the tuple is the date to the day resolution

--- a/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
+++ b/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
@@ -25,16 +25,19 @@ import com.google.common.cache.{CacheBuilder, CacheLoader}
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat
 import org.apache.accumulo.core.client.mapreduce.lib.util.{ConfiguratorBase, InputConfigurator}
 import org.apache.accumulo.core.data.{Key, Value}
+import org.apache.accumulo.core.util.{Pair => AccPair}
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.io.Text
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.KryoRegistrator
 import org.apache.spark.{SparkConf, SparkContext}
 import org.geotools.data.{DataStore, DataStoreFinder, DefaultTransaction, Query}
 import org.geotools.factory.CommonFactoryFinder
 import org.locationtech.geomesa.core.data._
-import org.locationtech.geomesa.core.index.{ExplainPrintln, STIdxStrategy, _}
+import org.locationtech.geomesa.core.index._
 import org.locationtech.geomesa.feature._
 import org.locationtech.geomesa.feature.kryo.{KryoFeatureSerializer, SimpleFeatureSerializer}
+import org.locationtech.geomesa.jobs.interop.mapreduce._
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
@@ -55,7 +58,12 @@ object GeoMesaSpark {
   def typeProp(typeName: String) = s"geomesa.types.$typeName"
   def jOpt(typeName: String, spec: String) = s"-D${typeProp(typeName)}=$spec"
 
-  def rdd(conf: Configuration, sc: SparkContext, ds: AccumuloDataStore, query: Query, useMock: Boolean = false): RDD[SimpleFeature] = {
+  def rdd(conf: Configuration,
+          sc: SparkContext,
+          ds: AccumuloDataStore,
+          query: Query,
+          useMock: Boolean = false,
+          numberOfSplits: Int = -1): RDD[SimpleFeature] = {
     val typeName = query.getTypeName
     val sft = ds.getSchema(typeName)
     val spec = SimpleFeatureTypes.encodeType(sft)
@@ -75,13 +83,20 @@ object GeoMesaSpark {
     InputConfigurator.setRanges(classOf[AccumuloInputFormat], conf, qp.ranges)
     qp.iterators.foreach { is => InputConfigurator.addIterator(classOf[AccumuloInputFormat], conf, is) }
 
-    val rdd = sc.newAPIHadoopRDD(conf, classOf[AccumuloInputFormat], classOf[Key], classOf[Value])
-
-    rdd.mapPartitions { iter =>
-      val sft = SimpleFeatureTypes.createType(typeName, spec)
-      val decoder = SimpleFeatureDecoder(sft, featureEncoding)
-      iter.map { case (k: Key, v: Value) => decoder.decode(v.get()) }
+    if (!qp.columnFamilies.isEmpty) {
+      InputConfigurator.fetchColumns(classOf[AccumuloInputFormat], conf, qp.columnFamilies.map(cf => new AccPair[Text, Text](cf, null)))
     }
+
+    if( numberOfSplits != -1 )
+    {
+      conf.setInt("SplitsDesired",
+        numberOfSplits * sc.getExecutorStorageStatus.length)
+      InputConfigurator.setAutoAdjustRanges(classOf[AccumuloInputFormat], conf, false)
+      InputConfigurator.setAutoAdjustRanges(classOf[GeoMesaInputFormat], conf, false)
+    }
+
+    sc.newAPIHadoopRDD(conf, classOf[GeoMesaInputFormat], classOf[Text], classOf[SimpleFeature]).map(U => U._2)
+
   }
 
   /**

--- a/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
+++ b/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
@@ -64,8 +64,7 @@ object GeoMesaSpark {
           sc: SparkContext,
           dsParams: Map[String, String],
           query: Query,
-          numberOfSplits: Option[Int])
-  {
+          numberOfSplits: Option[Int]): RDD[SimpleFeature] = {
     rdd(conf, sc, dsParams, query, false, numberOfSplits.getOrElse(-1))
   }
 

--- a/geomesa-compute/src/test/scala/org/locationtech/geomesa/compute/spark/GeoMesaSparkTest.scala
+++ b/geomesa-compute/src/test/scala/org/locationtech/geomesa/compute/spark/GeoMesaSparkTest.scala
@@ -32,7 +32,7 @@ import org.geotools.factory.Hints
 import org.joda.time.{DateTime, DateTimeZone}
 import org.junit
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.core.data.{AccumuloDataStore, AccumuloDataStoreFactory}
+import org.locationtech.geomesa.core.data.AccumuloDataStoreFactory
 import org.locationtech.geomesa.core.index.Constants
 import org.locationtech.geomesa.feature.ScalaSimpleFeatureFactory
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
@@ -76,6 +76,7 @@ class GeoMesaSparkTest extends Specification with Logging {
     c.tableOperations().addSplits(TEST_TABLE_NAME, new java.util.TreeSet[Text](splits.asJava))
 
     val dsf = new AccumuloDataStoreFactory
+
     val ds = dsf.createDataStore(dsParams.mapValues(_.asInstanceOf[JSerializable]).asJava)
     ds
   }
@@ -136,7 +137,7 @@ class GeoMesaSparkTest extends Specification with Logging {
       GeoMesaSpark.init(conf, ds)
       sc =  new SparkContext(conf) // will get shut down by shutdown method
 
-      val rdd = GeoMesaSpark.rdd(new Configuration(), sc, ds.asInstanceOf[AccumuloDataStore], new Query(typeName), useMock = true)
+      val rdd = GeoMesaSpark.rdd(new Configuration(), sc, dsParams, new Query(typeName), useMock = true)
 
       rdd.count() should equalTo(feats.length)
       feats.map(_.getAttribute("id")) should contain(rdd.take(1).head.getAttribute("id"))


### PR DESCRIPTION
This tidies up the solution I'd previously written, removing the deprecated function and committing small breaking changes to the GeoSpark API as a result. I believe this is a viable long-term solution, though some further attention should be devoted to understanding the behavior of the AutoAdjustRanges setting, which appears to persist in adjusting ranges even when set to false.

I opted not to use the GeoMesaInputFormat's configure function, as it sets the exact opposite of what we need for spark in a few places. Other than that, all logic for handling the splits is now pushed directly into the GetSplits function of the GeoMesaInputFormat as requested.