### PR TITLE
GEOMESA-829 HBase and Bigtable support

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/Z3Table.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/Z3Table.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.accumulo.data.tables
 
 import java.nio.ByteBuffer

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/IndexFilterHelpers.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/IndexFilterHelpers.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.accumulo.index
 
 import com.vividsolutions.jts.geom.{Geometry, Polygon}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/IndexValueEncoder.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/IndexValueEncoder.scala
@@ -300,6 +300,8 @@ object OldIndexValueEncoder {
   def getSchema(sft: SimpleFeatureType): Seq[String] = {
     import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 
+    import scala.collection.JavaConversions._
+
     val defaults = getDefaultSchema(sft)
     val descriptors =  sft.getAttributeDescriptors.filter(_.isIndexValue()).map(_.getLocalName)
     if (descriptors.isEmpty) {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategy.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.accumulo.index
 
 import com.google.common.primitives.{Bytes, Longs, Shorts}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3Iterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3Iterator.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.accumulo.iterators
 
 import com.google.common.primitives.Longs

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfig.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfig.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.accumulo.util
 
 import java.util.concurrent.TimeUnit

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreDefaults.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreDefaults.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.accumulo.data
 
 import java.text.SimpleDateFormat

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/filter/TestFilters.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/filter/TestFilters.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.accumulo.filter
 
 import org.locationtech.geomesa.filter

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/Z3IteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/Z3IteratorTest.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.accumulo.iterators
 
 import java.util

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfigTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/GeoMesaBatchWriterConfigTest.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.accumulo.util
 
 import java.util.concurrent.TimeUnit

--- a/geomesa-accumulo/geomesa-iterators/geomesa-iterators-feature-filter/src/main/scala/org/locationtech/geomesa/iterators/LazySimpleFeatureFilteringIterator.scala
+++ b/geomesa-accumulo/geomesa-iterators/geomesa-iterators-feature-filter/src/main/scala/org/locationtech/geomesa/iterators/LazySimpleFeatureFilteringIterator.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.iterators
 
 import java.nio.ByteBuffer

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/AndSplittingFilter.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/AndSplittingFilter.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.filter
 
 import org.geotools.filter.visitor.DefaultFilterVisitor

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/function/CurrentDateFunction.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/function/CurrentDateFunction.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.filter.function
 
 import org.geotools.filter.FunctionExpressionImpl

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/function/DateToLong.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/function/DateToLong.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.filter.function
 
 import java.{lang => jl}

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/function/FastProperty.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/function/FastProperty.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.filter.function
 
 import org.geotools.filter.FunctionExpressionImpl

--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterPackageObjectTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterPackageObjectTest.scala
@@ -11,7 +11,6 @@ package org.locationtech.geomesa.filter
 import com.typesafe.scalalogging.slf4j.Logging
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.filter.TestFilters._
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.filter._
 import org.specs2.mutable.Specification
@@ -22,6 +21,8 @@ import scala.collection.JavaConversions._
 
 @RunWith(classOf[JUnitRunner])
 class FilterPackageObjectTest extends Specification with Logging {
+
+  import TestFilters._
 
   "The partitionGeom function" should {
     val sft = SimpleFeatureTypes.createType("filterPackageTest", "g:Geometry,*geom:Geometry")

--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/OrSplittingFilterTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/OrSplittingFilterTest.scala
@@ -10,6 +10,7 @@ package org.locationtech.geomesa.filter
 
 import org.geotools.filter.text.cql2.CQL
 import org.junit.runner.RunWith
+import org.locationtech.geomesa.filter
 import org.opengis.filter._
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner

--- a/geomesa-hbase/geomesa-bigtable-datastore/pom.xml
+++ b/geomesa-hbase/geomesa-bigtable-datastore/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*********************************************************************-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>geomesa-hbase</artifactId>
+        <groupId>org.locationtech.geomesa</groupId>
+        <version>1.1.0-rc.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-bigtable-datastore</artifactId>
+    <name>GeoMesa Bigtable DataStore</name>
+
+    <properties>
+        <!-- The ALPN versions dictates a specific java version -->
+        <alpn.version>8.1.3.v20150130</alpn.version>
+        <bigtable.version>0.1.5</bigtable.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-hbase-datastore</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mortbay.jetty.alpn</groupId>
+            <artifactId>alpn-boot</artifactId>
+            <version>${alpn.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud.bigtable</groupId>
+            <artifactId>bigtable-hbase</artifactId>
+            <version>${bigtable.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hbase.hadoop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-app</artifactId>
+            <version>${hbase.hadoop.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/geomesa-hbase/geomesa-bigtable-geoserver-plugin/pom.xml
+++ b/geomesa-hbase/geomesa-bigtable-geoserver-plugin/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>geomesa-hbase</artifactId>
+        <groupId>org.locationtech.geomesa</groupId>
+        <version>1.1.0-rc.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-bigtable-geoserver-plugin</artifactId>
+    <name>GeoMesa Bigtable GeoServer Plugin</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-bigtable-datastore</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver.web</groupId>
+            <artifactId>gs-web-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wicket</groupId>
+            <artifactId>wicket</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded</shadedClassifierName>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>org.locationtech.geomesa.shade.commons</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>org.locationtech.geomesa.shade.google</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/geomesa-hbase/geomesa-bigtable-geoserver-plugin/src/main/resources/GeoServerApplication.properties
+++ b/geomesa-hbase/geomesa-bigtable-geoserver-plugin/src/main/resources/GeoServerApplication.properties
@@ -1,0 +1,1 @@
+BigtableDataStoreEditPanel.bigtableConnectionParams=Bigtable Connection Parameters

--- a/geomesa-hbase/geomesa-bigtable-geoserver-plugin/src/main/resources/applicationContext.xml
+++ b/geomesa-hbase/geomesa-bigtable-geoserver-plugin/src/main/resources/applicationContext.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2014 Commonwealth Computer Research, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="bigtableDataStorePanel" class="org.geoserver.web.data.resource.DataStorePanelInfo">
+        <property name="id" value="bigtableDataStorePanel"/>
+        <property name="factoryClass" value="org.locationtech.geomesa.hbase.data.HBaseDataStore"/>
+        <property name="iconBase" value="org.geoserver.web.GeoServerApplication"/>
+        <property name="icon" value="img/icons/geosilk/database_vector.png"/>
+        <property name="componentClass"
+                  value="org.locationtech.geomesa.hbase.plugin.BigtableDataStoreEditPanel"/>
+    </bean>
+
+</beans>

--- a/geomesa-hbase/geomesa-bigtable-geoserver-plugin/src/main/resources/org/locationtech/geomesa/hbase/plugin/BigtableDataStoreEditPanel.html
+++ b/geomesa-hbase/geomesa-bigtable-geoserver-plugin/src/main/resources/org/locationtech/geomesa/hbase/plugin/BigtableDataStoreEditPanel.html
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright 2014 Commonwealth Computer Research, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html xmlns:wicket="http://wicket.apache.org/">
+<body>
+<wicket:panel>
+    <fieldset>
+        <legend>
+            <span>
+                <wicket:message key="connectionParameters"/>
+            </span>
+        </legend>
+        <div><span wicket:id="bigtablename"></span></div>
+        <div><span wicket:id="zookeepers"></span></div>
+        <div><span wicket:id="zkPath"></span></div>
+    </fieldset>
+</wicket:panel>
+</body>
+</html>

--- a/geomesa-hbase/geomesa-bigtable-geoserver-plugin/src/main/scala/org/locationtech/geomesa/hbase/plugin/BigtableDataStoreEditPanel.scala
+++ b/geomesa-hbase/geomesa-bigtable-geoserver-plugin/src/main/scala/org/locationtech/geomesa/hbase/plugin/BigtableDataStoreEditPanel.scala
@@ -1,0 +1,82 @@
+package org.locationtech.geomesa.hbase.plugin
+
+/*
+ * Copyright 2014 Commonwealth Computer Research, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import org.apache.wicket.behavior.SimpleAttributeModifier
+import org.apache.wicket.markup.html.form.validation.IFormValidator
+import org.apache.wicket.markup.html.form.{Form, FormComponent}
+import org.apache.wicket.markup.html.panel.Panel
+import org.apache.wicket.model.{IModel, PropertyModel, ResourceModel}
+import org.geoserver.web.data.store.StoreEditPanel
+import org.geoserver.web.data.store.panel.{ParamPanel, PasswordParamPanel, TextParamPanel}
+import org.geoserver.web.util.MapModel
+import org.geotools.data.DataAccessFactory.Param
+import org.locationtech.geomesa.hbase.data.HBaseDataStore
+
+class BigtableDataStoreEditPanel(componentId: String, storeEditForm: Form[_])
+  extends StoreEditPanel(componentId, storeEditForm) {
+
+  val model = storeEditForm.getModel
+  setDefaultModel(model)
+  val paramsModel = new PropertyModel(model, "connectionParameters")
+
+  val tableName       = addTextPanel(paramsModel, HBaseDataStore.BIGTABLENAMEPARAM)
+
+  val dependentFormComponents =
+    Array[FormComponent[_]](tableName)
+
+  dependentFormComponents.foreach(_.setOutputMarkupId(true))
+
+  storeEditForm.add(new IFormValidator() {
+    override def getDependentFormComponents = dependentFormComponents
+    override def validate(form: Form[_]) {}
+  })
+
+  def addTextPanel(paramsModel: IModel[_], param: Param): FormComponent[_] = {
+    val paramName = param.key
+    val resourceKey = getClass.getSimpleName + "." + paramName
+    val required = param.required
+    val textParamPanel =
+      new TextParamPanel(paramName,
+        new MapModel(paramsModel, paramName).asInstanceOf[IModel[_]],
+        new ResourceModel(resourceKey, paramName), required)
+    addPanel(textParamPanel, param, resourceKey)
+  }
+
+  def addPasswordPanel(paramsModel: IModel[_], param: Param): FormComponent[_] = {
+    val paramName = param.key
+    val resourceKey = getClass.getSimpleName + "." + paramName
+    val required = param.required
+    val passParamPanel =
+      new PasswordParamPanel(paramName,
+        new MapModel(paramsModel, paramName).asInstanceOf[IModel[_]],
+        new ResourceModel(resourceKey, paramName), required)
+    addPanel(passParamPanel, param, resourceKey)
+  }
+
+  def addPanel(paramPanel: Panel with ParamPanel, param: Param, resourceKey: String): FormComponent[_] = {
+    paramPanel.getFormComponent.setType(classOf[String])
+    val defaultTitle = String.valueOf(param.description)
+    val titleModel = new ResourceModel(resourceKey + ".title", defaultTitle)
+    val title = String.valueOf(titleModel.getObject)
+    paramPanel.add(new SimpleAttributeModifier("title", title))
+    add(paramPanel)
+    paramPanel.getFormComponent
+  }
+
+}

--- a/geomesa-hbase/geomesa-hbase-datastore/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-datastore/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>geomesa-hbase</artifactId>
+        <groupId>org.locationtech.geomesa</groupId>
+        <version>1.1.0-rc.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-hbase-datastore</artifactId>
+    <name>GeoMesa HBase DataStore</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-z3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-filter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-feature-kryo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-data</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-client</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-common</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-protocol</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-server</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/resources/META-INF/services/org.geotools.data.DataStoreFactorySpi
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/resources/META-INF/services/org.geotools.data.DataStoreFactorySpi
@@ -1,0 +1,1 @@
+org.locationtech.geomesa.hbase.data.HBaseDataStoreFactory

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStore.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStore.scala
@@ -1,0 +1,116 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+package org.locationtech.geomesa.hbase.data
+
+import java.io.Serializable
+import java.util
+
+import org.apache.hadoop.hbase.client._
+import org.apache.hadoop.hbase.util.Bytes
+import org.apache.hadoop.hbase.{HBaseConfiguration, HColumnDescriptor, HTableDescriptor, TableName}
+import org.geotools.data.DataAccessFactory.Param
+import org.geotools.data.store.{ContentDataStore, ContentEntry, ContentFeatureSource}
+import org.geotools.data.{AbstractDataStoreFactory, DataStore, Transaction}
+import org.geotools.feature.NameImpl
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.feature.`type`.Name
+import org.opengis.feature.simple.SimpleFeatureType
+
+import scala.collection.JavaConversions._
+
+class HBaseDataStore(conn: Connection,
+                     catalog: String) extends ContentDataStore {
+
+  import HBaseDataStore._
+
+  private val CATALOG_TABLE = TableName.valueOf(catalog)
+  private val catalogTable = getOrCreateCatalogTable(conn, CATALOG_TABLE)
+  private val schemaCQ = Bytes.toBytes("schema")
+
+  override def createSchema(featureType: SimpleFeatureType): Unit = {
+    val name = featureType.getTypeName
+
+    // create the z3 index
+    val desc = new HTableDescriptor(TableName.valueOf(getZ3TableName(featureType)))
+    Seq(DATA_FAMILY_NAME).foreach { f => desc.addFamily(new HColumnDescriptor(f)) }
+    conn.getAdmin.createTable(desc)
+
+    // write the meta-data
+    val row = Bytes.toBytes(name)
+    val encodedSFT = Bytes.toBytes(SimpleFeatureTypes.encodeType(featureType))
+
+    val schema = new Put(row).addColumn(META_FAMILY_NAME, schemaCQ, encodedSFT)
+    catalogTable.put(schema)
+  }
+
+  def getZ3TableName(sft: SimpleFeatureType) = s"${sft.getTypeName}_z3"
+  def getZ3Table(sft: SimpleFeatureType) = conn.getTable(TableName.valueOf(getZ3TableName(sft)))
+
+  override def createFeatureSource(entry: ContentEntry): ContentFeatureSource = {
+    val sft =
+      Option(entry.getState(Transaction.AUTO_COMMIT).getFeatureType).getOrElse { getSchema(entry) }
+    new HBaseFeatureSource(entry, null, sft)
+  }
+
+  def getSchema(entry: ContentEntry) = {
+    val get = new Get(Bytes.toBytes(entry.getTypeName)).addColumn(META_FAMILY_NAME, schemaCQ)
+    val result = catalogTable.get(get)
+    val spec = Bytes.toString(result.getValue(META_FAMILY_NAME, schemaCQ))
+    SimpleFeatureTypes.createType(entry.getTypeName, spec)
+  }
+
+  override def createTypeNames(): util.List[Name] = {
+    // read types from catalog
+    val scan = new Scan().addColumn(META_FAMILY_NAME, schemaCQ)
+    val scanner = catalogTable.getScanner(scan)
+    scanner.iterator().map { r => Bytes.toString(r.getRow) }.map { n => new NameImpl(n) }.toList
+  }
+}
+
+class HBaseDataStoreFactory extends AbstractDataStoreFactory {
+
+  import HBaseDataStore._
+
+  override def createDataStore(map: util.Map[String, Serializable]): DataStore = {
+    val conf = HBaseConfiguration.create()
+    val conn = ConnectionFactory.createConnection(conf)
+    val catalog = BIGTABLENAMEPARAM.lookUp(map).asInstanceOf[String]
+    new HBaseDataStore(conn, catalog)
+  }
+
+  override def createNewDataStore(map: util.Map[String, Serializable]): DataStore = {
+    val conf = HBaseConfiguration.create()
+    val conn = ConnectionFactory.createConnection(conf)
+    val catalog = BIGTABLENAMEPARAM.lookUp(map).asInstanceOf[String]
+    getOrCreateCatalogTable(conn, TableName.valueOf(catalog))
+    new HBaseDataStore(conn, catalog)
+  }
+
+  override def getDescription: String = "GeoMesa HBase DataStore"
+
+  override def getParametersInfo: Array[Param] = Array(BIGTABLENAMEPARAM)
+}
+
+object HBaseDataStore {
+
+  val BIGTABLENAMEPARAM = new Param("bigtable.table.name", classOf[String], "Table name", true)
+  val META_FAMILY_NAME = Bytes.toBytes("M")
+  val META_FAMILY = new HColumnDescriptor(META_FAMILY_NAME)
+  val DATA_FAMILY_NAME = Bytes.toBytes("D")
+
+  def getOrCreateCatalogTable(conn: Connection, CATALOG_TABLE: TableName) = {
+    val admin = conn.getAdmin
+    if (!admin.tableExists(CATALOG_TABLE)) {
+      val desc = new HTableDescriptor(CATALOG_TABLE)
+      desc.addFamily(META_FAMILY)
+      admin.createTable(desc)
+    }
+    conn.getTable(CATALOG_TABLE)
+  }
+
+}

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseFeatureReader.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseFeatureReader.scala
@@ -1,0 +1,67 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+package org.locationtech.geomesa.hbase.data
+
+import com.google.common.primitives.{Bytes, Longs, Shorts}
+import org.apache.hadoop.hbase.client.{Scan, Table}
+import org.geotools.data.FeatureReader
+import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+
+import scala.collection.JavaConversions._
+import scala.util.Try
+
+class HBaseFeatureReader(table: Table,
+                         sft: SimpleFeatureType,
+                         week: Int,
+                         ranges: Seq[(Long, Long)],
+                         lx: Long, ly: Long, lt: Long,
+                         ux: Long, uy: Long, ut: Long,
+                         serde: KryoFeatureSerializer)
+  extends FeatureReader[SimpleFeatureType, SimpleFeature] {
+
+  val weekPrefix = Shorts.toByteArray(week.toShort)
+
+  val scans =
+    ranges.map { case (s, e) =>
+      val startRow = Bytes.concat(weekPrefix, Longs.toByteArray(s))
+      val endRow   = Bytes.concat(weekPrefix, Longs.toByteArray(e))
+      new Scan(startRow, endRow)
+        .addFamily(HBaseDataStore.DATA_FAMILY_NAME)
+    }
+
+  val scanners =
+    scans
+      .map { s => table.getScanner(s) }
+
+  val results =
+    Try {
+      scanners
+        .flatMap(_.toList)
+        .flatMap { r => r.getFamilyMap(HBaseDataStore.DATA_FAMILY_NAME).values().map(serde.deserialize) }
+        .iterator
+    }.getOrElse {
+      closeScanners()
+      Iterator.empty
+    }
+
+  override def next(): SimpleFeature = results.next()
+
+  override def hasNext: Boolean = results.hasNext
+
+  override def getFeatureType: SimpleFeatureType = sft
+
+  override def close(): Unit = closeScanners()
+
+  private def closeScanners(): Unit =
+    try {
+      scanners.foreach(_.close())
+    } catch {
+      case t: Throwable =>
+    }
+}

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseFeatureSource.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseFeatureSource.scala
@@ -1,0 +1,146 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+package org.locationtech.geomesa.hbase.data
+
+import com.vividsolutions.jts.geom.Envelope
+import org.geotools.data.store.{ContentEntry, ContentFeatureStore}
+import org.geotools.data.{FeatureReader, FeatureWriter, Query}
+import org.geotools.geometry.jts.ReferencedEnvelope
+import org.joda.time.Weeks
+import org.locationtech.geomesa.curve.Z3SFC
+import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
+import org.locationtech.geomesa.filter
+import org.locationtech.geomesa.utils.geotools
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import org.opengis.filter.And
+import org.opengis.filter.spatial.BinarySpatialOperator
+
+class HBaseFeatureSource(entry: ContentEntry,
+                         query: Query,
+                         sft: SimpleFeatureType)
+  extends ContentFeatureStore(entry, query) {
+  import geotools._
+
+  import scala.collection.JavaConversions._
+
+  private val dtgIndex =
+    sft.getAttributeDescriptors
+      .zipWithIndex
+      .find { case (ad, idx) => classOf[java.util.Date].equals(ad.getType.getBinding) }
+      .map  { case (_, idx)  => idx }
+      .getOrElse(throw new RuntimeException("No date attribute"))
+
+  private val Z3_CURVE = new Z3SFC
+  type FR = FeatureReader[SimpleFeatureType, SimpleFeature]
+  private val ds = entry.getDataStore.asInstanceOf[HBaseDataStore]
+
+  private val bounds = ReferencedEnvelope.create(new Envelope(-180, 180, -90, 90), CRS_EPSG_4326)
+
+  override def buildFeatureType(): SimpleFeatureType = sft
+
+  override def getBoundsInternal(query: Query): ReferencedEnvelope = bounds
+
+  override def getCountInternal(query: Query): Int = Int.MaxValue
+
+  override def getWriterInternal(query: Query, flags: Int): FeatureWriter[SimpleFeatureType, SimpleFeature] =
+    new HBaseFeatureWriter(sft, ds.getZ3Table(sft))
+
+  import filter._
+  override def getReaderInternal(query: Query): FR =
+    rewriteFilterInCNF(query.getFilter) match {
+      case a: And            => and(a)
+      case _                 => throw new RuntimeException("Not yet supported")
+    }
+
+
+  override def canFilter: Boolean = true
+  override def canSort: Boolean = true
+
+  private def and(a: And): FR = {
+    // TODO: currently assumes BBOX then DURING
+    import filter._
+
+    val dtFieldName = Some(sft.getDescriptor(dtgIndex).getLocalName)
+    val (i, _) = partitionTemporal(a.getChildren, dtFieldName)
+    val interval = FilterHelper.extractTemporal(dtFieldName)(i)
+
+    val (b, _) = partitionGeom(a, sft)
+    val geom = FilterHelper.extractGeometry(b.head.asInstanceOf[BinarySpatialOperator]).head
+
+    val env = geom.getEnvelopeInternal
+    val (lx, ly, ux, uy) = (env.getMinX, env.getMinY, env.getMaxX, env.getMaxY)
+
+    val epochWeekStart = Weeks.weeksBetween(EPOCH, interval.getStart)
+    val epochWeekEnd = Weeks.weeksBetween(EPOCH, interval.getEnd)
+    val weeks = scala.Range.inclusive(epochWeekStart.getWeeks, epochWeekEnd.getWeeks)
+    val lt = secondsInCurrentWeek(interval.getStart, epochWeekStart)
+    val ut = secondsInCurrentWeek(interval.getEnd, epochWeekStart)
+
+    val kryoFeatureSerializer = new KryoFeatureSerializer(sft)
+    if (weeks.length == 1) {
+      val z3ranges = Z3_CURVE.ranges(lx, ly, ux, uy, lt, ut, 8)
+      // TODO: cache serializers
+      new HBaseFeatureReader(
+        ds.getZ3Table(sft), sft, weeks.head, z3ranges,
+        Z3_CURVE.normLon(lx), Z3_CURVE.normLat(ly), interval.getStart.getMillis,
+        Z3_CURVE.normLon(ux), Z3_CURVE.normLat(uy), interval.getEnd.getMillis,
+        kryoFeatureSerializer)
+    } else {
+      val oneWeekInSeconds = Weeks.ONE.toStandardSeconds.getSeconds
+      val head +: xs :+ last = weeks.toList
+      // TODO: ignoring seconds for now
+      val z3ranges = Z3_CURVE.ranges(lx, ly, ux, uy, 0, oneWeekInSeconds, 8)
+      val middleQPs = xs.map { w =>
+        new HBaseFeatureReader(ds.getZ3Table(sft), sft, w, z3ranges,
+          Z3_CURVE.normLon(lx), Z3_CURVE.normLat(ly), interval.getStart.getMillis,
+          Z3_CURVE.normLon(ux), Z3_CURVE.normLat(uy), interval.getEnd.getMillis,
+          kryoFeatureSerializer)
+      }
+      val sr = new HBaseFeatureReader(ds.getZ3Table(sft), sft, head, z3ranges,
+        Z3_CURVE.normLon(lx), Z3_CURVE.normLat(ly), interval.getStart.getMillis,
+        Z3_CURVE.normLon(ux), Z3_CURVE.normLat(uy), interval.getEnd.getMillis,
+        kryoFeatureSerializer)
+
+      val er = new HBaseFeatureReader(ds.getZ3Table(sft), sft, last, z3ranges,
+        Z3_CURVE.normLon(lx), Z3_CURVE.normLat(ly), interval.getStart.getMillis,
+        Z3_CURVE.normLon(ux), Z3_CURVE.normLat(uy), interval.getEnd.getMillis,
+        kryoFeatureSerializer)
+
+      val readers = Seq(sr) ++ middleQPs ++ Seq(er)
+
+      new FeatureReader[SimpleFeatureType, SimpleFeature] {
+        val readerIter = readers.iterator
+        var curReader = readerIter.next()
+
+        override def next(): SimpleFeature = {
+          curReader.next()
+        }
+
+        override def hasNext: Boolean =
+          if(curReader.hasNext) true
+          else {
+            if(readerIter.hasNext) {
+              curReader = readerIter.next()
+              curReader.hasNext
+            } else false
+          }
+
+        override def getFeatureType: SimpleFeatureType = sft
+
+        override def close(): Unit = {}
+      }
+    }
+
+  }
+}
+
+
+
+
+
+

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseFeatureWriter.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseFeatureWriter.scala
@@ -1,0 +1,77 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+package org.locationtech.geomesa.hbase.data
+
+import java.nio.charset.StandardCharsets
+import java.util.Date
+
+import com.google.common.primitives.{Bytes, Longs, Shorts}
+import org.apache.hadoop.hbase.client.{Put, Table}
+import org.geotools.data.FeatureWriter
+import org.joda.time.DateTime
+import org.locationtech.geomesa.curve.Z3SFC
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+
+
+class HBaseFeatureWriter(sft: SimpleFeatureType, table: Table) extends FeatureWriter[SimpleFeatureType, SimpleFeature] {
+
+  import org.locationtech.geomesa.utils.geotools.Conversions._
+
+  import scala.collection.JavaConversions._
+
+  private val SFC = new Z3SFC
+  private var curFeature: SimpleFeature = null
+  private val dtgIndex =
+    sft.getAttributeDescriptors
+      .zipWithIndex
+      .find { case (ad, idx) => classOf[java.util.Date].equals(ad.getType.getBinding) }
+      .map  { case (_, idx)  => idx }
+      .getOrElse(throw new RuntimeException("No date attribute"))
+
+  private val encoder = new KryoFeatureSerializer(sft)
+
+  override def next(): SimpleFeature = {
+    curFeature = new ScalaSimpleFeature("", sft)
+    curFeature
+  }
+
+  override def remove(): Unit = ???
+
+  override def hasNext: Boolean = true
+
+  override def write(): Unit = {
+    // write
+    val geom = curFeature.point
+    val x = geom.getX
+    val y = geom.getY
+    val dtg = new DateTime(curFeature.getAttribute(dtgIndex).asInstanceOf[Date])
+    val weeks = epochWeeks(dtg)
+    val prefix = Shorts.toByteArray(weeks.getWeeks.toShort)
+
+    val secondsInWeek = secondsInCurrentWeek(dtg, weeks)
+    val z3 = SFC.index(x, y, secondsInWeek)
+    val z3idx = Longs.toByteArray(z3.z)
+
+    val idBytes = curFeature.getID.getBytes(StandardCharsets.UTF_8)
+    val row = Bytes.concat(prefix, z3idx)
+    val idCQ = Bytes.concat(z3idx, idBytes)
+    val serializedFeature = encoder.serialize(curFeature)
+    val put =
+      new Put(row)
+        .addImmutable(HBaseDataStore.DATA_FAMILY_NAME, idCQ, serializedFeature)
+
+    table.put(put)
+    curFeature = null
+  }
+
+  override def getFeatureType: SimpleFeatureType = sft
+
+  override def close(): Unit = {}
+}

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/package.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/package.scala
@@ -1,0 +1,20 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+package org.locationtech.geomesa.hbase
+
+import org.joda.time.{DateTime, Seconds, Weeks}
+
+package object data {
+  val EPOCH = new DateTime(0)
+
+  def epochWeeks(dtg: DateTime) = Weeks.weeksBetween(EPOCH, new DateTime(dtg))
+
+  def secondsInCurrentWeek(dtg: DateTime, weeks: Weeks) =
+    Seconds.secondsBetween(EPOCH, dtg).getSeconds - weeks.toStandardSeconds.getSeconds
+
+}

--- a/geomesa-hbase/pom.xml
+++ b/geomesa-hbase/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>geomesa</artifactId>
+        <groupId>org.locationtech.geomesa</groupId>
+        <version>1.1.0-rc.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-hbase</artifactId>
+    <name>GeoMesa HBase Parent</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>geomesa-hbase-datastore</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>bigtable</id>
+            <modules>
+                <module>geomesa-bigtable-datastore</module>
+                <module>geomesa-bigtable-geoserver-plugin</module>
+            </modules>
+        </profile>
+    </profiles>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.locationtech.geomesa</groupId>
+                <artifactId>geomesa-hbase-datastore</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+
+    <properties>
+        <hbase.version>1.0.0</hbase.version>
+        <hbase.hadoop.version>2.4.1</hbase.hadoop.version>
+    </properties>
+
+
+</project>

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaDataStoreHelper.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaDataStoreHelper.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.kafka
 
 import java.util.UUID

--- a/geomesa-security/src/main/scala/org/locationtech/geomesa/security/VisibilityFilter.scala
+++ b/geomesa-security/src/main/scala/org/locationtech/geomesa/security/VisibilityFilter.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.security
 
 import org.apache.accumulo.core.security.{ColumnVisibility, VisibilityEvaluator}

--- a/geomesa-security/src/main/scala/org/locationtech/geomesa/security/package.scala
+++ b/geomesa-security/src/main/scala/org/locationtech/geomesa/security/package.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa
 
 import java.{io => jio, util => ju}

--- a/geomesa-security/src/test/scala/org/locationtech/geomesa/security/SecureSimpleFeatureTest.scala
+++ b/geomesa-security/src/test/scala/org/locationtech/geomesa/security/SecureSimpleFeatureTest.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.security
 
 import org.opengis.feature.simple.SimpleFeature

--- a/geomesa-security/src/test/scala/org/locationtech/geomesa/security/TestAuthorizationsProvider.scala
+++ b/geomesa-security/src/test/scala/org/locationtech/geomesa/security/TestAuthorizationsProvider.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.security
 
 import org.apache.accumulo.core.security.Authorizations

--- a/geomesa-security/src/test/scala/org/locationtech/geomesa/security/VisibilityFilterTest.scala
+++ b/geomesa-security/src/test/scala/org/locationtech/geomesa/security/VisibilityFilterTest.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.security
 
 

--- a/geomesa-stream/geomesa-stream-api/src/main/scala/org/locationtech/geomesa/stream/SimpleFeatureStreamSource.scala
+++ b/geomesa-stream/geomesa-stream-api/src/main/scala/org/locationtech/geomesa/stream/SimpleFeatureStreamSource.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.stream
 
 import java.util.ServiceLoader

--- a/geomesa-stream/geomesa-stream-datastore/src/main/scala/org/locationtech/geomesa/stream/datastore/StreamDataStore.scala
+++ b/geomesa-stream/geomesa-stream-datastore/src/main/scala/org/locationtech/geomesa/stream/datastore/StreamDataStore.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.stream.datastore
 
 import java.awt.RenderingHints

--- a/geomesa-stream/geomesa-stream-datastore/src/test/scala/org/locationtech/geomesa/stream/datastore/StreamDataStoreTest.scala
+++ b/geomesa-stream/geomesa-stream-datastore/src/test/scala/org/locationtech/geomesa/stream/datastore/StreamDataStoreTest.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.stream.datastore
 
 import java.nio.charset.StandardCharsets

--- a/geomesa-stream/geomesa-stream-generic/src/main/scala/org/locationtech/geomesa/stream/generic/GenericSimpleFeatureStreamSourceFactory.scala
+++ b/geomesa-stream/geomesa-stream-generic/src/main/scala/org/locationtech/geomesa/stream/generic/GenericSimpleFeatureStreamSourceFactory.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.stream.generic
 
 import java.util.concurrent.{ExecutorService, Executors, LinkedBlockingQueue, TimeUnit}

--- a/geomesa-stream/geomesa-stream-generic/src/test/scala/org/locationtech/geomesa/stream/generic/GenericSimpleFeatureStreamSourceTest.scala
+++ b/geomesa-stream/geomesa-stream-generic/src/test/scala/org/locationtech/geomesa/stream/generic/GenericSimpleFeatureStreamSourceTest.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.stream.generic
 
 import java.net.{DatagramPacket, InetAddress}

--- a/geomesa-tools/pom.xml
+++ b/geomesa-tools/pom.xml
@@ -119,10 +119,6 @@
             <artifactId>zookeeper</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.media</groupId>
-            <artifactId>jai_core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
         </dependency>

--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/commands/convert/JPatternConverterTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/commands/convert/JPatternConverterTest.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.tools.commands.convert
 
 import com.beust.jcommander.JCommander

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/package.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/package.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.utils
 
 import org.geotools.data.FeatureReader

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/QuadTreeFeatureStore.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/QuadTreeFeatureStore.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.utils.index
 
 import com.vividsolutions.jts.geom.Geometry

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/index/QuadTreeFeatureStoreTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/index/QuadTreeFeatureStoreTest.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.utils.index
 
 import com.vividsolutions.jts.geom.{Coordinate, Geometry}

--- a/geomesa-web/geomesa-web-core/src/main/scala/org/locationtech/geomesa/web/scalatra/package.scala
+++ b/geomesa-web/geomesa-web-core/src/main/scala/org/locationtech/geomesa/web/scalatra/package.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.web
 
 import java.security.cert.X509Certificate

--- a/geomesa-web/geomesa-web-data/src/main/scala/org/locationtech/geomesa/web/data/DataEndpoint.scala
+++ b/geomesa-web/geomesa-web-data/src/main/scala/org/locationtech/geomesa/web/data/DataEndpoint.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.web.data
 
 import com.typesafe.scalalogging.slf4j.Logging

--- a/geomesa-web/geomesa-web-security/src/test/scala/org/locationtech/geomesa/web/security/TestAuthorizationsProvider.scala
+++ b/geomesa-web/geomesa-web-security/src/test/scala/org/locationtech/geomesa/web/security/TestAuthorizationsProvider.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.web.security
 
 import java.io.Serializable

--- a/geomesa-z3/pom.xml
+++ b/geomesa-z3/pom.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*********************************************************************-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>geomesa</artifactId>

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/MergeQueue.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/MergeQueue.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.curve
 
 class MergeQueue(initialSize: Int = 1) {

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/SpaceFillingCurve.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/SpaceFillingCurve.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.curve
 
 import org.joda.time.Weeks

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.curve
 
 class Z3(val z: Long) extends AnyVal {

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3Range.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3Range.scala
@@ -1,3 +1,10 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.curve
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <module>geomesa-examples</module>
         <module>geomesa-z3</module>
         <module>geomesa-accumulo</module>
+        <module>geomesa-hbase</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
* Added support for both HBase and Google Bigtable based on the HBase API
* Currently limited to point/time data sets
* Developers must enable Bigtable support by setting the 'bigtable' profile
  when building.  This is because the bigtable jar is not in maven central.

Signed-off-by: Anthony Fox <anthonyfox@ccri.com>