### PR TITLE
GEOMESA-825 Sort using indexes for performance.

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIdxStrategy.scala
@@ -84,7 +84,8 @@ trait AttributeIdxStrategy extends Strategy with Logging {
     val encoding = queryPlanner.featureEncoding
     val version = acc.getGeomesaVersion(sft)
     val hasDupes = sft.getDescriptor(attributeName).isMultiValued
-    val kvsToFeatures = queryPlanner.defaultKVsToFeatures(query)
+    val retSFT = QueryPlanner.getReturnSFT(query, sft)
+    val kvsToFeatures = queryPlanner.defaultKVsToFeatures(query, retSFT)
 
     // choose which iterator we want to use - joining iterator or attribute only iterator
     val iteratorChoice: IteratorConfig =

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategy.scala
@@ -120,7 +120,8 @@ class RecordIdxStrategy extends Strategy with Logging {
 
     val table = acc.getRecordTable(sft)
     val threads = acc.getSuggestedRecordThreads(sft)
-    val kvsToFeatures = queryPlanner.defaultKVsToFeatures(query)
+    val retSFT = QueryPlanner.getReturnSFT(query, sft)
+    val kvsToFeatures = queryPlanner.defaultKVsToFeatures(query, retSFT)
     Seq(BatchScanPlan(table, ranges.toSeq, iters, Seq.empty, kvsToFeatures, threads, hasDuplicates = false))
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/STIdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/STIdxStrategy.scala
@@ -112,7 +112,8 @@ class STIdxStrategy extends Strategy with Logging with IndexFilterHelpers {
     val iterators = qp.iterators ++ List(Some(stiiIterCfg), densityIterCfg).flatten
     val numThreads = acc.getSuggestedSpatioTemporalThreads(sft)
     val hasDupes = IndexSchema.mayContainDuplicates(sft)
-    val kvsToFeatures = queryPlanner.defaultKVsToFeatures(query)
+    val retSFT = QueryPlanner.getReturnSFT(query, sft)
+    val kvsToFeatures = queryPlanner.defaultKVsToFeatures(query, retSFT)
     val res = qp.copy(table = table, iterators = iterators, kvsToFeatures = kvsToFeatures, numThreads = numThreads, hasDuplicates = hasDupes)
     Seq(res)
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/LazySortedIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/LazySortedIteratorTest.scala
@@ -18,9 +18,11 @@ package org.locationtech.geomesa.accumulo.index
 import java.util.NoSuchElementException
 
 import org.geotools.factory.CommonFactoryFinder
+import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.util.CloseableIterator
-import org.opengis.feature.simple.SimpleFeature
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.sort.{SortBy, SortOrder}
 import org.specs2.matcher.MatchResult
 import org.specs2.mock.Mockito
@@ -34,11 +36,20 @@ class LazySortedIteratorTest extends Specification with Mockito {
   
   "LazySortedIterator" should {
 
-    val a =  mockSF(1, "A", 7)
-    val b =  mockSF(2, "B", 9)
-    val c1 = mockSF(3, "C", 6)
-    val c2 = mockSF(4, "C", 9)
-    val d =  mockSF(5, "D", 6)
+    val sft = SimpleFeatureTypes.createType("ns:test", "age:Int,name:String,foo:Int")
+    val builder = new SimpleFeatureBuilder(sft)
+
+    def buildSF(id: Int, name: String, age: Int): SimpleFeature = {
+      import scala.collection.JavaConversions._
+      builder.reset()
+      builder.addAll(List[AnyRef](age : java.lang.Integer, name))
+      builder.buildFeature(id.toString)
+    }
+    val a =  buildSF(1, "A", 7)
+    val b =  buildSF(2, "B", 9)
+    val c1 = buildSF(3, "C", 6)
+    val c2 = buildSF(4, "C", 9)
+    val d =  buildSF(5, "D", 6)
 
     "lazily sort" >> {
 
@@ -47,7 +58,7 @@ class LazySortedIteratorTest extends Specification with Mockito {
         features.hasNext returns true thenReturns true thenReturns false
         features.next returns b thenReturns a thenThrows new NoSuchElementException
 
-        val test = new LazySortedIterator(features, Array(SortBy.NATURAL_ORDER))
+        val test = new LazySortedIterator(features, Array(SortBy.NATURAL_ORDER), sft)
 
         there was no(features).hasNext
         there was no(features).next
@@ -65,7 +76,7 @@ class LazySortedIteratorTest extends Specification with Mockito {
         features.hasNext returns true thenReturns true thenReturns false
         features.next returns b thenReturns a thenThrows new NoSuchElementException
 
-        val test = new LazySortedIterator(features, Array(SortBy.NATURAL_ORDER))
+        val test = new LazySortedIterator(features, Array(SortBy.NATURAL_ORDER), sft)
 
         there was no(features).hasNext
         there was no(features).next
@@ -83,14 +94,14 @@ class LazySortedIteratorTest extends Specification with Mockito {
       val features = CloseableIterator(Iterator(b, c1, d, a, c2))
       val sortBy = Array(SortBy.NATURAL_ORDER)
 
-      test(features, sortBy, Seq(a, b, c1, c2, d))
+      test(features, sortBy, Seq(a, b, c1, c2, d), sft)
     }
 
     "be able to sort by id desc" >> {
       val features = CloseableIterator(Iterator(b, c1, d, a, c2))
       val sortBy =Array(SortBy.REVERSE_ORDER) 
       
-      test(features, sortBy, Seq(d, c2, c1, b, a))
+      test(features, sortBy, Seq(d, c2, c1, b, a), sft)
     }
 
     "be able to sort by an attribute asc" >> {
@@ -98,7 +109,7 @@ class LazySortedIteratorTest extends Specification with Mockito {
       val sortBy = Array(ff.sort("name", SortOrder.ASCENDING))
 
       // sort is stable
-      test(features, sortBy, Seq(a, b, c2, c1, d))
+      test(features, sortBy, Seq(a, b, c2, c1, d), sft)
     }
 
     "be able to sort by an attribute desc" >> {
@@ -106,37 +117,30 @@ class LazySortedIteratorTest extends Specification with Mockito {
       val sortBy = Array(ff.sort("name", SortOrder.DESCENDING))
 
       // sort is stable
-      test(features, sortBy, Seq(d, c2, c1, b, a))
+      test(features, sortBy, Seq(d, c2, c1, b, a), sft)
     }
 
     "be able to sort by an attribute and id" >> {
       val features = CloseableIterator(Iterator(b, c2, d, a, c1))
       val sortBy = Array(ff.sort("name", SortOrder.ASCENDING), SortBy.NATURAL_ORDER)
 
-      test(features, sortBy, Seq(a, b, c1, c2, d))
+      test(features, sortBy, Seq(a, b, c1, c2, d), sft)
     }
 
     "be able to sort by an multiple attributes" >> {
       val features = CloseableIterator(Iterator(a, b, c1, d, c2))
       val sortBy = Array(ff.sort("age", SortOrder.DESCENDING), ff.sort("name", SortOrder.ASCENDING))
 
-      test(features, sortBy, Seq(b, c2, a, c1, d))
+      test(features, sortBy, Seq(b, c2, a, c1, d), sft)
     }
   }
 
-  def mockSF(id: Int, name: String, age: Int): SimpleFeature = {
-    val sf = mock[SimpleFeature]
-    sf.getID returns id.toString
-    sf.getAttribute("name") returns name
-    sf.getAttribute("age") returns age.asInstanceOf[AnyRef]
-    sf
-  }
-
   def test(features: CloseableIterator[SimpleFeature],
-             sortBy: Array[SortBy],
-             expected: Seq[SimpleFeature]): MatchResult[Any] = {
+           sortBy: Array[SortBy],
+           expected: Seq[SimpleFeature],
+           sft: SimpleFeatureType): MatchResult[Any] = {
 
-    val test = new LazySortedIterator(features, sortBy)
+    val test = new LazySortedIterator(features, sortBy, sft)
 
     expected.foreach {f =>
       test.hasNext must beTrue

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryPlannerTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryPlannerTest.scala
@@ -16,25 +16,22 @@
 package org.locationtech.geomesa.accumulo.index
 
 import java.util.AbstractMap.SimpleEntry
-import java.util.Map.Entry
 
 import org.apache.accumulo.core.data.{Key, Value}
 import org.apache.hadoop.io.Text
 import org.geotools.data.Query
+import org.geotools.factory.CommonFactoryFinder
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.TestWithDataStore
-import org.locationtech.geomesa.accumulo.data.AccumuloConnectorCreator
-import org.locationtech.geomesa.accumulo.util.CloseableIterator
-import org.locationtech.geomesa.features.{ScalaSimpleFeature, SimpleFeatureSerializers, SerializationType, SimpleFeatureDeserializer}
+import org.locationtech.geomesa.accumulo.data.INTERNAL_GEOMESA_VERSION
+import org.locationtech.geomesa.features.{ScalaSimpleFeature, SerializationType, SimpleFeatureSerializers}
 import org.locationtech.geomesa.security._
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
-import org.opengis.feature.simple.SimpleFeature
 import org.opengis.filter.sort.SortBy
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import org.locationtech.geomesa.accumulo.data.INTERNAL_GEOMESA_VERSION
 
+import scala.collection.JavaConversions._
 
 @RunWith(classOf[JUnitRunner])
 class QueryPlannerTest extends Specification with Mockito with TestWithDataStore {
@@ -43,8 +40,10 @@ class QueryPlannerTest extends Specification with Mockito with TestWithDataStore
   val schema = ds.getIndexSchemaFmt(sftName)
   val sf = new ScalaSimpleFeature("id", sft)
   sf.setAttributes(Array[AnyRef]("POINT(45 45)", "2014/10/10T00:00:00Z", "string"))
+  val sf2 = new ScalaSimpleFeature("id2", sft)
+  sf2.setAttributes(Array[AnyRef]("POINT(45 45)", "2014/10/10T00:00:00Z", "astring"))
 
-  addFeatures(Seq(sf))
+  addFeatures(Seq(sf, sf2))
 
   "adaptStandardIterator" should {
     "return a LazySortedIterator when the query has an order by clause" >> {
@@ -82,10 +81,23 @@ class QueryPlannerTest extends Specification with Mockito with TestWithDataStore
         new SimpleEntry[Key, Value](key, value)
       }
 
-      val expectedResult = kvs.map(planner.defaultKVsToFeatures(query)).map(_.visibility)
+      val expectedResult = kvs.map(planner.defaultKVsToFeatures(query, sft)).map(_.visibility)
 
       expectedResult must haveSize(kvs.length)
       expectedResult mustEqual expectedVis
+    }
+
+    "sort with a projected SFT" >> {
+      val ff = CommonFactoryFinder.getFilterFactory2
+      val query = new Query(sft.getTypeName)
+      query.setSortBy(Array(SortBy.NATURAL_ORDER))
+      query.setProperties(List(ff.property("s")))
+
+      val planner = new QueryPlanner(sft, SerializationType.KRYO, schema, ds, NoOpHints, INTERNAL_GEOMESA_VERSION)
+      val result = planner.query(query).toList
+
+      result must containTheSameElementsAs(Seq(sf2, sf))
+
     }
   }
 }


### PR DESCRIPTION
Use the projected SFT to determine the indexes
because the data will possibly already have been
projected remotely.

Signed-off-by: Anthony Fox <anthonyfox@ccri.com>