### PR TITLE
GEOMESA-870 CSV deadlock fix

### DIFF
--- a/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
+++ b/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
@@ -70,7 +70,9 @@ class DelimitedTextConverter(format: CSVFormat,
     override def run(): Unit = {
       while (true) {
         val s = q.take()
-        if(s != null) {
+
+        // make sure the input is not null and is nonempty...if it is empty the threads will deadlock
+        if (s != null && s.nonEmpty) {
           writer.write(s)
           writer.write(separator)
           writer.flush()
@@ -82,6 +84,8 @@ class DelimitedTextConverter(format: CSVFormat,
   def fromInputType(string: String): Array[Any] = {
     import spire.syntax.cfor._
 
+    // empty strings cause deadlock
+    if (string == null || string.isEmpty) throw new IllegalArgumentException("Invalid input (empty)")
     q.put(string)
     val rec = parser.next()
     val len = rec.size()

--- a/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/NewLinesTest.scala
+++ b/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/NewLinesTest.scala
@@ -1,0 +1,73 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+package org.locationtech.geomesa.convert.text
+
+import com.typesafe.config.ConfigFactory
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.convert.SimpleFeatureConverters
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class NewLinesTest extends Specification {
+
+  sequential
+
+  "NewLinesTest" should {
+
+    val conf = ConfigFactory.parseString(
+      """
+        | converter = {
+        |   type         = "delimited-text",
+        |   format       = "DEFAULT",
+        |   id-field     = "uuid()",
+        |   fields = [
+        |     { name = "lat",      transform = "$1::double" },
+        |     { name = "lon",      transform = "$2::double" },
+        |     { name = "geom",     transform = "point($lat, $lon)" }
+        |   ]
+        | }
+      """.stripMargin)
+
+    val sft = SimpleFeatureTypes.createType(ConfigFactory.parseString(
+      """
+        |{
+        |  type-name = "newlinetest"
+        |  attributes = [
+        |    { name = "lat",      type = "Double", index = false },
+        |    { name = "lon",      type = "Double", index = false },
+        |    { name = "geom",     type = "Point",  index = true, srid = 4326, default = true }
+        |  ]
+        |}
+      """.stripMargin
+    ))
+
+    "process trailing newline" >> {
+      val converter = SimpleFeatureConverters.build[String](sft, conf)
+      val data = "45.0,45.0\n55.0,55.0\n".split("\n", -1)
+      data.length mustEqual 3
+
+      val res = converter.processInput(data.toIterator)
+      res.length mustEqual 2
+      converter.close()
+      success
+    }
+
+    "process middle of data newline" >> {
+      val converter = SimpleFeatureConverters.build[String](sft, conf)
+      val data = "45.0,45.0\n\n55.0,55.0\n".split("\n", -1)
+      data.length mustEqual 4
+
+      val res = converter.processInput(data.toIterator)
+      res.length mustEqual 2
+      converter.close()
+      success
+    }
+  }
+}


### PR DESCRIPTION
Fixes issues where delimited text convert module deadlocks when processing trailing newlines are found in CSV files (which happens often)

Signed-off-by: Andrew Hulbert <andrew.hulbert@ccri.com>