### PR TITLE
GEOMESA-819 Including size of query box in z3 range calculation

### DIFF
--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseFeatureSource.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseFeatureSource.scala
@@ -83,7 +83,7 @@ class HBaseFeatureSource(entry: ContentEntry,
 
     val kryoFeatureSerializer = new KryoFeatureSerializer(sft)
     if (weeks.length == 1) {
-      val z3ranges = Z3_CURVE.ranges(lx, ly, ux, uy, lt, ut, 8)
+      val z3ranges = Z3_CURVE.ranges((lx, ux), (ly, uy), (lt, ut))
       // TODO: cache serializers
       new HBaseFeatureReader(
         ds.getZ3Table(sft), sft, weeks.head, z3ranges,
@@ -94,7 +94,7 @@ class HBaseFeatureSource(entry: ContentEntry,
       val oneWeekInSeconds = Weeks.ONE.toStandardSeconds.getSeconds
       val head +: xs :+ last = weeks.toList
       // TODO: ignoring seconds for now
-      val z3ranges = Z3_CURVE.ranges(lx, ly, ux, uy, 0, oneWeekInSeconds, 8)
+      val z3ranges = Z3_CURVE.ranges((lx, ux), (ly, uy), (0, oneWeekInSeconds))
       val middleQPs = xs.map { w =>
         new HBaseFeatureReader(ds.getZ3Table(sft), sft, w, z3ranges,
           Z3_CURVE.normLon(lx), Z3_CURVE.normLat(ly), interval.getStart.getMillis,

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/SpaceFillingCurve.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/SpaceFillingCurve.scala
@@ -16,10 +16,7 @@ trait SpaceFillingCurve[T] {
   def tmax: Double
   def index(x: Double, y: Double, t: Long): T
   def invert(i: T): (Double, Double, Long)
-  def ranges(lx: Double, ly: Double,
-             ux: Double, uy: Double,
-             lt: Long,   ut: Long,
-             maxRecurse: Int): Seq[(Long, Long)]
+  def ranges(x: (Double, Double), y: (Double, Double), t: (Long, Long)): Seq[(Long, Long)]
   def normLon(x: Double) = math.ceil((180.0 + x) / 360.0 * xprec).toInt
   def denormLon(x: Double): Double = (x / xprec) * 360.0 - 180.0
   def normLat(y: Double) = math.ceil((90.0 + y) / 180.0 * yprec).toInt
@@ -35,21 +32,10 @@ class Z3SFC extends SpaceFillingCurve[Z3] {
   override val tprec: Long = math.pow(2, 20).toLong - 1
   override val tmax: Double = Weeks.weeks(1).toStandardSeconds.getSeconds.toDouble
 
-  override def index(x: Double, y: Double, t: Long): Z3 = {
-    val nx = normLon(x)
-    val ny = normLat(y)
-    val nt = normT(t)
-    Z3(nx, ny, nt)
-  }
+  override def index(x: Double, y: Double, t: Long): Z3 = Z3(normLon(x), normLat(y), normT(t))
 
-  override def ranges(lx: Double, ly: Double,
-                      ux: Double, uy: Double,
-                      lt: Long,   ut: Long,
-                      maxRecurse: Int): Seq[(Long, Long)] = {
-    val lz = Z3(normLon(lx), normLat(ly), normT(lt))
-    val uz = Z3(normLon(ux), normLat(uy), normT(ut))
-    Z3.zranges(lz, uz, maxRecurse)
-  }
+  override def ranges(x: (Double, Double), y: (Double, Double), t: (Long, Long)): Seq[(Long, Long)] =
+    Z3.zranges(index(x._1, y._1, t._1), index(x._2, y._2, t._2))
 
   override def invert(z: Z3): (Double, Double, Long) = {
     val (x,y,t) = z.decode

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3.scala
@@ -115,7 +115,7 @@ object Z3 {
     val maxRecurse = if (commonBits < 30) 7 else if (commonBits < 40) 6 else 5
 
     val searchRange = Z3Range(min, max)
-    var mq: MergeQueue = new MergeQueue // stores our results
+    var mq = new MergeQueue // stores our results
 
     def zranges(prefix: Long, offset: Int, oct: Long, level: Int): Unit = {
       val min: Long = prefix | (oct << offset) // QR + 000...

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3.scala
@@ -50,9 +50,10 @@ class Z3(val z: Long) extends AnyVal {
 
 object Z3 {
 
+  final val MAX_DIM = 3
   final val MAX_BITS = 21
   final val MAX_MASK = 0x1fffffL
-  final val MAX_DIM = 3
+  final val TOTAL_BITS = MAX_BITS * MAX_DIM
 
   def apply(zvalue: Long) = new Z3(zvalue)
 
@@ -107,49 +108,63 @@ object Z3 {
    * Recurse down the oct-tree and report all z-ranges which are contained
    * in the cube defined by the min and max points
    */
-  def zranges(min: Z3, max: Z3, maxRecurse: Int): Seq[(Long, Long)] = {
-    var mq: MergeQueue = new MergeQueue
-    val sr = Z3Range(min, max)
+  def zranges(min: Z3, max: Z3): Seq[(Long, Long)] = {
+    val (commonPrefix, commonBits) = longestCommonPrefix(min.z, max.z)
 
-    var recCounter = 0
-    var reportCounter = 0
+    // base our recursion on the depth of the tree that we get 'for free' from the common prefix
+    val maxRecurse = if (commonBits < 30) 7 else if (commonBits < 40) 6 else 5
 
-    def zranges(prefix: Long, offset: Int, quad: Long, level: Int): Unit = {
-      recCounter += 1
+    val searchRange = Z3Range(min, max)
+    var mq: MergeQueue = new MergeQueue // stores our results
 
-      val min: Long = prefix | (quad << offset) // QR + 000..
-      val max: Long = min | (1L << offset) - 1 // QR + 111..
-      val qr = Z3Range(new Z3(min), new Z3(max))
-      if (level <= maxRecurse) {
-        if (sr containsInUserSpace qr) {
-          // whole range matches, happy day
-          mq += (qr.min.z, qr.max.z)
-          reportCounter += 1
-        } else if (sr overlapsInUserSpace qr) { // TODO move this?
-          if (offset > 0) {
-            // some portion of this range are excluded
-            zranges(min, offset - MAX_DIM, 0, level + 1)
-            zranges(min, offset - MAX_DIM, 1, level + 1)
-            zranges(min, offset - MAX_DIM, 2, level + 1)
-            zranges(min, offset - MAX_DIM, 3, level + 1)
-            zranges(min, offset - MAX_DIM, 4, level + 1)
-            zranges(min, offset - MAX_DIM, 5, level + 1)
-            zranges(min, offset - MAX_DIM, 6, level + 1)
-            zranges(min, offset - MAX_DIM, 7, level + 1)
-            //let our children punt on each subrange
-          } else {
-            mq += (qr.min.z, qr.max.z)
-          }
+    def zranges(prefix: Long, offset: Int, oct: Long, level: Int): Unit = {
+      val min: Long = prefix | (oct << offset) // QR + 000...
+      val max: Long = min | (1L << offset) - 1 // QR + 111...
+      val octRange = Z3Range(new Z3(min), new Z3(max))
+
+      if (searchRange containsInUserSpace octRange) {
+        // whole range matches, happy day
+        mq += (octRange.min.z, octRange.max.z)
+      } else if (searchRange overlapsInUserSpace octRange) {
+        if (level < maxRecurse && offset > 0) {
+          // some portion of this range is excluded
+          // let our children work on each subrange
+          val nextOffset = offset - MAX_DIM
+          val nextLevel = level + 1
+          zranges(min, nextOffset, 0, nextLevel)
+          zranges(min, nextOffset, 1, nextLevel)
+          zranges(min, nextOffset, 2, nextLevel)
+          zranges(min, nextOffset, 3, nextLevel)
+          zranges(min, nextOffset, 4, nextLevel)
+          zranges(min, nextOffset, 5, nextLevel)
+          zranges(min, nextOffset, 6, nextLevel)
+          zranges(min, nextOffset, 7, nextLevel)
+        } else {
+          // bottom out - add the entire range so we don't miss anything
+          mq += (octRange.min.z, octRange.max.z)
         }
-      } else if ((sr overlaps qr) || (sr overlapsInUserSpace qr)) {
-        mq += (qr.min.z, qr.max.z)
       }
     }
 
-    val prefix: Long = 0
-    val offset = MAX_BITS * MAX_DIM
-    zranges(prefix, offset, 0, 0) // the entire space
+    // kick off recursion over the narrowed space
+    zranges(commonPrefix, TOTAL_BITS - commonBits, 0, 0)
+
+    // return our aggregated results
     mq.toSeq
+  }
+
+  /**
+   * Calculates the longest common binary prefix between two z longs
+   *
+   * @return (common prefix, number of bits in common)
+   */
+  def longestCommonPrefix(lower: Long, upper: Long): (Long, Int) = {
+    var bitShift = TOTAL_BITS - MAX_DIM
+    while ((lower >>> bitShift) == (upper >>> bitShift) && bitShift > -1) {
+      bitShift -= MAX_DIM
+    }
+    bitShift += MAX_DIM // increment back to the last valid value
+    (lower & (Long.MaxValue << bitShift), TOTAL_BITS - bitShift)
   }
 
   /**
@@ -173,8 +188,8 @@ object Z3 {
     def bit(x: Long, idx: Int) = {
       ((x & (1L << idx)) >> idx).toInt
     }
-    def over(bits: Long)  = (1L << (bits-1))
-    def under(bits: Long) = (1L << (bits-1)) - 1
+    def over(bits: Long)  = 1L << (bits - 1)
+    def under(bits: Long) = (1L << (bits - 1)) - 1
 
     var i = 64
     while (i > 0) {

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3Range.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3Range.scala
@@ -19,12 +19,25 @@ case class Z3Range(min: Z3, max: Z3) {
 
   def length: Int = (max.z - min.z + 1).toInt
 
+  // contains in index space (e.g. the long value)
   def contains(bits: Z3): Boolean = bits.z >= min.z && bits.z <= max.z
 
+  // contains in index space (e.g. the long value)
   def contains(r: Z3Range): Boolean = contains(r.min) && contains(r.max)
 
+  // overlap in index space (e.g. the long value)
   def overlaps(r: Z3Range): Boolean = contains(r.min) || contains(r.max)
 
+  // contains in user space - each dimension is contained
+  def containsInUserSpace(bits: Z3) = {
+    val (x, y, z) = bits.decode
+    x >= min.d0 && x <= max.d0 && y >= min.d1 && y <= max.d1 && z >= min.d2 && z <= max.d2
+  }
+
+  // contains in user space - each dimension is contained
+  def containsInUserSpace(r: Z3Range): Boolean = containsInUserSpace(r.min) && containsInUserSpace(r.max)
+
+  // overlap in user space - if any dimension overlaps
   def overlapsInUserSpace(r: Z3Range): Boolean =
     overlaps(min.d0, max.d0, r.min.d0, r.max.d0) &&
         overlaps(min.d1, max.d1, r.min.d1, r.max.d1) &&
@@ -32,15 +45,4 @@ case class Z3Range(min: Z3, max: Z3) {
 
   private def overlaps(a1: Int, a2: Int, b1: Int, b2: Int) = math.max(a1, b1) <= math.min(a2, b2)
 
-  def containsInUserSpace(bits: Z3) = {
-    val (x, y, z) = bits.decode
-    x >= min.d0 &&
-        x <= max.d0 &&
-        y >= min.d1 &&
-        y <= max.d1 &&
-        z >= min.d2 &&
-        z <= max.d2
-  }
-
-  def containsInUserSpace(r: Z3Range): Boolean = containsInUserSpace(r.min) && containsInUserSpace(r.max)
 }

--- a/geomesa-z3/src/test/scala/org/locationtech/geomesa/curve/Z3Test.scala
+++ b/geomesa-z3/src/test/scala/org/locationtech/geomesa/curve/Z3Test.scala
@@ -190,7 +190,8 @@ class Z3Test extends Specification {
         (sfc.index(35, 65, day), sfc.index(40, 70, day + hour * 6)), // 5^2 degrees, 6 hours
         (sfc.index(39.999, 60.999, day + 3000), sfc.index(40.001, 61.001, day + 3120)), // small bounds
         (sfc.index(51.0, 51.0, 6000), sfc.index(51.1, 51.1, 6100)), // small bounds
-        (sfc.index(51.0, 51.0, 30000), sfc.index(51.001, 51.001, 30100)) // small bounds
+        (sfc.index(51.0, 51.0, 30000), sfc.index(51.001, 51.001, 30100)), // small bounds
+        (Z3(sfc.index(51.0, 51.0, 30000).z - 1), Z3(sfc.index(51.0, 51.0, 30000).z + 1)) // 62 bits in common
       )
 
       def print(l: Z3, u: Z3, size: Int): Unit =

--- a/geomesa-z3/src/test/scala/org/locationtech/geomesa/curve/Z3Test.scala
+++ b/geomesa-z3/src/test/scala/org/locationtech/geomesa/curve/Z3Test.scala
@@ -162,34 +162,46 @@ class Z3Test extends Specification {
     "calculate ranges" >> {
       val min = Z3(2, 2, 0)
       val max = Z3(3, 6, 0)
-      val ranges = Z3.zranges(min, max, 100)
+      val ranges = Z3.zranges(min, max)
       ranges must haveLength(3)
       ranges must containTheSameElementsAs(Seq((Z3(2, 2, 0).z, Z3(3, 3, 0).z),
         (Z3(2, 4, 0).z, Z3(3, 5, 0).z), (Z3(2, 6, 0).z, Z3(3, 6, 0).z)))
     }
 
     "return non-empty ranges for a number of cases" >> {
+      val sfc = new Z3SFC
+      val week = sfc.tmax.toLong
+      val day = sfc.tmax.toLong / 7
+      val hour = sfc.tmax.toLong / 168
+
       val ranges = Seq(
-        (new Z3(0), new Z3(3961898555948381951l)),
-        (new Z3(0), new Z3(4611686018427387903l)),
-        (new Z3(0), new Z3(8645783181317881599l)),
-        (new Z3(3754665181066933258l), new Z3(3810634797035430054l)),
-        (new Z3(3754665181066933258l), new Z3(4460422259514436006l)),
-        (new Z3(3759195186253968780l), new Z3(3842344833344678918l)),
-        (new Z3(3759195186253968780l), new Z3(3873808578109778054l)),
-        (new Z3(3759336199158152616l), new Z3(3873808578109778054l)),
-        (new Z3(3763173268547295545l), new Z3(3763173268556857195l)),
-        (new Z3(3763831019838881066l), new Z3(4460422259514436006l)),
-        (new Z3(73185697271398432l), new Z3(4611686018427387903l)),
-        (new Z3(9165529533122820l), new Z3(3963006867897054943l)),
-        (new Z3(9165838771947808l), new Z3(4611686018427387903l))
+        (sfc.index(-180, -90, 0), sfc.index(180, 90, week)), // whole world, full week
+        (sfc.index(-180, -90, day), sfc.index(180, 90, day * 2)), // whole world, 1 day
+        (sfc.index(-180, -90, hour * 10), sfc.index(180, 90, hour * 11)), // whole world, 1 hour
+        (sfc.index(-180, -90, hour * 10), sfc.index(180, 90, hour * 64)), // whole world, 54 hours
+        (sfc.index(-180, -90, day * 2), sfc.index(180, 90, week)), // whole world, 5 day
+        (sfc.index(-90, -45, sfc.tmax.toLong / 4), sfc.index(90, 45, 3 * sfc.tmax.toLong / 4)), // half world, half week
+        (sfc.index(35, 65, 0), sfc.index(45, 75, day)), // 10^2 degrees, 1 day
+        (sfc.index(35, 55, 0), sfc.index(45, 65, week)), // 10^2 degrees, full week
+        (sfc.index(35, 55, day), sfc.index(45, 75, day * 2)), // 10x20 degrees, 1 day
+        (sfc.index(35, 55, day + hour * 6), sfc.index(45, 75, day * 2)), // 10x20 degrees, 18 hours
+        (sfc.index(35, 65, day + hour), sfc.index(45, 75, day * 6)), // 10^2 degrees, 5 days 23 hours
+        (sfc.index(35, 65, day), sfc.index(37, 68, day + hour * 6)), // 2x3 degrees, 6 hours
+        (sfc.index(35, 65, day), sfc.index(40, 70, day + hour * 6)), // 5^2 degrees, 6 hours
+        (sfc.index(39.999, 60.999, day + 3000), sfc.index(40.001, 61.001, day + 3120)), // small bounds
+        (sfc.index(51.0, 51.0, 6000), sfc.index(51.1, 51.1, 6100)), // small bounds
+        (sfc.index(51.0, 51.0, 30000), sfc.index(51.001, 51.001, 30100)) // small bounds
       )
 
-      forall(ranges) {
-        r =>
-          val ret = Z3.zranges(r._1, r._2, 8)
-          ret.length must be greaterThan(0)
+      def print(l: Z3, u: Z3, size: Int): Unit =
+        println(s"${round(sfc.invert(l))} ${round(sfc.invert(u))}\t$size")
+      def round(z: (Double, Double, Long)): (Double, Double, Long) =
+        (math.round(z._1 * 1000.0) / 1000.0, math.round(z._2 * 1000.0) / 1000.0, z._3)
+
+      forall(ranges) { r =>
+        val ret = Z3.zranges(r._1, r._2)
+        ret.length must beGreaterThan(0)
       }
-    } 
+    }
   }
 }


### PR DESCRIPTION
* Start recursion at the longest common prefix of the min/max bounds
* Depth of recursion depends on the size of our query region
* Compared to fixed recursion depth, increases ranges for small query regions and decreases ranges for large query regions
* Most queries will create less than 10k ranges - usually on the order of 2-4k for moderate queries and 30-500 for small queries

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>