### PR TITLE
GEOMESA-895 Add HashAttributeProcess for styling by any attribute

### DIFF
--- a/geomesa-process/src/main/scala/org/locationtech/geomesa/process/HashAttributeProcess.scala
+++ b/geomesa-process/src/main/scala/org/locationtech/geomesa/process/HashAttributeProcess.scala
@@ -1,0 +1,84 @@
+package org.locationtech.geomesa.process
+
+import com.google.common.hash.Hashing
+import org.geotools.data.DataUtilities
+import org.geotools.data.simple.SimpleFeatureCollection
+import org.geotools.feature.collection.DelegateSimpleFeatureIterator
+import org.geotools.feature.simple.{SimpleFeatureBuilder, SimpleFeatureTypeBuilder}
+import org.geotools.process.ProcessException
+import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
+import org.geotools.process.vector.VectorProcess
+
+trait HashAttribute {
+  import org.locationtech.geomesa.utils.geotools.Conversions._
+
+  import scala.collection.JavaConversions._
+
+  val hashFn = Hashing.goodFastHash(64)
+
+  def transformHash(hash: Int): AnyRef
+  def augmentSft(sft: SimpleFeatureTypeBuilder): Unit
+
+  @throws(classOf[ProcessException])
+  @DescribeResult(name = "result", description = "Output collection")
+  def execute(@DescribeParameter(name = "data", description = "Input features")
+              obsFeatures: SimpleFeatureCollection,
+              @DescribeParameter(name = "attribute", description = "The attribute to hash on")
+              attribute: String,
+              @DescribeParameter(name = "modulo", description = "The divisor")
+              modulo: Integer): SimpleFeatureCollection = {
+
+    val sft = obsFeatures.getSchema
+    val sftBuilder = new SimpleFeatureTypeBuilder()
+    sftBuilder.init(sft)
+    augmentSft(sftBuilder)
+    val targetSft = sftBuilder.buildFeatureType()
+    val featureBuilder = new SimpleFeatureBuilder(targetSft)
+
+    val results =
+      obsFeatures.features().map { sf =>
+        featureBuilder.reset()
+        featureBuilder.init(sf)
+        val attr = Option(sf.getAttribute(attribute).asInstanceOf[String]).getOrElse("")
+        val hash = math.abs(hashFn.hashString(attr).asInt()) % modulo
+        featureBuilder.set("hash", transformHash(hash))
+        featureBuilder.buildFeature(sf.getID)
+      }
+    DataUtilities.collection(new DelegateSimpleFeatureIterator(results))
+  }
+
+}
+
+@DescribeProcess(
+  title = "Hash Attribute Process",
+  description = "Adds an attribute to each SimpleFeature that hashes the configured attribute modulo the configured param"
+)
+class HashAttributeProcess extends VectorProcess with HashAttribute {
+  override def transformHash(hash: Int): AnyRef = Int.box(hash)
+
+  override def augmentSft(sftBuilder: SimpleFeatureTypeBuilder): Unit = {
+    sftBuilder.add("hash", classOf[Integer])
+  }
+}
+
+@DescribeProcess(
+  title = "Hash Attribute Color Process",
+  description = "Adds an attribute to each SimpleFeature that hashes the configured attribute modulo the configured param and emits a color"
+)
+class HashAttributeColorProcess extends VectorProcess with HashAttribute {
+  val colors =
+    Array[String](
+      "#6495ED",
+      "#B0C4DE",
+      "#00FFFF",
+      "#9ACD32",
+      "#00FA9A",
+      "#FFF8DC",
+      "#F5DEB3")
+
+  override def transformHash(hash: Int): AnyRef = colors(hash % colors.length)
+
+  override def augmentSft(sftBuilder: SimpleFeatureTypeBuilder): Unit = {
+    sftBuilder.add("hash", classOf[String])
+  }
+}

