### PR TITLE
GEOMESA-882 RemoveSchema not deleting empty z3 tables

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -357,6 +357,7 @@ class AccumuloDataStore(val connector: Connector,
       val deleter = connector.createBatchDeleter(name, auths, numThreads, defaultBWConfig)
       table.deleteFeaturesForType(sft, deleter)
       deleter.close()
+      if (table == Z3Table && tableOps.exists(name)) tableOps.delete(name)
     }
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -354,10 +354,13 @@ class AccumuloDataStore(val connector: Connector,
 
     GeoMesaTable.getTables(sft).foreach { table =>
       val name = getTableName(sft.getTypeName, table)
-      val deleter = connector.createBatchDeleter(name, auths, numThreads, defaultBWConfig)
-      table.deleteFeaturesForType(sft, deleter)
-      deleter.close()
-      if (table == Z3Table && tableOps.exists(name)) tableOps.delete(name)
+      if (table == Z3Table && tableOps.exists(name)) {
+        tableOps.delete(name)
+      } else {
+        val deleter = connector.createBatchDeleter(name, auths, numThreads, defaultBWConfig)
+        table.deleteFeaturesForType(sft, deleter)
+        deleter.close()
+      }
     }
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -354,12 +354,14 @@ class AccumuloDataStore(val connector: Connector,
 
     GeoMesaTable.getTables(sft).foreach { table =>
       val name = getTableName(sft.getTypeName, table)
-      if (table == Z3Table && tableOps.exists(name)) {
-        tableOps.delete(name)
-      } else {
-        val deleter = connector.createBatchDeleter(name, auths, numThreads, defaultBWConfig)
-        table.deleteFeaturesForType(sft, deleter)
-        deleter.close()
+      if (tableOps.exists(name)) {
+        if (table == Z3Table) {
+          tableOps.delete(name)
+        } else {
+          val deleter = connector.createBatchDeleter(name, auths, numThreads, defaultBWConfig)
+          table.deleteFeaturesForType(sft, deleter)
+          deleter.close()
+        }
       }
     }
   }


### PR DESCRIPTION
* fixed issue where removeschema left empty z3 tables on accumulo
* added a unit test specific to this case

Signed-off-by: Andrew Annex <aannex@ccri.com>