### PR TITLE
GEOMESA-735 Update Commandline BatchWriterConfig to allow for abbrevi…

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfig.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfig.scala
@@ -14,15 +14,52 @@ object GeoMesaBatchWriterConfig extends Logging {
   val WRITER_THREADS         = "geomesa.batchwriter.maxthreads"
   val WRITE_TIMEOUT          = "geomesa.batchwriter.timeout.seconds"  // Timeout measured in seconds.  Likely unnecessary.
 
-  val DEFAULT_LATENCY   = 10000l   // 10 seconds
+  val DEFAULT_LATENCY    = 10000l   // 10 seconds
   val DEFAULT_MAX_MEMORY = 1000000l // 1 megabyte
-  val DEFAULT_THREADS   = 10
+  val DEFAULT_THREADS    = 10
 
   protected [util] def fetchProperty(prop: String): Option[Long] =
     for {
       p <- Option(System.getProperty(prop))
       num <- Try(java.lang.Long.parseLong(p)).toOption
     } yield num
+
+  protected [util] def fetchMemoryProperty(prop: String): Option[Long] =
+    for {
+      p <- Option(System.getProperty(prop))
+      num <- parseMemoryProperty(p)
+    } yield num
+
+  protected [util] def parseMemoryProperty(prop: String): Option[Long] = {
+
+    //Scala regex matches the whole string, the leading ^ and trailing $ is implied.
+    //First group matches numbers, second group must correspond to suffixMap keys below
+    val matchSuffix = """(\d+)([KkMmGg])?""".r
+
+    //Define suffixes based on powers of 2
+    val suffixMap = Map(
+      "K" -> 1024l,
+      "k" -> 1024l,
+      "M" -> 1024l * 1024l,
+      "m" -> 1024l * 1024l,
+      "G" -> 1024l * 1024l * 1024l,
+      "g" -> 1024l * 1024l * 1024l
+    )
+
+    prop match {
+      case matchSuffix(number, null) =>
+        //For-comprehension here also matches Scala.Long and Java.Long types
+        for {
+          num <- Try(java.lang.Long.parseLong(number)).toOption
+        } yield num
+      case matchSuffix(number, suffix) if suffixMap.contains(suffix) =>
+          for {
+            //Because we are not using parseLong(), we need to check for overflow
+            num <- Try(java.lang.Long.valueOf(number.toLong * suffixMap(suffix))).filter(_ > 0).toOption
+          } yield num
+      case _ => None
+    }
+  }
 
   protected [util] def buildBWC: BatchWriterConfig = {
     val bwc = new BatchWriterConfig
@@ -37,9 +74,7 @@ object GeoMesaBatchWriterConfig extends Logging {
         bwc.setMaxLatency(milliLatency, TimeUnit.MILLISECONDS)
     }
 
-    // TODO: Allow users to specify member with syntax like 100M or 50k.
-    // https://geomesa.atlassian.net/browse/GEOMESA-735
-    val memory = fetchProperty(WRITER_MEMORY).getOrElse(DEFAULT_MAX_MEMORY)
+    val memory = fetchMemoryProperty(WRITER_MEMORY).getOrElse(DEFAULT_MAX_MEMORY)
     logger.trace(s"GeoMesaBatchWriter config: maxMemory set to $memory bytes.")
     bwc.setMaxMemory(memory)
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfigTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfigTest.scala
@@ -29,9 +29,9 @@ class GeoMesaBatchWriterConfigTest extends Specification {
       val timeoutProp = "33"
 
       System.setProperty(GeoMesaBatchWriterConfig.WRITER_LATENCY_MILLIS, latencyProp)
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY,        memoryProp)
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_THREADS,       threadsProp)
-      System.setProperty(GeoMesaBatchWriterConfig.WRITE_TIMEOUT,        timeoutProp)
+      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY,         memoryProp)
+      System.setProperty(GeoMesaBatchWriterConfig.WRITER_THREADS,        threadsProp)
+      System.setProperty(GeoMesaBatchWriterConfig.WRITE_TIMEOUT,         timeoutProp)
 
       val nbwc = GeoMesaBatchWriterConfig.buildBWC
 
