### PR TITLE
GEOMESA-795 Write attribute histogram results to accumulo "_stats" table

### DIFF
--- a/geomesa-jobs/README.md
+++ b/geomesa-jobs/README.md
@@ -83,6 +83,7 @@ geomesa> yarn jar geomesa-jobs/target/geomesa-jobs-accumulo1.5-1.0.0-shaded.jar 
     --geomesa.input.tableName <catalog-table> \
     --geomesa.input.feature <feature> \
     --geomesa.input.transform <attribute transforms - space separated> \ # optional
+    --geomesa.hist.write.to.accumulo <true/false> \ #optional
     --geomesa.hist.attribute <attribute to histogram> \
     --geomesa.hist.file.out <hdfs path to write results> \
     --geomesa.hist.group.attributes <additional attributes that will be used to group the results - space separated> \ # optional

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/analytics/HistogramJob.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/analytics/HistogramJob.scala
@@ -19,7 +19,9 @@ package org.locationtech.geomesa.jobs.analytics
 import com.twitter.algebird.Aggregator
 import com.twitter.scalding._
 import com.twitter.scalding.typed.UnsortedGrouped
+import org.apache.accumulo.core.data.Mutation
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.io.Text
 import org.geotools.data.DataStoreFinder
 import org.locationtech.geomesa.accumulo.data._
 import org.locationtech.geomesa.jobs.GeoMesaBaseJob
@@ -30,7 +32,6 @@ import org.locationtech.geomesa.jobs.scalding._
 import org.opengis.feature.simple.SimpleFeature
 
 import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
 import scala.math.Ordering
 
 /**
@@ -47,14 +48,18 @@ class HistogramJob(args: Args) extends GeoMesaBaseJob(args) {
   val groupBy    = args.nonStrictList(GROUP_BY)
   val uniqueBy   = args.nonStrictList(UNIQUE_BY)
   val transforms = Option(args.list(TRANSFORM_IN).toArray).filter(_.nonEmpty)
+  val writeToAccumulo  = args.boolean(WRITE_TO_ACCUMULO)
 
   val input = GeoMesaInputOptions(dsParams, feature, filter, transforms)
+  lazy val dsParamsAccOutput = dsParams.updated("tableName", s"${dsParams.get("tableName").get}_stats")
+  lazy val accOutput = AccumuloOutputOptions(dsParamsAccOutput)
+
   val output = args(FILE_OUT)
 
   // TODO we could look up attribute values by index for performance gain
   // verify input params - inside a block so they don't get serialized
   {
-    val ds = DataStoreFinder.getDataStore(dsParams.asJava).asInstanceOf[AccumuloDataStore]
+    val ds = DataStoreFinder.getDataStore(dsParams).asInstanceOf[AccumuloDataStore]
     val sft = ds.getSchema(feature)
     assert(sft != null, s"The feature '$feature' does not exist in the input data store")
     val descriptors = sft.getAttributeDescriptors.map(_.getLocalName)
@@ -96,16 +101,26 @@ class HistogramJob(args: Args) extends GeoMesaBaseJob(args) {
   val aggregates: UnsortedGrouped[Product, Long] = groups.aggregate(Aggregator.size)
 
   // write out the histogram to a tsv file - we create the tabs ourselves since length isn't known
-  aggregates.toTypedPipe.map { case (group, count) => s"${group.productIterator.mkString("\t")}\t$count" }
+  if (writeToAccumulo) {
+    aggregates.toTypedPipe
+      .map{ case (group, count) =>
+      val mut = new Mutation(new Text(s"$feature~$attribute~${group.productElement(group.productArity - 1).toString}"))
+      mut.put(new Text(s"${group.productIterator.mkString("\t")}"), new Text(count.toString.getBytes), EMPTY_VALUE)
+      (null: Text, mut)
+    }.write(AccumuloSource(accOutput))
+  } else {
+    aggregates.toTypedPipe.map { case (group, count) => s"${group.productIterator.mkString("\t")}\t$count" }
       .write(TypedTsv[String](output))
+  }
 }
 
 object HistogramJob {
 
-  val ATTRIBUTE   = "geomesa.hist.attribute"
-  val GROUP_BY    = "geomesa.hist.group.attributes"
-  val UNIQUE_BY   = "geomesa.hist.unique.attributes"
-  val FILE_OUT    = "geomesa.hist.file.out"
+  val ATTRIBUTE         = "geomesa.hist.attribute"
+  val GROUP_BY          = "geomesa.hist.group.attributes"
+  val UNIQUE_BY         = "geomesa.hist.unique.attributes"
+  val FILE_OUT          = "geomesa.hist.file.out"
+  val WRITE_TO_ACCUMULO = "geomesa.hist.write.to.accumulo"
 
   implicit class RichList[A <: Object](val l: List[A]) extends AnyVal {
 
@@ -150,12 +165,14 @@ object HistogramJob {
              dsParams: Map[String, String],
              feature: String,
              attribute: String,
-             groupBy: List[String] = List.empty,
-             uniqueBy: List[String] = List.empty) = {
-    val args = Seq(FEATURE_IN -> List(feature),
-                   ATTRIBUTE  -> List(attribute),
-                   GROUP_BY   -> groupBy,
-                   UNIQUE_BY  -> uniqueBy).toMap ++ toInArgs(dsParams)
+             groupBy: List[String]    = List.empty,
+             uniqueBy: List[String]   = List.empty,
+             writeToAccumulo: Boolean = false) = {
+    val args = Seq(FEATURE_IN        -> List(feature),
+                   ATTRIBUTE         -> List(attribute),
+                   GROUP_BY          -> groupBy,
+                   UNIQUE_BY         -> uniqueBy,
+                   WRITE_TO_ACCUMULO -> List(writeToAccumulo.toString)).toMap ++ toInArgs(dsParams)
     val instantiateJob = (args: Args) => new HistogramJob(args)
     GeoMesaBaseJob.runJob(conf, args, instantiateJob)
   }

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/scalding/AccumuloSourceOptions.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/scalding/AccumuloSourceOptions.scala
@@ -51,6 +51,17 @@ case class AccumuloInputOptions(
     scanIsolation: Option[Boolean] = None,
     logLevel: Option[Level] = None) extends AccumuloSourceOptions
 
+object AccumuloInputOptions {
+  def apply(dsParams: Map[String, String]) = {
+    new AccumuloInputOptions(
+      dsParams.getOrElse("instanceId", "None"),
+      dsParams.getOrElse("zookeepers", "None"),
+      dsParams.getOrElse("user", "None"),
+      dsParams.getOrElse("password", "None"),
+      dsParams.getOrElse("tableName", "None"))
+  }
+}
+
 case class AccumuloOutputOptions(
     instance: String,
     zooKeepers: String,
@@ -61,6 +72,18 @@ case class AccumuloOutputOptions(
     memory: Option[Long] = None,
     createTable: Boolean = false,
     logLevel: Option[Level] = None) extends AccumuloSourceOptions
+
+object AccumuloOutputOptions {
+  def apply(dsParams: Map[String, String]) = {
+    new AccumuloOutputOptions(
+      dsParams.getOrElse("instanceId", "None"),
+      dsParams.getOrElse("zookeepers", "None"),
+      dsParams.getOrElse("user", "None"),
+      dsParams.getOrElse("password", "None"),
+      dsParams.getOrElse("tableName", "None"),
+      createTable = true)
+  }
+}
 
 case class SerializedRange(start: Endpoint, end: Endpoint)
 
@@ -82,13 +105,13 @@ object SerializedRange {
      */
 
     def startBracket = """[\(\[]""".r ^^ {
-      case b if b == "(" => Bracket(false)
-      case b if b == "[" => Bracket(true)
+      case b if b == "(" => Bracket(inclusive = false)
+      case b if b == "[" => Bracket(inclusive = true)
     }
 
     def endBracket = """[\)\]]""".r ^^ {
-      case b if b == ")" => Bracket(false)
-      case b if b == "]" => Bracket(true)
+      case b if b == ")" => Bracket(inclusive = false)
+      case b if b == "]" => Bracket(inclusive = true)
     }
 
     def part = """[^\[\]\(\),\s]+""".r
