### PR TITLE
GEOMESA-934 remove gdal from DRJ

### DIFF
--- a/geomesa-distributed-runtime/pom.xml
+++ b/geomesa-distributed-runtime/pom.xml
@@ -35,6 +35,14 @@
                     <groupId>org.geotools</groupId>
                     <artifactId>gt-epsg-hsql</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-geotiff</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-imageio-ext-gdal</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -42,7 +50,6 @@
             <artifactId>gt-opengis</artifactId>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
* Removes gdal from geomesa-raster for distributed runtime jar

Signed-off-by: Andrew Annex <aannex@ccri.com>