@@ -44,6 +44,89 @@ class GeoMesaBatchWriterConfigTest extends Specification {
       nbwc.getMaxMemory                         must be equalTo java.lang.Long.parseLong(memoryProp)
       nbwc.getMaxWriteThreads                   must be equalTo java.lang.Integer.parseInt(threadsProp)
       nbwc.getTimeout(TimeUnit.SECONDS)         must be equalTo java.lang.Long.parseLong(timeoutProp)
+    }
+  }
+
+  "GeoMesaBatchWriterConfig" should {
+    "respect system properties for memory with a K suffix" in {
+      val memoryProp  = "1234K"
+      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+
+      val nbwc = GeoMesaBatchWriterConfig.buildBWC
+      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+
+      nbwc.getMaxMemory must be equalTo java.lang.Long.valueOf(1234l * 1024l)
+    }
+
+    "respect system properties for memory with a k suffix" in {
+      val memoryProp  = "1234k"
+      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+
+      val nbwc = GeoMesaBatchWriterConfig.buildBWC
+      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+
+      nbwc.getMaxMemory must be equalTo java.lang.Long.valueOf(1234l * 1024l)
+    }
+
+    "respect system properties for memory with a M suffix" in {
+      val memoryProp  = "1234M"
+      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+
+      val nbwc = GeoMesaBatchWriterConfig.buildBWC
+      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+
+      nbwc.getMaxMemory must be equalTo java.lang.Long.valueOf(1234l * 1024l * 1024l)
+    }
+
+    "respect system properties for memory with a m suffix" in {
+      val memoryProp  = "1234m"
+      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+
+      val nbwc = GeoMesaBatchWriterConfig.buildBWC
+      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+
+      nbwc.getMaxMemory must be equalTo java.lang.Long.valueOf(1234l * 1024l * 1024l)
+    }
+
+    "respect system properties for memory with a G suffix" in {
+      val memoryProp  = "1234G"
+      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+
+      val nbwc = GeoMesaBatchWriterConfig.buildBWC
+      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+
+      nbwc.getMaxMemory must be equalTo java.lang.Long.valueOf(1234l * 1024l * 1024l * 1024l)
+    }
+
+    "respect system properties for memory with a g suffix" in {
+      val memoryProp  = "1234g"
+      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+
+      val nbwc = GeoMesaBatchWriterConfig.buildBWC
+      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+
+      nbwc.getMaxMemory must be equalTo java.lang.Long.valueOf(1234l * 1024l * 1024l * 1024l)
+    }
+
+    "respect system properties for invalid non-suffixed memory specifications exceeding Long limits" in {
+      //java.Long.MAX_VALUE =  9223372036854775807
+      val memoryProp        = "9999999999999999999"
+      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+
+      val nbwc = GeoMesaBatchWriterConfig.buildBWC
+      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+
+      nbwc.getMaxMemory must be equalTo GeoMesaBatchWriterConfig.DEFAULT_MAX_MEMORY
+    }
+
+    "respect system properties for invalid suffixed memory specifications exceeding Long limits" in {
+      val memoryProp = java.lang.Long.MAX_VALUE.toString + "k"
+      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+
+      val nbwc = GeoMesaBatchWriterConfig.buildBWC
+      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+
+      nbwc.getMaxMemory must be equalTo GeoMesaBatchWriterConfig.DEFAULT_MAX_MEMORY
     }
   }
 
@@ -61,9 +144,100 @@ class GeoMesaBatchWriterConfigTest extends Specification {
 
     "return None correctly when the System property is not parseable as a Long" in {
       System.setProperty("baz", "fizzbuzz")
-      val ret = GeoMesaBatchWriterConfig.fetchProperty("foo")
+      val ret = GeoMesaBatchWriterConfig.fetchProperty("baz")
+      System.clearProperty("baz")
+      ret should equalTo(None)
+    }
+  }
+
+  "fetchMemoryProperty" should {
+    "retrieve a long correctly" in {
+      System.setProperty("foo", "123456789")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("foo")
+      ret should equalTo(Some(123456789l))
+    }
+
+    "retrieve a long correctly with a K suffix" in {
+      System.setProperty("foo", "123456789K")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("foo")
+      ret should equalTo(Some(123456789l * 1024l))
+    }
+
+    "retrieve a long correctly with a k suffix" in {
+      System.setProperty("foo", "123456789k")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("foo")
+      ret should equalTo(Some(123456789l * 1024l))
+    }
+
+    "retrieve a long correctly with a M suffix" in {
+      System.setProperty("foo", "123456789m")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("foo")
+      ret should equalTo(Some(123456789l * 1024l * 1024l))
+    }
+
+    "retrieve a long correctly with a m suffix" in {
+      System.setProperty("foo", "123456789m")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("foo")
+      ret should equalTo(Some(123456789l * 1024l * 1024l))
+    }
+
+    "retrieve a long correctly with a G suffix" in {
+      System.setProperty("foo", "123456789G")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("foo")
+      ret should equalTo(Some(123456789l * 1024l * 1024l * 1024l))
+    }
+
+    "retrieve a long correctly with a g suffix" in {
+      System.setProperty("foo", "123456789g")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("foo")
+      ret should equalTo(Some(123456789l * 1024l * 1024l * 1024l))
+    }
+
+    "return None correctly" in {
+      GeoMesaBatchWriterConfig.fetchMemoryProperty("bar") should equalTo(None)
+    }
+
+    "return None correctly when the System property is not parseable as a Long" in {
+      System.setProperty("baz", "fizzbuzz")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("baz")
+      System.clearProperty("baz")
+      ret should equalTo(None)
+    }
+
+    "return None correctly when the System property is not parseable as a Long with a suffix" in {
+      System.setProperty("baz", "64fizzbuzz")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      System.clearProperty("baz")
+      ret should equalTo(None)
+    }
+
+    "return None correctly when the System property is not parseable as a Long with a prefix" in {
+      System.setProperty("baz", "fizzbuzz64")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("baz")
+      System.clearProperty("baz")
+      ret should equalTo(None)
+    }
+
+    "return None correctly when the System property is not parseable with trailing garbage" in {
+      System.setProperty("baz", "64k bazbaz")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("baz")
+      System.clearProperty("baz")
+      ret should equalTo(None)
+    }
+
+    "return None correctly when the System property is not parseable with leading garbage" in {
+      System.setProperty("baz", "foofoo 64G")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("baz")
       System.clearProperty("baz")
       ret should equalTo(None)
     }
   }
 }
+


### PR DESCRIPTION
…ations

Suffixes K, M, and G (case-insensitive) multiply memory specifications
by 1024, 1024 ^ 2, and 1024 ^ 3, respectively.

Signed-off-by: Daniel Floyd <daniel.j.floyd@gmail.com>