### PR TITLE
GEOMESA-828 Adding configurable query timeouts

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/accumulo.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/accumulo.scala
@@ -52,6 +52,32 @@ package object accumulo {
   val GEOMESA_ITERATORS_INDEX_SCHEMA             = "geomesa.iterators.index.schema"
   val GEOMESA_ITERATORS_VERSION                  = "geomesa.iterators.version"
 
+  object GeomesaSystemProperties {
+
+    val CONFIG_FILE = PropAndDefault("geomesa.config.file", "geomesa-site.xml")
+
+    object QueryProperties {
+      val QUERY_EXACT_COUNT    = PropAndDefault("geomesa.force.count", "false")
+      val QUERY_TIMEOUT_MILLIS = PropAndDefault("geomesa.query.timeout.millis", "300000") // default 5 minutes
+    }
+
+    object BatchWriterProperties {
+      // Measured in millis, default 10 seconds
+      val WRITER_LATENCY_MILLIS  = PropAndDefault("geomesa.batchwriter.latency.millis", "10000")
+      // Measured in bytes, default 1 megabyte
+      val WRITER_MEMORY_BYTES    = PropAndDefault("geomesa.batchwriter.memory", "1000000")
+      val WRITER_THREADS         = PropAndDefault("geomesa.batchwriter.maxthreads", "10")
+      // Timeout measured in seconds.  Likely unnecessary.
+      val WRITE_TIMEOUT_MILLIS   = PropAndDefault("geomesa.batchwriter.timeout.millis", null)
+    }
+
+    case class PropAndDefault(property: String, default: String) {
+      def get: String = sys.props.getOrElse(property, default)
+      def set(value: String): Unit = sys.props.put(property, value)
+      def clear(): Unit = sys.props.remove(property)
+    }
+  }
+
   /**
    * Sums the values by key and returns a map containing all of the keys in the maps, with values
    * equal to the sum of all of the values for that key in the maps.

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/accumulo.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/accumulo.scala
@@ -58,7 +58,7 @@ package object accumulo {
 
     object QueryProperties {
       val QUERY_EXACT_COUNT    = PropAndDefault("geomesa.force.count", "false")
-      val QUERY_TIMEOUT_MILLIS = PropAndDefault("geomesa.query.timeout.millis", "300000") // default 5 minutes
+      val QUERY_TIMEOUT_MILLIS = PropAndDefault("geomesa.query.timeout.millis", null) // default is no timeout
     }
 
     object BatchWriterProperties {
@@ -73,6 +73,7 @@ package object accumulo {
 
     case class PropAndDefault(property: String, default: String) {
       def get: String = sys.props.getOrElse(property, default)
+      def option: Option[String] = sys.props.get(property).orElse(Option(default))
       def set(value: String): Unit = sys.props.put(property, value)
       def clear(): Unit = sys.props.remove(property)
     }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/conf/AccGeoConfiguration.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/conf/AccGeoConfiguration.scala
@@ -18,6 +18,7 @@ package org.locationtech.geomesa.accumulo.conf
 
 import org.apache.accumulo.core.conf.{AccumuloConfiguration, DefaultConfiguration}
 import org.apache.hadoop.conf.Configuration
+import org.locationtech.geomesa.accumulo.GeomesaSystemProperties
 
 import scala.collection.JavaConversions._
 
@@ -49,7 +50,7 @@ object AccGeoConfiguration {
   lazy val accConf: DefaultConfiguration = AccumuloConfiguration.getDefaultConfiguration
 
   lazy val accGeoConf = {
-    val configFile = System.getProperty("geomesa.config.file", "geomesa-site.xml")
+    val configFile = GeomesaSystemProperties.CONFIG_FILE.get
     val c = new Configuration(false)
     loadResource(configFile) match {
       case null => println("WARN: Config '" + configFile + "' not available")

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -84,8 +84,8 @@ class AccumuloDataStore(val connector: Connector,
   // having at least as many shards as tservers provides optimal parallelism in queries
   protected[accumulo] val DEFAULT_MAX_SHARD = connector.instanceOperations().getTabletServers.size()
 
-  protected[data] val queryTimeoutMillis =
-    queryTimeoutConfig.getOrElse(GeomesaSystemProperties.QueryProperties.QUERY_TIMEOUT_MILLIS.get.toLong)
+  protected[data] val queryTimeoutMillis: Option[Long] = queryTimeoutConfig
+      .orElse(GeomesaSystemProperties.QueryProperties.QUERY_TIMEOUT_MILLIS.option.map(_.toLong))
 
   // record scans are single-row ranges - increasing the threads too much actually causes performance to decrease
   private val recordScanThreads = recordThreadsConfig.getOrElse(10)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
@@ -95,6 +95,7 @@ class AccumuloDataStoreFactory extends DataStoreFactorySpi {
         tableName,
         authorizationsProvider,
         visibility,
+        queryTimeoutParam.lookupOpt[Int](params).map(i => i * 1000L),
         queryThreadsParam.lookupOpt(params),
         recordThreadsParam.lookupOpt(params),
         writeThreadsParam.lookupOpt(params),
@@ -106,6 +107,7 @@ class AccumuloDataStoreFactory extends DataStoreFactorySpi {
         tableName,
         authorizationsProvider,
         visibility,
+        queryTimeoutParam.lookupOpt[Int](params).map(i => i * 1000L),
         queryThreadsParam.lookupOpt(params),
         recordThreadsParam.lookupOpt(params),
         writeThreadsParam.lookupOpt(params),
@@ -147,14 +149,15 @@ object AccumuloDataStoreFactory {
   }
 
   object params {
-    val connParam           = new Param("connector", classOf[Connector], "The Accumulo connector", false)
-    val instanceIdParam     = new Param("instanceId", classOf[String], "The Accumulo Instance ID", true)
+    val connParam           = new Param("connector", classOf[Connector], "Accumulo connector", false)
+    val instanceIdParam     = new Param("instanceId", classOf[String], "Accumulo Instance ID", true)
     val zookeepersParam     = new Param("zookeepers", classOf[String], "Zookeepers", true)
     val userParam           = new Param("user", classOf[String], "Accumulo user", true)
-    val passwordParam       = new Param("password", classOf[String], "Password", true)
+    val passwordParam       = new Param("password", classOf[String], "Accumulo password", true)
     val authsParam          = org.locationtech.geomesa.security.authsParam
     val visibilityParam     = new Param("visibilities", classOf[String], "Accumulo visibilities to apply to all written data", false)
-    val tableNameParam      = new Param("tableName", classOf[String], "The Accumulo Table Name", true)
+    val tableNameParam      = new Param("tableName", classOf[String], "Accumulo catalog table name", true)
+    val queryTimeoutParam   = new Param("queryTimeout", classOf[Integer], "The max time a query will be allowed to run before being killed, in seconds", false)
     val queryThreadsParam   = new Param("queryThreads", classOf[Integer], "The number of threads to use per query", false)
     val recordThreadsParam  = new Param("recordThreads", classOf[Integer], "The number of threads to use for record retrieval", false)
     val writeMemoryParam    = new Param("writeMemory", classOf[Integer], "The memory allocation to use for writing records", false)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureReader.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureReader.scala
@@ -31,7 +31,7 @@ class AccumuloFeatureReader(queryPlanner: QueryPlanner, val query: Query, dataSt
   private val start = System.currentTimeMillis()
   private val closed = new AtomicBoolean(false)
 
-  ThreadManagement.register(this, start, dataStore.queryTimeoutMillis)
+  dataStore.queryTimeoutMillis.foreach(timeout => ThreadManagement.register(this, start, timeout))
 
   private val writeStats = dataStore.isInstanceOf[StatWriter]
   implicit val timings = if (writeStats) new TimingsImpl else NoOpTimings
@@ -44,7 +44,7 @@ class AccumuloFeatureReader(queryPlanner: QueryPlanner, val query: Query, dataSt
 
   override def close() = if (!closed.getAndSet(true)) {
     iter.close()
-    ThreadManagement.unregister(this, start, dataStore.queryTimeoutMillis)
+    dataStore.queryTimeoutMillis.foreach(timeout => ThreadManagement.unregister(this, start, timeout))
     if (writeStats) {
       val stat = QueryStat(queryPlanner.sft.getTypeName,
           System.currentTimeMillis(),

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/ThreadManagement.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/ThreadManagement.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0 which
+ * accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ */
+
+package org.locationtech.geomesa.accumulo.data
+
+import java.util.concurrent.{Executors, PriorityBlockingQueue, TimeUnit}
+
+import com.typesafe.scalalogging.slf4j.Logging
+import org.locationtech.geomesa.accumulo.stats.QueryStatTransform
+
+/**
+ * Singleton for registering and managing running queries.
+ */
+object ThreadManagement extends Logging {
+
+  private val interval = 5000L // how often we check for expired readers
+  private val ordering = new Ordering[ReaderAndTime]() {
+    // head of queue will be ones the will timeout first
+    override def compare(x: ReaderAndTime, y: ReaderAndTime) = x.killAt.compareTo(y.killAt)
+  }
+  private val openReaders = new PriorityBlockingQueue[ReaderAndTime](11, ordering) // size will grow unbounded
+
+  private val reaper = new Runnable() {
+    override def run() = {
+      val time = System.currentTimeMillis()
+      var loop = true
+      var numClosed = 0
+      while (loop) {
+        val holder = openReaders.poll()
+        if (holder == null) {
+          loop = false
+        } else if (holder.killAt < time) {
+          if (!holder.reader.isClosed) {
+            logger.warn(s"Stopping query on schema '${holder.reader.query.getTypeName}' with filter " +
+                s"'${QueryStatTransform.filterToString(holder.reader.query.getFilter)}' " +
+                s"based on timeout of ${holder.timeout}ms")
+            holder.reader.close()
+            numClosed += 1
+          }
+        } else {
+          if (!holder.reader.isClosed) {
+            openReaders.offer(holder)
+          }
+          loop = false
+        }
+      }
+      logger.trace(s"Force closed $numClosed queries with ${openReaders.size()} queries still running.")
+    }
+  }
+
+  private val executor = Executors.newSingleThreadScheduledExecutor()
+  executor.scheduleWithFixedDelay(reaper, interval, interval, TimeUnit.MILLISECONDS)
+  sys.addShutdownHook(executor.shutdown())
+
+  /**
+   * Register a query with the thread manager
+   */
+  def register(reader: AccumuloFeatureReader, start: Long, timeout: Long): Unit =
+    openReaders.offer(ReaderAndTime(reader, start + timeout, timeout))
+
+  /**
+   * Unregister a query with the thread manager once the query has been closed
+   */
+  def unregister(reader: AccumuloFeatureReader, start: Long, timeout: Long): Unit =
+    openReaders.remove(ReaderAndTime(reader, start + timeout, timeout))
+
+  case class ReaderAndTime(reader: AccumuloFeatureReader, killAt: Long, timeout: Long)
+}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfig.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfig.scala
@@ -4,33 +4,20 @@ import java.util.concurrent.TimeUnit
 
 import com.typesafe.scalalogging.slf4j.Logging
 import org.apache.accumulo.core.client.BatchWriterConfig
+import org.locationtech.geomesa.accumulo.GeomesaSystemProperties
+import org.locationtech.geomesa.accumulo.GeomesaSystemProperties.PropAndDefault
 
 import scala.util.Try
 
 object GeoMesaBatchWriterConfig extends Logging {
-  val WRITER_LATENCY_SECONDS = "geomesa.batchwriter.latency.seconds"  // Measured in seconds
-  val WRITER_LATENCY_MILLIS  = "geomesa.batchwriter.latency.millis"   // Measured in millis
-  val WRITER_MEMORY          = "geomesa.batchwriter.memory"           // Measured in bytes
-  val WRITER_THREADS         = "geomesa.batchwriter.maxthreads"
-  val WRITE_TIMEOUT          = "geomesa.batchwriter.timeout.seconds"  // Timeout measured in seconds.  Likely unnecessary.
 
-  val DEFAULT_LATENCY    = 10000l   // 10 seconds
-  val DEFAULT_MAX_MEMORY = 1000000l // 1 megabyte
-  val DEFAULT_THREADS    = 10
+  protected[util] def fetchProperty(prop: PropAndDefault): Option[Long] =
+    for { p <- Option(prop.get); num <- Try(java.lang.Long.parseLong(p)).toOption } yield num
 
-  protected [util] def fetchProperty(prop: String): Option[Long] =
-    for {
-      p <- Option(System.getProperty(prop))
-      num <- Try(java.lang.Long.parseLong(p)).toOption
-    } yield num
+  protected[util] def fetchMemoryProperty(prop: PropAndDefault): Option[Long] =
+    for { p <- Option(prop.get); num <- parseMemoryProperty(p) } yield num
 
-  protected [util] def fetchMemoryProperty(prop: String): Option[Long] =
-    for {
-      p <- Option(System.getProperty(prop))
-      num <- parseMemoryProperty(p)
-    } yield num
-
-  protected [util] def parseMemoryProperty(prop: String): Option[Long] = {
+  protected[util] def parseMemoryProperty(prop: String): Option[Long] = {
 
     //Scala regex matches the whole string, the leading ^ and trailing $ is implied.
     //First group matches numbers, second group must correspond to suffixMap keys below
@@ -53,38 +40,37 @@ object GeoMesaBatchWriterConfig extends Logging {
           num <- Try(java.lang.Long.parseLong(number)).toOption
         } yield num
       case matchSuffix(number, suffix) if suffixMap.contains(suffix) =>
-          for {
-            //Because we are not using parseLong(), we need to check for overflow
-            num <- Try(java.lang.Long.valueOf(number.toLong * suffixMap(suffix))).filter(_ > 0).toOption
-          } yield num
+        for {
+        //Because we are not using parseLong(), we need to check for overflow
+          num <- Try(java.lang.Long.valueOf(number.toLong * suffixMap(suffix))).filter(_ > 0).toOption
+        } yield num
       case _ => None
     }
   }
 
-  protected [util] def buildBWC: BatchWriterConfig = {
+  protected[util] def buildBWC: BatchWriterConfig = {
+    import GeomesaSystemProperties.BatchWriterProperties
+
     val bwc = new BatchWriterConfig
 
-    fetchProperty(WRITER_LATENCY_SECONDS) match {
-      case Some(latency) =>
-        logger.trace(s"GeoMesaBatchWriter config: maxLatency set to $latency seconds.")
-        bwc.setMaxLatency(latency, TimeUnit.SECONDS)
-      case None =>
-        val milliLatency = fetchProperty(WRITER_LATENCY_MILLIS).getOrElse(DEFAULT_LATENCY)
-        logger.trace(s"GeoMesaBatchWriter config: maxLatency set to $milliLatency milliseconds.")
-        bwc.setMaxLatency(milliLatency, TimeUnit.MILLISECONDS)
-    }
+    val latency = fetchProperty(BatchWriterProperties.WRITER_LATENCY_MILLIS)
+        .getOrElse(GeomesaSystemProperties.BatchWriterProperties.WRITER_LATENCY_MILLIS.default.toLong)
+    logger.trace(s"GeoMesaBatchWriter config: maxLatency set to $latency milliseconds.")
+    bwc.setMaxLatency(latency, TimeUnit.MILLISECONDS)
 
-    val memory = fetchMemoryProperty(WRITER_MEMORY).getOrElse(DEFAULT_MAX_MEMORY)
+    val memory = fetchMemoryProperty(BatchWriterProperties.WRITER_MEMORY_BYTES)
+        .getOrElse(BatchWriterProperties.WRITER_MEMORY_BYTES.default.toLong)
     logger.trace(s"GeoMesaBatchWriter config: maxMemory set to $memory bytes.")
     bwc.setMaxMemory(memory)
 
-    val threads = fetchProperty(WRITER_THREADS).map(_.toInt).getOrElse(DEFAULT_THREADS)
+    val threads = fetchProperty(BatchWriterProperties.WRITER_THREADS).map(_.toInt)
+        .getOrElse(BatchWriterProperties.WRITER_THREADS.default.toInt)
     logger.trace(s"GeoMesaBatchWriter config: maxWriteThreads set to $threads.")
     bwc.setMaxWriteThreads(threads.toInt)
 
-    fetchProperty(WRITE_TIMEOUT).foreach { timeout =>
+    fetchProperty(BatchWriterProperties.WRITE_TIMEOUT_MILLIS).foreach { timeout =>
       logger.trace(s"GeoMesaBatchWriter config: maxTimeout set to $timeout seconds.")
-      bwc.setTimeout(timeout, TimeUnit.SECONDS)
+      bwc.setTimeout(timeout, TimeUnit.MILLISECONDS)
     }
 
     bwc

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfigTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfigTest.scala
@@ -3,6 +3,8 @@ package org.locationtech.geomesa.accumulo.util
 import java.util.concurrent.TimeUnit
 
 import org.junit.runner.RunWith
+import org.locationtech.geomesa.accumulo.GeomesaSystemProperties
+import org.locationtech.geomesa.accumulo.GeomesaSystemProperties.PropAndDefault
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -11,13 +13,15 @@ import org.specs2.runner.JUnitRunner
 class GeoMesaBatchWriterConfigTest extends Specification {
   val bwc = GeoMesaBatchWriterConfig.buildBWC    // Builds new BWC which has not been mutated by some other test.
 
+  import GeomesaSystemProperties.BatchWriterProperties
+
   sequential
 
   "GeoMesaBatchWriterConfig" should {
     "have defaults set" in {
-      bwc.getMaxMemory                         must be equalTo GeoMesaBatchWriterConfig.DEFAULT_MAX_MEMORY
-      bwc.getMaxLatency(TimeUnit.MILLISECONDS) must be equalTo GeoMesaBatchWriterConfig.DEFAULT_LATENCY
-      bwc.getMaxWriteThreads                   must be equalTo GeoMesaBatchWriterConfig.DEFAULT_THREADS
+      bwc.getMaxMemory                         must be equalTo BatchWriterProperties.WRITER_MEMORY_BYTES.default.toLong
+      bwc.getMaxLatency(TimeUnit.MILLISECONDS) must be equalTo BatchWriterProperties.WRITER_LATENCY_MILLIS.default.toLong
+      bwc.getMaxWriteThreads                   must be equalTo BatchWriterProperties.WRITER_THREADS.default.toInt
     }
   }
 
@@ -28,82 +32,82 @@ class GeoMesaBatchWriterConfigTest extends Specification {
       val threadsProp = "25"
       val timeoutProp = "33"
 
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_LATENCY_MILLIS, latencyProp)
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY,         memoryProp)
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_THREADS,        threadsProp)
-      System.setProperty(GeoMesaBatchWriterConfig.WRITE_TIMEOUT,         timeoutProp)
+      BatchWriterProperties.WRITER_LATENCY_MILLIS.set(latencyProp)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.set(memoryProp)
+      BatchWriterProperties.WRITER_THREADS.set(threadsProp)
+      BatchWriterProperties.WRITE_TIMEOUT_MILLIS.set(timeoutProp)
 
       val nbwc = GeoMesaBatchWriterConfig.buildBWC
 
-      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_LATENCY_MILLIS)
-      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
-      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_THREADS)
-      System.clearProperty(GeoMesaBatchWriterConfig.WRITE_TIMEOUT)
+      BatchWriterProperties.WRITER_LATENCY_MILLIS.clear()
+      BatchWriterProperties.WRITER_MEMORY_BYTES.clear()
+      BatchWriterProperties.WRITER_THREADS.clear()
+      BatchWriterProperties.WRITE_TIMEOUT_MILLIS.clear()
 
       nbwc.getMaxLatency(TimeUnit.MILLISECONDS) must be equalTo java.lang.Long.parseLong(latencyProp)
       nbwc.getMaxMemory                         must be equalTo java.lang.Long.parseLong(memoryProp)
       nbwc.getMaxWriteThreads                   must be equalTo java.lang.Integer.parseInt(threadsProp)
-      nbwc.getTimeout(TimeUnit.SECONDS)         must be equalTo java.lang.Long.parseLong(timeoutProp)
+      nbwc.getTimeout(TimeUnit.MILLISECONDS)    must be equalTo java.lang.Long.parseLong(timeoutProp)
     }
   }
 
   "GeoMesaBatchWriterConfig" should {
     "respect system properties for memory with a K suffix" in {
       val memoryProp  = "1234K"
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.set(memoryProp)
 
       val nbwc = GeoMesaBatchWriterConfig.buildBWC
-      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.clear()
 
       nbwc.getMaxMemory must be equalTo java.lang.Long.valueOf(1234l * 1024l)
     }
 
     "respect system properties for memory with a k suffix" in {
       val memoryProp  = "1234k"
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.set(memoryProp)
 
       val nbwc = GeoMesaBatchWriterConfig.buildBWC
-      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.clear()
 
       nbwc.getMaxMemory must be equalTo java.lang.Long.valueOf(1234l * 1024l)
     }
 
     "respect system properties for memory with a M suffix" in {
       val memoryProp  = "1234M"
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.set(memoryProp)
 
       val nbwc = GeoMesaBatchWriterConfig.buildBWC
-      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.clear()
 
       nbwc.getMaxMemory must be equalTo java.lang.Long.valueOf(1234l * 1024l * 1024l)
     }
 
     "respect system properties for memory with a m suffix" in {
       val memoryProp  = "1234m"
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.set(memoryProp)
 
       val nbwc = GeoMesaBatchWriterConfig.buildBWC
-      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.clear()
 
       nbwc.getMaxMemory must be equalTo java.lang.Long.valueOf(1234l * 1024l * 1024l)
     }
 
     "respect system properties for memory with a G suffix" in {
       val memoryProp  = "1234G"
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.set(memoryProp)
 
       val nbwc = GeoMesaBatchWriterConfig.buildBWC
-      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.clear()
 
       nbwc.getMaxMemory must be equalTo java.lang.Long.valueOf(1234l * 1024l * 1024l * 1024l)
     }
 
     "respect system properties for memory with a g suffix" in {
       val memoryProp  = "1234g"
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.set(memoryProp)
 
       val nbwc = GeoMesaBatchWriterConfig.buildBWC
-      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.clear()
 
       nbwc.getMaxMemory must be equalTo java.lang.Long.valueOf(1234l * 1024l * 1024l * 1024l)
     }
@@ -111,130 +115,132 @@ class GeoMesaBatchWriterConfigTest extends Specification {
     "respect system properties for invalid non-suffixed memory specifications exceeding Long limits" in {
       //java.Long.MAX_VALUE =  9223372036854775807
       val memoryProp        = "9999999999999999999"
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.set(memoryProp)
 
       val nbwc = GeoMesaBatchWriterConfig.buildBWC
-      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.clear()
 
-      nbwc.getMaxMemory must be equalTo GeoMesaBatchWriterConfig.DEFAULT_MAX_MEMORY
+      nbwc.getMaxMemory must be equalTo BatchWriterProperties.WRITER_MEMORY_BYTES.default.toLong
     }
 
     "respect system properties for invalid suffixed memory specifications exceeding Long limits" in {
       val memoryProp = java.lang.Long.MAX_VALUE.toString + "k"
-      System.setProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY, memoryProp)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.set(memoryProp)
 
       val nbwc = GeoMesaBatchWriterConfig.buildBWC
-      System.clearProperty(GeoMesaBatchWriterConfig.WRITER_MEMORY)
+      BatchWriterProperties.WRITER_MEMORY_BYTES.clear()
 
-      nbwc.getMaxMemory must be equalTo GeoMesaBatchWriterConfig.DEFAULT_MAX_MEMORY
+      nbwc.getMaxMemory must be equalTo BatchWriterProperties.WRITER_MEMORY_BYTES.default.toLong
     }
   }
 
   "fetchProperty" should {
     "retrieve a long correctly" in {
       System.setProperty("foo", "123456789")
-      val ret = GeoMesaBatchWriterConfig.fetchProperty("foo")
+      val ret = GeoMesaBatchWriterConfig.fetchProperty(PropAndDefault("foo", null))
       System.clearProperty("foo")
       ret should equalTo(Some(123456789l))
     }
 
     "return None correctly" in {
-      GeoMesaBatchWriterConfig.fetchProperty("bar") should equalTo(None)
+      GeoMesaBatchWriterConfig.fetchProperty(PropAndDefault("bar", null)) should equalTo(None)
     }
 
     "return None correctly when the System property is not parseable as a Long" in {
       System.setProperty("baz", "fizzbuzz")
-      val ret = GeoMesaBatchWriterConfig.fetchProperty("baz")
+      val ret = GeoMesaBatchWriterConfig.fetchProperty(PropAndDefault("foo", null))
       System.clearProperty("baz")
       ret should equalTo(None)
     }
   }
 
   "fetchMemoryProperty" should {
+    val fooMemory = PropAndDefault("foo", null)
+    val bazMemory = PropAndDefault("baz", null)
     "retrieve a long correctly" in {
       System.setProperty("foo", "123456789")
-      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty(fooMemory)
       System.clearProperty("foo")
       ret should equalTo(Some(123456789l))
     }
 
     "retrieve a long correctly with a K suffix" in {
       System.setProperty("foo", "123456789K")
-      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty(fooMemory)
       System.clearProperty("foo")
       ret should equalTo(Some(123456789l * 1024l))
     }
 
     "retrieve a long correctly with a k suffix" in {
       System.setProperty("foo", "123456789k")
-      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty(fooMemory)
       System.clearProperty("foo")
       ret should equalTo(Some(123456789l * 1024l))
     }
 
     "retrieve a long correctly with a M suffix" in {
       System.setProperty("foo", "123456789m")
-      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty(fooMemory)
       System.clearProperty("foo")
       ret should equalTo(Some(123456789l * 1024l * 1024l))
     }
 
     "retrieve a long correctly with a m suffix" in {
       System.setProperty("foo", "123456789m")
-      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty(fooMemory)
       System.clearProperty("foo")
       ret should equalTo(Some(123456789l * 1024l * 1024l))
     }
 
     "retrieve a long correctly with a G suffix" in {
       System.setProperty("foo", "123456789G")
-      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty(fooMemory)
       System.clearProperty("foo")
       ret should equalTo(Some(123456789l * 1024l * 1024l * 1024l))
     }
 
     "retrieve a long correctly with a g suffix" in {
       System.setProperty("foo", "123456789g")
-      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty(fooMemory)
       System.clearProperty("foo")
       ret should equalTo(Some(123456789l * 1024l * 1024l * 1024l))
     }
 
     "return None correctly" in {
-      GeoMesaBatchWriterConfig.fetchMemoryProperty("bar") should equalTo(None)
+      GeoMesaBatchWriterConfig.fetchMemoryProperty(bazMemory) should equalTo(None)
     }
 
     "return None correctly when the System property is not parseable as a Long" in {
       System.setProperty("baz", "fizzbuzz")
-      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("baz")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty(bazMemory)
       System.clearProperty("baz")
       ret should equalTo(None)
     }
 
     "return None correctly when the System property is not parseable as a Long with a suffix" in {
       System.setProperty("baz", "64fizzbuzz")
-      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("foo")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty(fooMemory)
       System.clearProperty("baz")
       ret should equalTo(None)
     }
 
     "return None correctly when the System property is not parseable as a Long with a prefix" in {
       System.setProperty("baz", "fizzbuzz64")
-      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("baz")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty(bazMemory)
       System.clearProperty("baz")
       ret should equalTo(None)
     }
 
     "return None correctly when the System property is not parseable with trailing garbage" in {
       System.setProperty("baz", "64k bazbaz")
-      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("baz")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty(bazMemory)
       System.clearProperty("baz")
       ret should equalTo(None)
     }
 
     "return None correctly when the System property is not parseable with leading garbage" in {
       System.setProperty("baz", "foofoo 64G")
-      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty("baz")
+      val ret = GeoMesaBatchWriterConfig.fetchMemoryProperty(bazMemory)
       System.clearProperty("baz")
       ret should equalTo(None)
     }


### PR DESCRIPTION
* Can be configured at the data store level or by system property 'geomesa.query.timeout.millis'
* Reaper thread keeps track of running queries
* Moved system properties into centralized place in accumulo package

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>

Note: stacks on top of https://github.com/locationtech/geomesa/pull/607, please only consider the last commit(s).