### PR TITLE
GEOMESA-806 Don't run multiple queries when only secondary filters have OR clauses

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -770,14 +770,18 @@ class AccumuloDataStore(val connector: Connector,
    * Gets the query plan for a given query. The query plan consists of the tables, ranges, iterators etc
    * required to run a query against accumulo.
    */
-  def getQueryPlan(featureName: String, query: Query): Seq[QueryPlan] =
-    planQuery(featureName, query, ExplainNull)
+  def getQueryPlan(query: Query): Seq[QueryPlan] = {
+    require(query.getTypeName != null, "Type name is required in the query")
+    planQuery(query.getTypeName, query, ExplainNull)
+  }
 
   /**
    * Prints the query plan for a given query to the provided output.
    */
-  def explainQuery(featureName: String, query: Query, o: ExplainerOutputType = ExplainPrintln): Unit =
-    planQuery(featureName, query, o)
+  def explainQuery(query: Query, o: ExplainerOutputType = ExplainPrintln): Unit = {
+    require(query.getTypeName != null, "Type name is required in the query")
+    planQuery(query.getTypeName, query, o)
+  }
 
   /**
    *

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/QueryFilterSplitter.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/QueryFilterSplitter.scala
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0 which
+ * accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ */
+
+package org.locationtech.geomesa.accumulo.index
+
+import com.typesafe.scalalogging.slf4j.Logging
+import org.geotools.filter.text.ecql.ECQL
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType.StrategyType
+import org.locationtech.geomesa.accumulo.stats.QueryStatTransform
+import org.locationtech.geomesa.filter._
+import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+import org.opengis.feature.simple.SimpleFeatureType
+import org.opengis.filter.{And, Filter, Id, Or}
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * Class for splitting queries up based on Boolean clauses and the available query strategies.
+ */
+class QueryFilterSplitter(sft: SimpleFeatureType, includeZ3: Boolean) extends Logging {
+
+  private lazy val wholeWorldGeom = ff.bbox(sft.getGeomField, -180.0, -90.0, 180.0, 90.0, "EPSG:4326")
+
+  /**
+   * Splits the query up into different filter plans to be evaluated. Each filter plan will consist of one or
+   * more query plans. Each query plan will have a primary part (that would be used for query planning)
+   * and an optional secondary part (that would be applied as a secondary filter).
+   *
+   * Examples:
+   *
+   * bbox(geom) AND attr1 = ? =>
+   *
+   * Seq(FilterPlan(Seq(QueryFilter(ST,Seq([ geom bbox ]),Some([ attr1 = ? ])))))
+   *
+   * bbox(geom) OR attr1 = ? =>
+   *
+   * Seq(FilterPlan(Seq(QueryFilter(ST,Seq([ geom bbox ]),None), QueryFilter(ATTRIBUTE,Seq([ attr1 = ? ]),None))))
+   *
+   * bbox(geom) AND dtg DURING ? AND attr1 = ? =>
+   *
+   * Seq(FilterPlan(Seq(QueryFilter(Z3,Seq([ geom bbox ], [ dtg during ? ]),Some([ attr1 = ? ])))),
+   *     FilterPlan(Seq(QueryFilter(ATTRIBUTE,Seq([ attr1 = ? ]),Some([ geom bbox AND dtg during ? ])))))
+   * note: spatial and temporal filters are combined.
+   *
+   * (bbox(geom) OR geom INTERSECT) AND attr1 = ? =>
+   *
+   * Seq(FilterPlan(Seq(QueryFilter(ST,Seq([ geom bbox ]),Some([ attr1 = ? ])), QueryFilter(ST,Seq([ geom intersect ]),Some([ attr1 = ? ]))))
+   *     FilterPlan(Seq(QueryFilter(ATTRIBUTE,Seq([ attr1 = ? ]),Some([ geom bbox OR geom intersect ])))))
+   *
+   * note: ors will not be split if they are part of the secondary filter
+   *
+   */
+  def getQueryOptions(filter: Filter): Seq[FilterPlan] = {
+    rewriteFilterInDNF(filter) match {
+      case o: Or  => getOrQueryOptions(o)
+      case f      => getAndQueryOptions(f)
+    }
+  }
+
+  private def getAndQueryOptions(f: Filter): Seq[FilterPlan] = {
+    f match {
+      case a: And => getAndQueryOptions(a.getChildren.sortBy(ECQL.toCQL))
+      case _      => getAndQueryOptions(Seq(f))
+    }
+  }
+
+  /**
+   * Gets options based on 'anded' filters
+   */
+  private def getAndQueryOptions(filters: Seq[Filter]): Seq[FilterPlan] = {
+
+    // check for filter.exclude - nothing will be returned
+    if (filters.contains(Filter.EXCLUDE)) {
+      return Seq.empty
+    }
+
+    val options = ArrayBuffer.empty[FilterPlan]
+
+    // filter out any whole world geoms, since they are essentially meaningless
+    val (invalid, validFilters) = filters.filter(_ != Filter.INCLUDE).partition(FilterHelper.isFilterWholeWorld)
+    if (invalid.nonEmpty) {
+      logger.debug(s"Dropping whole world filters: ${invalid.map(filterToString).mkString(", ")}")
+    }
+    val (spatial, temporal, attribute, dateAttribute, others) = partitionFilters(validFilters)
+
+    // z3 and spatio-temporal
+    if (includeZ3 && temporal.nonEmpty) {
+      // z3 works pretty well for temporal only queries, but it still needs a spatial
+      // filter, even if it is just a whole world bbox
+      val ensureSpatial = if (spatial.nonEmpty) spatial else Seq(wholeWorldGeom)
+      val primary = ensureSpatial ++ temporal
+      val secondary = andOption(attribute ++ others)
+      options.append(FilterPlan(Seq(QueryFilter(StrategyType.Z3, primary, secondary))))
+    } else if (spatial.nonEmpty) {
+      val primary = spatial ++ temporal
+      val secondary = andOption(attribute ++ others)
+      options.append(FilterPlan(Seq(QueryFilter(StrategyType.ST, primary, secondary))))
+    }
+
+    // ids
+    if (others.nonEmpty) {
+      val ids = others.collect { case id: Id => id }
+      if (ids.nonEmpty) {
+        val primary = ids
+        val nonIds = others.filterNot(ids.contains) ++ spatial ++ temporal ++ attribute
+        val secondary = andOption(nonIds)
+        options.append(FilterPlan(Seq(QueryFilter(StrategyType.RECORD, primary, secondary))))
+      }
+    }
+
+    // attributes
+    if (attribute.nonEmpty || dateAttribute.nonEmpty) {
+      val allAttributes = attribute ++ dateAttribute
+      val attributes = allAttributes.groupBy(getAttributeProperty(_).get.name)
+      attributes.foreach { case (name, thisAttribute) =>
+        val primary = thisAttribute
+        val nonPrimary = allAttributes.filterNot(thisAttribute.contains) ++
+            temporal.filterNot(thisAttribute.contains) ++ spatial ++ others
+        val secondary = andOption(nonPrimary)
+        options.append(FilterPlan(Seq(QueryFilter(StrategyType.ATTRIBUTE, primary, secondary))))
+      }
+    }
+
+    // fall back - full table scan
+    if (options.isEmpty) {
+      options.append(fullTableScanOption(andOption(validFilters)))
+    }
+    options.toSeq
+  }
+
+  private def getOrQueryOptions(filter: Or): Seq[FilterPlan] = {
+
+    // for each child of the or, get the query options
+    // each filter plan should only have a single query filter
+    def getChildOptions: Seq[Seq[FilterPlan]] = filter.getChildren.map(getAndQueryOptions)
+
+    // combine the filter plans so that each plan has multiple query filters
+    // use the permutations of the different options for each child
+    def reduceChildOptions(childOptions: Seq[Seq[FilterPlan]]): Seq[FilterPlan] =
+      childOptions.reduce { (left, right) =>
+        left.flatMap(l => right.map(r => FilterPlan(l.filters ++ r.filters)))
+      }
+
+    // try to combine query filters in each filter plan if they have the same primary filter
+    // this avoids scanning the same ranges twice with different secondary predicates
+    def combineSecondaryFilters(options: Seq[FilterPlan]): Seq[FilterPlan] = options.map { r =>
+      val groups = r.filters.distinct.groupBy(d => (d.strategy, d.primary)).map { case (group, secondaries) =>
+        QueryFilter(group._1, group._2, orOption(secondaries.flatMap(_.secondary)))
+      }
+      FilterPlan(groups.toSeq)
+    }
+
+    // if a filter plan has any query filters that scan a subset of the range of a different query filter,
+    // then we can combine them, as we have to scan the larger range anyway
+    def mergeOverlappedFilters(options: Seq[FilterPlan]): Seq[FilterPlan] = options.map { filterPlan =>
+      val filters = ArrayBuffer(filterPlan.filters: _*)
+      var merged: QueryFilter = null
+      var i = 0
+      while (i < filters.length) {
+        val toMerge = filters(i)
+        if (toMerge != null) {
+          var j = 0
+          while (j < filters.length && merged == null) {
+            if (i != j) {
+              val mergeTo = filters(j)
+              if (mergeTo != null) {
+                merged = tryMerge(toMerge, mergeTo)
+              }
+            }
+            j += 1
+          }
+          if (merged != null) {
+            // remove the merged query filter and replace the one merged into
+            filters.update(i, null)
+            filters.update(j - 1, merged)
+            merged = null
+          }
+        }
+        i += 1
+      }
+
+      // if we have replaced anything, recreate the filter plan
+      val overlapped = filters.filter(_ != null)
+      if (overlapped.length < filterPlan.filters.length) {
+        FilterPlan(overlapped)
+      } else {
+        filterPlan
+      }
+    }
+
+    mergeOverlappedFilters(combineSecondaryFilters(reduceChildOptions(getChildOptions)))
+  }
+
+  /**
+   * Splits filters up according to the filter type. Note that the 'dateAttribute' will be a duplicate
+   * of a filter in the 'temporal' filter list.
+   */
+  private def partitionFilters(filters: Seq[Filter]) = {
+    val (spatial, nonSpatial)         = partitionPrimarySpatials(filters, sft)
+    val (temporal, nonSpatioTemporal) = partitionPrimaryTemporals(nonSpatial, sft)
+    val (attribute, others)           = partitionIndexedAttributes(nonSpatioTemporal, sft)
+    val dateAttribute                 = partitionIndexedAttributes(temporal, sft)._1
+
+    (spatial, temporal, attribute, dateAttribute, others)
+  }
+
+  /**
+   * Try to merge the two query filters. Return the merged query filter if successful, else null.
+   */
+  private def tryMerge(toMerge: QueryFilter, mergeTo: QueryFilter): QueryFilter = {
+    if (mergeTo.primary.forall(_ == Filter.INCLUDE)) {
+      // this is a full table scan, we can just append the OR to the secondary filter
+      val secondary = orOption(mergeTo.secondary.toSeq ++ andOption(toMerge.primary ++ toMerge.secondary.toSeq))
+      mergeTo.copy(secondary = secondary)
+    } else {
+      // TODO we could technically check for overlapping geoms, date ranges, attribute ranges, etc
+      // not sure it's worth it though
+      null
+    }
+  }
+
+  /**
+   * Will perform a full table scan - used when we don't have anything better. Uses record table
+   */
+  private def fullTableScanOption(filter: Option[Filter]): FilterPlan =
+    FilterPlan(Seq(QueryFilter(StrategyType.RECORD, Seq(Filter.INCLUDE), filter)))
+}
+
+/**
+ * Filters split into a 'primary' that will be used for range planning,
+ * and a 'secondary' that will be applied as a final step.
+ */
+case class QueryFilter(strategy: StrategyType, primary: Seq[Filter], secondary: Option[Filter] = None) {
+  lazy val filter = andFilters(primary ++ secondary)
+  lazy val filterString: String =
+    s"primary filter: ${primary.map(QueryStatTransform.filterToString).mkString(", ")}, " +
+      s"secondary filter: ${secondary.map(QueryStatTransform.filterToString).getOrElse("None")}"
+}
+
+/**
+ * A series of queries required to satisfy a filter - basically split on ORs
+ */
+case class FilterPlan(filters: Seq[QueryFilter])
+

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/QueryStrategyDecider.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/QueryStrategyDecider.scala
@@ -9,80 +9,45 @@
 package org.locationtech.geomesa.accumulo.index
 
 import org.geotools.data.Query
-import org.geotools.factory.CommonFactoryFinder
 import org.locationtech.geomesa.accumulo.data.INTERNAL_GEOMESA_VERSION
+import org.locationtech.geomesa.accumulo.data.tables.Z3Table
 import org.locationtech.geomesa.accumulo.index.QueryHints._
-import org.locationtech.geomesa.filter.FilterHelper._
-import org.locationtech.geomesa.utils.geotools.RichIterator.RichIterator
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType.StrategyType
 import org.opengis.feature.simple.SimpleFeatureType
-import org.opengis.filter.{And, Filter, Id, PropertyIsLike}
+import org.opengis.filter.Filter
 
-import scala.collection.JavaConversions._
-
-trait VersionedQueryStrategyDecider {
-  def chooseStrategy(sft: SimpleFeatureType, query: Query, hints: StrategyHints): Strategy
-}
-
-object VersionedQueryStrategyDecider {
-  def apply(version: Int): VersionedQueryStrategyDecider = {
-    if (version <= 4) new QueryStrategyDeciderV4 else new QueryStrategyDeciderV5
-  }
+trait QueryStrategyDecider {
+  def chooseStrategies(sft: SimpleFeatureType,
+                       query: Query,
+                       hints: StrategyHints,
+                       requested: Option[StrategyType]): Seq[Strategy]
 }
 
 object QueryStrategyDecider {
+
   // first element is null so that the array index aligns with the version
-  val strategies = Array[VersionedQueryStrategyDecider](null) ++
-      (1 to INTERNAL_GEOMESA_VERSION).map(VersionedQueryStrategyDecider.apply)
+  private val strategies: Array[QueryStrategyDecider] =
+    Array[QueryStrategyDecider](null) ++ (1 to INTERNAL_GEOMESA_VERSION).map(QueryStrategyDecider.apply)
 
-  def chooseStrategy(sft: SimpleFeatureType, query: Query, hints: StrategyHints, version: Int): Strategy =
-    strategies(version).chooseStrategy(sft, query, hints)
-
-  // TODO try to use wildcard values from the Filter itself (https://geomesa.atlassian.net/browse/GEOMESA-309)
-  // Currently pulling the wildcard values from the filter
-  // leads to inconsistent results...so use % as wildcard
-  val MULTICHAR_WILDCARD = "%"
-  val SINGLE_CHAR_WILDCARD = "_"
-  val NULLBYTE = Array[Byte](0.toByte)
-
-  /* Like queries that can be handled by current reverse index */
-  def likeEligible(filter: PropertyIsLike) = containsNoSingles(filter) && trailingOnlyWildcard(filter)
-
-  /* contains no single character wildcards */
-  def containsNoSingles(filter: PropertyIsLike) =
-    !filter.getLiteral.replace("\\\\", "").replace(s"\\$SINGLE_CHAR_WILDCARD", "").contains(SINGLE_CHAR_WILDCARD)
-
-  def trailingOnlyWildcard(filter: PropertyIsLike) =
-    (filter.getLiteral.endsWith(MULTICHAR_WILDCARD) &&
-      filter.getLiteral.indexOf(MULTICHAR_WILDCARD) == filter.getLiteral.length - MULTICHAR_WILDCARD.length) ||
-      filter.getLiteral.indexOf(MULTICHAR_WILDCARD) == -1
-
-}
-
-class QueryStrategyDeciderV4 extends VersionedQueryStrategyDecider {
-
-  val REASONABLE_COST = 10000
-  val OPTIMAL_COST = 10
-
-  def chooseStrategy(sft: SimpleFeatureType, query: Query, hints: StrategyHints): Strategy = {
-    // check for density queries
-    if (query.getHints.containsKey(DENSITY_BBOX_KEY) || query.getHints.contains(TIME_BUCKETS_KEY)) {
-      // TODO GEOMESA-322 use other strategies with density iterator
-      return new STIdxStrategy
-    }
-
-    query.getFilter match {
-      case id: Id   => new RecordIdxStrategy
-      case and: And => processFilters(decomposeAnd(and), sft, hints)
-      case cql =>
-        // a single clause - check for indexed attributes or fall back to spatio-temporal
-        AttributeIndexStrategy.getStrategy(cql, sft, hints).map(_.strategy).getOrElse(new STIdxStrategy)
-    }
+  def apply(version: Int): QueryStrategyDecider = {
+    if (version <= 4) new QueryStrategyDeciderV4 else new QueryStrategyDeciderV5
   }
 
+  def chooseStrategies(sft: SimpleFeatureType,
+                       query: Query,
+                       hints: StrategyHints,
+                       requested: Option[StrategyType],
+                       version: Int): Seq[Strategy] = {
+    strategies(version).chooseStrategies(sft, query, hints, requested)
+  }
+}
+
+class QueryStrategyDeciderV5 extends QueryStrategyDecider {
+
   /**
-   * Scans the filter and identify the type of predicates present.
-   *
-   * Choose the query strategy to be employed here. This is the priority:
+   * Scans the filter and identify the type of predicates present, then picks a strategy based on cost.
+   * Currently, the costs are hard-coded to conform to the following priority:
    *
    *   * If an ID predicate is present, it is assumed that only a small number of IDs are requested
    *            --> The Record Index is scanned, and the other ECQL filters, if any, are then applied
@@ -99,71 +64,71 @@ class QueryStrategyDeciderV4 extends VersionedQueryStrategyDecider {
    *   * If filters are not identified, use the STIdxStrategy
    *            --> The ST Index is scanned (likely a full table scan) and the ECQL filters are applied
    */
-  def processFilters(filters: Seq[Filter], sft: SimpleFeatureType, hints: StrategyHints): Strategy = {
-    // record strategy takes priority
-    val recordStrategy = filters.iterator.flatMap(f => RecordIdxStrategy.getStrategy(f, sft, hints)).headOption
-    recordStrategy match {
-      case Some(s) => s.strategy
-      case None    => processNonRecordFilters(filters, sft, hints)
+  override def chooseStrategies(sft: SimpleFeatureType,
+                                query: Query,
+                                hints: StrategyHints,
+                                requested: Option[StrategyType]): Seq[Strategy] = {
+
+    // get the various options that we could potentially use
+    val options = new QueryFilterSplitter(sft, supportsZ3(sft)).getQueryOptions(query.getFilter)
+
+    if (requested.isDefined) {
+      // see if one of the normal plans matches the requested type - if not, force it
+      val strategy = requested.get
+      options.find(_.filters.forall(_.strategy == strategy)) match {
+        case Some(plan) => plan.filters.map(createStrategy)
+        case None => Seq(createStrategy(QueryFilter(strategy, Seq(Filter.INCLUDE), Some(query.getFilter))))
+      }
+    } else if (options.isEmpty) {
+      Seq.empty // corresponds to filter.exclude
+    } else {
+      val filterPlan = if (query.getHints.isDensityQuery) {
+        // TODO GEOMESA-322 use other strategies with density iterator
+        val st = options.find(_.filters.forall(q => q.strategy == StrategyType.Z3 ||
+            q.strategy == StrategyType.ST))
+        st.getOrElse {
+          val fallback = if (query.getFilter == Filter.INCLUDE) None else Some(query.getFilter)
+          FilterPlan(Seq(QueryFilter(StrategyType.ST, Seq(Filter.INCLUDE), fallback)))
+        }
+
+      } else if (options.length == 1) {
+        // only a single option, so don't bother with cost
+        options.head
+      } else {
+        // choose the best option based on cost
+        options.sortBy { filterPlan =>
+          filterPlan.filters.map { filter =>
+            filter.strategy match {
+              case StrategyType.Z3 => Z3IdxStrategy.getCost(filter, sft, hints)
+              case StrategyType.ST => STIdxStrategy.getCost(filter, sft, hints)
+              case StrategyType.RECORD => RecordIdxStrategy.getCost(filter, sft, hints)
+              case StrategyType.ATTRIBUTE => AttributeIdxStrategy.getCost(filter, sft, hints)
+              case _ => throw new IllegalStateException(s"Unknown query plan requested: ${filter.strategy}")
+            }
+          }.sum
+        }.head
+      }
+      filterPlan.filters.map(createStrategy)
     }
   }
 
   /**
-   * We've already eliminated record filters - look for attribute + spatio-temporal filters
+   * Mapping from strategy type enum to concrete implementation class
    */
-  def processNonRecordFilters(filters: Seq[Filter], sft: SimpleFeatureType, hints: StrategyHints): Strategy = {
-    // look for reasonable cost attribute strategies - expensive ones will not be considered
-    val attributeStrategies =
-      filters.flatMap(f => AttributeIndexStrategy.getStrategy(f, sft, hints)).filter(_.cost < REASONABLE_COST)
-
-    // next look for low cost (high-cardinality) attribute filters - cost is set in the attribute strategy
-    val highCardinalityStrategy = attributeStrategies.find(_.cost < OPTIMAL_COST)
-    highCardinalityStrategy match {
-      case Some(s) => s.strategy
-      case None    => processStFilters(filters, attributeStrategies.headOption, sft, hints)
+  private def createStrategy(filter: QueryFilter): Strategy = {
+    filter.strategy match {
+      case StrategyType.Z3        => new Z3IdxStrategy(filter)
+      case StrategyType.ST        => new STIdxStrategy(filter)
+      case StrategyType.RECORD    => new RecordIdxStrategy(filter)
+      case StrategyType.ATTRIBUTE => new AttributeIdxStrategy(filter)
+      case _ => throw new IllegalStateException(s"Unknown query plan requested: ${filter.strategy}")
     }
   }
 
-  /**
-   * We've eliminated the best attribute strategies - look for spatio-temporal and use the best attribute
-   * strategy available as a fallback.
-   */
-  def processStFilters(filters: Seq[Filter],
-                       fallback: Option[StrategyDecision],
-                       sft: SimpleFeatureType,
-                       hints: StrategyHints): Strategy = {
-    // finally, prefer spatial filters if available
-    val stStrategy = filters.iterator.flatMap(f => STIdxStrategy.getStrategy(f, sft, hints)).headOption
-    stStrategy.orElse(fallback).map(_.strategy).getOrElse(new STIdxStrategy)
-  }
+  def supportsZ3(sft: SimpleFeatureType): Boolean = Z3Table.supports(sft)
 }
 
-class QueryStrategyDeciderV5 extends QueryStrategyDeciderV4 {
-
-  val ff = CommonFactoryFinder.getFilterFactory2
-
-  /**
-   * Adds in preferred z3 density check before falling back to regular checks
-   */
-  override def chooseStrategy(sft: SimpleFeatureType, query: Query, hints: StrategyHints): Strategy = {
-    if (query.getHints.containsKey(DENSITY_BBOX_KEY) && query.getFilter.isInstanceOf[And]) {
-      val filters = decomposeAnd(query.getFilter.asInstanceOf[And]) // z3 needs at least a geom and dtg
-      Z3IdxStrategy.getStrategy(ff.and(filters), sft, hints).map(_.strategy).foreach { s =>
-        return s
-      }
-    }
-    super.chooseStrategy(sft, query, hints)
-  }
-
-  /**
-   * Adds in a preferred z3 check before falling back to regular st index
-   */
-  override def processStFilters(filters: Seq[Filter],
-                                fallback: Option[StrategyDecision],
-                                sft: SimpleFeatureType,
-                                hints: StrategyHints): Strategy = {
-    // Prefer z3 index if it is available, else fallback to the old STIdxStrategy
-    val z3Strategy = Z3IdxStrategy.getStrategy(ff.and(filters), sft, hints).map(_.strategy)
-    z3Strategy.getOrElse(super.processStFilters(filters, fallback, sft, hints))
-  }
+class QueryStrategyDeciderV4 extends QueryStrategyDeciderV5 {
+  // version 4 does not ever support z3
+  override def supportsZ3(sft: SimpleFeatureType): Boolean = false
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategy.scala
@@ -8,115 +8,81 @@
 
 package org.locationtech.geomesa.accumulo.index
 
-import java.util
-
 import com.typesafe.scalalogging.slf4j.Logging
-import org.apache.accumulo.core.data
-import org.geotools.data.Query
+import org.apache.accumulo.core.data.{Range => aRange}
+import org.apache.hadoop.io.Text
+import org.geotools.factory.Hints
 import org.locationtech.geomesa.accumulo.data.tables.RecordTable
 import org.locationtech.geomesa.accumulo.index.QueryHints.RichHints
 import org.locationtech.geomesa.accumulo.index.Strategy._
 import org.locationtech.geomesa.accumulo.iterators.{BinAggregatingIterator, IteratorTrigger}
 import org.locationtech.geomesa.filter._
 import org.opengis.feature.simple.SimpleFeatureType
-import org.opengis.filter.identity.{FeatureId, Identifier}
 import org.opengis.filter.{Filter, Id}
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 
 object RecordIdxStrategy extends StrategyProvider {
 
-  override def getStrategy(filter: Filter, sft: SimpleFeatureType, hints: StrategyHints) =
-    if (filterIsId(filter)) Some(StrategyDecision(new RecordIdxStrategy, -1)) else None
+  // record searches are the least expensive as they are single row lookups (per id)
+  override def getCost(filter: QueryFilter, sft: SimpleFeatureType, hints: StrategyHints) = 1
 
-  def intersectIDFilters(filters: Seq[Filter]): Option[Id] = filters.size match {
-    case 0 => None                                             // empty filter sequence
-    case 1 => Some(filters.head).map ( _.asInstanceOf[Id] )    // single filter
-    case _ =>                                                  // multiple filters -- need to intersect
+  def intersectIdFilters(filters: Seq[Filter]): Option[Id] = {
+    if (filters.length < 2) {
+      filters.headOption.map(_.asInstanceOf[Id])
+    } else {
       // get the Set of IDs in *each* filter and convert to a Scala immutable Set
-      val ids = filters.map ( _.asInstanceOf[Id].getIDs.asScala.toSet )
-      // take the intersection of all sets
-      val intersectionIDs = ids.reduceLeft ( _ intersect _ )
-      // convert back to a Option[Id]
-      if (intersectionIDs.isEmpty) None
-      else {
-        val newIDSet: util.Set[FeatureId] = intersectionIDs.map ( x => ff.featureId(x.toString) ).asJava
-        val newFilter = ff.id(newIDSet)
-        Some(newFilter)
-      }
+      // take the intersection of all sets, since the filters and joined with 'and'
+      val ids = filters.map(_.asInstanceOf[Id].getIDs.map(_.toString).toSet).reduceLeft(_ intersect _)
+      if (ids.nonEmpty) Some(ff.id(ids.map(ff.featureId))) else None
     }
-
+  }
 }
 
-class RecordIdxStrategy extends Strategy with Logging {
+class RecordIdxStrategy(val filter: QueryFilter) extends Strategy with Logging {
 
-  override def getQueryPlans(query: Query, queryPlanner: QueryPlanner, output: ExplainerOutputType) = {
+  override def getQueryPlans(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType) = {
 
     val sft = queryPlanner.sft
     val acc = queryPlanner.acc
     val featureEncoding = queryPlanner.featureEncoding
-
-    output(s"Searching the record table with filter ${query.getFilter}")
-
-    val (idFilters, oFilters) =  partitionID(query.getFilter)
-
-    // recombine non-ID filters
-    val ecql = FilterHelper.filterListAsAnd(oFilters)
-
-    // Multiple sets of IDs in a ID Filter are ORs. ANDs of these call for the intersection to be taken.
-    // intersect together all groups of ID Filters, producing Some[Id] if the intersection returns something
-    val combinedIDFilter: Option[Id] = RecordIdxStrategy.intersectIDFilters(idFilters)
-
-    val identifiers: Option[Set[Identifier]] = combinedIDFilter.map ( _.getIdentifiers.asScala.toSet )
-
     val prefix = getTableSharingPrefix(sft)
 
-    val rangesAsOption: Option[Set[data.Range]] = identifiers.map {
-      aSet => aSet.map {
-        id => org.apache.accumulo.core.data.Range.exact(RecordTable.getRowKey(prefix, id.toString))
+    val ranges = if (filter.primary.forall(_ == Filter.INCLUDE)) {
+      // allow for full table scans - we use the record index for queries that can't be satisfied elsewhere
+      logger.warn(s"Running full table scan for schema ${sft.getTypeName} with filter " +
+          s"${filter.secondary.map(filterToString).getOrElse("INCLUDE")}")
+      val start = new Text(prefix)
+      Seq(new aRange(start, true, aRange.followingPrefix(start), false))
+    } else {
+      // Multiple sets of IDs in a ID Filter are ORs. ANDs of these call for the intersection to be taken.
+      // intersect together all groups of ID Filters, producing Some[Id] if the intersection returns something
+      val combinedIdFilter = RecordIdxStrategy.intersectIdFilters(filter.primary)
+      val identifiers = combinedIdFilter.toSeq.flatMap(_.getIdentifiers.map(_.toString))
+      output(s"Extracted ID filter: ${identifiers.mkString(", ")}")
+      if (identifiers.nonEmpty) {
+        identifiers.map(id => aRange.exact(RecordTable.getRowKey(prefix, id)))
+      } else {
+        // TODO GEOMESA-347 instead pass empty query plan
+        Seq.empty
       }
     }
 
-    // check that the Set of Ranges exists and is not empty
-    val ranges = rangesAsOption match {
-      case Some(filterSet) if filterSet.nonEmpty => filterSet
-      case _ =>
-        // TODO: for below instead pass empty query plan (https://geomesa.atlassian.net/browse/GEOMESA-347)
-        logger.warn(s"Filter ${query.getFilter} results in no valid range for record table")
-        Seq.empty
-    }
-
-    output(s"Extracted ID filter: ${combinedIDFilter.get}")
-
-    output(s"Extracted Other filters: $oFilters")
-
-    output(s"Setting ${ranges.size} ranges.")
-
-    val iteratorConfig = IteratorTrigger.chooseIterator(ecql, query, sft)
-
-    val cfg = if (iteratorConfig.hasTransformOrFilter) {
-      // TODO apply optimization for when transforms cover filter
-      val cfg = configureRecordTableIterator(sft, featureEncoding, ecql, query)
-      output(s"RecordTableIterator: ${cfg.toString }")
-      Some(cfg)
+    val iters = if (filter.secondary.isDefined || getTransformSchema(hints).isDefined) {
+      Seq(configureRecordTableIterator(sft, featureEncoding, filter.secondary, hints))
     } else {
-      None
+      Seq.empty
     }
-
-    // TODO GEOMESA-322 use other strategies with density iterator
-    //val topIterCfg = getTopIterCfg(query, geometryToCover, schema, featureEncoder, featureType)
-
-    val iters = Seq(cfg).flatten
 
     val table = acc.getRecordTable(sft)
     val threads = acc.getSuggestedRecordThreads(sft)
-    val kvsToFeatures = if (query.getHints.isBinQuery) {
+    val kvsToFeatures = if (hints.isBinQuery) {
       // TODO GEOMESA-822 we can use the aggregating iterator if the features are kryo encoded
-      BinAggregatingIterator.nonAggregatedKvsToFeatures(query, sft, featureEncoding)
+      BinAggregatingIterator.nonAggregatedKvsToFeatures(sft, hints, featureEncoding)
     } else {
-      queryPlanner.defaultKVsToFeatures(query)
+      queryPlanner.defaultKVsToFeatures(hints)
     }
-    Seq(BatchScanPlan(table, ranges.toSeq, iters, Seq.empty, kvsToFeatures, threads, hasDuplicates = false))
+    Seq(BatchScanPlan(table, ranges, iters, Seq.empty, kvsToFeatures, threads, hasDuplicates = false))
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategy.scala
@@ -6,7 +6,7 @@ import com.vividsolutions.jts.geom.{Geometry, GeometryCollection}
 import org.apache.accumulo.core.client.IteratorSetting
 import org.apache.accumulo.core.data.Range
 import org.apache.hadoop.io.Text
-import org.geotools.data.Query
+import org.geotools.factory.Hints
 import org.joda.time.Weeks
 import org.locationtech.geomesa.accumulo.data.tables.Z3Table
 import org.locationtech.geomesa.accumulo.index
@@ -14,39 +14,32 @@ import org.locationtech.geomesa.accumulo.index.QueryHints.RichHints
 import org.locationtech.geomesa.accumulo.index.QueryPlanners.FeatureFunction
 import org.locationtech.geomesa.accumulo.iterators.{BinAggregatingIterator, Z3DensityIterator, Z3Iterator}
 import org.locationtech.geomesa.curve.Z3SFC
-import org.locationtech.geomesa.filter
-import org.locationtech.geomesa.filter.FilterHelper
+import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.iterators.{KryoLazyFilterTransformIterator, LazyFilterTransformIterator}
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.opengis.feature.simple.SimpleFeatureType
-import org.opengis.filter.Filter
-import org.opengis.filter.spatial.BinarySpatialOperator
 
-import scala.collection.JavaConversions._
-
-class Z3IdxStrategy extends Strategy with Logging with IndexFilterHelpers  {
+class Z3IdxStrategy(val filter: QueryFilter) extends Strategy with Logging with IndexFilterHelpers  {
 
   import FilterHelper._
   import Z3IdxStrategy._
-  import filter._
 
   val Z3_CURVE = new Z3SFC
 
   /**
    * Plans the query - strategy implementations need to define this
    */
-  override def getQueryPlans(query: Query, queryPlanner: QueryPlanner, output: ExplainerOutputType) = {
+  override def getQueryPlans(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType) = {
     val sft = queryPlanner.sft
     val acc = queryPlanner.acc
 
     val dtgField = getDtgFieldName(sft)
 
-    val (geomFilters, otherFilters) = partitionGeom(query.getFilter, sft)
-    val (temporalFilters, ecqlFilters) = partitionTemporal(otherFilters, dtgField)
+    val (geomFilters, temporalFilters) = filter.primary.partition(isSpatialFilter)
+    val ecql = filter.secondary
 
-    output(s"Geometry filters: $geomFilters")
-    output(s"Temporal filters: $temporalFilters")
-    output(s"Other filters: $ecqlFilters")
+    output(s"Geometry filters: ${filtersToString(geomFilters)}")
+    output(s"Temporal filters: ${filtersToString(temporalFilters)}")
 
     val tweakedGeomFilters = geomFilters.map(updateTopologicalFilters(_, sft))
 
@@ -66,22 +59,16 @@ class Z3IdxStrategy extends Strategy with Logging with IndexFilterHelpers  {
     output(s"GeomsToCover: $geometryToCover")
     output(s"Interval:  $interval")
 
-    val ecql = ecqlFilters.length match {
-      case 0 => None
-      case 1 => Some(ecqlFilters.head)
-      case _ => Some(ff.and(ecqlFilters))
-    }
-
     val fp = FILTERING_ITER_PRIORITY
 
-    val (iterators, kvsToFeatures, colFamily) = if (query.getHints.isBinQuery) {
-      val trackId = query.getHints.getBinTrackIdField
-      val geom = query.getHints.getBinGeomField
-      val dtg = query.getHints.getBinDtgField
-      val label = query.getHints.getBinLabelField
+    val (iterators, kvsToFeatures, colFamily) = if (hints.isBinQuery) {
+      val trackId = hints.getBinTrackIdField
+      val geom = hints.getBinGeomField
+      val dtg = hints.getBinDtgField
+      val label = hints.getBinLabelField
 
-      val batchSize = query.getHints.getBinBatchSize
-      val sort = query.getHints.isBinSorting
+      val batchSize = hints.getBinBatchSize
+      val sort = hints.isBinSorting
 
       // if possible, use the pre-computed values
       // can't use if there are non-st filters or if custom fields are requested
@@ -96,16 +83,16 @@ class Z3IdxStrategy extends Strategy with Logging with IndexFilterHelpers  {
           (Seq(iter), Z3Table.FULL_CF)
         }
       (iters, BinAggregatingIterator.kvsToFeatures(), cf)
-    } else if (query.getHints.isDensityQuery) {
-      val envelope = query.getHints.getDensityEnvelope.get
-      val (width, height) = query.getHints.getDensityBounds.get
-      val weight = query.getHints.getDensityWeight
+    } else if (hints.isDensityQuery) {
+      val envelope = hints.getDensityEnvelope.get
+      val (width, height) = hints.getDensityBounds.get
+      val weight = hints.getDensityWeight
       val iter = Z3DensityIterator.configure(sft, ecql, envelope, width, height, weight, fp)
       (Seq(iter), Z3DensityIterator.kvsToFeatures(), Z3Table.FULL_CF)
     } else {
       val transforms = for {
-        tdef <- index.getTransformDefinition(query)
-        tsft <- index.getTransformSchema(query)
+        tdef <- index.getTransformDefinition(hints)
+        tsft <- index.getTransformSchema(hints)
       } yield { (tdef, tsft) }
       output(s"Transforms: $transforms")
 
@@ -114,7 +101,7 @@ class Z3IdxStrategy extends Strategy with Logging with IndexFilterHelpers  {
         case _ =>
           Seq(LazyFilterTransformIterator.configure[KryoLazyFilterTransformIterator](sft, ecql, transforms, fp))
       }
-      (iters, Z3Table.adaptZ3KryoIterator(query.getHints.getReturnSft), Z3Table.FULL_CF)
+      (iters, Z3Table.adaptZ3KryoIterator(hints.getReturnSft), Z3Table.FULL_CF)
     }
 
     val z3table = acc.getZ3Table(sft)
@@ -176,29 +163,15 @@ class Z3IdxStrategy extends Strategy with Logging with IndexFilterHelpers  {
 
 object Z3IdxStrategy extends StrategyProvider {
 
-  import filter._
-
   val Z3_ITER_PRIORITY = 21
   val FILTERING_ITER_PRIORITY = 25
 
   /**
-   * Returns details on a potential strategy if the filter is valid for this strategy.
+   * Gets the estimated cost of running the query. Currently, cost is hard-coded to sort between
+   * strategies the way we want. Z3 should be more than id lookups (at 1), high-cardinality attributes (at 1)
+   * and less than STidx (at 400) and unknown cardinality attributes (at 999).
    *
-   * @param filter
-   * @param sft
-   * @return
+   * Eventually cost will be computed based on dynamic metadata and the query.
    */
-  override def getStrategy(filter: Filter, sft: SimpleFeatureType, hints: StrategyHints): Option[StrategyDecision] = {
-    val (geomFilter, other) = partitionGeom(filter, sft)
-    val dtgFieldName = getDtgFieldName(sft)
-    val (temporal, _) = partitionTemporal(other, dtgFieldName)
-    if (Z3Table.supports(sft) && geomFilter.nonEmpty && temporal.nonEmpty && spatialFilters(geomFilter.head)) {
-      val geom = sft.getGeometryDescriptor.getLocalName
-      val e1 = geomFilter.head.asInstanceOf[BinarySpatialOperator].getExpression1
-      val e2 = geomFilter.head.asInstanceOf[BinarySpatialOperator].getExpression2
-      checkOrder(e1, e2).filter(_.name == geom).map(_ => StrategyDecision(new Z3IdxStrategy, -1))
-     } else {
-      None
-    }
-  }
+  override def getCost(filter: QueryFilter, sft: SimpleFeatureType, hints: StrategyHints) = 200
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/index.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/index.scala
@@ -78,14 +78,23 @@ package object index {
   /**
    * Get the transforms set in the query
    */
-  def getTransformDefinition(query: Query): Option[String] =
-    Option(query.getHints.get(TRANSFORMS).asInstanceOf[String])
+  def getTransformDefinition(query: Query): Option[String] = getTransformDefinition(query.getHints)
+
+  /**
+   * Get the transforms set in the query
+   */
+  def getTransformDefinition(hints: Hints): Option[String] = Option(hints.get(TRANSFORMS).asInstanceOf[String])
 
   /**
    * Get the transform schema set in the query
    */
-  def getTransformSchema(query: Query): Option[SimpleFeatureType] =
-    Option(query.getHints.get(TRANSFORM_SCHEMA).asInstanceOf[SimpleFeatureType])
+  def getTransformSchema(query: Query): Option[SimpleFeatureType] = getTransformSchema(query.getHints)
+
+  /**
+   * Get the transform schema set in the query hints
+   */
+  def getTransformSchema(hints: Hints): Option[SimpleFeatureType] =
+    Option(hints.get(TRANSFORM_SCHEMA).asInstanceOf[SimpleFeatureType])
 
   val spec = "geom:Geometry:srid=4326,dtg:Date,dtg_end_time:Date"
   val indexSFT = SimpleFeatureTypes.createType("geomesa-idx", spec)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithDataStore.scala
@@ -75,7 +75,7 @@ trait TestWithDataStore {
 
   def explain(query: Query): String = {
     val o = new ExplainString
-    ds.explainQuery(sftName, query, o)
+    ds.explainQuery(query, o)
     o.toString()
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTest.scala
@@ -33,6 +33,7 @@ import org.geotools.referencing.CRS
 import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.index.QueryHints._
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
 import org.locationtech.geomesa.accumulo.index._
 import org.locationtech.geomesa.accumulo.iterators.{BinAggregatingIterator, IndexIterator, TestData}
 import org.locationtech.geomesa.accumulo.util.{CloseableIterator, GeoMesaBatchWriterConfig, SelfClosingIterator}
@@ -196,7 +197,7 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
       def testThreads(numThreads: Int) = {
         val params = dsParams ++ Map(param -> numThreads)
         val dst = DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
-        val qpt = dst.getQueryPlan(sftName, query)
+        val qpt = dst.getQueryPlan(query)
         qpt must haveSize(1)
         qpt.head.table mustEqual dst.getZ3Table(sftName)
         qpt.head.numThreads mustEqual numThreads
@@ -205,7 +206,7 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
       forall(Seq(1, 5, 8, 20, 100))(testThreads)
 
       // check default
-      val qpt = ds.getQueryPlan(sftName, query)
+      val qpt = ds.getQueryPlan(query)
       qpt must haveSize(1)
       qpt.head.table mustEqual ds.getZ3Table(sftName)
       qpt.head.numThreads mustEqual 8
@@ -248,17 +249,17 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
 
       val explainNull = {
         val o = new ExplainString
-        ds.explainQuery(sftName, queryNull, o)
+        ds.explainQuery(queryNull, o)
         o.toString()
       }
       val explainEmpty = {
         val o = new ExplainString
-        ds.explainQuery(sftName, queryEmpty, o)
+        ds.explainQuery(queryEmpty, o)
         o.toString()
       }
 
-      explainNull must contain("Geometry filters: List([ null bbox POLYGON ((40 44, 40 54, 50 54, 50 44, 40 44)) ])")
-      explainEmpty must contain("Geometry filters: List([  bbox POLYGON ((40 44, 40 54, 50 54, 50 44, 40 44)) ])")
+      explainNull must contain("Geometry filters: BBOX(null, 40.0,44.0,50.0,54.0)")
+      explainEmpty must contain("Geometry filters: BBOX(, 40.0,44.0,50.0,54.0)")
 
       val featuresNull = ds.getFeatureSource(sftName).getFeatures(queryNull).features.toSeq.map(_.getID)
       val featuresEmpty = ds.getFeatureSource(sftName).getFeatures(queryEmpty).features.toSeq.map(_.getID)
@@ -552,10 +553,9 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
 
       val query = new Query(sftName, ECQL.toFilter("BBOX(geom,40,40,50,50)"))
       query.getHints.put(BIN_TRACK_KEY, "name")
-      val strategy = new STIdxStrategy()
       val queryPlanner = new QueryPlanner(sft, ds.getFeatureEncoding(sft),
         ds.getIndexSchemaFmt(sftName), ds, ds.strategyHints(sft), ds.getGeomesaVersion(sft))
-      val results = queryPlanner.runQuery(query, Some(strategy)).map(_.getAttribute(BIN_ATTRIBUTE_INDEX)).toSeq
+      val results = queryPlanner.runQuery(query, Some(StrategyType.ST)).map(_.getAttribute(BIN_ATTRIBUTE_INDEX)).toSeq
       forall(results)(_ must beAnInstanceOf[Array[Byte]])
       val bins = results.flatMap(_.asInstanceOf[Array[Byte]].grouped(16).map(Convert2ViewerFunction.decode))
       bins must haveSize(2)
@@ -691,7 +691,7 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
       val fr = ds.getFeatureReader(sftName)
       fr must not beNull;
       val out = new ExplainString
-      ds.explainQuery(sftName, new Query(sftName, Filter.INCLUDE), out)
+      ds.explainQuery(new Query(sftName, Filter.INCLUDE), out)
       val explain = out.toString()
       explain must startWith(s"Planning Query")
     }
@@ -1144,7 +1144,7 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
       // verify that the IndexIterator is getting used with the extra field
       val explain = {
         val out = new ExplainString
-        ds.explainQuery(sftName, query, out)
+        ds.explainQuery(query, out)
         out.toString()
       }
       explain must contain(classOf[IndexIterator].getName)
@@ -1191,7 +1191,7 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
       // verify that the IndexIterator is getting used
       val explain = {
         val out = new ExplainString
-        ds.explainQuery(sftName, query, out)
+        ds.explainQuery(query, out)
         out.toString()
       }
       explain must contain(classOf[IndexIterator].getName)
@@ -1216,7 +1216,7 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
       val query = new Query(sftName, filter, Array("geom"))
       val explain = {
         val o = new ExplainString
-        ds.explainQuery(sftName, query, o)
+        ds.explainQuery(query, o)
         o.toString()
       }
       ds.removeSchema(sftName)
@@ -1230,12 +1230,11 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
       val query = new Query(sftName, filter, Array("geom"))
       val explain = {
         val o = new ExplainString
-        ds.explainQuery(sftName, query, o)
+        ds.explainQuery(query, o)
         o.toString()
       }
       ds.removeSchema(sftName)
-      explain must contain("No STII Filter")
-      explain must contain("Filter: AcceptEverythingFilter")
+      explain.split("\n").filter(_.startsWith("Filter:")).toSeq mustEqual Seq("Filter: primary filter: INCLUDE, secondary filter: None")
     }
 
     "create key plan that does not use STII when given something larger than the Whole World bbox" in {
@@ -1245,12 +1244,11 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
       val query = new Query(sftName, filter, Array("geom"))
       val explain = {
         val o = new ExplainString
-        ds.explainQuery(sftName, query, o)
+        ds.explainQuery(query, o)
         o.toString()
       }
       ds.removeSchema(sftName)
-      explain must contain("No STII Filter")
-      explain must contain("Filter: AcceptEverythingFilter")
+      explain.split("\n").filter(_.startsWith("Filter:")).toSeq mustEqual Seq("Filter: primary filter: INCLUDE, secondary filter: None")
     }
 
     "create key plan that does not use STII when given an or'd geometry query with redundant bbox" in {
@@ -1261,13 +1259,11 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
       val query = new Query(sftName, filter, Array("geom"))
       val explain = {
         val o = new ExplainString
-        ds.explainQuery(sftName, query, o)
+        ds.explainQuery(query, o)
         o.toString()
       }
       ds.removeSchema(sftName)
-      explain must not contain("STII Filter: [ geom bbox ")
-      explain must contain("No STII Filter")
-      explain must contain("Filter: AcceptEverythingFilter")
+      explain.split("\n").filter(_.startsWith("Filter:")) mustEqual Seq("Filter: primary filter: INCLUDE, secondary filter: None")
     }.pendingUntilFixed("Fixed query planner to deal with OR'd redundant geom with whole world")
 
     "create key plan that does not use STII when given two bboxes that when unioned are the whole world" in {
@@ -1278,7 +1274,7 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
       val query = new Query(sftName, filter, Array("geom"))
       val explain = {
         val o = new ExplainString
-        ds.explainQuery(sftName, query, o)
+        ds.explainQuery(query, o)
         o.toString()
       }
       ds.removeSchema(sftName)
@@ -1308,7 +1304,7 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
 
       val explain = {
         val o = new ExplainString
-        ds.explainQuery(sftName1, query, o)
+        ds.explainQuery(query, o)
         o.toString()
       }
       explain must not contain "GeoHashKeyPlanner: KeyInvalid"

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureReaderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureReaderTest.scala
@@ -24,13 +24,13 @@ class AccumuloFeatureReaderTest extends Specification with TestWithDataStore {
   "AccumuloFeatureReader" should {
 
     "be able to run explainQuery" in {
-      val query = new Query()
+      val query = new Query(sftName)
       val fs = "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
       val f = ECQL.toFilter(fs)
       query.setFilter(f)
 
       val out = new ExplainString()
-      ds.explainQuery(sftName, query, out)
+      ds.explainQuery(query, out)
 
       val explanation = out.toString()
       explanation must not be null

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
@@ -22,7 +22,7 @@ import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.TestWithDataStore
 import org.locationtech.geomesa.accumulo.data.tables.GeoMesaTable
-import org.locationtech.geomesa.accumulo.index.{AttributeIdxEqualsStrategy, QueryStrategyDecider}
+import org.locationtech.geomesa.accumulo.index.{AttributeIdxStrategy, QueryStrategyDecider}
 import org.locationtech.geomesa.features.avro.AvroSimpleFeatureFactory
 import org.locationtech.geomesa.utils.geotools.Conversions._
 import org.locationtech.geomesa.utils.text.WKTUtils
@@ -363,7 +363,7 @@ class AccumuloFeatureWriterTest extends Specification with TestWithDataStore wit
 
       val hints = ds.strategyHints(sft)
       val q = new Query(sft.getTypeName, filter)
-      QueryStrategyDecider.chooseStrategy(sft, q, hints, INTERNAL_GEOMESA_VERSION) must beAnInstanceOf[AttributeIdxEqualsStrategy]
+      QueryStrategyDecider.chooseStrategies(sft, q, hints, None, INTERNAL_GEOMESA_VERSION).head must beAnInstanceOf[AttributeIdxStrategy]
 
       import org.locationtech.geomesa.utils.geotools.Conversions._
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/filter/TestFilters.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/filter/TestFilters.scala
@@ -189,9 +189,6 @@ object TestFilters {
     "attr1 = 'dummy' AND INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28))) AND attr2 = 'dummy'",
     "attr1 = 'dummy' AND INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))",
     "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))",
-    "attr1 = 'val56'",
-    "attr1 ILIKE '2nd1%'",
-    "attr1 ILIKE '2nd1%'",
     // The next query is *not* 'like-eligible'.  As such, we do *not* want to use it with the current attribute inde.
     "attr2 ILIKE '%1' AND INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23)))",
     "dtgNonIdx DURING 2010-08-08T00:00:00.000Z/2010-08-08T23:59:59.000Z AND INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))) AND attr2 = 'val56'"
@@ -208,13 +205,19 @@ object TestFilters {
     "attr1 = 'val56' AND attr2 = 'val56'",
     "attr2 = 'val56' AND attr1 = 'val3'",
     "attr1 = 'val56' AND attr1 = 'val57' AND attr2 = 'val56'",
+    "high = 'val56' AND dtg DURING 2010-08-08T00:00:00.000Z/2010-08-08T23:59:59.000Z",
+    "dtg DURING 2010-08-08T00:00:00.000Z/2010-08-08T23:59:59.000Z AND high = 'val56'",
+    "attr2 = 'val56' AND NOT (INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))))"
+  )
+
+  val z3Predicates = Seq(
     "attr2 = 'val56' AND dtg DURING 2010-08-08T00:00:00.000Z/2010-08-08T23:59:59.000Z",
-    "dtg DURING 2010-08-08T00:00:00.000Z/2010-08-08T23:59:59.000Z AND attr2 = 'val56'",
-    "attr2 = 'val56' AND NOT (INTERSECTS(geom, POLYGON ((45 23, 48 23, 48 27, 45 27, 45 23))))",
     "attr2 = 'val56' AND dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z'",
+    "dtg DURING 2010-08-08T00:00:00.000Z/2010-08-08T23:59:59.000Z AND attr2 = 'val56'",
     "dtg BETWEEN '2010-07-01T00:00:00.000Z' AND '2010-07-31T00:00:00.000Z' AND attr2 = 'val56'"
   )
 
+  // id queries
   val idPredicates = Seq(
     "IN('|data|100001','|data|100002')" ,
     "IN('|data|100003','|data|100005') AND IN('|data|100001')",
@@ -228,5 +231,12 @@ object TestFilters {
     "IN('|data|100001') AND WITHIN(geom, POLYGON ((40 20, 50 20, 50 30, 40 30, 40 20)))",
     "dtg DURING 2010-06-01T00:00:00.000Z/2010-08-31T23:59:59.000Z AND IN('|data|100001','|data|100002')" +
       "AND WITHIN(geom, POLYGON ((40 20, 50 20, 50 30, 40 30, 40 20))) AND attr2 = '2nd100001'"
+  )
+
+  // anything that can't be fulfilled with any other indexing strategy goes here
+  val nonIndexedPredicates = Seq(
+    "attr1 = 'val56'",
+    "attr1 ILIKE '2nd1%'",
+    "attr1 ILIKE '2nd1%'"
   )
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/CoveringAttributeIndexTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/CoveringAttributeIndexTest.scala
@@ -37,6 +37,8 @@ class CoveringAttributeIndexTest extends Specification with TestWithDataStore {
     }
   })
 
+  val joinIndicator = "Join Table:"
+
   "AttributeIndexStrategy" should {
 
     "support full coverage of attributes" in {
@@ -55,7 +57,7 @@ class CoveringAttributeIndexTest extends Specification with TestWithDataStore {
 
     "support transforms in fully covered indices" in {
       val query = new Query(sftName, ECQL.toFilter("name = '3name3'"), Array("name", "age", "dtg", "geom"))
-      explain(query).indexOf("Using record join iterator") mustEqual(-1)
+      explain(query).indexOf(joinIndicator) mustEqual(-1)
 
       val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
 
@@ -69,7 +71,7 @@ class CoveringAttributeIndexTest extends Specification with TestWithDataStore {
 
     "support ecql filters in fully covered indices" in {
       val query = new Query(sftName, ECQL.toFilter("name >= '3name3' AND height = '9.0'"))
-      explain(query).indexOf("Using record join iterator") mustEqual(-1)
+      explain(query).indexOf(joinIndicator) mustEqual(-1)
 
       val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
 
@@ -84,7 +86,7 @@ class CoveringAttributeIndexTest extends Specification with TestWithDataStore {
     "support ecql filters and covering transforms in fully covered indices" in {
       val query = new Query(sftName, ECQL.toFilter("name >= '3name3' AND height = '9.0'"),
         Array("name", "height", "dtg", "geom"))
-      explain(query).indexOf("Using record join iterator") mustEqual(-1)
+      explain(query).indexOf(joinIndicator) mustEqual(-1)
 
       val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
 
@@ -99,7 +101,7 @@ class CoveringAttributeIndexTest extends Specification with TestWithDataStore {
     "support ecql filters and non-covering transforms in fully covered indices" in {
       val query = new Query(sftName, ECQL.toFilter("name >= '3name3' AND height = '9.0'"),
         Array("name", "age", "dtg", "geom"))
-      explain(query).indexOf("Using record join iterator") mustEqual(-1)
+      explain(query).indexOf(joinIndicator) mustEqual(-1)
 
       val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
 
@@ -113,7 +115,7 @@ class CoveringAttributeIndexTest extends Specification with TestWithDataStore {
 
     "support join coverage of attributes" in {
       val query = new Query(sftName, ECQL.toFilter("age = '5'"))
-      explain(query).indexOf("Using record join iterator") must beGreaterThan(-1)
+      explain(query).indexOf(joinIndicator) must beGreaterThan(-1)
 
       val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
 
@@ -127,7 +129,7 @@ class CoveringAttributeIndexTest extends Specification with TestWithDataStore {
 
     "be backwards compatible with index spec" in {
       val query = new Query(sftName, ECQL.toFilter("weight = '4.0'"))
-      explain(query).indexOf("Using record join iterator") must beGreaterThan(-1)
+      explain(query).indexOf(joinIndicator) must beGreaterThan(-1)
 
       val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features()).toList
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/FilterHelperTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/FilterHelperTest.scala
@@ -132,7 +132,7 @@ class FilterHelperTest extends Specification with Mockito with Logging {
 
         val extractedInterval = extractDT(Seq(filter))
         val expectedInterval = new Interval(start, end)
-        println(s"Extracted interval $extractedInterval from filter ${ECQL.toCQL(filter)}")
+        logger.debug(s"Extracted interval $extractedInterval from filter ${ECQL.toCQL(filter)}")
         extractedInterval must equalTo(expectedInterval)
       }
     }
@@ -153,7 +153,7 @@ class FilterHelperTest extends Specification with Mockito with Logging {
         val extractedMixed2Interval = extractDT(mixedFilters2)
 
         val expectedInterval = interval(t1).overlap(interval(t2))
-        println(s"Extracted interval $extractedBetweenInterval from filters ${betweenFilters.map(ECQL.toCQL)}")
+        logger.debug(s"Extracted interval $extractedBetweenInterval from filters ${betweenFilters.map(ECQL.toCQL)}")
         extractedBetweenInterval must equalTo(expectedInterval)
         extractedDuringInterval must equalTo(expectedInterval)
         extractedMixed1Interval must equalTo(expectedInterval)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryFilterSplitterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryFilterSplitterTest.scala
@@ -1,0 +1,416 @@
+/*
+ * Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0 which
+ * accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ */
+
+package org.locationtech.geomesa.accumulo.index
+
+import org.geotools.factory.CommonFactoryFinder
+import org.geotools.filter.text.ecql.ECQL
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
+import org.locationtech.geomesa.accumulo.util.SftBuilder
+import org.locationtech.geomesa.accumulo.util.SftBuilder.Opts
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.stats.Cardinality
+import org.opengis.filter.Filter
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class QueryFilterSplitterTest extends Specification {
+
+  val sft = new SftBuilder()
+    .stringType("attr1")
+    .stringType("attr2", index = true)
+    .stringType("high", Opts(index = true, cardinality = Cardinality.HIGH))
+    .stringType("low", Opts(index = true, cardinality = Cardinality.LOW))
+    .date("dtg", default = true)
+    .point("geom", default = true)
+    .build("QueryFilterSplitterTest")
+
+  val ff = CommonFactoryFinder.getFilterFactory2
+  val splitter = new QueryFilterSplitter(sft, true)
+
+  val geom                = "BBOX(geom,40,40,50,50)"
+  val geom2               = "BBOX(geom,60,60,70,70)"
+  val geomOverlap         = "BBOX(geom,35,35,55,55)"
+  val dtg                 = "dtg DURING 2014-01-01T00:00:00Z/2014-01-01T23:59:59Z"
+  val dtg2                = "dtg DURING 2014-01-02T00:00:00Z/2014-01-02T23:59:59"
+  val dtgOverlap          = "dtg DURING 2014-01-01T00:00:00Z/2014-01-02T23:59:59Z"
+  val nonIndexedAttr      = "attr1 = 'test'"
+  val nonIndexedAttr2     = "attr1 = 'test2'"
+  val indexedAttr         = "attr2 = 'test'"
+  val indexedAttr2        = "attr2 = 'test2'"
+  val highCardinaltiyAttr = "high = 'test'"
+  val lowCardinaltiyAttr  = "low = 'test'"
+
+  val wholeWorld          = "BBOX(geom,-180,-90,180,90)"
+
+  def and(clauses: String*) = ff.and(clauses.map(ECQL.toFilter))
+  def or(clauses: String*)  = ff.or(clauses.map(ECQL.toFilter))
+  def f(filter: String)     = ECQL.toFilter(filter)
+
+  implicit def filterToString(f: Filter): String = ECQL.toCQL(f)
+  implicit def stringToFilter(f: String): Filter = ECQL.toFilter(f)
+
+  "QueryFilterSplitter" should {
+    "return for filter include" >> {
+      val filter = Filter.INCLUDE
+      val options = splitter.getQueryOptions(Filter.INCLUDE)
+      options must haveLength(1)
+      options.head.filters must haveLength(1)
+      options.head.filters.head.strategy mustEqual StrategyType.RECORD
+      options.head.filters.head.primary mustEqual Seq(filter)
+      options.head.filters.head.secondary must beNone
+    }
+    "return none for filter exclude" >> {
+      val options = splitter.getQueryOptions(Filter.EXCLUDE)
+      options must beEmpty
+    }
+    "work for spatio-temporal queries" >> {
+      "with a simple and" >> {
+        val filter = and(geom, dtg)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.Z3
+        options.head.filters.head.primary mustEqual Seq(f(geom), f(dtg))
+        options.head.filters.head.secondary must beNone
+      }
+      "with multiple geometries" >> {
+        val filter = and(geom, geom2, dtg)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.Z3
+        options.head.filters.head.primary mustEqual Seq(f(geom), f(geom2), f(dtg))
+        options.head.filters.head.secondary must beNone
+      }
+      "with multiple dates" >> {
+        val filter = and(geom, dtg, dtg2)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.Z3
+        options.head.filters.head.primary mustEqual Seq(f(geom), f(dtg), f(dtg2))
+        options.head.filters.head.secondary must beNone
+      }
+      "with multiple geometries and dates" >> {
+        val filter = and(geom, geom2, dtg, dtg2)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.Z3
+        options.head.filters.head.primary mustEqual Seq(f(geom), f(geom2), f(dtg), f(dtg2))
+        options.head.filters.head.secondary must beNone
+      }
+      "with simple ors" >> {
+        val filter = or(and(geom, dtg), and(geom2, dtg2))
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(2)
+        forall(options.head.filters)(_.strategy mustEqual StrategyType.Z3)
+        options.head.filters.map(_.primary) must containTheSameElementsAs(Seq(Seq(f(geom), f(dtg)), Seq(f(geom2), f(dtg2))))
+        forall(options.head.filters)(_.secondary must beNone)
+      }
+      "while ignoring world-covering geoms" >> {
+        val filter = f(wholeWorld)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.RECORD
+        options.head.filters.head.primary mustEqual Seq(Filter.INCLUDE)
+        options.head.filters.head.secondary must beNone
+      }
+      "while ignoring world-covering geoms when other filters are present" >> {
+        val filter = and(wholeWorld, geom, dtg)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.Z3
+        options.head.filters.head.primary mustEqual Seq(f(geom), f(dtg))
+        options.head.filters.head.secondary must beNone
+      }
+    }
+    "work for single clause filters" >> {
+      "spatial" >> {
+        val filter = f(geom)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.ST
+        options.head.filters.head.primary mustEqual Seq(filter)
+        options.head.filters.head.secondary must beNone
+      }
+      "temporal" >> {
+        val filter = f(dtg)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.Z3
+        options.head.filters.head.primary mustEqual Seq(wholeWorld, dtg).map(f)
+        options.head.filters.head.secondary must beNone
+      }
+      "non-indexed attributes" >> {
+        val filter = f(nonIndexedAttr)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.RECORD
+        options.head.filters.head.primary mustEqual Seq(Filter.INCLUDE)
+        options.head.filters.head.secondary must beSome(filter)
+      }
+      "indexed attributes" >> {
+        val filter = f(indexedAttr)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.ATTRIBUTE
+        options.head.filters.head.primary mustEqual Seq(filter)
+        options.head.filters.head.secondary must beNone
+      }
+      "low-cardinality attributes" >> {
+        val filter = f(lowCardinaltiyAttr)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.ATTRIBUTE
+        options.head.filters.head.primary mustEqual Seq(filter)
+        options.head.filters.head.secondary must beNone
+      }
+      "high-cardinality attributes" >> {
+        val filter = f(highCardinaltiyAttr)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.ATTRIBUTE
+        options.head.filters.head.primary mustEqual Seq(filter)
+        options.head.filters.head.secondary must beNone
+      }
+    }
+    "work for simple ands" >> {
+      "spatial" >> {
+        val filter = and(geom, geom2)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.ST
+        options.head.filters.head.primary mustEqual Seq(geom, geom2).map(f)
+        options.head.filters.head.secondary must beNone
+      }
+      "temporal" >> {
+        val filter = and(dtg, dtg2)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.Z3
+        options.head.filters.head.primary mustEqual Seq(wholeWorld, dtg, dtg2).map(f)
+        options.head.filters.head.secondary must beNone
+      }
+      "non-indexed attributes" >> {
+        val filter = and(nonIndexedAttr, nonIndexedAttr2)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.RECORD
+        options.head.filters.head.primary mustEqual Seq(Filter.INCLUDE)
+        options.head.filters.head.secondary must beSome(filter)
+      }
+      "indexed attributes" >> {
+        val filter = and(indexedAttr, indexedAttr2)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.ATTRIBUTE
+        options.head.filters.head.primary mustEqual Seq(indexedAttr, indexedAttr2).map(f)
+        options.head.filters.head.secondary must beNone
+      }
+      "low-cardinality attributes" >> {
+        val filter = and(lowCardinaltiyAttr, nonIndexedAttr)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.ATTRIBUTE
+        options.head.filters.head.primary mustEqual Seq(f(lowCardinaltiyAttr))
+        options.head.filters.head.secondary must beSome(f(nonIndexedAttr))
+      }
+    }
+    "split filters on AND" >> {
+      "with spatiotemporal clauses" >> {
+        val filter = and(geom, dtg)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.Z3
+        options.head.filters.head.primary mustEqual Seq(geom, dtg).map(f)
+        options.head.filters.head.secondary must beNone
+      }
+      "filters with spatiotemporal and non-indexed attributes clauses" >> {
+        val filter = and(geom, dtg, nonIndexedAttr)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.Z3
+        options.head.filters.head.primary mustEqual Seq(geom, dtg).map(f)
+        options.head.filters.head.secondary must beSome(f(nonIndexedAttr))
+      }
+      "with spatiotemporal and indexed attributes clauses" >> {
+        val filter = and(geom, dtg, indexedAttr)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(2)
+        forall(options)(_.filters must haveLength(1))
+        val z3 = options.find(_.filters.head.strategy == StrategyType.Z3)
+        z3 must beSome
+        z3.get.filters.head.primary mustEqual Seq(geom, dtg).map(f)
+        z3.get.filters.head.secondary must beSome(f(indexedAttr))
+        val attr = options.find(_.filters.head.strategy == StrategyType.ATTRIBUTE)
+        attr must beSome
+        attr.get.filters.head.primary mustEqual Seq(f(indexedAttr))
+        attr.get.filters.head.secondary must beSome(and(geom, dtg))
+      }
+      "with spatiotemporal, indexed and non-indexed attributes clauses" >> {
+        val filter = and(geom, dtg, indexedAttr, nonIndexedAttr)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(2)
+        forall(options)(_.filters must haveLength(1))
+        val z3 = options.find(_.filters.head.strategy == StrategyType.Z3)
+        z3 must beSome
+        z3.get.filters.head.primary mustEqual Seq(geom, dtg).map(f)
+        z3.get.filters.head.secondary must beSome(and(indexedAttr, nonIndexedAttr))
+        val attr = options.find(_.filters.head.strategy == StrategyType.ATTRIBUTE)
+        attr must beSome
+        attr.get.filters.head.primary mustEqual Seq(f(indexedAttr))
+        attr.get.filters.head.secondary must beSome(and(geom, dtg, nonIndexedAttr))
+      }
+    }
+    "split filters on OR" >> {
+      "with spatiotemporal clauses" >> {
+        val filter = or(geom, dtg)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(2)
+        val z3 = options.head.filters.find(_.strategy == StrategyType.Z3)
+        z3 must beSome
+        z3.get.primary mustEqual Seq(wholeWorld, dtg).map(f)
+        z3.get.secondary must beNone
+        val st = options.head.filters.find(_.strategy == StrategyType.ST)
+        st must beSome
+        st.get.primary mustEqual Seq(f(geom))
+        st.get.secondary must beNone
+      }
+      "with multiple spatial clauses" >> {
+        val filter = or(geom, geom2)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(2)
+        forall(options.head.filters)(_.strategy mustEqual StrategyType.ST)
+        options.head.filters.map(_.primary) must containTheSameElementsAs(Seq(Seq(f(geom)), Seq(f(geom2))))
+        forall(options.head.filters)(_.secondary must beNone)
+      }
+      "with spatiotemporal and indexed attribute clauses" >> {
+        val filter = or(geom, indexedAttr)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(2)
+        options.head.filters.map(_.strategy) must containTheSameElementsAs(Seq(StrategyType.ST, StrategyType.ATTRIBUTE))
+        options.head.filters.find(_.strategy == StrategyType.ST).get.primary mustEqual Seq(f(geom))
+        options.head.filters.find(_.strategy == StrategyType.ATTRIBUTE).get.primary mustEqual Seq(f(indexedAttr))
+        forall(options.head.filters)(_.secondary must beNone)
+      }
+      "and collapse overlapping query filters" >> {
+        "with spatiotemporal and non-indexed attribute clauses" >> {
+          val filter = or(geom, nonIndexedAttr)
+          val options = splitter.getQueryOptions(filter)
+          options must haveLength(1)
+          options.head.filters must haveLength(1)
+          options.head.filters.head.strategy mustEqual StrategyType.RECORD
+          options.head.filters.head.primary mustEqual Seq(Filter.INCLUDE)
+          options.head.filters.head.secondary must beSome(filter)
+        }
+        "with overlapping geometries" >> {
+          val filter = or(geom, geomOverlap)
+          val options = splitter.getQueryOptions(filter)
+          options must haveLength(1)
+          options.head.filters must haveLength(1)
+          options.head.filters.head.strategy mustEqual StrategyType.ST
+          options.head.filters.head.primary mustEqual Seq(f(geomOverlap))
+          options.head.filters.head.secondary must beNone
+        }.pendingUntilFixed("not implemented")
+        "with overlapping dates" >> {
+          val filter = or(dtg, dtgOverlap)
+          val options = splitter.getQueryOptions(filter)
+          options must haveLength(1)
+          options.head.filters must haveLength(1)
+          options.head.filters.head.strategy mustEqual StrategyType.Z3
+          options.head.filters.head.primary mustEqual Seq(wholeWorld, dtgOverlap).map(f)
+          options.head.filters.head.secondary must beNone
+        }.pendingUntilFixed("not implemented")
+        "with overlapping geometries and dates" >> {
+          val filter = or(and(geom, dtg), and(geomOverlap, dtgOverlap))
+          val options = splitter.getQueryOptions(filter)
+          options must haveLength(1)
+          options.head.filters must haveLength(1)
+          options.head.filters.head.strategy mustEqual StrategyType.Z3
+          options.head.filters.head.primary mustEqual Seq(geomOverlap, dtgOverlap).map(f)
+          options.head.filters.head.secondary must beNone
+        }.pendingUntilFixed("not implemented")
+      }
+    }
+    "split nested filters" >> {
+      "with ANDs" >> {
+        val filter = and(geom, and(dtg, nonIndexedAttr))
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.Z3
+        options.head.filters.head.primary mustEqual Seq(geom, dtg).map(f)
+        options.head.filters.head.secondary must beSome(f(nonIndexedAttr))
+      }
+      "with ORs" >> {
+        val filter = or(geom, or(dtg, indexedAttr))
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(3)
+        options.head.filters.map(_.strategy) must
+            containTheSameElementsAs(Seq(StrategyType.Z3, StrategyType.ST, StrategyType.ATTRIBUTE))
+        options.head.filters.map(_.primary) must
+            containTheSameElementsAs(Seq(Seq(f(geom)), Seq(f(wholeWorld), f(dtg)), Seq(f(indexedAttr))))
+        forall(options.head.filters)(_.secondary must beNone)
+      }
+      "with ANDs and ORs" >> {
+        "with spatiotemporal clauses and non-indexed attributes" >> {
+          val filter = f(and(geom, dtg, or(nonIndexedAttr, nonIndexedAttr2)))
+          val options = splitter.getQueryOptions(filter)
+          options must haveLength(1)
+          options.head.filters must haveLength(1)
+          options.head.filters.head.strategy mustEqual StrategyType.Z3
+          options.head.filters.head.primary mustEqual Seq(geom, dtg).map(f)
+          options.head.filters.head.secondary must beSome(or(nonIndexedAttr, nonIndexedAttr2))
+        }
+      }
+    }
+    "support indexed date attributes" >> {
+      val sft = SimpleFeatureTypes.createType("dtgIndex", "dtg:Date:index=full,*geom:Point:srid=4326")
+      val splitter = new QueryFilterSplitter(sft, true)
+      val filter = f("dtg TEQUALS 2014-01-01T12:30:00.000Z")
+      val options = splitter.getQueryOptions(filter)
+      options must haveLength(2)
+      val z3 = options.find(_.filters.exists(_.strategy == StrategyType.Z3))
+      z3 must beSome
+      z3.get.filters must haveLength(1)
+      z3.get.filters.head.primary mustEqual Seq(f(wholeWorld), filter)
+      z3.get.filters.head.secondary must beNone
+      val attr = options.find(_.filters.exists(_.strategy == StrategyType.ATTRIBUTE))
+      attr must beSome
+      attr.get.filters must haveLength(1)
+      attr.get.filters.head.primary mustEqual Seq(filter)
+      attr.get.filters.head.secondary must beNone
+    }
+  }
+}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryPlannerTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryPlannerTest.scala
@@ -16,7 +16,6 @@ import org.geotools.factory.CommonFactoryFinder
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.TestWithDataStore
 import org.locationtech.geomesa.accumulo.data.INTERNAL_GEOMESA_VERSION
-import org.locationtech.geomesa.accumulo.util.SelfClosingIterator
 import org.locationtech.geomesa.features.{ScalaSimpleFeature, SerializationType, SimpleFeatureSerializers}
 import org.locationtech.geomesa.security._
 import org.opengis.filter.sort.SortBy
@@ -75,7 +74,7 @@ class QueryPlannerTest extends Specification with Mockito with TestWithDataStore
         new SimpleEntry[Key, Value](key, value)
       }
 
-      val expectedResult = kvs.map(planner.defaultKVsToFeatures(query)).map(_.visibility)
+      val expectedResult = kvs.map(planner.defaultKVsToFeatures(query.getHints)).map(_.visibility)
 
       expectedResult must haveSize(kvs.length)
       expectedResult mustEqual expectedVis

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategyTest.scala
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.TestWithDataStore
 import org.locationtech.geomesa.accumulo.data.INTERNAL_GEOMESA_VERSION
 import org.locationtech.geomesa.accumulo.data.tables.Z3Table
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
 import org.locationtech.geomesa.accumulo.iterators.BinAggregatingIterator
 import org.locationtech.geomesa.features.{ScalaSimpleFeature, SerializationType}
 import org.locationtech.geomesa.filter.function.{Convert2ViewerFunction, ExtendedValues}
@@ -58,7 +59,7 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
   addFeatures(features)
 
   implicit val ff = CommonFactoryFinder.getFilterFactory2
-  val strategy = new Z3IdxStrategy
+  val strategy = StrategyType.Z3
   val queryPlanner = new QueryPlanner(sft, SerializationType.KRYO, null, ds, NoOpHints, INTERNAL_GEOMESA_VERSION)
   val output = ExplainNull
 
@@ -274,6 +275,6 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
   }
 
   def getQueryPlans(query: Query): Seq[QueryPlan] = {
-    strategy.getQueryPlans(query, queryPlanner, output)
+    queryPlanner.planQuery(query, Some(strategy), output)
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/AttributeIndexIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/AttributeIndexIteratorTest.scala
@@ -100,7 +100,7 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
     def checkExplainStrategy(filter: String) = {
       val query = new Query(sftName, ECQL.toFilter(filter), Array("geom", "dtg"))
       val explain = new ExplainString()
-      ds.explainQuery(sftName, query, explain)
+      ds.explainQuery(query, explain)
       val output = explain.toString()
       val iter = output.split("\n").filter(_.startsWith("Iterators")).headOption
       iter must beSome
@@ -134,7 +134,7 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
       filters.foreach { case (filter, prop) =>
         val query = new Query(sftName, ECQL.toFilter(filter), Array("geom", "dtg") ++ prop)
         val explain = new ExplainString()
-        ds.explainQuery(sftName, query, explain)
+        ds.explainQuery(query, explain)
         val output = explain.toString().split("\n")
         output.forall(s => !s.startsWith("AttributeIndexIterator:")) must beTrue
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/process/knn/GenerateKNNQueryTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/process/knn/GenerateKNNQueryTest.scala
@@ -101,7 +101,7 @@ class GenerateKNNQueryTest extends Specification {
       val newFilter =  newQuery.getFilter
 
       // process the newFilter to split out the geometry part
-      val (geomFilters, otherFilters) = partitionGeom(newFilter, sft)
+      val (geomFilters, otherFilters) = partitionPrimarySpatials(newFilter, sft)
 
       // rewrite the geometry filter
       val tweakedGeomFilters = geomFilters.map ( FilterHelper.updateTopologicalFilters(_, sft) )

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/process/query/QueryProcessTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/process/query/QueryProcessTest.scala
@@ -15,6 +15,7 @@ import org.geotools.feature.DefaultFeatureCollection
 import org.geotools.filter.text.cql2.CQL
 import org.joda.time.{DateTime, DateTimeZone}
 import org.junit.runner.RunWith
+import org.locationtech.geomesa.accumulo.TestWithDataStore
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloFeatureStore}
 import org.locationtech.geomesa.accumulo.index.Constants
 import org.locationtech.geomesa.features.avro.AvroSimpleFeatureFactory
@@ -26,51 +27,24 @@ import org.specs2.runner.JUnitRunner
 import scala.collection.JavaConversions._
 
 @RunWith(classOf[JUnitRunner])
-class QueryProcessTest extends Specification {
+class QueryProcessTest extends Specification with TestWithDataStore {
 
   sequential
 
-  val dtgField = org.locationtech.geomesa.accumulo.process.tube.DEFAULT_DTG_FIELD
-  val geotimeAttributes = s"*geom:Geometry:srid=4326,$dtgField:Date"
+  val dtg = org.locationtech.geomesa.accumulo.process.tube.DEFAULT_DTG_FIELD
+  override val spec = s"type:String,*geom:Geometry:srid=4326,$dtg:Date"
 
-  def createStore: AccumuloDataStore =
-  // the specific parameter values should not matter, as we
-  // are requesting a mock data store connection to Accumulo
-    DataStoreFinder.getDataStore(Map(
-      "instanceId"        -> "mycloud",
-      "zookeepers"        -> "zoo1:2181,zoo2:2181,zoo3:2181",
-      "user"              -> "myuser",
-      "password"          -> "mypassword",
-      "auths"             -> "A,B,C",
-      "tableName"         -> "testwrite",
-      "useMock"           -> "true",
-      "featureEncoding"   -> "avro")).asInstanceOf[AccumuloDataStore]
-
-  val sftName = "geomesaQueryTestType"
-  val sft = SimpleFeatureTypes.createType(sftName, s"type:String,$geotimeAttributes")
-  sft.getUserData()(Constants.SF_PROPERTY_START_TIME) = dtgField
-
-  val ds = createStore
-
-  ds.createSchema(sft)
-  val fs = ds.getFeatureSource(sftName).asInstanceOf[AccumuloFeatureStore]
-
-  val featureCollection = new DefaultFeatureCollection(sftName, sft)
-
-  List("a", "b").foreach { name =>
-    List(1, 2, 3, 4).zip(List(45, 46, 47, 48)).foreach { case (i, lat) =>
+  val features = List("a", "b").flatMap { name =>
+    List(1, 2, 3, 4).zip(List(45, 46, 47, 48)).map { case (i, lat) =>
       val sf = AvroSimpleFeatureFactory.buildAvroFeature(sft, List(), name + i.toString)
       sf.setDefaultGeometry(WKTUtils.read(f"POINT($lat%d $lat%d)"))
       sf.setAttribute(org.locationtech.geomesa.accumulo.process.tube.DEFAULT_DTG_FIELD, new DateTime("2011-01-01T00:00:00Z", DateTimeZone.UTC).toDate)
       sf.setAttribute("type", name)
-      sf.getUserData()(Hints.USE_PROVIDED_FID) = java.lang.Boolean.TRUE
-      featureCollection.add(sf)
+      sf
     }
   }
 
-  // write the feature to the store
-  val res = fs.addFeatures(featureCollection)
-
+  addFeatures(features)
 
   "GeomesaQuery" should {
     "return things without a filter" in {
@@ -124,7 +98,7 @@ class QueryProcessTest extends Specification {
       val geomesaQuery = new QueryProcess
       val results = geomesaQuery.execute(features, CQL.toFilter("bbox(geom, 45.0, 45.0, 46.0, 46.0)"))
 
-      var poly = WKTUtils.read("POLYGON((45 45, 46 45, 46 46, 45 46, 45 45))")
+      val poly = WKTUtils.read("POLYGON((45 45, 46 45, 46 46, 45 46, 45 45))")
 
       val f = results.features()
       while (f.hasNext) {

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/package.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/package.scala
@@ -285,9 +285,11 @@ package object filter {
     }
   }
 
+  def isTemporalFilter(f: Filter, dtg: String): Boolean = getAttributeProperty(f).exists(_.name == dtg)
+
   def isPrimaryTemporalFilter(f: Filter, sft: SimpleFeatureType): Boolean = {
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-    sft.getDtgField.exists(dtg => getAttributeProperty(f).exists(_.name == dtg))
+    sft.getDtgField.exists(isTemporalFilter(f, _))
   }
 
   def isIndexedAttributeFilter(f: Filter, sft: SimpleFeatureType): Boolean = {

--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterPackageObjectTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterPackageObjectTest.scala
@@ -29,7 +29,7 @@ class FilterPackageObjectTest extends Specification with Logging {
 
     "filter bbox based on default geom" in {
       val filter = ECQL.toFilter("BBOX(geom, -45.0,-45.0,45.0,45.0) AND BBOX(g, -30.0,-30.0,30.0,30.0)")
-      val (geoms, nongeoms) = partitionGeom(filter, sft)
+      val (geoms, nongeoms) = partitionPrimarySpatials(filter, sft)
       geoms must haveLength(1)
       nongeoms must haveLength(1)
       ECQL.toCQL(geoms(0)) mustEqual("BBOX(geom, -45.0,-45.0,45.0,45.0)")
@@ -39,7 +39,7 @@ class FilterPackageObjectTest extends Specification with Logging {
       val filter =
         ECQL.toFilter("INTERSECTS(geom, POLYGON ((-45 -45, -45 45, 45 45, 45 -45, -45 -45))) " +
           "AND INTERSECTS(g, POLYGON ((-30 -30, -30 30, 30 30, 30 -30, -30 -30)))")
-      val (geoms, nongeoms) = partitionGeom(filter, sft)
+      val (geoms, nongeoms) = partitionPrimarySpatials(filter, sft)
       geoms must haveLength(1)
       nongeoms must haveLength(1)
       ECQL.toCQL(geoms(0)) mustEqual("INTERSECTS(geom, POLYGON ((-45 -45, -45 45, 45 45, 45 -45, -45 -45)))")
@@ -49,7 +49,7 @@ class FilterPackageObjectTest extends Specification with Logging {
       val filter =
         ECQL.toFilter("INTERSECTS(POLYGON ((-30 -30, -30 30, 30 30, 30 -30, -30 -30)), g) " +
             "AND INTERSECTS(POLYGON ((-45 -45, -45 45, 45 45, 45 -45, -45 -45)), geom)")
-      val (geoms, nongeoms) = partitionGeom(filter, sft)
+      val (geoms, nongeoms) = partitionPrimarySpatials(filter, sft)
       geoms must haveLength(1)
       nongeoms must haveLength(1)
       ECQL.toCQL(geoms(0)) mustEqual("INTERSECTS(POLYGON ((-45 -45, -45 45, 45 45, 45 -45, -45 -45)), geom)")
@@ -60,7 +60,7 @@ class FilterPackageObjectTest extends Specification with Logging {
       val filters= Seq(1 && geomFilter && 2, 1 && 2 && geomFilter, geomFilter && 1 && 2)
 
       forall(filters) { filter => 
-        val (geoms, nongeoms) = partitionGeom(filter, sft)
+        val (geoms, nongeoms) = partitionPrimarySpatials(filter, sft)
         geoms must haveLength(1)
         nongeoms must haveLength(2)
       }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseFeatureSource.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseFeatureSource.scala
@@ -65,11 +65,11 @@ class HBaseFeatureSource(entry: ContentEntry,
     // TODO: currently assumes BBOX then DURING
     import filter._
 
-    val dtFieldName = Some(sft.getDescriptor(dtgIndex).getLocalName)
-    val (i, _) = partitionTemporal(a.getChildren, dtFieldName)
-    val interval = FilterHelper.extractTemporal(dtFieldName)(i)
+    val dtFieldName = sft.getDescriptor(dtgIndex).getLocalName
+    val (i, _) = a.getChildren.partition(isTemporalFilter(_, dtFieldName))
+    val interval = FilterHelper.extractTemporal(Some(dtFieldName))(i)
 
-    val (b, _) = partitionGeom(a, sft)
+    val (b, _) = partitionPrimarySpatials(a.getChildren, sft)
     val geom = FilterHelper.extractGeometry(b.head.asInstanceOf[BinarySpatialOperator]).head
 
     val env = geom.getEnvelopeInternal

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaInputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaInputFormat.scala
@@ -24,6 +24,7 @@ import org.geotools.data.{DataStoreFinder, Query}
 import org.geotools.filter.identity.FeatureIdImpl
 import org.geotools.filter.text.ecql.ECQL
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloDataStoreFactory}
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
 import org.locationtech.geomesa.accumulo.index.{getTransformSchema, _}
 import org.locationtech.geomesa.accumulo.stats.QueryStatTransform
 import org.locationtech.geomesa.features.SerializationType.SerializationType
@@ -64,7 +65,7 @@ object GeoMesaInputFormat extends Logging {
     // set up the underlying accumulo input format
     val user = AccumuloDataStoreFactory.params.userParam.lookUp(dsParams).asInstanceOf[String]
     val password = AccumuloDataStoreFactory.params.passwordParam.lookUp(dsParams).asInstanceOf[String]
-    InputFormatBase.setConnectorInfo(job, user, new PasswordToken(password.getBytes()))
+    InputFormatBase.setConnectorInfo(job, user, new PasswordToken(password.getBytes))
 
     val instance = AccumuloDataStoreFactory.params.instanceIdParam.lookUp(dsParams).asInstanceOf[String]
     val zookeepers = AccumuloDataStoreFactory.params.zookeepersParam.lookUp(dsParams).asInstanceOf[String]
@@ -75,7 +76,7 @@ object GeoMesaInputFormat extends Logging {
 
     // run an explain query to set up the iterators, ranges, etc
     val featureTypeName = query.getTypeName
-    val queryPlans = ds.getQueryPlan(featureTypeName, query)
+    val queryPlans = ds.getQueryPlan(query)
 
     // see if the plan is something we can execute from a single table
     val tryPlan = if (queryPlans.length > 1) None else queryPlans.headOption.filter {
@@ -92,7 +93,7 @@ object GeoMesaInputFormat extends Logging {
       val hints = ds.strategyHints(sft)
       val version = ds.getGeomesaVersion(sft)
       val queryPlanner = new QueryPlanner(sft, featureEncoding, indexSchema, ds, hints, version)
-      val qps = queryPlanner.planQuery(query, Some(new STIdxStrategy()), ExplainNull)
+      val qps = queryPlanner.planQuery(query, Some(StrategyType.ST), ExplainNull)
       if (qps.length > 1) {
         logger.error("The query being executed requires multiple scans, which is not currently " +
             "supported by geomesa. Your result set will be partially incomplete. This is most likely due " +

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/ExplainCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/ExplainCommand.scala
@@ -20,7 +20,7 @@ class ExplainCommand(parent: JCommander) extends CommandWithCatalog(parent) with
   override def execute() =
     try {
       val q = new Query(params.featureName, ECQL.toFilter(params.cqlFilter))
-      ds.explainQuery(params.featureName, q)
+      ds.explainQuery(q)
     } catch {
       case e: Exception =>
         logger.error(s"Error: Could not explain the query (${params.cqlFilter}): ${e.getMessage}", e)


### PR DESCRIPTION
* Strategies have been refactored to include the query they are executing - this avoids determining the correct filters twice
* New class - QueryFilterSplitter - handles logic for splitting filters on Boolean clauses and combining them for a particular strategy
* Filters that can't be satisfied by any index now run against the record table instead of the ST table, in anticipation of eventually removing the ST table

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>