### PR TITLE
GEOMESA-987,GEOMESA-988 - Adding user name to query stats; adding rest api for retrieving query stats

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -16,7 +16,6 @@ import java.util.concurrent.TimeUnit
 import com.typesafe.scalalogging.slf4j.Logging
 import org.apache.accumulo.core.client._
 import org.apache.accumulo.core.client.mock.MockConnector
-import org.apache.accumulo.core.client.security.tokens.AuthenticationToken
 import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreMutex
 import org.apache.curator.retry.ExponentialBackoffRetry
@@ -32,12 +31,12 @@ import org.locationtech.geomesa.accumulo.data.AccumuloDataStore._
 import org.locationtech.geomesa.accumulo.data.tables._
 import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType.StrategyType
 import org.locationtech.geomesa.accumulo.index._
-import org.locationtech.geomesa.accumulo.stats.{StatWriter, QueryStat, Stat}
+import org.locationtech.geomesa.accumulo.stats.{QueryStat, Stat, StatWriter}
 import org.locationtech.geomesa.accumulo.util.GeoMesaBatchWriterConfig
 import org.locationtech.geomesa.accumulo.{AccumuloVersion, GeomesaSystemProperties}
 import org.locationtech.geomesa.features.SerializationType.SerializationType
 import org.locationtech.geomesa.features.{SerializationType, SimpleFeatureSerializers}
