### PR TITLE
GEOMESA-735 - Update Commandline BatchWriterConfig to allow for abbreviations.

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfig.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfig.scala
@@ -14,15 +14,51 @@ object GeoMesaBatchWriterConfig extends Logging {
   val WRITER_THREADS         = "geomesa.batchwriter.maxthreads"
   val WRITE_TIMEOUT          = "geomesa.batchwriter.timeout.seconds"  // Timeout measured in seconds.  Likely unnecessary.
 
-  val DEFAULT_LATENCY   = 10000l   // 10 seconds
+  val DEFAULT_LATENCY    = 10000l   // 10 seconds
   val DEFAULT_MAX_MEMORY = 1000000l // 1 megabyte
-  val DEFAULT_THREADS   = 10
+  val DEFAULT_THREADS    = 10
 
   protected [util] def fetchProperty(prop: String): Option[Long] =
     for {
       p <- Option(System.getProperty(prop))
       num <- Try(java.lang.Long.parseLong(p)).toOption
     } yield num
+
+  protected [util] def fetchMemoryProperty(prop: String): Option[Long] =
+    for {
+      p <- Option(System.getProperty(prop))
+      num <- parseMemoryProperty(p)
+    } yield num
+
+  protected [util] def parseMemoryProperty(prop: String): Option[Long] = {
+
+    //Scala regex matches the whole string, the leading ^ and trailing $ is implied.
+    val matchSuffix = """(\d+)([A-Za-z]+)?""".r
+
+    //Define suffixes based on powers of 2
+    val suffixMap = Map(
+      "K" -> 1024l,
+      "k" -> 1024l,
+      "M" -> 1024l * 1024l,
+      "m" -> 1024l * 1024l,
+      "G" -> 1024l * 1024l * 1024l,
+      "g" -> 1024l * 1024l * 1024l
+    )
+
+    prop match {
+      case matchSuffix(number, null) =>
+        for {
+          num <- Try(java.lang.Long.parseLong(number)).toOption
+        } yield num
+      case matchSuffix(number, suffix) =>
+        if(suffixMap.contains(suffix))
+          for {
+            num <- Try(java.lang.Long.valueOf(number.toLong * suffixMap(suffix))).toOption
+          } yield num
+        else None
+      case _ => None
+    }
+  }
 
   protected [util] def buildBWC: BatchWriterConfig = {
     val bwc = new BatchWriterConfig
@@ -37,9 +73,7 @@ object GeoMesaBatchWriterConfig extends Logging {
         bwc.setMaxLatency(milliLatency, TimeUnit.MILLISECONDS)
     }
 
-    // TODO: Allow users to specify member with syntax like 100M or 50k.
-    // https://geomesa.atlassian.net/browse/GEOMESA-735
-    val memory = fetchProperty(WRITER_MEMORY).getOrElse(DEFAULT_MAX_MEMORY)
+    val memory = fetchMemoryProperty(WRITER_MEMORY).getOrElse(DEFAULT_MAX_MEMORY)
     logger.trace(s"GeoMesaBatchWriter config: maxMemory set to $memory bytes.")
     bwc.setMaxMemory(memory)
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfigTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfigTest.scala
@@ -29,9 +29,9 @@ class GeoMesaBatchWriterConfigTest extends Specification {
       val timeoutProp = "33"
 
       System.setProperty(GeoMesaBatchWriterConfig.WRITER_LATENCY_MILLIS, latencyProp)
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY,        memoryProp)
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_THREADS,       threadsProp)
-      System.setProperty(GeoMesaBatchWriterConfig.WRITE_TIMEOUT,        timeoutProp)
+      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY,         memoryProp)
+      System.setProperty(GeoMesaBatchWriterConfig.WRITER_THREADS,        threadsProp)
+      System.setProperty(GeoMesaBatchWriterConfig.WRITE_TIMEOUT,         timeoutProp)
 
       val nbwc = GeoMesaBatchWriterConfig.buildBWC
 
@@ -66,4 +66,60 @@ class GeoMesaBatchWriterConfigTest extends Specification {
       ret should equalTo(None)
     }
   }
+
+  "fetchMemoryProperty" should {
+    "retrieve a long correctly" in {
+      System.setProperty("foo", "123456789")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("foo")
+      ret should equalTo(Some(123456789l))
+    }
+
+    "return None correctly" in {
+      GeoMesaBatchWriterConfig.fetchMemoryProperty("bar") should equalTo(None)
+    }
+
+    "return None correctly when the System property is not parseable as a Long" in {
+      System.setProperty("baz", "fizzbuzz")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("baz")
+      ret should equalTo(None)
+    }
+
+    "retrieve a long correctly with a suffix" in {
+      System.setProperty("foo", "123456789K")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("foo")
+      ret should equalTo(Some(123456789l * 1024l))
+    }
+
+    "return None correctly when the System property is not parseable as a Long with a suffix" in {
+      System.setProperty("baz", "64fizzbuzz")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("baz")
+      ret should equalTo(None)
+    }
+
+    "return None correctly when the System property is not parseable as a Long with a prefix" in {
+      System.setProperty("baz", "fizzbuzz64")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("baz")
+      ret should equalTo(None)
+    }
+
+    "return None correctly when the System property is not parseable with trailing garbage" in {
+      System.setProperty("baz", "64k bazbaz")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("baz")
+      ret should equalTo(None)
+    }
+
+    "return None correctly when the System property is not parseable with leading garbage" in {
+      System.setProperty("baz", "foofoo 64G")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("baz")
+      ret should equalTo(None)
+    }
+  }
 }
+


### PR DESCRIPTION
Suffixes K, M, and G (case-insensitive) multiply memory specifications by 1024, 1024 * 1024, and 1024 * 1024 * 1024, respectively.

