### PR TITLE
add basic date time format

### DIFF
--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/Transformers.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/Transformers.scala
@@ -240,13 +240,14 @@ class StringFunctionFactory extends TransformerFunctionFactory {
 class DateFunctionFactory extends TransformerFunctionFactory {
 
   override def functions: Seq[TransformerFn] =
-    Seq(now, customFormatDateParser, datetime, isodate, isodatetime, dateHourMinuteSecondMillis, millisToDate)
+    Seq(now, customFormatDateParser, datetime, isodate, isodatetime, basicDateTimeNoMillis, dateHourMinuteSecondMillis, millisToDate)
 
   val now = TransformerFn("now") { args => DateTime.now.toDate }
   val customFormatDateParser = CustomFormatDateParser()
   val datetime = StandardDateParser("datetime", ISODateTimeFormat.dateTime().withZoneUTC())
   val isodate = StandardDateParser("isodate", ISODateTimeFormat.basicDate().withZoneUTC())
   val isodatetime = StandardDateParser("isodatetime", ISODateTimeFormat.basicDateTime().withZoneUTC())
+  val basicDateTimeNoMillis = StandardDateParser("basicDateTimeNoMillis", ISODateTimeFormat.basicDateTimeNoMillis().withZoneUTC())
   val dateHourMinuteSecondMillis = StandardDateParser("dateHourMinuteSecondMillis", ISODateTimeFormat.dateHourMinuteSecondMillis().withZoneUTC())
   val millisToDate = TransformerFn("millisToDate") { args => new Date(args(0).asInstanceOf[Long]) }
 


### PR DESCRIPTION
This format is needed because there isn't enough string escaping in place to specify it manually