### PR TITLE
GEOMESA-887 Remove non-deterministic QuadTree test

### DIFF
--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/index/SynchronizedQuadtreeTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/index/SynchronizedQuadtreeTest.scala
@@ -8,19 +8,17 @@
 
 package org.locationtech.geomesa.utils.index
 
-import java.util.ConcurrentModificationException
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.Lock
 
 import com.typesafe.scalalogging.slf4j.Logging
 import com.vividsolutions.jts.geom.Point
-import com.vividsolutions.jts.index.quadtree.Quadtree
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
-import scala.util.{Random, Try}
+import scala.util.Random
 
 @RunWith(classOf[JUnitRunner])
 class SynchronizedQuadtreeTest extends Specification with Logging {
@@ -49,35 +47,6 @@ class SynchronizedQuadtreeTest extends Specification with Logging {
         Thread.sleep(1)
         i += 1
       }
-      t1.join()
-      success
-    }
-
-    "normal quadtree should not be thread safe" in {
-      val qt = new Quadtree
-      val pt = WKTUtils.read("POINT(45 50)")
-      val env = pt.getEnvelopeInternal
-      val wholeWorld = WKTUtils.read("POLYGON((-180 -90,180 -90,180 90,-180 90,-180 -90))").getEnvelopeInternal
-      val t1 = new Thread(new Runnable() {
-        override def run() = {
-          var i = 0
-          while (i < 1000) {
-            qt.insert(env, pt)
-            Thread.sleep(1)
-            i += 1
-          }
-        }
-      })
-      t1.start()
-      val read = Try({
-        var i = 0
-        while (i < 1000) {
-          qt.query(wholeWorld)
-          Thread.sleep(1)
-          i += 1
-        }
-      })
-      read should beAFailedTry(beAnInstanceOf[ConcurrentModificationException])
       t1.join()
       success
     }


### PR DESCRIPTION
This test fails because it is non-deterministic

Signed-off-by: Andrew Hulbert <andrew.hulbert@ccri.com>

