### PR TITLE
GEOMESA-877 Move SFTBuilder to utils from accumulo

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/csv/CSVParser.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/csv/CSVParser.scala
@@ -14,7 +14,7 @@ import java.util.Date
 import com.vividsolutions.jts.geom._
 import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
-import org.locationtech.geomesa.accumulo.util.SftBuilder
+import org.locationtech.geomesa.utils.geotools.SftBuilder
 import org.locationtech.geomesa.utils.text.WKTUtils
 
 import scala.annotation.tailrec

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/csv/package.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/csv/package.scala
@@ -23,8 +23,7 @@ import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureStore}
 import org.geotools.feature.DefaultFeatureCollection
 import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.locationtech.geomesa.accumulo.csv.CSVParser._
-import org.locationtech.geomesa.accumulo.util.SftBuilder
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.{SftBuilder, SimpleFeatureTypes}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.JavaConversions._

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilder.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilder.scala
@@ -1,0 +1,53 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+package org.locationtech.geomesa.accumulo.util
+
+import org.locationtech.geomesa.accumulo.data.TableSplitter
+import org.locationtech.geomesa.utils.geotools.SftBuilder._
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.Splitter
+import org.locationtech.geomesa.utils.geotools.{SftBuilder, SimpleFeatureTypes}
+
+class AccumuloSftBuilder extends SftBuilder {
+  private var splitterOpt: Option[Splitter] = None
+
+  def recordSplitter(clazz: String, splitOptions: Map[String,String]) = {
+    this.splitterOpt = Some(Splitter(clazz, splitOptions))
+    this
+  }
+
+  def recordSplitter(clazz: Class[_ <: TableSplitter], splitOptions: Map[String,String]): SftBuilder = {
+    recordSplitter(clazz.getName, splitOptions)
+    this
+  }
+
+  // note that SimpleFeatureTypes requires that splitter and splitter opts be ordered properly
+  private def splitPart = splitterOpt.map { s =>
+    List(
+      SimpleFeatureTypes.TABLE_SPLITTER + "=" + s.splitterClazz,
+      SimpleFeatureTypes.TABLE_SPLITTER_OPTIONS + "=" + singleQuote(encodeMap(s.options, SepPart, SepEntry))
+    ).mkString(",")
+  }
+
+  private def singleQuote(s: String) = "'" + s + "'"
+
+  // public accessors
+  /** Get the type spec string associated with this builder...doesn't include dtg info */
+  override def getSpec = {
+    val entryLst = List(entries.mkString(SepEntry))
+    val options = List(splitPart, enabledIndexesPart).flatten
+    (entryLst ++ options).mkString(";")
+  }
+
+  private def enabledIndexesPart = enabledIndexesOpt.map { s =>
+    SimpleFeatureTypes.ENABLED_INDEXES + "=" + singleQuote(s.indexes.mkString(","))
+  }
+}
+
+
+
+

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilder.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilder.scala
@@ -35,7 +35,3 @@ class AccumuloSftBuilder extends InitBuilder[AccumuloSftBuilder] {
 
   override def options = super.options ++ List(splitPart).flatten
 }
