### PR TITLE
GEOMESA-788 Down-ported New Partitioning Logic Into GeoMesaInputFormat

### DIFF
--- a/geomesa-compute/pom.xml
+++ b/geomesa-compute/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>geomesa-core-accumulo1.5</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-jobs-accumulo1.5</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-core</artifactId>
             <scope>compile</scope>

--- a/geomesa-compute/scripts/test/scala/localtest.scala
+++ b/geomesa-compute/scripts/test/scala/localtest.scala
@@ -51,7 +51,7 @@ val sconf = GeoMesaSpark.init(new SparkConf(true).setAppName("localtest").setMas
 val sc = new SparkContext(sconf)
 
 // Create an RDD from a query
-val queryRDD = org.locationtech.geomesa.compute.spark.GeoMesaSpark.rdd(conf, sc, ds, q)
+val queryRDD = org.locationtech.geomesa.compute.spark.GeoMesaSpark.rdd(conf, sc, params, q)
 
 // Convert RDD[SimpleFeature] to RDD[(String, SimpleFeature)] where the first
 // element of the tuple is the date to the day resolution

--- a/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
+++ b/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
@@ -24,18 +24,22 @@ import com.esotericsoftware.kryo.io.{Input, Output}
 import com.google.common.cache.{CacheBuilder, CacheLoader}
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat
 import org.apache.accumulo.core.client.mapreduce.lib.util.{ConfiguratorBase, InputConfigurator}
-import org.apache.accumulo.core.data.{Key, Value}
+import org.apache.accumulo.core.util.{Pair => AccPair}
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.io.Text
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.KryoRegistrator
 import org.apache.spark.{SparkConf, SparkContext}
 import org.geotools.data.{DataStore, DataStoreFinder, DefaultTransaction, Query}
 import org.geotools.factory.CommonFactoryFinder
+import org.geotools.filter.text.ecql.ECQL
 import org.locationtech.geomesa.core.data._
-import org.locationtech.geomesa.core.index.{ExplainPrintln, STIdxStrategy, _}
-import org.locationtech.geomesa.feature._
+import org.locationtech.geomesa.core.index._
 import org.locationtech.geomesa.feature.kryo.{KryoFeatureSerializer, SimpleFeatureSerializer}
+import org.locationtech.geomesa.jobs.GeoMesaConfigurator
+import org.locationtech.geomesa.jobs.interop.mapreduce._
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.filter._
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.JavaConversions._
@@ -43,19 +47,34 @@ import scala.collection.JavaConversions._
 object GeoMesaSpark {
 
   def init(conf: SparkConf, ds: DataStore): SparkConf = {
-    val typeOptions = ds.getTypeNames.map { t => (t, SimpleFeatureTypes.encodeType(ds.getSchema(t))) }
-    typeOptions.foreach { case (k,v) => System.setProperty(typeProp(k), v) }
-    val extraOpts = typeOptions.map { case (k,v) => jOpt(k, v) }.mkString(" ")
-    
+    val typeOptions = ds.getTypeNames.map { t => (t, SimpleFeatureTypes.encodeType(ds.getSchema(t)))}
+    typeOptions.foreach { case (k, v) => System.setProperty(typeProp(k), v)}
+    val extraOpts = typeOptions.map { case (k, v) => jOpt(k, v)}.mkString(" ")
+
     conf.set("spark.executor.extraJavaOptions", extraOpts)
     conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
     conf.set("spark.kryo.registrator", classOf[GeoMesaSparkKryoRegistrator].getCanonicalName)
   }
 
   def typeProp(typeName: String) = s"geomesa.types.$typeName"
+
   def jOpt(typeName: String, spec: String) = s"-D${typeProp(typeName)}=$spec"
 
-  def rdd(conf: Configuration, sc: SparkContext, ds: AccumuloDataStore, query: Query, useMock: Boolean = false): RDD[SimpleFeature] = {
+  def rdd(conf: Configuration,
+          sc: SparkContext,
+          dsParams: Map[String, String],
+          query: Query,
+          numberOfSplits: Option[Int]): RDD[SimpleFeature] = {
+    rdd(conf, sc, dsParams, query, false, numberOfSplits.getOrElse(-1))
+  }
+
+  def rdd(conf: Configuration,
+          sc: SparkContext,
+          dsParams: Map[String, String],
+          query: Query,
+          useMock: Boolean = false,
+          numberOfSplits: Int = -1): RDD[SimpleFeature] = {
+    val ds = DataStoreFinder.getDataStore(dsParams).asInstanceOf[AccumuloDataStore]
     val typeName = query.getTypeName
     val sft = ds.getSchema(typeName)
     val spec = SimpleFeatureTypes.encodeType(sft)
@@ -68,20 +87,43 @@ object GeoMesaSpark {
 
     ConfiguratorBase.setConnectorInfo(classOf[AccumuloInputFormat], conf, ds.connector.whoami(), ds.authToken)
 
-    if(useMock) ConfiguratorBase.setMockInstance(classOf[AccumuloInputFormat], conf, ds.connector.getInstance().getInstanceName)
-    else ConfiguratorBase.setZooKeeperInstance(classOf[AccumuloInputFormat], conf, ds.connector.getInstance().getInstanceName, ds.connector.getInstance().getZooKeepers)
-
+    if (useMock){
+      ConfiguratorBase.setMockInstance(classOf[AccumuloInputFormat],
+        conf,
+        ds.connector.getInstance().getInstanceName)
+    } else {
+      ConfiguratorBase.setZooKeeperInstance(classOf[AccumuloInputFormat],
+        conf,
+        ds.connector.getInstance().getInstanceName,
+        ds.connector.getInstance().getZooKeepers)
+    }
     InputConfigurator.setInputTableName(classOf[AccumuloInputFormat], conf, ds.getSpatioTemporalTable(sft))
     InputConfigurator.setRanges(classOf[AccumuloInputFormat], conf, qp.ranges)
-    qp.iterators.foreach { is => InputConfigurator.addIterator(classOf[AccumuloInputFormat], conf, is) }
+    qp.iterators.foreach { is => InputConfigurator.addIterator(classOf[AccumuloInputFormat], conf, is)}
 
-    val rdd = sc.newAPIHadoopRDD(conf, classOf[AccumuloInputFormat], classOf[Key], classOf[Value])
-
-    rdd.mapPartitions { iter =>
-      val sft = SimpleFeatureTypes.createType(typeName, spec)
-      val decoder = SimpleFeatureDecoder(sft, featureEncoding)
-      iter.map { case (k: Key, v: Value) => decoder.decode(v.get()) }
+    if (!qp.columnFamilies.isEmpty) {
+      InputConfigurator.fetchColumns(classOf[AccumuloInputFormat],
+        conf,
+        qp.columnFamilies.map(cf => new AccPair[Text, Text](cf, null)))
     }
+
+    if (numberOfSplits != -1) {
+      conf.setInt("SplitsDesired",
+        numberOfSplits * sc.getExecutorStorageStatus.length)
+      InputConfigurator.setAutoAdjustRanges(classOf[AccumuloInputFormat], conf, false)
+      InputConfigurator.setAutoAdjustRanges(classOf[GeoMesaInputFormat], conf, false)
+    }
+    GeoMesaConfigurator.setSerialization(conf)
+    GeoMesaConfigurator.setDataStoreInParams(conf, dsParams)
+    GeoMesaConfigurator.setFeatureType(conf, typeName)
+    if (query.getFilter != Filter.INCLUDE) {
+      GeoMesaConfigurator.setFilter(conf, ECQL.toCQL(query.getFilter))
+    }
+
+    getTransformSchema(query).foreach(GeoMesaConfigurator.setTransformSchema(conf, _))
+
+    sc.newAPIHadoopRDD(conf, classOf[GeoMesaInputFormat], classOf[Text], classOf[SimpleFeature]).map(U => U._2)
+
   }
 
   /**
@@ -113,16 +155,16 @@ object GeoMesaSpark {
     }
   }
 
-  def countByDay(conf: Configuration, sccc: SparkContext, ds: AccumuloDataStore, query: Query, dateField: String = "dtg") = {
-    val d = rdd(conf, sccc, ds, query)
+  def countByDay(conf: Configuration, sccc: SparkContext, dsParams: Map[String, String], query: Query, dateField: String = "dtg") = {
+    val d = rdd(conf, sccc, dsParams, query)
     val dayAndFeature = d.mapPartitions { iter =>
       val df = new SimpleDateFormat("yyyyMMdd")
       val ff = CommonFactoryFinder.getFilterFactory2
       val exp = ff.property(dateField)
-      iter.map { f => (df.format(exp.evaluate(f).asInstanceOf[java.util.Date]), f) }
+      iter.map { f => (df.format(exp.evaluate(f).asInstanceOf[java.util.Date]), f)}
     }
-    val groupedByDay = dayAndFeature.groupBy { case (date, _) => date }
-    groupedByDay.map { case (date, iter) => (date, iter.size) }
+    val groupedByDay = dayAndFeature.groupBy { case (date, _) => date}
+    groupedByDay.map { case (date, iter) => (date, iter.size)}
   }
 
 }

--- a/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
+++ b/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
@@ -65,7 +65,7 @@ object GeoMesaSpark {
           dsParams: Map[String, String],
           query: Query,
           numberOfSplits: Option[Int]): RDD[SimpleFeature] = {
-    rdd(conf, sc, dsParams, query, false, numberOfSplits.getOrElse(-1))
+    rdd(conf, sc, dsParams, query, false, numberOfSplits)
   }
 
   def rdd(conf: Configuration,
@@ -73,7 +73,7 @@ object GeoMesaSpark {
           dsParams: Map[String, String],
           query: Query,
           useMock: Boolean = false,
-          numberOfSplits: Int = -1): RDD[SimpleFeature] = {
+          numberOfSplits: Option[Int] = None): RDD[SimpleFeature] = {
     val ds = DataStoreFinder.getDataStore(dsParams).asInstanceOf[AccumuloDataStore]
     val typeName = query.getTypeName
     val sft = ds.getSchema(typeName)
@@ -107,9 +107,9 @@ object GeoMesaSpark {
         qp.columnFamilies.map(cf => new AccPair[Text, Text](cf, null)))
     }
 
-    if (numberOfSplits != -1) {
-      conf.setInt("SplitsDesired",
-        numberOfSplits * sc.getExecutorStorageStatus.length)
+    if (numberOfSplits.isDefined) {
+      GeoMesaInputFormat.configureSplits(conf,
+        numberOfSplits.get * sc.getExecutorStorageStatus.length)
       InputConfigurator.setAutoAdjustRanges(classOf[AccumuloInputFormat], conf, false)
       InputConfigurator.setAutoAdjustRanges(classOf[GeoMesaInputFormat], conf, false)
     }

--- a/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
+++ b/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
@@ -108,7 +108,7 @@ object GeoMesaSpark {
     }
 
     if (numberOfSplits.isDefined) {
-      GeoMesaInputFormat.configureSplits(conf,
+      GeoMesaConfigurator.setDesiredSplits(conf,
         numberOfSplits.get * sc.getExecutorStorageStatus.length)
       InputConfigurator.setAutoAdjustRanges(classOf[AccumuloInputFormat], conf, false)
       InputConfigurator.setAutoAdjustRanges(classOf[GeoMesaInputFormat], conf, false)

--- a/geomesa-compute/src/test/scala/org/locationtech/geomesa/compute/spark/GeoMesaSparkTest.scala
+++ b/geomesa-compute/src/test/scala/org/locationtech/geomesa/compute/spark/GeoMesaSparkTest.scala
@@ -32,7 +32,7 @@ import org.geotools.factory.Hints
 import org.joda.time.{DateTime, DateTimeZone}
 import org.junit
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.core.data.{AccumuloDataStore, AccumuloDataStoreFactory}
+import org.locationtech.geomesa.core.data.AccumuloDataStoreFactory
 import org.locationtech.geomesa.core.index.Constants
 import org.locationtech.geomesa.feature.ScalaSimpleFeatureFactory
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
@@ -76,6 +76,7 @@ class GeoMesaSparkTest extends Specification with Logging {
     c.tableOperations().addSplits(TEST_TABLE_NAME, new java.util.TreeSet[Text](splits.asJava))
 
     val dsf = new AccumuloDataStoreFactory
+
     val ds = dsf.createDataStore(dsParams.mapValues(_.asInstanceOf[JSerializable]).asJava)
     ds
   }
@@ -136,7 +137,7 @@ class GeoMesaSparkTest extends Specification with Logging {
       GeoMesaSpark.init(conf, ds)
       sc =  new SparkContext(conf) // will get shut down by shutdown method
 
-      val rdd = GeoMesaSpark.rdd(new Configuration(), sc, ds.asInstanceOf[AccumuloDataStore], new Query(typeName), useMock = true)
+      val rdd = GeoMesaSpark.rdd(new Configuration(), sc, dsParams, new Query(typeName), useMock = true)
 
       rdd.count() should equalTo(feats.length)
       feats.map(_.getAttribute("id")) should contain(rdd.take(1).head.getAttribute("id"))

--- a/geomesa-jobs/src/main/java/org/locationtech/geomesa/jobs/interop/mapreduce/GeoMesaInputFormat.java
+++ b/geomesa-jobs/src/main/java/org/locationtech/geomesa/jobs/interop/mapreduce/GeoMesaInputFormat.java
@@ -64,16 +64,6 @@ public class GeoMesaInputFormat extends InputFormat<Text, SimpleFeature> {
         GeoMesaInputFormat$.MODULE$.configure(job, scalaParams, query);
     }
 
-    public static void configureSplits(Configuration conf, Integer desiredSplits)
-    {
-        GeoMesaInputFormat$.MODULE$.configureSplits(conf,desiredSplits);
-    }
-
-    public static int getConfiguredSplits(Configuration conf)
-    {
-        return GeoMesaInputFormat$.MODULE$.getConfiguredSplits(conf);
-    }
-
     @Deprecated
     public static void configure(Job job,
                                  Map<String, String> dataStoreParams,

--- a/geomesa-jobs/src/main/java/org/locationtech/geomesa/jobs/interop/mapreduce/GeoMesaInputFormat.java
+++ b/geomesa-jobs/src/main/java/org/locationtech/geomesa/jobs/interop/mapreduce/GeoMesaInputFormat.java
@@ -16,6 +16,7 @@
 
 package org.locationtech.geomesa.jobs.interop.mapreduce;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -61,6 +62,16 @@ public class GeoMesaInputFormat extends InputFormat<Text, SimpleFeature> {
                 JavaConverters.asScalaMapConverter(dataStoreParams).asScala()
                               .toMap(Predef.<Tuple2<String, String>>conforms());
         GeoMesaInputFormat$.MODULE$.configure(job, scalaParams, query);
+    }
+
+    public static void configureSplits(Configuration conf, Integer desiredSplits)
+    {
+        GeoMesaInputFormat$.MODULE$.configureSplits(conf,desiredSplits);
+    }
+
+    public static int getConfiguredSplits(Configuration conf)
+    {
+        return GeoMesaInputFormat$.MODULE$.getConfiguredSplits(conf);
     }
 
     @Deprecated

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/GeoMesaConfigurator.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/GeoMesaConfigurator.scala
@@ -43,6 +43,7 @@ object GeoMesaConfigurator {
   private val sftKey           = s"$prefix.sft"
   private val transformsKey    = s"$prefix.transforms.schema"
   private val transformNameKey = s"$prefix.transforms.name"
+  private val desiredSplits = s"$prefix.splitCount.userPreference"
   private val serializersKey   = "io.serializations"
 
   private val writableSerialization      = classOf[WritableSerialization].getName
@@ -69,6 +70,20 @@ object GeoMesaConfigurator {
     conf.set(sftKey, featureType)
   def getFeatureType(job: Job): String = getFeatureType(job.getConfiguration)
   def getFeatureType(conf: Configuration): String = conf.get(sftKey)
+
+  /**
+   * Configure the number of desired splits. This should be called with the final intended
+   * value. In general, you should use the number of shards * a guess about the number of
+   * partitions or splits you want per shard. The default is 2. Behavior is undefined for
+   * numbers less than 1.
+   *
+   * @param conf
+   * @param countOfSplits
+   */
+  def setDesiredSplits(conf: Configuration, countOfSplits : Int) : Unit =
+    conf.setInt(desiredSplits, countOfSplits)
+  def getDesiredSplits(job : Job): Int = getDesiredSplits(job.getConfiguration)
+  def getDesiredSplits(conf : Configuration): Int = conf.getInt(desiredSplits, -1)
 
   // set/get the cql filter
   def setFilter(conf: Configuration, filter: String): Unit = conf.set(filterKey, filter)

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/GeoMesaConfigurator.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/GeoMesaConfigurator.scala
@@ -43,7 +43,7 @@ object GeoMesaConfigurator {
   private val sftKey           = s"$prefix.sft"
   private val transformsKey    = s"$prefix.transforms.schema"
   private val transformNameKey = s"$prefix.transforms.name"
-  private val desiredSplits = s"$prefix.splitCount.userPreference"
+  private val desiredSplits    = s"$prefix.mapreduce.split.count.strongHint"
   private val serializersKey   = "io.serializations"
 
   private val writableSerialization      = classOf[WritableSerialization].getName

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaInputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaInputFormat.scala
@@ -130,13 +130,14 @@ object GeoMesaInputFormat extends Logging {
 /**
  * Input format that allows processing of simple features from GeoMesa based on a CQL query
  */
-class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] {
+class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with Logging {
 
   val delegate = new AccumuloInputFormat
 
   var sft: SimpleFeatureType = null
   var encoding: FeatureEncoding = null
   var numShards: Int = -1
+  var desiredSplitCount: Int = -1
 
   private def init(conf: Configuration) = if (sft == null) {
     val params = GeoMesaConfigurator.getDataStoreInParams(conf)
@@ -144,6 +145,7 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] {
     sft = ds.getSchema(GeoMesaConfigurator.getFeatureType(conf))
     encoding = ds.getFeatureEncoding(sft)
     numShards = IndexSchema.maxShard(ds.getIndexSchemaFmt(sft.getTypeName))
+    desiredSplitCount = GeoMesaConfigurator.getDesiredSplits(conf)
   }
 
   /**
@@ -159,11 +161,15 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] {
   override def getSplits(job: JobConf, numSplits: Int) = {
     init(job)
     val accumuloSplits = delegate.getSplits(job, numSplits)
-    // try to create 2 mappers per node - account for case where there are less splits than shards
-    val groupSize = Math.max(numShards * 2, accumuloSplits.length / (numShards * 2))
+    // fallback on creating 2 mappers per node if desiredSplits is unset.
+    // Account for case where there are less splits than shards
+    val groupSize =  if (desiredSplitCount > 1) {
+      Math.max(1, accumuloSplits.length / desiredSplitCount)
+    } else {
+      Math.max(numShards * 2, accumuloSplits.length / (numShards * 2))
+    }
 
-    // We know each range will only have a single location because of autoAdjustRanges
-    val splits = accumuloSplits.groupBy(_.getLocations()(0)).flatMap { case (location, splits) =>
+    val splitsSet = accumuloSplits.groupBy(_.getLocations()(0)).flatMap { case (location, splits) =>
       splits.grouped(groupSize).map { group =>
         val split = new GroupedSplit()
         split.location = location
@@ -171,7 +177,12 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] {
         split
       }
     }
-    splits.toArray
+    //we've dumped all ranges into groups by location, and tried to get enough splits by breaking up those groups.
+    //we may eventually need to go ahead and do some pretty grim mojo to break each split down small enough
+    //so that we don't blow executor's memory pools. Right now, that's not happening, so I'm not going to push it.
+    logger.info(s"Got ${splitsSet.toList.length} splits" +
+      s" using desired=$desiredSplitCount from ${accumuloSplits.length}")
+    splitsSet.toArray
   }
 
   override def getRecordReader(split: InputSplit, job: JobConf, reporter: Reporter) = {

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaInputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaInputFormat.scala
@@ -177,9 +177,7 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with Logging {
         split
       }
     }
-    //we've dumped all ranges into groups by location, and tried to get enough splits by breaking up those groups.
-    //we may eventually need to go ahead and do some pretty grim mojo to break each split down small enough
-    //so that we don't blow executor's memory pools. Right now, that's not happening, so I'm not going to push it.
+
     logger.info(s"Got ${splitsSet.toList.length} splits" +
       s" using desired=$desiredSplitCount from ${accumuloSplits.length}")
     splitsSet.toArray

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
@@ -176,9 +176,7 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with Logging {
         split
       }
     }
-    //we've dumped all ranges into groups by location, and tried to get enough splits by breaking up those groups.
-    //we may eventually need to go ahead and do some pretty grim mojo to break each split down small enough
-    //so that we don't blow executor's memory pools. Right now, that's not happening, so I'm not going to push it.
+
     logger.info(s"Got ${splitsSet.toList.length} splits" +
       s" using desired=$desiredSplitCount from ${accumuloSplits.length}")
     splitsSet.toList

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
@@ -145,7 +145,7 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with Logging {
     val ds = DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
     sft = ds.getSchema(GeoMesaConfigurator.getFeatureType(conf))
     encoding = ds.getFeatureEncoding(sft)
-    numShards = IndexSchema.maxShard(ds.getIndexSchemaFmt(sft.getTypeName))
+    numShards = Math.max(IndexSchema.maxShard(ds.getIndexSchemaFmt(sft.getTypeName)), 1)
     desiredSplitCount = conf.getInt("SplitsDesired", desiredSplitCount)
   }
 


### PR DESCRIPTION
Squashed commits covering breaking changes to the GeoSpark API to support controlled splitting in the GeoMesaInputFormat. This allows a user to supply a hint about how many partitions he or she would like to get per executor. 

This could use a second pair of eyes, as there's still sometimes fewer ranges initially than we would expect from a call to the AccumuloInputFormat's getSplits. It looks as though the AutoAdjustRanges behavior is being used even though the flag to disable it is set. @elahrvivaz or @ronq, if you could take a look, it might be good.