@@ -133,15 +156,15 @@ object SerializedRange {
       sb.clear()
       if (r.isStartKeyInclusive) sb.append("[") else sb.append("(")
       if (!r.isInfiniteStartKey) {
-        sb.append(r.getStartKey.getRow().toString)
-        sb.append(" ").append(r.getStartKey.getColumnFamily().toString)
-        sb.append(" ").append(r.getStartKey.getColumnQualifier().toString)
+        sb.append(r.getStartKey.getRow.toString)
+        sb.append(" ").append(r.getStartKey.getColumnFamily.toString)
+        sb.append(" ").append(r.getStartKey.getColumnQualifier.toString)
       }
       sb.append(",")
       if (!r.isInfiniteStopKey) {
-        sb.append(r.getEndKey.getRow().toString)
-        sb.append(" ").append(r.getEndKey.getColumnFamily().toString)
-        sb.append(" ").append(r.getEndKey.getColumnQualifier().toString)
+        sb.append(r.getEndKey.getRow.toString)
+        sb.append(" ").append(r.getEndKey.getColumnFamily.toString)
+        sb.append(" ").append(r.getEndKey.getColumnQualifier.toString)
       }
       if (r.isEndKeyInclusive) sb.append("]") else sb.append(")")
       sb.toString()


### PR DESCRIPTION
Attribute histogram job results can now be written back to accumulo in a {feature-name}_stats table by setting the "geomesa.hist.write.to.accumulo" to true.