-import org.locationtech.geomesa.security.AuthorizationsProvider
+import org.locationtech.geomesa.security.{AuditProvider, AuthorizationsProvider}
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.{FeatureSpec, NonGeomAttributeSpec}
@@ -64,34 +63,18 @@ import scala.util.{Failure, Success, Try}
  *  contain multiple features addressed by their featureName.
  */
 class AccumuloDataStore(val connector: Connector,
-                        val authToken: AuthenticationToken,
                         val catalogTable: String,
                         val authorizationsProvider: AuthorizationsProvider,
+                        val auditProvider: AuditProvider,
                         val writeVisibilities: String,
-                        val queryTimeoutConfig: Option[Long] = None,
-                        val queryThreadsConfig: Option[Int] = None,
-                        val recordThreadsConfig: Option[Int] = None,
-                        val writeThreadsConfig: Option[Int] = None,
-                        val cachingConfig: Boolean = false)
+                        val config: AccumuloDataStoreConfig)
     extends AbstractDataStore(true) with AccumuloConnectorCreator with StrategyHintsProvider with Logging {
 
   // having at least as many shards as tservers provides optimal parallelism in queries
   val DEFAULT_MAX_SHARD = connector.instanceOperations().getTabletServers.size()
 
-  protected[data] val queryTimeoutMillis: Option[Long] = queryTimeoutConfig
+  protected[data] val queryTimeoutMillis: Option[Long] = config.queryTimeout
       .orElse(GeomesaSystemProperties.QueryProperties.QUERY_TIMEOUT_MILLIS.option.map(_.toLong))
-
-  // record scans are single-row ranges - increasing the threads too much actually causes performance to decrease
-  private val recordScanThreads = recordThreadsConfig.getOrElse(10)
-
-  private val writeThreads = writeThreadsConfig.getOrElse(10)
-
-  // cap on the number of threads for any one query
-  // if we let threads get too high, performance will suffer for simultaneous clients
-  private val MAX_QUERY_THREADS = 15
-
-  // floor on the number of query threads, even if the number of shards is 1
-  private val MIN_QUERY_THREADS = 5
 
   // equivalent to: s"%~#s%$maxShard#r%${name}#cstr%0,3#gh%yyyyMMddHH#d::%~#s%3,2#gh::%~#s%#id"
   def buildDefaultSpatioTemporalSchema(name: String, maxShard: Int = DEFAULT_MAX_SHARD): String =
@@ -118,8 +101,7 @@ class AccumuloDataStore(val connector: Connector,
   private val visibilityCheckCache = new mutable.HashMap[(String, String), Boolean]()
                                          with mutable.SynchronizedMap[(String, String), Boolean]
 
-  private val defaultBWConfig =
-    GeoMesaBatchWriterConfig().setMaxWriteThreads(writeThreads)
+  private val defaultBWConfig = GeoMesaBatchWriterConfig().setMaxWriteThreads(config.writeThreads)
 
   private val tableOps = connector.tableOperations()
 
@@ -218,7 +200,7 @@ class AccumuloDataStore(val connector: Connector,
    */
   def getStatTable(stat: Stat): String = {
     stat match {
-      case QueryStat(featureName, _, _, _, _, _, _) => getQueriesTableName(featureName)
+      case qs: QueryStat => getQueriesTableName(qs.typeName)
       case _ => throw new NotImplementedError()
     }
   }
@@ -356,16 +338,13 @@ class AccumuloDataStore(val connector: Connector,
 
   private def deleteSharedTables(sft: SimpleFeatureType) = {
     val auths = authorizationsProvider.getAuthorizations
-    val numThreads = queryThreadsConfig.getOrElse(Math.min(MAX_QUERY_THREADS,
-      Math.max(MIN_QUERY_THREADS, getSpatioTemporalMaxShard(sft))))
-
     GeoMesaTable.getTables(sft).par.foreach { table =>
       val name = getTableName(sft.getTypeName, table)
       if (tableOps.exists(name)) {
         if (table == Z3Table) {
           tableOps.delete(name)
         } else {
-          val deleter = connector.createBatchDeleter(name, auths, numThreads, defaultBWConfig)
+          val deleter = connector.createBatchDeleter(name, auths, config.queryThreads, defaultBWConfig)
           table.deleteFeaturesForType(sft, deleter)
           deleter.close()
         }
@@ -507,7 +486,7 @@ class AccumuloDataStore(val connector: Connector,
   // a featureStore
   override def getFeatureSource(typeName: Name): SimpleFeatureSource = {
     validateMetadata(typeName.getLocalPart)
-    if (cachingConfig) {
+    if (config.caching) {
       new AccumuloFeatureStore(this, typeName) with CachingFeatureSource
     } else {
       new AccumuloFeatureStore(this, typeName)
@@ -704,7 +683,7 @@ class AccumuloDataStore(val connector: Connector,
   // This override is important as it allows us to optimize and plan our search with the Query.
   override def getFeatureReader(featureName: String, query: Query): AccumuloFeatureReader = {
     val sw = Some(this).collect { case w: StatWriter => w }
-    AccumuloFeatureReader(query, getQueryPlanner(featureName), queryTimeoutMillis, sw)
+    AccumuloFeatureReader(query, getQueryPlanner(featureName), queryTimeoutMillis, sw, auditProvider)
   }
 
   // override the abstract data store method - we already handle all projections, transformations, etc
@@ -792,15 +771,11 @@ class AccumuloDataStore(val connector: Connector,
 
   override def getSuggestedThreads(featureName: String, table: GeoMesaTable): Int = {
     table match {
-      case RecordTable         => recordScanThreads
-      case Z3Table             => queryThreadsConfig.getOrElse(8)
-      case AttributeTable      => queryThreadsConfig.getOrElse(8)
+      case RecordTable         => config.recordThreads
+      case Z3Table             => config.queryThreads
+      case AttributeTable      => config.queryThreads
       case AttributeTableV5    => 1
-      case SpatioTemporalTable =>
-        queryThreadsConfig.getOrElse {
-          val shards = getSpatioTemporalMaxShard(getSchema(featureName))
-          Math.min(MAX_QUERY_THREADS, Math.max(MIN_QUERY_THREADS, shards))
-        }
+      case SpatioTemporalTable => config.queryThreads
       case _ => throw new NotImplementedError("Unknown table")
     }
   }
@@ -861,3 +836,9 @@ object AccumuloDataStore {
     GeoMesaTable.concatenateNameParts(catalogTable, "queries")
 }
 
+// record scans are single-row ranges - increasing the threads too much actually causes performance to decrease
+case class AccumuloDataStoreConfig(queryTimeout: Option[Long],
+                                   queryThreads: Int,
+                                   recordThreads: Int,
+                                   writeThreads: Int,
+                                   caching: Boolean)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -32,6 +32,7 @@ import org.locationtech.geomesa.accumulo.data.AccumuloDataStore._
 import org.locationtech.geomesa.accumulo.data.tables._
 import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType.StrategyType
 import org.locationtech.geomesa.accumulo.index._
+import org.locationtech.geomesa.accumulo.stats.{StatWriter, QueryStat, Stat}
 import org.locationtech.geomesa.accumulo.util.GeoMesaBatchWriterConfig
 import org.locationtech.geomesa.accumulo.{AccumuloVersion, GeomesaSystemProperties}
 import org.locationtech.geomesa.features.SerializationType.SerializationType
@@ -210,6 +211,16 @@ class AccumuloDataStore(val connector: Connector,
     val sft = getSchema(featureName)
     val table = getTableName(featureName, AttributeTable)
     AttributeTable.configureTable(sft, table, tableOps)
+  }
+
+  /**
+   * Implements method from StatWriter
+   */
+  def getStatTable(stat: Stat): String = {
+    stat match {
+      case QueryStat(featureName, _, _, _, _, _, _) => getQueriesTableName(featureName)
+      case _ => throw new NotImplementedError()
+    }
   }
 
   /**
@@ -678,7 +689,7 @@ class AccumuloDataStore(val connector: Connector,
         sft.setTableSharingPrefix("")
       }
 
-      metadata.read(featureName, TABLES_ENABLED_KEY).map { enabledTablesStr =>
+      metadata.read(featureName, TABLES_ENABLED_KEY).foreach { enabledTablesStr =>
         sft.setEnabledTables(enabledTablesStr)
       }
 
@@ -692,8 +703,8 @@ class AccumuloDataStore(val connector: Connector,
 
   // This override is important as it allows us to optimize and plan our search with the Query.
   override def getFeatureReader(featureName: String, query: Query): AccumuloFeatureReader = {
-    val qp = getQueryPlanner(featureName, this)
-    new AccumuloFeatureReader(qp, query, this)
+    val sw = Some(this).collect { case w: StatWriter => w }
+    AccumuloFeatureReader(query, getQueryPlanner(featureName), queryTimeoutMillis, sw)
   }
 
   // override the abstract data store method - we already handle all projections, transformations, etc
@@ -724,18 +735,18 @@ class AccumuloDataStore(val connector: Connector,
                         query: Query,
                         strategy: Option[StrategyType],
                         o: ExplainerOutputType): Seq[QueryPlan] =
-    getQueryPlanner(featureName, this).planQuery(query, None, o)
+    getQueryPlanner(featureName).planQuery(query, None, o)
 
   /**
    * Gets a query planner. Also has side-effect of setting transforms in the query.
    */
-  private def getQueryPlanner(featureName: String, cc: AccumuloConnectorCreator): QueryPlanner = {
+  protected[data] def getQueryPlanner(featureName: String): QueryPlanner = {
     validateMetadata(featureName)
     val sft = getSchema(featureName)
     val indexSchemaFmt = getIndexSchemaFmt(featureName)
     val featureEncoding = getFeatureEncoding(sft)
     val hints = strategyHints(sft)
-    new QueryPlanner(sft, featureEncoding, indexSchemaFmt, cc, hints)
+    new QueryPlanner(sft, featureEncoding, indexSchemaFmt, this, hints)
   }
 
   /* create a general purpose writer that is capable of insert, deletes, and updates */

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureReader.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureReader.scala
@@ -12,45 +12,112 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import org.geotools.data.{FeatureReader, Query}
 import org.locationtech.geomesa.accumulo.index.QueryHints.RichHints
+import org.locationtech.geomesa.accumulo.index.QueryPlanner.SFIter
 import org.locationtech.geomesa.accumulo.index._
 import org.locationtech.geomesa.accumulo.stats._
 import org.locationtech.geomesa.filter.filterToString
-import org.locationtech.geomesa.utils.stats.{MethodProfiling, NoOpTimings, TimingsImpl}
+import org.locationtech.geomesa.utils.stats.{Timings, MethodProfiling, TimingsImpl}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
-class AccumuloFeatureReader(queryPlanner: QueryPlanner, val query: Query, dataStore: AccumuloDataStore)
-    extends FeatureReader[SimpleFeatureType, SimpleFeature] with MethodProfiling {
+trait AccumuloFeatureReader extends FeatureReader[SimpleFeatureType, SimpleFeature] {
 
-  private val start = System.currentTimeMillis()
   private val closed = new AtomicBoolean(false)
+  private lazy val start = System.currentTimeMillis()
 
-  dataStore.queryTimeoutMillis.foreach(timeout => ThreadManagement.register(this, start, timeout))
+  timeout.foreach(t => ThreadManagement.register(this, start, t))
 
-  private val writeStats = dataStore.isInstanceOf[StatWriter]
-  implicit val timings = if (writeStats) new TimingsImpl else NoOpTimings
+  def query: Query
+  def timeout: Option[Long]
+  def isClosed: Boolean = closed.get()
 
-  private val iter = profile(queryPlanner.runQuery(query), "planning")
-
-  override def next() = profile(iter.next(), "next")
-
-  override def hasNext = profile(iter.hasNext, "hasNext")
-
-  override def close() = if (!closed.getAndSet(true)) {
-    iter.close()
-    dataStore.queryTimeoutMillis.foreach(timeout => ThreadManagement.unregister(this, start, timeout))
-    if (writeStats) {
-      val stat = QueryStat(queryPlanner.sft.getTypeName,
-          System.currentTimeMillis(),
-          filterToString(query.getFilter),
-          QueryStatTransform.hintsToString(query.getHints),
-          timings.time("planning"),
-          timings.time("next") + timings.time("hasNext"),
-          timings.occurrences("next").toInt)
-      dataStore.asInstanceOf[StatWriter].writeStat(stat, dataStore.getQueriesTableName(queryPlanner.sft))
-    }
-  }
+  protected def closeOnce(): Unit
 
   override def getFeatureType = query.getHints.getReturnSft
 
-  def isClosed: Boolean = closed.get()
+  override def close() = if (!closed.getAndSet(true)) {
+    timeout.foreach(t => ThreadManagement.unregister(this, start, t))
+    closeOnce()
+  }
+}
+
+object AccumuloFeatureReader extends MethodProfiling {
+  def apply(query: Query, qp: QueryPlanner, timeout: Option[Long], writer: Option[StatWriter]) = {
+    writer match {
+      case None => new AccumuloFeatureReaderImpl(query, qp, timeout)
+      case Some(sw) => new AccumuloFeatureReaderWithStats(query, qp, timeout, sw)
+    }
+  }
+}
+
+class AccumuloFeatureReaderImpl(val query: Query, qp: QueryPlanner, val timeout: Option[Long])
+    extends AccumuloFeatureReader {
+
+  private val iter = qp.runQuery(query)
+
+  override def next(): SimpleFeature = iter.next()
+  override def hasNext: Boolean = iter.hasNext
+  override protected def closeOnce(): Unit = iter.close()
+}
+
+class AccumuloFeatureReaderWithStats(val query: Query,
+                                     qp: QueryPlanner,
+                                     val timeout: Option[Long],
+                                     sw: StatWriter)
+    extends AccumuloFeatureReader with MethodProfiling {
+
+  implicit val timings = new TimingsImpl
+  private val iter = profile(qp.runQuery(query), "planning")
+
+  // because the query planner configures the query hints, we can't check for bin hints
+  // until after setting up the iterator
+  private val delegate = if (query.getHints.isBinQuery) {
+    new AccumuloFeatureReaderBinDelegate(iter, query, qp)
+  } else {
+    new AccumuloFeatureReaderDelegate(iter, query, qp)
+  }
+
+  override def next(): SimpleFeature = delegate.next()
+  override def hasNext: Boolean = delegate.hasNext
+
+  override protected def closeOnce(): Unit = {
+    delegate.close()
+    val count = delegate.getCount
+    val stat = QueryStat(qp.sft.getTypeName,
+      System.currentTimeMillis(),
+      filterToString(query.getFilter),
+      QueryStatTransform.hintsToString(query.getHints),
+      timings.time("planning"),
+      timings.time("next") + timings.time("hasNext"),
+      count
+    )
+    sw.writeStat(stat)
+  }
+}
+
+private class AccumuloFeatureReaderDelegate(iter: SFIter, query: Query, qp: QueryPlanner)(implicit timings: Timings)
+    extends FeatureReader[SimpleFeatureType, SimpleFeature] with MethodProfiling {
+
+  override def getFeatureType: SimpleFeatureType = query.getHints.getReturnSft
+  override def next(): SimpleFeature = profile(iter.next(), "next")
+  override def hasNext: Boolean = profile(iter.hasNext, "hasNext")
+  override def close(): Unit = iter.close()
+
+  def getCount: Int = timings.occurrences("next").toInt
+}
+
+private class AccumuloFeatureReaderBinDelegate(iter: SFIter, query: Query, qp: QueryPlanner)(implicit timings: Timings)
+    extends AccumuloFeatureReaderDelegate(iter, query, qp)(timings) {
+
+  import org.locationtech.geomesa.accumulo.iterators.BinAggregatingIterator.BIN_ATTRIBUTE_INDEX
+
+  private var count = 0
+  private val bytesPerHit = if (query.getHints.getBinLabelField.isDefined) 24 else 16
+
+  override def next(): SimpleFeature = {
+    val sf = super.next()
+    count += (sf.getAttribute(BIN_ATTRIBUTE_INDEX).asInstanceOf[Array[Byte]].length / bytesPerHit)
+    sf
+  }
+
+  override def getCount: Int = count
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/stats/ParamsAuditProvider.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/stats/ParamsAuditProvider.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0 which
+ * accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ */
+
+package org.locationtech.geomesa.accumulo.stats
+
+import java.io.Serializable
+import java.util.{Map => jMap}
+
+import org.apache.accumulo.core.client.Connector
+import org.locationtech.geomesa.accumulo.data.AccumuloDataStoreFactory
+import org.locationtech.geomesa.security.AuditProvider
+
+import scala.collection.JavaConversions._
+
+class ParamsAuditProvider extends AuditProvider {
+
+  private var id = "unknown"
+
+  override def getCurrentUserId: String = id
+
+  override val getCurrentUserDetails: jMap[AnyRef, AnyRef] = Map.empty[AnyRef, AnyRef]
+
+  override def configure(params: jMap[String, Serializable]): Unit = {
+    import AccumuloDataStoreFactory.params._
+    val user = if (params.containsKey(connParam.key)) {
+      connParam.lookUp(params).asInstanceOf[Connector].whoami()
+    } else if (params.containsKey(userParam)) {
+      userParam.lookUp(params).asInstanceOf[String]
+    } else {
+      null
+    }
+    if (user != null) {
+      id = s"accumulo[$user]"
+    }
+  }
+
+}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/stats/RasterQueryStat.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/stats/RasterQueryStat.scala
@@ -17,7 +17,7 @@ import org.calrissian.mango.types.encoders.lexi.LongReverseEncoder
 /**
  * Class for capturing query-related stats
  */
-case class RasterQueryStat(featureName:   String,
+case class RasterQueryStat(typeName:   String,
                            date:          Long,
                            rasterQuery:   String,
                            planningTime:  Long,
@@ -40,7 +40,7 @@ object RasterQueryStatTransform extends StatTransform[RasterQueryStat] {
   val NUMBER_OF_CQ_DATA_TYPES = 6
 
   override def createMutation(stat: Stat) = {
-    new Mutation(s"${stat.featureName}~${reverseEncoder.encode(stat.date)}")
+    new Mutation(s"${stat.typeName}~${reverseEncoder.encode(stat.date)}")
   }
 
   override def statToMutation(stat: RasterQueryStat): Mutation = {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/stats/Stat.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/stats/Stat.scala
@@ -22,7 +22,7 @@ import scala.util.Random
  * Base trait for all stat types
  */
 trait Stat {
-  def featureName: String
+  def typeName: String
   def date: Long
 }
 
@@ -31,7 +31,7 @@ trait Stat {
  */
 trait StatTransform[S <: Stat] extends Logging {
 
-  protected def createMutation(stat: Stat) = new Mutation(s"${stat.featureName}~${StatTransform.dateFormat.print(stat.date)}")
+  protected def createMutation(stat: Stat) = new Mutation(s"${stat.typeName}~${StatTransform.dateFormat.print(stat.date)}")
 
   protected def createRandomColumnFamily = Random.nextInt(9999).formatted("%1$04d")
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/stats/StatReader.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/stats/StatReader.scala
@@ -8,11 +8,10 @@
 
 package org.locationtech.geomesa.accumulo.stats
 
-import java.util.Date
-
 import org.apache.accumulo.core.client.{Connector, Scanner}
 import org.apache.accumulo.core.data.{Range => AccRange}
 import org.apache.accumulo.core.security.Authorizations
+import org.joda.time.Interval
 
 /**
  * Abstract class for querying stats
@@ -30,17 +29,16 @@ abstract class StatReader[S <: Stat](connector: Connector, statTableForFeatureNa
    * attributes, for instance).
    *
    * @param featureName
-   * @param start
-   * @param end
+   * @param dates
    * @param authorizations
    * @return
    */
-  def query(featureName: String, start: Date, end: Date, authorizations: Authorizations): Iterator[S] = {
+  def query(featureName: String, dates: Interval, authorizations: Authorizations): Iterator[S] = {
     val table = statTableForFeatureName(featureName)
 
     val scanner = connector.createScanner(table, authorizations)
-    val rangeStart = s"$featureName~${StatTransform.dateFormat.print(start.getTime)}"
-    val rangeEnd = s"$featureName~${StatTransform.dateFormat.print(end.getTime)}"
+    val rangeStart = s"$featureName~${StatTransform.dateFormat.print(dates.getStart)}"
+    val rangeEnd = s"$featureName~${StatTransform.dateFormat.print(dates.getEnd)}"
     scanner.setRange(new AccRange(rangeStart, rangeEnd))
 
     configureScanner(scanner)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/stats/StatWriter.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/stats/StatWriter.scala
@@ -24,12 +24,17 @@ import scala.collection.JavaConversions._
 
 trait StatWriter {
 
-  def connector: Connector
-
   // start the background thread
   if (!connector.isInstanceOf[MockConnector]) {
     StatWriter.startIfNeeded()
   }
+
+  def connector: Connector
+
+  /**
+   * The table to write a stat to
+   */
+  def getStatTable(stat: Stat): String
 
   /**
    * Writes a stat to accumulo. This implementation adds the stat to a bounded queue, which should
@@ -37,8 +42,7 @@ trait StatWriter {
    *
    * @param stat
    */
-  def writeStat(stat: Stat, statTable: String): Unit =
-    StatWriter.queueStat(stat, TableInstance(connector, statTable))
+  def writeStat(stat: Stat): Unit = StatWriter.queueStat(stat, TableInstance(connector, getStatTable(stat)))
 }
 
 /**

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
@@ -349,5 +349,17 @@ class AccumuloDataStoreQueryTest extends Specification with TestWithMultipleSfts
 
       success
     }
+
+    "be able to run explainQuery" in {
+      val filter = ECQL.toFilter("INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))")
+      val query = new Query(defaultSft.getTypeName, filter)
+
+      val out = new ExplainString()
+      ds.explainQuery(query, out)
+
+      val explanation = out.toString()
+      explanation must not be null
+      explanation.trim must not beEmpty
+    }
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTest.scala
@@ -386,7 +386,7 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
         "tableName"         -> sftName,
         "useMock"           -> "true",
         "caching"           -> false,
-        "featureEncoding"   -> "avro")).asInstanceOf[AccumuloDataStore].cachingConfig must beFalse
+        "featureEncoding"   -> "avro")).asInstanceOf[AccumuloDataStore].config.caching must beFalse
 
       DataStoreFinder.getDataStore(Map(
         "instanceId"        -> "mycloud",
@@ -397,7 +397,7 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
         "tableName"         -> sftName,
         "useMock"           -> "true",
         "caching"           -> true,
-        "featureEncoding"   -> "avro")).asInstanceOf[AccumuloDataStore].cachingConfig must beTrue
+        "featureEncoding"   -> "avro")).asInstanceOf[AccumuloDataStore].config.caching must beTrue
     }
 
     "not use caching by default" in {
@@ -408,11 +408,11 @@ class AccumuloDataStoreTest extends Specification with AccumuloDataStoreDefaults
         "connector" -> connector,
         "tableName" -> sftName)
       val ds = DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
-      ds.cachingConfig must beFalse
+      ds.config.caching must beFalse
     }
 
     "not use caching by default with mocks" in {
-      ds.cachingConfig must beFalse
+      ds.config.caching must beFalse
     }
 
     "Allow extra attributes in the STIDX entries" in {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureReaderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureReaderTest.scala
@@ -9,15 +9,16 @@
 package org.locationtech.geomesa.accumulo.data
 
 import org.apache.accumulo.core.client.Connector
-import org.geotools.data.{DataUtilities, Query}
+import org.geotools.data.Query
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo._
-import org.locationtech.geomesa.accumulo.stats.{QueryStat, Stat, StatWriter}
+import org.locationtech.geomesa.accumulo.index.QueryHints
+import org.locationtech.geomesa.accumulo.stats.{ParamsAuditProvider, QueryStat, Stat, StatWriter}
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import org.locationtech.geomesa.accumulo.index.QueryHints
+
 import scala.collection.mutable.ArrayBuffer
 
 @RunWith(classOf[JUnitRunner])
@@ -49,7 +50,7 @@ class AccumuloFeatureReaderTest extends Specification with TestWithDataStore {
         override def writeStat(stat: Stat): Unit = stats.append(stat)
       }
 
-      val reader = AccumuloFeatureReader(query, qp, None, Some(sw))
+      val reader = AccumuloFeatureReader(query, qp, None, Some(sw), new ParamsAuditProvider)
 
       var count = 0
       while (reader.hasNext) { reader.next(); count += 1 }
@@ -58,7 +59,7 @@ class AccumuloFeatureReaderTest extends Specification with TestWithDataStore {
       count mustEqual 10
       stats must haveLength(1)
       stats.head must beAnInstanceOf[QueryStat]
-      stats.head.asInstanceOf[QueryStat].numResults mustEqual 10
+      stats.head.asInstanceOf[QueryStat].hits mustEqual 10
     }
 
     "be able to count bin results" in {
@@ -74,7 +75,7 @@ class AccumuloFeatureReaderTest extends Specification with TestWithDataStore {
         override def writeStat(stat: Stat): Unit = stats.append(stat)
       }
 
-      val reader = AccumuloFeatureReader(query, qp, None, Some(sw))
+      val reader = AccumuloFeatureReader(query, qp, None, Some(sw), new ParamsAuditProvider)
 
       var count = 0
       while (reader.hasNext) { reader.next(); count += 1 }
@@ -83,7 +84,7 @@ class AccumuloFeatureReaderTest extends Specification with TestWithDataStore {
       count must beLessThan(10)
       stats must haveLength(1)
       stats.head must beAnInstanceOf[QueryStat]
-      stats.head.asInstanceOf[QueryStat].numResults mustEqual 10
+      stats.head.asInstanceOf[QueryStat].hits mustEqual 10
     }
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureReaderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureReaderTest.scala
@@ -8,32 +8,82 @@
 
 package org.locationtech.geomesa.accumulo.data
 
-import org.geotools.data.Query
+import org.apache.accumulo.core.client.Connector
+import org.geotools.data.{DataUtilities, Query}
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo._
-import org.locationtech.geomesa.accumulo.index.ExplainString
+import org.locationtech.geomesa.accumulo.stats.{QueryStat, Stat, StatWriter}
+import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
+import org.locationtech.geomesa.accumulo.index.QueryHints
+import scala.collection.mutable.ArrayBuffer
 
 @RunWith(classOf[JUnitRunner])
 class AccumuloFeatureReaderTest extends Specification with TestWithDataStore {
 
-  override def spec = s"foo:String,baz:Date,dtg:Date,*geom:Geometry"
+  override def spec = s"name:String,dtg:Date,*geom:Point"
+
+  val features = (0 until 10).map { i =>
+    val sf = new ScalaSimpleFeature(i.toString, sft)
+    sf.setAttribute(0, s"name$i")
+    sf.setAttribute(1, "2010-05-07T12:00:00.000Z")
+    sf.setAttribute(2, "POINT(0 0)")
+    sf
+  }
+
+  addFeatures(features)
+
+  val filter = ECQL.toFilter("bbox(geom, -10, -10, 10, 10) and dtg during 2010-05-07T00:00:00.000Z/2010-05-08T00:00:00.000Z")
 
   "AccumuloFeatureReader" should {
+    "be able to collect stats" in {
+      val stats = ArrayBuffer.empty[Stat]
+      val query = new Query(sftName, filter)
 
-    "be able to run explainQuery" in {
-      val query = new Query(sftName)
-      val fs = "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
-      val f = ECQL.toFilter(fs)
-      query.setFilter(f)
+      val qp = ds.getQueryPlanner(sftName)
+      val sw = new StatWriter {
+        override def getStatTable(stat: Stat): String = ???
+        override def connector: Connector = ds.connector
+        override def writeStat(stat: Stat): Unit = stats.append(stat)
+      }
 
-      val out = new ExplainString()
-      ds.explainQuery(query, out)
+      val reader = AccumuloFeatureReader(query, qp, None, Some(sw))
 
-      val explanation = out.toString()
-      explanation must not be null
+      var count = 0
+      while (reader.hasNext) { reader.next(); count += 1 }
+      reader.close()
+
+      count mustEqual 10
+      stats must haveLength(1)
+      stats.head must beAnInstanceOf[QueryStat]
+      stats.head.asInstanceOf[QueryStat].numResults mustEqual 10
+    }
+
+    "be able to count bin results" in {
+      val stats = ArrayBuffer.empty[Stat]
+      val query = new Query(sftName, filter)
+      query.getHints.put(QueryHints.BIN_TRACK_KEY, "name")
+      query.getHints.put(QueryHints.BIN_BATCH_SIZE_KEY, 100)
+
+      val qp = ds.getQueryPlanner(sftName)
+      val sw = new StatWriter {
+        override def getStatTable(stat: Stat): String = ???
+        override def connector: Connector = ds.connector
+        override def writeStat(stat: Stat): Unit = stats.append(stat)
+      }
+
+      val reader = AccumuloFeatureReader(query, qp, None, Some(sw))
+
+      var count = 0
+      while (reader.hasNext) { reader.next(); count += 1 }
+      reader.close()
+
+      count must beLessThan(10)
+      stats must haveLength(1)
+      stats.head must beAnInstanceOf[QueryStat]
+      stats.head.asInstanceOf[QueryStat].numResults mustEqual 10
     }
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/stats/LiveStatReaderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/stats/LiveStatReaderTest.scala
@@ -8,11 +8,10 @@
 
 package org.locationtech.geomesa.accumulo.stats
 
-import java.util.Date
-
 import org.apache.accumulo.core.client.ZooKeeperInstance
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
 import org.apache.accumulo.core.security.Authorizations
+import org.joda.time.Interval
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -36,7 +35,7 @@ class LiveStatReaderTest extends Specification {
 
       val reader = new QueryStatReader(connector, (fName: String) => s"${table}_${fName}_queries")
 
-      val results = reader.query(feature, new Date(0), new Date(), new Authorizations())
+      val results = reader.query(feature, new Interval(0, System.currentTimeMillis()), new Authorizations())
 
       results.foreach(println)
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/stats/QueryStatTransformTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/stats/QueryStatTransformTest.scala
@@ -39,7 +39,7 @@ class QueryStatTransformTest extends Specification {
     "convert query stats to and from accumulo" in {
 
       // currently we don't restore table and feature in the query stat - thus setting them null here
-      val stat = QueryStat(featureName, 500L, "attr=1", "hint1=true", 101L, 201L, 11)
+      val stat = QueryStat(featureName, 500L, "user1", "attr=1", "hint1=true", 101L, 201L, 11)
 
       val writer = connector.createBatchWriter(table, GeoMesaBatchWriterConfig())
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/stats/StatWriterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/stats/StatWriterTest.scala
@@ -8,12 +8,11 @@
 
 package org.locationtech.geomesa.accumulo.stats
 
-import java.util.Date
-
 import org.apache.accumulo.core.client.mock.MockInstance
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
 import org.apache.accumulo.core.client.{Connector, TableNotFoundException}
 import org.apache.accumulo.core.security.Authorizations
+import org.joda.time.Interval
 import org.joda.time.format.DateTimeFormat
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
@@ -48,6 +47,7 @@ class StatWriterTest extends Specification {
 
       writer.writeStat(QueryStat(featureName,
                                  df.parseMillis("2014.07.26 13:20:01"),
+                                 "user1",
                                  "query1",
                                  "hint1=true",
                                  101L,
@@ -55,6 +55,7 @@ class StatWriterTest extends Specification {
                                  11))
       writer.writeStat(QueryStat(featureName,
                                  df.parseMillis("2014.07.26 14:20:01"),
+                                 "user1",
                                  "query2",
                                  "hint2=true",
                                  102L,
@@ -62,6 +63,7 @@ class StatWriterTest extends Specification {
                                  12))
       writer.writeStat(QueryStat(featureName,
                                  df.parseMillis("2014.07.27 13:20:01"),
+                                 "user1",
                                  "query3",
                                  "hint3=true",
                                  102L,
@@ -69,7 +71,7 @@ class StatWriterTest extends Specification {
                                  12))
 
       try {
-        val unwritten = statReader.query(featureName, new Date(0), new Date(), auths).toList
+        val unwritten = statReader.query(featureName, new Interval(0, df.parseMillis("2014.07.29 00:00:00")), auths).toList
         unwritten must not beNull;
         unwritten.size mustEqual 0
       } catch {
@@ -79,7 +81,7 @@ class StatWriterTest extends Specification {
       // this should write the queued stats
       StatWriter.run()
 
-      val written = statReader.query(featureName, new Date(0), new Date(), auths).toList
+      val written = statReader.query(featureName, new Interval(0, df.parseMillis("2014.07.29 00:00:00")), auths).toList
 
       written must not beNull;
       written.size mustEqual 3

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/stats/StatWriterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/stats/StatWriterTest.scala
@@ -35,6 +35,7 @@ class StatWriterTest extends Specification {
   // mock class we can extend with statwriter
   class MockWriter(c: Connector) {
     val connector = c
+    def getStatTable(stat: Stat) = statsTable
   }
 
   val statReader = new QueryStatReader(connector, (_: String) => statsTable)
@@ -51,24 +52,21 @@ class StatWriterTest extends Specification {
                                  "hint1=true",
                                  101L,
                                  201L,
-                                 11),
-                       statsTable)
+                                 11))
       writer.writeStat(QueryStat(featureName,
                                  df.parseMillis("2014.07.26 14:20:01"),
                                  "query2",
                                  "hint2=true",
                                  102L,
                                  202L,
-                                 12),
-                       statsTable)
+                                 12))
       writer.writeStat(QueryStat(featureName,
                                  df.parseMillis("2014.07.27 13:20:01"),
                                  "query3",
                                  "hint3=true",
                                  102L,
                                  202L,
-                                 12),
-                       statsTable)
+                                 12))
 
       try {
         val unwritten = statReader.query(featureName, new Date(0), new Date(), auths).toList

--- a/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
+++ b/geomesa-compute/src/main/scala/org/locationtech/geomesa/compute/spark/GeoMesaSpark.scala
@@ -16,6 +16,7 @@ import com.google.common.cache.{CacheBuilder, CacheLoader}
 import com.typesafe.scalalogging.slf4j.Logging
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat
 import org.apache.accumulo.core.client.mapreduce.lib.util.{ConfiguratorBase, InputConfigurator}
+import org.apache.accumulo.core.client.security.tokens.PasswordToken
 import org.apache.accumulo.core.security.Authorizations
 import org.apache.accumulo.core.util.{Pair => AccPair}
 import org.apache.hadoop.conf.Configuration
@@ -75,11 +76,13 @@ object GeoMesaSpark extends Logging {
           numberOfSplits: Option[Int] = None): RDD[SimpleFeature] = {
     val ds = DataStoreFinder.getDataStore(dsParams).asInstanceOf[AccumuloDataStore]
     val typeName = query.getTypeName
+    val username = AccumuloDataStoreFactory.params.userParam.lookUp(dsParams).toString
+    val password = new PasswordToken(AccumuloDataStoreFactory.params.passwordParam.lookUp(dsParams).toString.getBytes)
 
     // get the query plan to set up the iterators, ranges, etc
     val qp = JobUtils.getSingleQueryPlan(ds, query)
 
-    ConfiguratorBase.setConnectorInfo(classOf[AccumuloInputFormat], conf, ds.connector.whoami(), ds.authToken)
+    ConfiguratorBase.setConnectorInfo(classOf[AccumuloInputFormat], conf, username, password)
 
     if (useMock){
       ConfiguratorBase.setMockInstance(classOf[AccumuloInputFormat],

--- a/geomesa-plugin/pom.xml
+++ b/geomesa-plugin/pom.xml
@@ -209,6 +209,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>3.1.0.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.media</groupId>
             <artifactId>jai_core</artifactId>
             <scope>provided</scope>

--- a/geomesa-plugin/src/main/resources/META-INF/services/org.locationtech.geomesa.security.AuditProvider
+++ b/geomesa-plugin/src/main/resources/META-INF/services/org.locationtech.geomesa.security.AuditProvider
@@ -1,0 +1,1 @@
+org.locationtech.geomesa.plugin.security.SpringAuditProvider

--- a/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/security/SpringAuditProvider.scala
+++ b/geomesa-plugin/src/main/scala/org/locationtech/geomesa/plugin/security/SpringAuditProvider.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0 which
+ * accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ */
+
+package org.locationtech.geomesa.plugin.security
+
+import java.io.Serializable
+import java.util.{Map => jMap}
+
+import org.locationtech.geomesa.security.AuditProvider
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.UserDetails
+
+import scala.collection.JavaConverters._
+
+class SpringAuditProvider extends AuditProvider {
+
+  override def getCurrentUserId: String = {
+    val principal = getAuth.flatMap(a => Option(a.getPrincipal)).getOrElse("unknown")
+    principal match {
+      case p: UserDetails => p.getUsername
+      case p => p.toString
+    }
+  }
+
+  override def getCurrentUserDetails: jMap[AnyRef, AnyRef] = {
+    getAuth match {
+      case None => Map.empty[AnyRef, AnyRef].asJava
+      case Some(auth) =>
+        Map[AnyRef, AnyRef](
+          SpringAuditProvider.AUTHORITIES   -> auth.getAuthorities,
+          SpringAuditProvider.DETAILS       -> auth.getDetails,
+          SpringAuditProvider.CREDENTIALS   -> auth.getCredentials,
+          SpringAuditProvider.AUTHENTICATED -> auth.isAuthenticated.asInstanceOf[AnyRef]
+        ).asJava
+    }
+  }
+
+  override def configure(params: jMap[String, Serializable]): Unit = {}
+
+  private def getAuth: Option[Authentication] =
+    Option(SecurityContextHolder.getContext).flatMap(c => Option(c.getAuthentication))
+}
+
+object SpringAuditProvider {
+  val AUTHORITIES   = "authorities"
+  val DETAILS       = "details"
+  val CREDENTIALS   = "credentials"
+  val AUTHENTICATED = "authenticated"
+}

--- a/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterStore.scala
+++ b/geomesa-raster/src/main/scala/org/locationtech/geomesa/raster/data/AccumuloRasterStore.scala
@@ -23,7 +23,7 @@ import org.geotools.coverage.grid.GridEnvelope2D
 import org.joda.time.DateTime
 import org.locationtech.geomesa.accumulo.index.Strategy._
 import org.locationtech.geomesa.accumulo.iterators.BBOXCombiner._
-import org.locationtech.geomesa.accumulo.stats.{RasterQueryStat, RasterQueryStatTransform, StatWriter}
+import org.locationtech.geomesa.accumulo.stats.{Stat, RasterQueryStat, RasterQueryStatTransform, StatWriter}
 import org.locationtech.geomesa.accumulo.util.SelfClosingIterator
 import org.locationtech.geomesa.raster._
 import org.locationtech.geomesa.raster.index.RasterIndexSchema
@@ -76,7 +76,7 @@ class AccumuloRasterStore(val connector: Connector,
                                  timings.time("scanning") - timings.time("planning"),
                                  timings.time("mosaic"),
                                  numRasters)
-      this.writeStat(stat, profileTable)
+      this.writeStat(stat)
     }
     image
   }
@@ -288,6 +288,7 @@ class AccumuloRasterStore(val connector: Connector,
     }
   }
 
+  def getStatTable(stat: Stat): String = profileTable
 }
 
 object AccumuloRasterStore {

--- a/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/AccumuloRasterQueryPlannerTest.scala
+++ b/geomesa-raster/src/test/scala/org/locationtech/geomesa/raster/data/AccumuloRasterQueryPlannerTest.scala
@@ -9,6 +9,7 @@
 package org.locationtech.geomesa.raster.data
 
 import com.google.common.collect.{ImmutableMap, ImmutableSetMultimap}
+import com.typesafe.scalalogging.slf4j.Logging
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.raster.RasterTestsUtils._
 import org.locationtech.geomesa.raster._
@@ -18,7 +19,7 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class AccumuloRasterQueryPlannerTest extends Specification {
+class AccumuloRasterQueryPlannerTest extends Specification with Logging {
 
   sequential
 
@@ -53,7 +54,7 @@ class AccumuloRasterQueryPlannerTest extends Specification {
 
     val queryResolution = lexiDecodeStringToDouble(encodedDouble)
 
-    println(s"Query pixel size: $size. Expected query resolution: $expectedResolution.  " +
+    logger.debug(s"Query pixel size: $size. Expected query resolution: $expectedResolution.  " +
       s"Returned query resolution $queryResolution.")
 
     val roundedResolution = BigDecimal(expectedResolution).round(mc).toDouble

--- a/geomesa-security/src/main/java/org/locationtech/geomesa/security/AuditProvider.java
+++ b/geomesa-security/src/main/java/org/locationtech/geomesa/security/AuditProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0 which
+ * accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ */
+package org.locationtech.geomesa.security;
+
+import org.apache.accumulo.core.security.Authorizations;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * An interface to define passing audit information.
+ */
+public interface AuditProvider {
+
+    public static final String AUDIT_PROVIDER_SYS_PROPERTY = "geomesa.audit.provider.impl";
+
+    /**
+     * Gets the current user.
+     *
+     * @return
+     */
+    public String getCurrentUserId();
+
+    /**
+     * Gets user details.
+     *
+     * @return
+     */
+    public Map<Object, Object> getCurrentUserDetails();
+
+    /**
+     * Configures this instance with parameters passed into the DataStoreFinder
+     *
+     * @param params
+     */
+    public void configure(Map<String, Serializable> params);
+}

--- a/geomesa-security/src/main/scala/org/locationtech/geomesa/security/package.scala
+++ b/geomesa-security/src/main/scala/org/locationtech/geomesa/security/package.scala
@@ -69,11 +69,9 @@ package object security {
           case 1 => providers.head
           case _ =>
             throw new IllegalStateException(
-              s"""
-                 | Found multiple AuthorizationsProvider implementations. Please specify the one
-                 | to use with the system property '${AuthorizationsProvider.AUTH_PROVIDER_SYS_PROPERTY}' ::
-                                                                                                                         | ${providers.map(_.getClass.getName).mkString(", ")}
-                """.stripMargin)
+              "Found multiple AuthorizationsProvider implementations. Please specify the one to use with " +
+                  s"the system property '${AuthorizationsProvider.AUTH_PROVIDER_SYS_PROPERTY}' :: " +
+                  s"${providers.map(_.getClass.getName).mkString(", ")}")
         }
     }
 
@@ -85,5 +83,29 @@ package object security {
     authorizationsProvider.configure(modifiedParams)
 
     authorizationsProvider
+  }
+
+  def getAuditProvider(params: ju.Map[String, jio.Serializable]): Option[AuditProvider] = {
+    import scala.collection.JavaConversions._
+
+    val providers = ServiceRegistry.lookupProviders(classOf[AuditProvider]).toBuffer
+
+    // if the user specifies an auth provider to use, try to use that impl
+    val specified = Option(System.getProperty(AuditProvider.AUDIT_PROVIDER_SYS_PROPERTY)).map { prop =>
+      providers.find(_.getClass.getName == prop).getOrElse {
+        throw new RuntimeException(s"Could not load audit provider $prop")
+      }
+    }
+    val provider = specified.orElse {
+      if (providers.length > 1) {
+        throw new IllegalStateException(
+          "Found multiple AuditProvider implementations. Please specify the one to use with the system " +
+              s"property '${AuditProvider.AUDIT_PROVIDER_SYS_PROPERTY}' :: " +
+              s"${providers.map(_.getClass.getName).mkString(", ")}")
+      }
+      providers.headOption
+    }
+    provider.foreach(_.configure(params))
+    provider
   }
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/FeatureCreator.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/FeatureCreator.scala
@@ -18,7 +18,7 @@ import org.opengis.feature.simple.SimpleFeatureType
 object FeatureCreator extends Logging {
 
   def createFeature(params: CreateFeatureParams, convert: String = null): Unit = {
-    val ds = new DataStoreHelper(params).getOrCreateDs()
+    val ds = new DataStoreHelper(params).getDataStore()
     createFeature(
       ds,
       SftArgParser.getSft(params.spec, params.featureName, convert),
@@ -30,7 +30,7 @@ object FeatureCreator extends Logging {
 
 
   def createFeature(params: GeoMesaParams, sft: SimpleFeatureType): Unit =
-    new DataStoreHelper(params).getOrCreateDs().createSchema(sft)
+    new DataStoreHelper(params).getDataStore().createSchema(sft)
 
   def createFeature(ds: AccumuloDataStore,
                     sft: SimpleFeatureType,

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/Command.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/Command.scala
@@ -25,6 +25,6 @@ abstract class Command(parent: JCommander) {
  */
 abstract class CommandWithCatalog(parent: JCommander) extends Command(parent) with AccumuloProperties {
   override val params: GeoMesaParams
-  lazy val ds = new DataStoreHelper(params).getExistingStore
+  lazy val ds = new DataStoreHelper(params).getDataStore
   lazy val catalog = params.catalog
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestCommand.scala
@@ -26,7 +26,7 @@ class IngestCommand(parent: JCommander) extends Command(parent) with Logging {
   override def execute(): Unit = {
     val fmt = Option(params.format).getOrElse(getFileExtension(params.files(0)))
     if (fmt == SHP) {
-      val ds = new DataStoreHelper(params).getOrCreateDs()
+      val ds = new DataStoreHelper(params).getDataStore()
       GeneralShapefileIngest.shpToDataStore(params.files(0), ds, params.featureName)
     } else {
       new DelimitedIngest(params).run()

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/TableConfCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/TableConfCommand.scala
@@ -110,7 +110,7 @@ object TableConfCommand {
     @Parameter(names = Array("-t", "--table-suffix"), description = "Table suffix to operate on (attr_idx, st_idx, or records)", required = true)
     var tableSuffix: String = null
 
-    lazy val ds = new DataStoreHelper(this).getExistingStore
+    lazy val ds = new DataStoreHelper(this).getDataStore()
     lazy val tableName = getTableName(ds, this)
   }
 

--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/ShpIngestTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/ShpIngestTest.scala
@@ -72,7 +72,7 @@ class ShpIngestTest extends Specification {
     ingestParams.catalog = "testshpingestcatalog"
     ingestParams.useMock = true
 
-    val ds = new DataStoreHelper(ingestParams).getOrCreateDs
+    val ds = new DataStoreHelper(ingestParams).getDataStore()
 
     "should properly ingest a shapefile" >> {
       ingestParams.files.add(shpFile.getPath)

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/cache/FilePersistence.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/cache/FilePersistence.scala
@@ -38,9 +38,11 @@ class FilePersistence(dir: File, file: String) extends Logging {
   }
 
   def keys(): Set[String] = properties.keySet().toSet.asInstanceOf[Set[String]]
+  def keys(prefix: String): Set[String] = keys().filter(_.startsWith(prefix))
 
   def entries(): Set[(String, String)] =
     properties.entrySet().map(e => (e.getKey, e.getValue)).toSet.asInstanceOf[Set[(String, String)]]
+  def entries(prefix: String): Set[(String, String)] = entries().filter(_._1.startsWith(prefix))
 
   /**
    * Returns the specified property

--- a/geomesa-web/geomesa-web-core/src/main/scala/org/locationtech/geomesa/web/core/GeoMesaDataStoreServlet.scala
+++ b/geomesa-web/geomesa-web-core/src/main/scala/org/locationtech/geomesa/web/core/GeoMesaDataStoreServlet.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0 which
+ * accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ */
+
+package org.locationtech.geomesa.web.core
+
+import org.geotools.data.DataStoreFinder
+import org.locationtech.geomesa.utils.cache.FilePersistence
+import org.scalatra.{BadRequest, Ok}
+
+import scala.collection.JavaConversions._
+
+trait GeoMesaDataStoreServlet extends GeoMesaScalatraServlet {
+
+  def persistence: FilePersistence
+
+  override def datastoreParams: Map[String, String] = {
+    val ds = super.datastoreParams
+    if (ds.nonEmpty) {
+      ds
+    } else {
+      params.get("alias").map(getPersistedDataStore).getOrElse(Map.empty)
+    }
+  }
+
+  /**
+   * Gets a persisted data store config
+   */
+  def getPersistedDataStore(alias: String): Map[String, String] = {
+    val key = keyFor(alias)
+    persistence.entries(key).map { case (k, v) => (k.substring(key.length), v) }.toMap
+  }
+
+  /**
+   * Gets all persisted data stores by alias
+   */
+  def getPersistedDataStores: Map[String, Map[String, String]] = {
+    val aliases = persistence.keys("ds.").map(k => k.substring(3, k.indexOf('.', 3)))
+    aliases.map(a => a -> getPersistedDataStore(a)).toMap
+  }
+
+  /**
+   * Registers a data store, making it available for later use
+   */
+  post("/ds/:alias") {
+    val dsParams = datastoreParams
+    val ds = DataStoreFinder.getDataStore(dsParams)
+    if (ds == null) {
+      BadRequest(reason = "Could not load data store using the provided parameters.")
+    } else {
+      ds.dispose()
+      val alias = params("alias")
+      val prefix = keyFor(alias)
+      val toPersist = dsParams.map { case (k, v) => keyFor(alias, k) -> v }
+      try {
+        persistence.removeAll(persistence.keys(prefix).toSeq)
+        persistence.persistAll(toPersist)
+        Ok()
+      } catch {
+        case e: Exception => handleError(s"Error persisting data store '$alias':", e)
+      }
+    }
+  }
+
+  /**
+   * Retrieve an existing data store
+   */
+  get("/ds/:alias") {
+    try {
+      getPersistedDataStore(params("alias"))
+    } catch {
+      case e: Exception => handleError(s"Error reading data store:", e)
+    }
+  }
+
+  /**
+   * Remove the reference to an existing data store
+   */
+  delete("/ds/:alias") {
+    val alias = params("alias")
+    val prefix = keyFor(alias)
+    try {
+      persistence.removeAll(persistence.keys(prefix).toSeq)
+      Ok()
+    } catch {
+      case e: Exception => handleError(s"Error removing data store '$alias':", e)
+    }
+  }
+
+  /**
+   * Retrieve all existing data stores
+   */
+  get("/ds/?") {
+    try {
+      getPersistedDataStores
+    } catch {
+      case e: Exception => handleError(s"Error reading data stores:", e)
+    }
+  }
+
+  private def keyFor(alias: String, param: String = "") = s"ds.$alias.$param"
+}

--- a/geomesa-web/geomesa-web-core/src/main/scala/org/locationtech/geomesa/web/core/SpringScalatraBootstrap.scala
+++ b/geomesa-web/geomesa-web-core/src/main/scala/org/locationtech/geomesa/web/core/SpringScalatraBootstrap.scala
@@ -11,16 +11,21 @@ package org.locationtech.geomesa.web.core
 import javax.servlet.ServletContext
 import javax.servlet.http.{HttpServletRequest, HttpServletRequestWrapper, HttpServletResponse}
 
+import com.typesafe.scalalogging.slf4j.Logging
+import org.apache.commons.lang.exception.ExceptionUtils
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStoreFactory
-import org.scalatra.ScalatraServlet
 import org.scalatra.servlet.RichServletContext
+import org.scalatra.{InternalServerError, ScalatraServlet}
 import org.springframework.context.{ApplicationContext, ApplicationContextAware}
 import org.springframework.web.context.ServletContextAware
 
 import scala.beans.BeanProperty
 import scala.collection.JavaConversions._
 
-trait GeoMesaScalatraServlet extends ScalatraServlet {
+trait GeoMesaScalatraServlet extends ScalatraServlet with Logging {
+
+  @BeanProperty var debug: Boolean = false
+
   def root: String
 
   override def handle(req: HttpServletRequest, res: HttpServletResponse): Unit = req match {
@@ -28,13 +33,30 @@ trait GeoMesaScalatraServlet extends ScalatraServlet {
     case _ => super.handle(req, res)
   }
 
+  /**
+   * Pulls data store relevant values out of the request params
+   */
   def datastoreParams: Map[String, String] =
     GeoMesaScalatraServlet.dsKeys.flatMap(k => params.get(k).map(k -> _)).toMap
+
+  /**
+   * Common error handler that accounts for debug setting
+   */
+  def handleError(msg: String, e: Exception) = {
+    logger.error(msg, e)
+    if (debug) {
+      InternalServerError(reason = msg, body = s"${e.getMessage}\n${ExceptionUtils.getStackTrace(e)}")
+    } else {
+      InternalServerError()
+    }
+  }
 }
 
-class SpringScalatraBootstrap
-  extends ApplicationContextAware
-  with ServletContextAware {
+object GeoMesaScalatraServlet {
+  val dsKeys = new AccumuloDataStoreFactory().getParametersInfo.map(_.getName)
+}
+
+class SpringScalatraBootstrap extends ApplicationContextAware with ServletContextAware with Logging {
 
   @BeanProperty var applicationContext: ApplicationContext = _
   @BeanProperty var servletContext: ServletContext = _
@@ -44,30 +66,9 @@ class SpringScalatraBootstrap
     val richCtx = new RichServletContext(servletContext)
     val servlets = applicationContext.getBeansOfType(classOf[GeoMesaScalatraServlet])
     for ((name, servlet) <- servlets) {
-      println(s"Mounting servlet bean '$name' at path '/$rootPath/${servlet.root}'")
-      richCtx.mount(servlet, s"/$rootPath/${servlet.root}/*")
+      val path = s"/$rootPath/${servlet.root}"
+      logger.info(s"Mounting servlet bean '$name' at path '$path'")
+      richCtx.mount(servlet, s"$path/*")
     }
-  }
-}
-
-object GeoMesaScalatraServlet {
-
-  val dsKeys = {
-    import AccumuloDataStoreFactory.params._
-    Seq(
-      instanceIdParam,
-      zookeepersParam,
-      userParam,
-      passwordParam,
-      authsParam,
-      visibilityParam,
-      tableNameParam,
-      queryTimeoutParam,
-      queryThreadsParam,
-      recordThreadsParam,
-      writeThreadsParam,
-      statsParam,
-      cachingParam
-    ).map(_.getName)
   }
 }

--- a/geomesa-web/geomesa-web-data/src/main/resources/applicationContext.xml
+++ b/geomesa-web/geomesa-web-data/src/main/resources/applicationContext.xml
@@ -14,11 +14,16 @@
   <bean name="dataEndpoint" class="org.locationtech.geomesa.web.data.DataEndpoint"/>
 
   <bean name="analyticEndpoint" class="org.locationtech.geomesa.web.analytics.AnalyticEndpoint">
-    <constructor-arg index="0" ref="analyticsPersistence"/>
+    <constructor-arg index="0" ref="dataPersistence"/>
     <property name="debug" value="true"/>
   </bean>
 
-  <bean name="analyticsPersistence" class="org.locationtech.geomesa.utils.cache.FilePersistence">
+  <bean name="statsEndpoint" class="org.locationtech.geomesa.web.analytics.StatsEndpoint">
+    <constructor-arg index="0" ref="dataPersistence"/>
+    <property name="debug" value="true"/>
+  </bean>
+
+  <bean name="dataPersistence" class="org.locationtech.geomesa.utils.cache.FilePersistence">
     <constructor-arg index="0" ref="configDir"/>
     <constructor-arg index="1" value="geomesa-analytics"/>
   </bean>

--- a/geomesa-web/geomesa-web-data/src/main/scala/org/locationtech/geomesa/web/analytics/StatsEndpoint.scala
+++ b/geomesa-web/geomesa-web-data/src/main/scala/org/locationtech/geomesa/web/analytics/StatsEndpoint.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0 which
+ * accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ */
+
+package org.locationtech.geomesa.web.analytics
+
+import org.geotools.data.DataStoreFinder
+import org.joda.time.Interval
+import org.joda.time.format.ISODateTimeFormat
+import org.json4s.{DefaultFormats, Formats}
+import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
+import org.locationtech.geomesa.accumulo.stats.QueryStatReader
+import org.locationtech.geomesa.utils.cache.FilePersistence
+import org.locationtech.geomesa.web.core.GeoMesaDataStoreServlet
+import org.scalatra.BadRequest
+import org.scalatra.json.NativeJsonSupport
+
+import scala.collection.JavaConversions._
+import scala.util.Try
+
+class StatsEndpoint(val persistence: FilePersistence) extends GeoMesaDataStoreServlet with NativeJsonSupport {
+
+  override def root: String = "stats"
+
+  override def defaultFormat: Symbol = 'json
+  override protected implicit def jsonFormats: Formats = DefaultFormats
+
+  private val dtFormat = ISODateTimeFormat.dateTime().withZoneUTC()
+
+  before() {
+    contentType = formats(format)
+  }
+
+  /**
+   * Retrieves stored query stats.
+   *
+   * params:
+   *   'typeName' - simple feature type to query
+   *   'dates' - date range for results - format is 2015-11-01T00:00:00.000Z/2015-12-5T00:00:00.000Z
+   *   'who' - (optional) user to filter on
+   */
+  get("/:alias/queries/?") {
+    try {
+      val ds = DataStoreFinder.getDataStore(datastoreParams).asInstanceOf[AccumuloDataStore]
+      val sft = params.get("typeName").orNull
+      // corresponds to 2015-11-01T00:00:00.000Z/2015-12-5T00:00:00.000Z - same as used by geotools
+      val dates = params.get("dates").flatMap(d => Try(d.split("/").map(dtFormat.parseDateTime)).toOption).orNull
+      if (ds == null || sft == null || dates == null || dates.length != 2) {
+        val reason = new StringBuilder
+        if (ds == null) {
+          reason.append("Could not load data store using the provided parameters. ")
+        }
+        if (sft == null) {
+          reason.append("typeName not specified. ")
+        }
+        if (dates == null || dates.length != 2) {
+          reason.append("date not specified or invalid. ")
+        }
+        BadRequest(reason = reason.toString())
+      } else {
+        val reader = new QueryStatReader(ds.connector, ds.getQueriesTableName(_: String))
+        val interval = new Interval(dates(0), dates(1))
+        // json response doesn't seem to handle iterators directly, have to convert to iterable
+        val iter = reader.query(sft, interval, ds.authorizationsProvider.getAuthorizations).toIterable
+        // we do the user filtering here, instead of in the tservers - revisit if performance becomes an issue
+        // 'user' appears to be reserved by scalatra
+        params.get("who") match {
+          case None => iter
+          case Some(user) => iter.filter(_.user == user)
+        }
+      }
+    } catch {
+      case e: Exception => handleError(s"Error reading queries:", e)
+    }
+  }
+}


### PR DESCRIPTION
NOTE: This PR stacks on top of [726](https://github.com/locationtech/geomesa/pull/726), only the second+ commits should be considered here.

* New SPI interface for retrieving current user information: org.locationtech.geomesa.security.AuditProvider
* Implementation is specified by the system property 'geomesa.audit.provider.impl'
* A default implementation is provided with the geomesa-plugin that pulls user info from Spring Security

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>