### PR TITLE
GEOMESA-881 Fixing incomplete result sets in GeoMesaSpark

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -32,6 +32,7 @@ import org.locationtech.geomesa.CURRENT_SCHEMA_VERSION
 import org.locationtech.geomesa.accumulo.GeomesaSystemProperties
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore._
 import org.locationtech.geomesa.accumulo.data.tables._
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType.StrategyType
 import org.locationtech.geomesa.accumulo.index._
 import org.locationtech.geomesa.accumulo.util.GeoMesaBatchWriterConfig
 import org.locationtech.geomesa.features.SerializationType.SerializationType
@@ -698,9 +699,9 @@ class AccumuloDataStore(val connector: Connector,
    * Gets the query plan for a given query. The query plan consists of the tables, ranges, iterators etc
    * required to run a query against accumulo.
    */
-  def getQueryPlan(query: Query): Seq[QueryPlan] = {
+  def getQueryPlan(query: Query, strategy: Option[StrategyType] = None): Seq[QueryPlan] = {
     require(query.getTypeName != null, "Type name is required in the query")
-    planQuery(query.getTypeName, query, ExplainNull)
+    planQuery(query.getTypeName, query, strategy, ExplainNull)
   }
 
   /**
@@ -708,13 +709,16 @@ class AccumuloDataStore(val connector: Connector,
    */
   def explainQuery(query: Query, o: ExplainerOutputType = ExplainPrintln): Unit = {
     require(query.getTypeName != null, "Type name is required in the query")
-    planQuery(query.getTypeName, query, o)
+    planQuery(query.getTypeName, query, None, o)
   }
 
   /**
    * Plan the query, but don't execute it
    */
-  private def planQuery(featureName: String, query: Query, o: ExplainerOutputType): Seq[QueryPlan] =
+  private def planQuery(featureName: String,
+                        query: Query,
+                        strategy: Option[StrategyType],
+                        o: ExplainerOutputType): Seq[QueryPlan] =
     getQueryPlanner(featureName, this).planQuery(query, None, o)
 
   /**

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIdxStrategyV5.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIdxStrategyV5.scala
@@ -47,7 +47,7 @@ class AttributeIdxStrategyV5(val filter: QueryFilter) extends Strategy with Logg
   /**
    * Perform scan against the Attribute Index Table and get an iterator returning records from the Record table
    */
-  override def getQueryPlans(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType) = {
+  override def getQueryPlan(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType) = {
     val propsAndRanges = filter.primary.map(getPropertyAndRange(_, queryPlanner.sft))
     val attributeName = propsAndRanges.head._1
     val ranges = propsAndRanges.map(_._2)
@@ -95,7 +95,7 @@ class AttributeIdxStrategyV5(val filter: QueryFilter) extends Strategy with Logg
 
         // there won't be any non-date/time-filters if the index only iterator has been selected
         val table = acc.getTableName(sft.getTypeName, AttributeTableV5)
-        ranges.map(ScanPlan(table, _, attributeIterators.toSeq, Seq.empty, kvsToFeatures, hasDupes))
+        BatchScanPlan(table, ranges, attributeIterators.toSeq, Seq.empty, kvsToFeatures, 1, hasDupes)
 
       case RecordJoinIterator =>
         val recordIterators = scala.collection.mutable.ArrayBuffer.empty[IteratorSetting]
@@ -125,7 +125,7 @@ class AttributeIdxStrategyV5(val filter: QueryFilter) extends Strategy with Logg
         val attrTable = acc.getTableName(sft.getTypeName, AttributeTableV5)
         val attrThreads = acc.getSuggestedThreads(sft.getTypeName, AttributeTableV5)
         val attrIters = attributeIterators.toSeq
-        Seq(JoinPlan(attrTable, ranges, attrIters, Seq.empty, attrThreads, hasDupes, joinFunction, joinQuery))
+        JoinPlan(attrTable, ranges, attrIters, Seq.empty, attrThreads, hasDupes, joinFunction, joinQuery)
     }
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategy.scala
@@ -43,7 +43,7 @@ object RecordIdxStrategy extends StrategyProvider {
 
 class RecordIdxStrategy(val filter: QueryFilter) extends Strategy with Logging {
 
-  override def getQueryPlans(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType) = {
+  override def getQueryPlan(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType) = {
 
     val sft = queryPlanner.sft
     val acc = queryPlanner.acc
@@ -73,7 +73,7 @@ class RecordIdxStrategy(val filter: QueryFilter) extends Strategy with Logging {
     val table = acc.getTableName(sft.getTypeName, RecordTable)
     val threads = acc.getSuggestedThreads(sft.getTypeName, RecordTable)
 
-    val plan = if (sft.getSchemaVersion > 5) {
+    if (sft.getSchemaVersion > 5) {
       // optimized path when we know we're using kryo serialization
       val priority = 25
       if (hints.isBinQuery) {
@@ -103,7 +103,5 @@ class RecordIdxStrategy(val filter: QueryFilter) extends Strategy with Logging {
       }
       BatchScanPlan(table, ranges, iters, Seq.empty, kvsToFeatures, threads, hasDuplicates = false)
     }
-
-    Seq(plan)
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/STIdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/STIdxStrategy.scala
@@ -32,7 +32,7 @@ import scala.collection.JavaConversions._
 
 class STIdxStrategy(val filter: QueryFilter) extends Strategy with Logging with IndexFilterHelpers {
 
-  override def getQueryPlans(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType) = {
+  override def getQueryPlan(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType) = {
 
     val sft             = queryPlanner.sft
     val acc             = queryPlanner.acc
@@ -128,10 +128,8 @@ class STIdxStrategy(val filter: QueryFilter) extends Strategy with Logging with 
     val table = acc.getTableName(sft.getTypeName, SpatioTemporalTable)
     val numThreads = acc.getSuggestedThreads(sft.getTypeName, SpatioTemporalTable)
     val hasDupes = STIdxStrategy.mayContainDuplicates(hints, sft)
-    val res = qp.copy(table = table, iterators = iterators, kvsToFeatures = kvsToFeatures,
+    qp.copy(table = table, iterators = iterators, kvsToFeatures = kvsToFeatures,
       numThreads = numThreads, hasDuplicates = hasDupes)
-
-    Seq(res)
   }
 
   private def getSTIIIterCfg(iteratorConfig: IteratorConfig,

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Strategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Strategy.scala
@@ -38,7 +38,7 @@ trait Strategy extends Logging {
   /**
    * Plans the query - strategy implementations need to define this
    */
-  def getQueryPlans(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType): Seq[QueryPlan]
+  def getQueryPlan(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType): QueryPlan
 }
 
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/Z3IteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/Z3IteratorTest.scala
@@ -47,15 +47,15 @@ class Z3IteratorTest extends Specification {
                         map: util.Map[String, String],
                         iteratorEnvironment: IteratorEnvironment): Unit = {}
       override def seek(range: Range, collection: util.Collection[ByteSequence], b: Boolean): Unit = {
-        println("seek called")
         key = null
         staged = null
       }
       override def hasTop: Boolean = staged != null
     }
 
+    val zMap = Map(0.toShort -> (zmin.z, zmax.z))
     val iter = new Z3Iterator
-    iter.init(srcIter, Map("zmin" -> s"${zmin.z}", "zmax" -> s"${zmax.z}"), null)
+    iter.init(srcIter, Map(Z3Iterator.zKey -> Z3Iterator.mapToString(zMap)), null)
 
     "keep in bounds values" >> {
       val test1 = Z3Curve.index(-76.0, 38.5, 500)

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
@@ -29,7 +29,7 @@ import org.locationtech.geomesa.accumulo.index._
 import org.locationtech.geomesa.features.SerializationType.SerializationType
 import org.locationtech.geomesa.features.SimpleFeatureDeserializers
 import org.locationtech.geomesa.filter.filterToString
-import org.locationtech.geomesa.jobs.GeoMesaConfigurator
+import org.locationtech.geomesa.jobs.{JobUtils, GeoMesaConfigurator}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 
@@ -75,34 +75,12 @@ object GeoMesaInputFormat extends Logging {
     val auths = Option(AccumuloDataStoreFactory.params.authsParam.lookUp(dsParams).asInstanceOf[String])
     auths.foreach(a => InputFormatBaseAdapter.setScanAuthorizations(job, new Authorizations(a.split(","): _*)))
 
-    // run an explain query to set up the iterators, ranges, etc
     val featureTypeName = query.getTypeName
-    val queryPlans = ds.getQueryPlan(query)
 
-    // see if the plan is something we can execute from a single table
-    val tryPlan = if (queryPlans.length > 1) None else queryPlans.headOption.filter {
-      case qp: JoinPlan => false
-      case _ => true
-    }
+    // get the query plan to set up the iterators, ranges, etc
+    val queryPlan = JobUtils.getSingleQueryPlan(ds, query)
 
-    val queryPlan = tryPlan.getOrElse {
-      // this query has a join or requires multiple scans - instead, fall back to the ST index
-      logger.warn("Desired query plan requires multiple scans - falling back to spatio-temporal scan")
-      val sft = ds.getSchema(featureTypeName)
-      val featureEncoding = ds.getFeatureEncoding(sft)
-      val indexSchema = ds.getIndexSchemaFmt(featureTypeName)
-      val hints = ds.strategyHints(sft)
-      val queryPlanner = new QueryPlanner(sft, featureEncoding, indexSchema, ds, hints)
-      val qps = queryPlanner.planQuery(query, Some(StrategyType.ST), ExplainNull)
-      if (qps.length > 1) {
-        logger.error("The query being executed requires multiple scans, which is not currently " +
-            "supported by geomesa. Your result set will be partially incomplete. This is most likely due " +
-            s"to an OR clause in your query. Query: ${filterToString(query.getFilter)}")
-      }
-      qps.head
-    }
-
-    // use the explain results to set the accumulo input format options
+    // use the query plan to set the accumulo input format options
     InputFormatBase.setInputTableName(job, queryPlan.table)
     if (queryPlan.ranges.nonEmpty) {
       InputFormatBase.setRanges(job, queryPlan.ranges)


### PR DESCRIPTION
* M/r and spark jobs can't operate on multiple query plans, as the input format can only be configured once.
* M/r and spark jobs will now fall back to a full table scan instead of returning incomplete results if there are multiple query plans
* Z3Strategy was tweaked to only use a single query plan
* Only 'OR' queries should create multiple query plans now

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>