### PR TITLE
GEOMESA-875 Configurable index tables

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -145,6 +145,7 @@ class AccumuloDataStore(val connector: Connector,
     val recordTableValue            = RecordTable.formatTableName(catalogTable, sft)
     val queriesTableValue           = formatQueriesTableName(catalogTable)
     val tableSharingValue           = sft.isTableSharing.toString
+    val enabledTablesValue          = sft.getEnabledTables.toString
     val dataStoreVersion            = CURRENT_SCHEMA_VERSION.toString
 
     // store each metadata in the associated key
@@ -160,6 +161,7 @@ class AccumuloDataStore(val connector: Connector,
         RECORD_TABLE_KEY      -> recordTableValue,
         QUERIES_TABLE_KEY     -> queriesTableValue,
         SHARED_TABLES_KEY     -> tableSharingValue,
+        TABLES_ENABLED_KEY    -> enabledTablesValue,
         VERSION_KEY           -> dataStoreVersion
       ) ++ (if (dtgValue.isDefined) Map(DTGFIELD_KEY -> dtgValue.get) else Map.empty)
 
@@ -683,6 +685,11 @@ class AccumuloDataStore(val connector: Connector,
         sft.setTableSharing(false)
         sft.setTableSharingPrefix("")
       }
+
+      metadata.read(featureName, TABLES_ENABLED_KEY).map { enabledTablesStr =>
+        sft.setEnabledTables(enabledTablesStr)
+      }
+
       sft
     }.orNull
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/package.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/package.scala
@@ -15,6 +15,7 @@ import org.geotools.data.FeatureWriter
 import org.geotools.factory.Hints.ClassKey
 import org.joda.time.{DateTime, Interval}
 import org.locationtech.geomesa.features.SerializationType
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 package object data {
@@ -46,6 +47,7 @@ package object data {
   val Z3_TABLE_KEY           = "tables.z3.name"
   val QUERIES_TABLE_KEY      = "tables.queries.name"
   val SHARED_TABLES_KEY      = "tables.sharing"
+  val TABLES_ENABLED_KEY     = SimpleFeatureTypes.ENABLED_INDEXES
   val SCHEMA_ID_KEY          = "id"
   val VERSION_KEY            = "version"
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/AvailableTables.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/AvailableTables.scala
@@ -1,0 +1,20 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.accumulo.data.tables
+
+object AvailableTables {
+  val AllTables: List[GeoMesaTable] = List(AttributeTable, RecordTable, Z3Table, SpatioTemporalTable)
+  val AllTablesStr: List[String] = List(AttributeTable, RecordTable, Z3Table, SpatioTemporalTable).map(_.suffix)
+  val DefaultTables: List[GeoMesaTable] = AllTables
+  val DefaultTablesStr: List[String] = AllTables.map(_.suffix)
+  val Z3TableSchemeStr: List[String] = List(AttributeTable, RecordTable, Z3Table).map(_.suffix)
+  
+  def toTables(sList: List[String]) = sList.flatMap( s => AvailableTables.AllTables.find(_.suffix == s))
+  
+}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/GeoMesaTable.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/GeoMesaTable.scala
@@ -62,8 +62,15 @@ trait GeoMesaTable {
 
 object GeoMesaTable {
 
-  def getTables(sft: SimpleFeatureType): Seq[GeoMesaTable] =
-    Seq(RecordTable, SpatioTemporalTable, AttributeTableV5, AttributeTable, Z3Table).filter(_.supports(sft))
+  def getTables(sft: SimpleFeatureType): Seq[GeoMesaTable] = {
+    val enabled = {
+      val s = sft.getEnabledTables.toString
+      if (s.nonEmpty) AvailableTables.toTables(s.split(",").toList) else AvailableTables.AllTables
+    }
+    Seq(RecordTable, SpatioTemporalTable, AttributeTableV5, AttributeTable, Z3Table)
+      .filter(_.supports(sft))
+      .filter(enabled.contains)
+  }
 
   def getTableNames(sft: SimpleFeatureType, acc: AccumuloConnectorCreator): Seq[String] =
     getTables(sft).map(acc.getTableName(sft.getTypeName, _))

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTest.scala
@@ -128,7 +128,7 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
 
     "create a schema with custom record splitting options" in {
       val spec = "name:String,dtg:Date,*geom:Point:srid=4326;table.splitter.class=" +
-          s"${classOf[DigitSplitter].getName},table.splitter.options=fmt:%02d,min:0,max:99"
+          s"${classOf[DigitSplitter].getName},table.splitter.options='fmt:%02d,min:0,max:99'"
       val sft = SimpleFeatureTypes.createType("customsplit", spec)
       sft.setTableSharing(false)
       ds.createSchema(sft)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/ConfigurableIndexesTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/ConfigurableIndexesTest.scala
@@ -1,0 +1,104 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.accumulo.index
+
+import org.geotools.factory.CommonFactoryFinder
+import org.geotools.filter.text.ecql.ECQL
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.accumulo.data.tables.AvailableTables
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
+import org.locationtech.geomesa.accumulo.util.SftBuilder
+import org.opengis.filter.Filter
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class ConfigurableIndexesTest extends Specification {
+
+  val sft = new SftBuilder()
+    .date("dtg", default = true)
+    .point("geom", default = true)
+    .withIndexes(AvailableTables.Z3TableSchemeStr)
+    .build("ConfigurableIndexesTest")
+
+  val splitter = new QueryFilterSplitter(sft)
+
+  val ff = CommonFactoryFinder.getFilterFactory2
+
+  val geom                = "BBOX(geom,40,40,50,50)"
+  val geom2               = "BBOX(geom,60,60,70,70)"
+  val indexedAttr         = "attr2 = 'test'"
+  val dtg                 = "dtg DURING 2014-01-01T00:00:00Z/2014-01-01T23:59:59Z"
+
+  def and(clauses: String*) = ff.and(clauses.map(ECQL.toFilter))
+  def or(clauses: String*)  = ff.or(clauses.map(ECQL.toFilter))
+  def f(filter: String)     = ECQL.toFilter(filter)
+
+
+  implicit def filterToString(f: Filter): String = ECQL.toCQL(f)
+  implicit def stringToFilter(f: String): Filter = ECQL.toFilter(f)
+
+  "AccumuloDataStore" should {
+
+    "fall back to records for ST queries" >> {
+      "spatial" >> {
+        val filter = f(geom)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.RECORD
+        options.head.filters.head.primary mustEqual Seq(Filter.INCLUDE)
+        options.head.filters.head.secondary mustEqual Some(filter)
+      }
+    }
+
+    "fall back to records table on simple ands" >> {
+      "spatial" >> {
+        val filter = and(geom, geom2)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.RECORD
+        options.head.filters.head.primary mustEqual Seq(Filter.INCLUDE)
+        options.head.filters.head.secondary mustEqual Some(filter)
+      }
+      "with multiple spatial clauses" >> {
+        val filter = or(geom, geom2)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        forall(options.head.filters)(_.strategy mustEqual StrategyType.RECORD)
+        options.head.filters.map(_.primary) must containTheSameElementsAs(Seq(Seq(Filter.INCLUDE)))
+        forall(options.head.filters)(_.secondary mustEqual Some(filter))
+      }
+      "with spatiotemporal and indexed attribute clauses" >> {
+        val filter = or(geom, indexedAttr)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.map(_.strategy) must containTheSameElementsAs(Seq(StrategyType.RECORD))
+        options.head.filters.find(_.strategy == StrategyType.RECORD).get.primary mustEqual Seq(Filter.INCLUDE)
+        forall(options.head.filters)(_.secondary mustEqual Some(filter))
+      }
+      "with ORs" >> {
+        val filter = or(geom, or(dtg, indexedAttr))
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
+        options.head.filters must haveLength(1)
+        options.head.filters.map(_.strategy) must
+          containTheSameElementsAs(Seq(StrategyType.RECORD))
+        options.head.filters.map(_.primary) must
+          containTheSameElementsAs(Seq(Seq(Filter.INCLUDE)))
+        forall(options.head.filters)(_.secondary mustEqual Some(or(or(geom, indexedAttr), dtg)))
+      }
+    }
+  }
+}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryFilterSplitterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryFilterSplitterTest.scala
@@ -11,6 +11,7 @@ package org.locationtech.geomesa.accumulo.index
 import org.geotools.factory.CommonFactoryFinder
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
+import org.locationtech.geomesa.accumulo.data.tables.AvailableTables
 import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
 import org.locationtech.geomesa.accumulo.util.SftBuilder
 import org.locationtech.geomesa.accumulo.util.SftBuilder.Opts
@@ -32,6 +33,7 @@ class QueryFilterSplitterTest extends Specification {
     .stringType("low", Opts(index = true, cardinality = Cardinality.LOW))
     .date("dtg", default = true)
     .point("geom", default = true)
+    .withIndexes(AvailableTables.DefaultTablesStr)
     .build("QueryFilterSplitterTest")
 
   val ff = CommonFactoryFinder.getFilterFactory2

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/GeoMesaStoreEditPanel.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/GeoMesaStoreEditPanel.scala
@@ -1,3 +1,11 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
 package org.locationtech.geomesa.plugin
 
 import org.apache.wicket.behavior.SimpleAttributeModifier
@@ -8,14 +16,6 @@ import org.geoserver.web.data.store.StoreEditPanel
 import org.geoserver.web.data.store.panel.{CheckBoxParamPanel, ParamPanel, PasswordParamPanel, TextParamPanel}
 import org.geoserver.web.util.MapModel
 import org.geotools.data.DataAccessFactory.Param
-
-/***********************************************************************
-* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License, Version 2.0 which
-* accompanies this distribution and is available at
-* http://www.opensource.org/licenses/apache2.0.php.
-*************************************************************************/
 
 abstract class GeoMesaStoreEditPanel (componentId: String, storeEditForm: Form[_])
     extends StoreEditPanel(componentId, storeEditForm) {

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -231,6 +231,9 @@ object RichSimpleFeatureType {
     def getTableSharingPrefix: String = userData[String](SHARING_PREFIX_KEY).getOrElse("")
     def setTableSharingPrefix(prefix: String): Unit = sft.getUserData.put(SHARING_PREFIX_KEY, prefix)
 
+    def getEnabledTables: String = userData[String](SimpleFeatureTypes.ENABLED_INDEXES).getOrElse("")
+    def setEnabledTables(tables: String): Unit = sft.getUserData.put(SimpleFeatureTypes.ENABLED_INDEXES, tables)
+
     def userData[T](key: AnyRef): Option[T] = Option(sft.getUserData.get(key).asInstanceOf[T])
   }
 }


### PR DESCRIPTION
* Store configurable tables in metadata
* Create only tables for specified indexes
* Modify SFT spec to allow arbitrary feature kv pairs in SFT

Signed-off-by: Andrew Hulbert <ahulbert@ccri.com>