-
-
-
-

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilder.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilder.scala
@@ -10,17 +10,17 @@ package org.locationtech.geomesa.accumulo.util
 import org.locationtech.geomesa.accumulo.data.TableSplitter
 import org.locationtech.geomesa.utils.geotools.SftBuilder._
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.Splitter
-import org.locationtech.geomesa.utils.geotools.{SftBuilder, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.geotools.{InitBuilder, SimpleFeatureTypes}
 
-class AccumuloSftBuilder extends SftBuilder {
+class AccumuloSftBuilder extends InitBuilder[AccumuloSftBuilder] {
   private var splitterOpt: Option[Splitter] = None
 
-  def recordSplitter(clazz: String, splitOptions: Map[String,String]) = {
+  def recordSplitter(clazz: String, splitOptions: Map[String,String]): AccumuloSftBuilder = {
     this.splitterOpt = Some(Splitter(clazz, splitOptions))
     this
   }
 
-  def recordSplitter(clazz: Class[_ <: TableSplitter], splitOptions: Map[String,String]): SftBuilder = {
+  def recordSplitter(clazz: Class[_ <: TableSplitter], splitOptions: Map[String,String]): AccumuloSftBuilder = {
     recordSplitter(clazz.getName, splitOptions)
     this
   }
@@ -28,7 +28,7 @@ class AccumuloSftBuilder extends SftBuilder {
   // note that SimpleFeatureTypes requires that splitter and splitter opts be ordered properly
   private def splitPart = splitterOpt.map { s =>
     List(
-      s"${SimpleFeatureTypes.TABLE_SPLITTER}=s${s.splitterClazz}",
+      s"${SimpleFeatureTypes.TABLE_SPLITTER}=${s.splitterClazz}",
       s"${SimpleFeatureTypes.TABLE_SPLITTER_OPTIONS}='${encodeMap(s.options, SepPart, SepEntry)}'"
     ).mkString(",")
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilder.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilder.scala
@@ -28,24 +28,12 @@ class AccumuloSftBuilder extends SftBuilder {
   // note that SimpleFeatureTypes requires that splitter and splitter opts be ordered properly
   private def splitPart = splitterOpt.map { s =>
     List(
-      SimpleFeatureTypes.TABLE_SPLITTER + "=" + s.splitterClazz,
-      SimpleFeatureTypes.TABLE_SPLITTER_OPTIONS + "=" + singleQuote(encodeMap(s.options, SepPart, SepEntry))
+      s"${SimpleFeatureTypes.TABLE_SPLITTER}=s${s.splitterClazz}",
+      s"${SimpleFeatureTypes.TABLE_SPLITTER_OPTIONS}='${encodeMap(s.options, SepPart, SepEntry)}'"
     ).mkString(",")
   }
 
-  private def singleQuote(s: String) = "'" + s + "'"
-
-  // public accessors
-  /** Get the type spec string associated with this builder...doesn't include dtg info */
-  override def getSpec = {
-    val entryLst = List(entries.mkString(SepEntry))
-    val options = List(splitPart, enabledIndexesPart).flatten
-    (entryLst ++ options).mkString(";")
-  }
-
-  private def enabledIndexesPart = enabledIndexesOpt.map { s =>
-    SimpleFeatureTypes.ENABLED_INDEXES + "=" + singleQuote(s.indexes.mkString(","))
-  }
+  override def options = super.options ++ List(splitPart).flatten
 }
 
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/HighCardinalityAttributeOrQueryTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/HighCardinalityAttributeOrQueryTest.scala
@@ -13,10 +13,10 @@ import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.TestWithDataStore
 import org.locationtech.geomesa.accumulo.data.tables.AvailableTables
-import org.locationtech.geomesa.accumulo.util.SftBuilder
-import org.locationtech.geomesa.accumulo.util.SftBuilder.Opts
 import org.locationtech.geomesa.features.avro.AvroSimpleFeatureFactory
 import org.locationtech.geomesa.utils.geotools.Conversions._
+import org.locationtech.geomesa.utils.geotools.SftBuilder
+import org.locationtech.geomesa.utils.geotools.SftBuilder.Opts
 import org.locationtech.geomesa.utils.stats.Cardinality
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.specs2.mutable.Specification

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/ConfigurableIndexesTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/ConfigurableIndexesTest.scala
@@ -13,7 +13,7 @@ import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.data.tables.AvailableTables
 import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
-import org.locationtech.geomesa.accumulo.util.SftBuilder
+import org.locationtech.geomesa.utils.geotools.SftBuilder
 import org.opengis.filter.Filter
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryFilterSplitterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryFilterSplitterTest.scala
@@ -14,10 +14,9 @@ import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.data.tables.AvailableTables
 import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
-import org.locationtech.geomesa.accumulo.util.SftBuilder
-import org.locationtech.geomesa.accumulo.util.SftBuilder.Opts
 import org.locationtech.geomesa.filter
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.SftBuilder.Opts
+import org.locationtech.geomesa.utils.geotools.{SftBuilder, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.stats.Cardinality
 import org.opengis.filter._
 import org.specs2.matcher.MatchResult

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryStrategyDeciderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryStrategyDeciderTest.scala
@@ -15,11 +15,10 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.CURRENT_SCHEMA_VERSION
 import org.locationtech.geomesa.accumulo.filter.TestFilters._
 import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
-import org.locationtech.geomesa.accumulo.util.SftBuilder
-import org.locationtech.geomesa.accumulo.util.SftBuilder.Opts
-import org.locationtech.geomesa.filter.visitor.{LocalNameVisitorImpl, LocalNameVisitor}
+import org.locationtech.geomesa.filter.visitor.LocalNameVisitorImpl
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.SftBuilder.Opts
+import org.locationtech.geomesa.utils.geotools.{SftBuilder, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.stats.Cardinality
 import org.opengis.filter.{And, Filter}
 import org.specs2.mutable.Specification

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilderTest.scala
@@ -24,9 +24,9 @@ class AccumuloSftBuilderTest extends Specification {
   "SpecBuilder" >> {
     "configure table splitters as strings" >> {
       val sft1 = new AccumuloSftBuilder()
-        .recordSplitter(classOf[DigitSplitter].getName, Map("fmt" ->"%02d", "min" -> "0", "max" -> "99"))
         .intType("i")
         .longType("l")
+        .recordSplitter(classOf[DigitSplitter].getName, Map("fmt" ->"%02d", "min" -> "0", "max" -> "99"))
         .build("test")
 
       // better - uses class directly (or at least less annoying)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilderTest.scala
@@ -1,0 +1,54 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+package org.locationtech.geomesa.accumulo.util
+
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.accumulo.data.DigitSplitter
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.feature.simple.SimpleFeatureType
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class AccumuloSftBuilderTest extends Specification {
+
+  sequential
+
+  "SpecBuilder" >> {
+    "configure table splitters as strings" >> {
+      val sft1 = new AccumuloSftBuilder()
+        .recordSplitter(classOf[DigitSplitter].getName, Map("fmt" ->"%02d", "min" -> "0", "max" -> "99"))
+        .intType("i")
+        .longType("l")
+        .build("test")
+
+      // better - uses class directly (or at least less annoying)
+      val sft2 = new AccumuloSftBuilder()
+        .recordSplitter(classOf[DigitSplitter], Map("fmt" ->"%02d", "min" -> "0", "max" -> "99"))
+        .intType("i")
+        .longType("l")
+        .build("test")
+
+      def test(sft: SimpleFeatureType) = {
+        sft.getAttributeCount mustEqual 2
+        sft.getAttributeDescriptors.map(_.getLocalName) must containAllOf(List("i", "l"))
+
+        sft.getUserData.get(SimpleFeatureTypes.TABLE_SPLITTER) must be equalTo classOf[DigitSplitter].getName
+        val opts = sft.getUserData.get(SimpleFeatureTypes.TABLE_SPLITTER_OPTIONS).asInstanceOf[Map[String, String]]
+        opts.size must be equalTo 3
+        opts("fmt") must be equalTo "%02d"
+        opts("min") must be equalTo "0"
+        opts("max") must be equalTo "99"
+      }
+
+      List(sft1, sft2) forall test
+    }
+  }
+}

--- a/geomesa-process/src/main/scala/org/locationtech/geomesa/process/Point2PointProcess.scala
+++ b/geomesa-process/src/main/scala/org/locationtech/geomesa/process/Point2PointProcess.scala
@@ -19,9 +19,7 @@ import org.geotools.process.vector.VectorProcess
 import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.joda.time.DateTime
 import org.joda.time.DateTime.Property
-import org.locationtech.geomesa.accumulo.util.SftBuilder
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
-import org.opengis.feature.`type`.GeometryType
+import org.locationtech.geomesa.utils.geotools.SftBuilder
 import org.opengis.feature.simple.SimpleFeature
 
 @DescribeProcess(title = "Point2PointProcess", description = "Aggregates a collection of points into a collection of line segments")
@@ -55,8 +53,6 @@ class Point2PointProcess extends VectorProcess {
                ): SimpleFeatureCollection = {
 
     import org.locationtech.geomesa.utils.geotools.Conversions._
-
-    import scala.collection.JavaConversions._
 
     val queryType = data.getSchema
     val sftBuilder = new SimpleFeatureTypeBuilder()

--- a/geomesa-process/src/test/scala/org/locationtech/geomesa/process/Point2PointProcessTest.scala
+++ b/geomesa-process/src/test/scala/org/locationtech/geomesa/process/Point2PointProcessTest.scala
@@ -17,8 +17,8 @@ import org.geotools.feature.DefaultFeatureCollection
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloFeatureStore}
-import org.locationtech.geomesa.accumulo.util.SftBuilder
 import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.utils.geotools.SftBuilder
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner

--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/ScaldingDelimitedIngestJobTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/ScaldingDelimitedIngestJobTest.scala
@@ -18,12 +18,11 @@ import org.joda.time.{DateTime, DateTimeZone}
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStoreFactory.params
-import org.locationtech.geomesa.accumulo.util.SftBuilder
 import org.locationtech.geomesa.features.avro.AvroSimpleFeature
 import org.locationtech.geomesa.tools.Utils.IngestParams
 import org.locationtech.geomesa.tools.ingest.{ColsParser, ScaldingDelimitedIngestJob}
 import org.locationtech.geomesa.utils.geotools.Conversions._
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.{SftBuilder, SimpleFeatureTypes}
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SftBuilder.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SftBuilder.scala
@@ -17,8 +17,7 @@ import org.locationtech.geomesa.utils.stats.Cardinality.Cardinality
 import scala.collection.mutable.ListBuffer
 import scala.reflect.runtime.universe.{Type => UType, _}
 
-
-abstract class InitBuilder[T <: InitBuilder[T]] {
+abstract class InitBuilder[T] {
   import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
   val entries = new ListBuffer[String]

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SftBuilder.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SftBuilder.scala
@@ -148,19 +148,18 @@ class SftBuilder {
     case _ => Seq.empty
   }
 
-  private def singleQuote(s: String) = "'" + s + "'"
-
   private def enabledIndexesPart = enabledIndexesOpt.map { s =>
-    SimpleFeatureTypes.ENABLED_INDEXES + "=" + singleQuote(s.indexes.mkString(","))
+    s"${SimpleFeatureTypes.ENABLED_INDEXES}='${s.indexes.mkString(",")}'"
   }
 
   // public accessors
   /** Get the type spec string associated with this builder...doesn't include dtg info */
   def getSpec = {
     val entryLst = List(entries.mkString(SepEntry))
-    val options = List(enabledIndexesPart).flatten
     (entryLst ++ options).mkString(";")
   }
+
+  def options = List(enabledIndexesPart).flatten
 
   /** builds a SimpleFeatureType object from this builder */
   def build(nameSpec: String) = {

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SftBuilder.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SftBuilder.scala
@@ -125,7 +125,7 @@ abstract class InitBuilder[T <: InitBuilder[T]] {
       case t if tt == typeOf[UUID]          => "UUID"
     }
 
- .  private def append(name: String, opts: Opts, typeStr: String) = {
+  private def append(name: String, opts: Opts, typeStr: String) = {
     val parts = List(name, typeStr) ++ indexPart(opts.index) ++ stIndexPart(opts.stIndex) ++
         cardinalityPart(opts.cardinality)
     entries += parts.mkString(SepPart)

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/SftBuilderTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/SftBuilderTest.scala
@@ -1,29 +1,25 @@
 /***********************************************************************
-* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License, Version 2.0 which
-* accompanies this distribution and is available at
-* http://www.opensource.org/licenses/apache2.0.php.
-*************************************************************************/
-package org.locationtech.geomesa.accumulo.util
+  * Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Apache License, Version 2.0 which
+  * accompanies this distribution and is available at
+  * http://www.opensource.org/licenses/apache2.0.php.
+  *************************************************************************/
+package org.locationtech.geomesa.utils.geotools
 
 import java.util.{Date, UUID}
 
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.accumulo.data.DigitSplitter
-import org.locationtech.geomesa.accumulo.index._
-import org.locationtech.geomesa.accumulo.util.SftBuilder.Opts
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.SftBuilder.Opts
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes._
-import org.opengis.feature.simple.SimpleFeatureType
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
 import scala.collection.JavaConversions._
 
 @RunWith(classOf[JUnitRunner])
 class SftBuilderTest extends Specification {
+  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
   sequential
 
@@ -50,35 +46,6 @@ class SftBuilderTest extends Specification {
         .getSpec
       val expected = "i:Integer,l:Long,f:Float,d:Double,s:String,dt:Date,u:UUID".split(",").map(_+":index=true").mkString(",")
       spec mustEqual expected
-    }
-
-    "configure table splitters as strings" >> {
-      val sft1 = new SftBuilder()
-        .intType("i")
-        .longType("l")
-        .recordSplitter(classOf[DigitSplitter].getName, Map("fmt" ->"%02d", "min" -> "0", "max" -> "99"))
-        .build("test")
-
-      // better - uses class directly (or at least less annoying)
-      val sft2 = new SftBuilder()
-        .intType("i")
-        .longType("l")
-        .recordSplitter(classOf[DigitSplitter], Map("fmt" ->"%02d", "min" -> "0", "max" -> "99"))
-        .build("test")
-
-      def test(sft: SimpleFeatureType) = {
-        sft.getAttributeCount mustEqual 2
-        sft.getAttributeDescriptors.map(_.getLocalName) must containAllOf(List("i", "l"))
-
-        sft.getUserData.get(SimpleFeatureTypes.TABLE_SPLITTER) must be equalTo classOf[DigitSplitter].getName
-        val opts = sft.getUserData.get(SimpleFeatureTypes.TABLE_SPLITTER_OPTIONS).asInstanceOf[Map[String, String]]
-        opts.size must be equalTo 3
-        opts("fmt") must be equalTo "%02d"
-        opts("min") must be equalTo "0"
-        opts("max") must be equalTo "99"
-      }
-
-      List(sft1, sft2) forall test
     }
 
     // Example of fold...also can do more complex things like zipping to automatically build SFTs

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/SftBuilderTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/SftBuilderTest.scala
@@ -1,10 +1,10 @@
 /***********************************************************************
-  * Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
-  * All rights reserved. This program and the accompanying materials
-  * are made available under the terms of the Apache License, Version 2.0 which
-  * accompanies this distribution and is available at
-  * http://www.opensource.org/licenses/apache2.0.php.
-  *************************************************************************/
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 package org.locationtech.geomesa.utils.geotools
 
 import java.util.{Date, UUID}


### PR DESCRIPTION
Moved SftBuilder to utils and made AccumuloSftBuilder, which extends SftBuilder, to get access to splitter information. Refactored classes using SftBuilder to import the correct class.

Signed-off-by: Jake Kenneally <jdk2pq@ccri.com>