### PR TITLE
GEOMESA-891 Allow geoserver requests to specify the query strategy

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/QueryPlanner.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/QueryPlanner.scala
@@ -9,7 +9,9 @@
 package org.locationtech.geomesa.accumulo.index
 
 import java.util.Map.Entry
+import java.util.{Locale, Map => jMap}
 
+import com.typesafe.scalalogging.slf4j.Logging
 import com.vividsolutions.jts.geom.Geometry
 import org.apache.accumulo.core.data.{Key, Range => AccRange, Value}
 import org.geotools.data.Query
@@ -43,6 +45,7 @@ import org.opengis.filter.sort.{SortBy, SortOrder}
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
+import scala.util.Try
 
 /**
  * Executes a query against geomesa
@@ -137,7 +140,8 @@ case class QueryPlanner(sft: SimpleFeatureType,
 
     implicit val timings = new TimingsImpl
     val queryPlans = profile({
-      val strategies = QueryStrategyDecider.chooseStrategies(sft, query, hints, requested, output)
+      val requestedStrategy = requested.orElse(query.getHints.getRequestedStrategy)
+      val strategies = QueryStrategyDecider.chooseStrategies(sft, query, hints, requestedStrategy, output)
       strategies.map { strategy =>
         output(s"Strategy: ${strategy.getClass.getSimpleName}")
         output(s"Filter: ${strategy.filter}")
@@ -189,7 +193,7 @@ case class QueryPlanner(sft: SimpleFeatureType,
   }
 }
 
-object QueryPlanner {
+object QueryPlanner extends Logging {
 
   val iteratorPriority_RowRegex                        = 0
   val iteratorPriority_AttributeIndexFilteringIterator = 10
@@ -222,6 +226,38 @@ object QueryPlanner {
     QueryPlanner.setQueryTransforms(query, sft)
     // set return SFT in the query
     QueryPlanner.setReturnSft(query, sft)
+    // handle any params passed in through geoserver
+    QueryPlanner.handleGeoServerParams(query)
+  }
+
+  /**
+   * Checks the 'view params' passed in through geoserver and converts them to the appropriate query hints.
+   * This kind of a hack, but it's the only way geoserver exposes custom data to the underlying data store.
+   *
+   * Note - keys in the map are always uppercase.
+   */
+  def handleGeoServerParams(query: Query): Unit = {
+    val viewParams = query.getHints.get(Hints.VIRTUAL_TABLE_PARAMETERS).asInstanceOf[jMap[String, String]]
+    if (viewParams != null) {
+      def withName(name: String) = {
+        val value = Try(Strategy.StrategyType.withName(name.toUpperCase(Locale.US)))
+        if (value.isFailure) {
+          logger.error(s"Ignoring invalid strategy name from view params: $name. Valid values " +
+              s"are ${Strategy.StrategyType.values.mkString(", ")}")
+        }
+        value.toOption
+      }
+      Option(viewParams.get("STRATEGY")).flatMap(withName).foreach { strategy =>
+        val old = query.getHints.get(QUERY_STRATEGY_KEY)
+        if (old == null) {
+          logger.debug(s"Using strategy $strategy from view params")
+          query.getHints.put(QUERY_STRATEGY_KEY, strategy)
+        } else if (old != strategy) {
+          logger.warn("Ignoring query hint from geoserver in favor of hint directly set in query. " +
+              s"Using $old and disregarding $strategy")
+        }
+      }
+    }
   }
 
   /**

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/index.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/index.scala
@@ -17,6 +17,7 @@ import org.geotools.filter.identity.FeatureIdImpl
 import org.geotools.geometry.jts.ReferencedEnvelope
 import org.joda.time.{DateTime, DateTimeZone}
 import org.locationtech.geomesa.accumulo.data._
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType._
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.identity.FeatureId
@@ -40,6 +41,7 @@ package object index {
 
   object QueryHints {
     val RETURN_SFT_KEY       = new ClassKey(classOf[SimpleFeatureType])
+    val QUERY_STRATEGY_KEY   = new ClassKey(classOf[StrategyType])
 
     val DENSITY_BBOX_KEY     = new ClassKey(classOf[ReferencedEnvelope])
     val DENSITY_WEIGHT       = new ClassKey(classOf[java.lang.String])
@@ -64,6 +66,8 @@ package object index {
 
     implicit class RichHints(val hints: Hints) extends AnyRef {
       def getReturnSft: SimpleFeatureType = hints.get(RETURN_SFT_KEY).asInstanceOf[SimpleFeatureType]
+      def getRequestedStrategy: Option[StrategyType] =
+        Option(hints.get(QUERY_STRATEGY_KEY).asInstanceOf[StrategyType])
       def isBinQuery: Boolean = hints.containsKey(BIN_TRACK_KEY)
       def getBinTrackIdField: String = hints.get(BIN_TRACK_KEY).asInstanceOf[String]
       def getBinGeomField: Option[String] = Option(hints.get(BIN_GEOM_KEY).asInstanceOf[String])


### PR DESCRIPTION
* Append e.g. '&viewparams=strategy:attribute' to the request
* Valid strategies are currently Z3, ST, RECORD, ATTRIBUTE
* Note: not all queries will work with a given strategy

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>