--- a/geomesa-process/src/main/scala/org/locationtech/geomesa/process/Point2PointProcess.scala
+++ b/geomesa-process/src/main/scala/org/locationtech/geomesa/process/Point2PointProcess.scala
@@ -1,0 +1,98 @@
+package org.locationtech.geomesa.process
+
+import java.util.Date
+
+import com.vividsolutions.jts.geom.Point
+import org.geotools.data.DataUtilities
+import org.geotools.data.simple.SimpleFeatureCollection
+import org.geotools.feature.simple.{SimpleFeatureBuilder, SimpleFeatureTypeBuilder}
+import org.geotools.geometry.jts.{JTS, JTSFactoryFinder}
+import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
+import org.geotools.process.vector.VectorProcess
+import org.geotools.referencing.crs.DefaultGeographicCRS
+import org.joda.time.DateTime
+import org.joda.time.DateTime.Property
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.feature.`type`.GeometryType
+import org.opengis.feature.simple.SimpleFeature
+
+import scala.util.Try
+
+@DescribeProcess(title = "Point2PointProcess", description = "Aggregates a collection of points into a linestring.")
+class Point2PointProcess extends VectorProcess {
+
+  private val baseType = SimpleFeatureTypes.createType("geomesa", "point2point", "length:Double,*ls:LineString:srid=4326")
+  private val gf = JTSFactoryFinder.getGeometryFactory
+
+  @DescribeResult(name = "result", description = "Aggregated feature collection")
+  def execute(
+
+               @DescribeParameter(name = "data", description = "Input feature collection")
+               data: SimpleFeatureCollection,
+
+               @DescribeParameter(name = "groupingField", description = "Field on which to group")
+               groupingField: String,
+
+               @DescribeParameter(name = "sortField", description = "Field on which to sort")
+               sortField: String,
+
+               @DescribeParameter(name = "minimumNumberOfPoints", description = "Minimum number of points")
+               minPoints: Int,
+
+               @DescribeParameter(name = "breakOnDay", description = "Break connections on day marks")
+               breakOnDay: Boolean
+
+               ): SimpleFeatureCollection = {
+
+    import org.locationtech.geomesa.utils.geotools.Conversions._
+
+    import scala.collection.JavaConversions._
+
+    val queryType = data.getSchema
+    val sftBuilder = new SimpleFeatureTypeBuilder()
+    sftBuilder.init(baseType)
+    queryType.getAttributeDescriptors
+      .filterNot { _.getType.isInstanceOf[GeometryType] }
+      .foreach { attr => sftBuilder.add(attr) }
+
+    val sft = sftBuilder.buildFeatureType()
+
+    val builder = new SimpleFeatureBuilder(sft)
+
+    val groupingFieldIndex = data.getSchema.indexOf(groupingField)
+    val sortFieldIndex = data.getSchema.indexOf(sortField)
+
+    val lineFeatures =
+      data.features().toList
+        .groupBy(_.get(groupingFieldIndex).asInstanceOf[String])
+        .filter { case (_, coll) => coll.size > minPoints }
+        .flatMap { case (group, coll) =>
+
+        val globalSorted = coll.sortBy(_.get(sortFieldIndex).asInstanceOf[java.util.Date])
+
+        val groups =
+          if(!breakOnDay) Array(globalSorted)
+          else
+            globalSorted
+              .groupBy { f => getDayOfYear(sortFieldIndex, f) }
+              .filter { case (_, g) => g.size >= 2 }  // need at least two points in a day to create a
+              .map { case (_, g) => g }.toArray
+
+        groups.flatMap { sorted =>
+          Try {
+            val pts = sorted.map(_.getDefaultGeometry.asInstanceOf[Point].getCoordinate)
+            val ls = gf.createLineString(pts.toArray)
+            val length = pts.sliding(2, 1).map { case List(s, e) => JTS.orthodromicDistance(s, e, DefaultGeographicCRS.WGS84) }.sum
+            val sf = builder.buildFeature(group)
+            sf.setAttributes(Array[AnyRef](Double.box(length), ls) ++ sorted.head.getAttributes)
+            sf
+          }.toOption
+        }
+      }
+
+    DataUtilities.collection(lineFeatures.toArray)
+  }
+
+  def getDayOfYear(sortFieldIndex: Int, f: SimpleFeature): Property =
+    new DateTime(f.getAttribute(sortFieldIndex).asInstanceOf[Date]).dayOfYear()
+}

--- a/geomesa-process/src/main/scala/org/locationtech/geomesa/process/ProcessFactory.scala
+++ b/geomesa-process/src/main/scala/org/locationtech/geomesa/process/ProcessFactory.scala
@@ -23,10 +23,13 @@ class ProcessFactory
     Text.text("GeoMesa Process Factory"),
     "geomesa",
     classOf[DensityProcess],
+    classOf[Point2PointProcess],
     classOf[TemporalDensityProcess],
     classOf[TubeSelectProcess],
     classOf[ProximitySearchProcess],
     classOf[QueryProcess],
     classOf[KNearestNeighborSearchProcess],
-    classOf[UniqueProcess]
+    classOf[UniqueProcess],
+    classOf[HashAttributeProcess],
+    classOf[HashAttributeColorProcess]
   )


### PR DESCRIPTION
* Added a HashAttributeProcess and a HashAttributeColorProcess
* Takes an attribute name from the environment params and hashes modulo
  a configurable param to an integer.  Can be used to select a color
  per attribute
* Added a Point2Point process that creates line strings via a join on
  an attribute specified by the caller

Signed-off-by: Anthony Fox <anthonyfox@ccri.com>