### PR TITLE
GEOMESA-1013 Converter library cleanup and standardization

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriter.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriter.scala
@@ -56,8 +56,11 @@ object AccumuloFeatureWriter extends Logging {
     lazy val dataValue = new Value(encoder.serialize(feature))
   }
 
-  def featureWriter(writers: Seq[(BatchWriter, FeatureToMutations)]): FeatureWriterFn =
-    feature => writers.foreach { case (bw, fToM) => bw.addMutations(fToM(feature)) }
+  def featureWriter(writers: Seq[(BatchWriter, FeatureToMutations)]): FeatureWriterFn = feature => {
+    // calculate all the mutations first, so that if something fails we won't have a partially written feature
+    val mutations = writers.map { case (bw, fToM) => (bw, fToM(feature)) }
+    mutations.foreach { case (bw, m) => bw.addMutations(m) }
+  }
 
   /**
    * Gets writers and table names for each table (e.g. index) that supports the sft

--- a/geomesa-convert/README.md
+++ b/geomesa-convert/README.md
@@ -1,4 +1,4 @@
-A configurable and extensible library for converting data into SimpleFeatures
+A configurable and extensible library for converting data into SimpleFeatures.
 
 ## Overview
 
@@ -17,7 +17,7 @@ transformations is very much like ```awk``` syntax.  Fields with names that corr
 attributes in the ```SimpleFeatureType``` are assumed to be intermediate fields used for deriving attributes.  Fields 
 can reference other fields by name for building up complex attributes.
 
-## Example usage
+## Example Usage
 
 Suppose you have a ```SimpleFeatureType``` with the following schema: ```phrase:String,dtg:Date,geom:Point:srid=4326``` 
 and comma-separated data as shown below.
@@ -34,7 +34,7 @@ appropriate converter for taking this csv data and transforming it into our ```S
       format       = "CSV",
       id-field     = "md5($0)",
       fields = [
-        { name = "phrase", transform = "concat($1, $2)" },
+        { name = "phrase", transform = "concatenate($1, $2)" },
         { name = "lat",    transform = "$4::double" },
         { name = "lon",    transform = "$5::double" },
         { name = "dtg",    transform = "dateHourMinuteSecondMillis($3)" },
@@ -45,50 +45,58 @@ appropriate converter for taking this csv data and transforming it into our ```S
 The ```id``` of the ```SimpleFeature``` is formed from an md5 hash of the entire record (```$0``` is the original data) 
 and the other fields are formed from appropriate transforms.
 
-## Transformation functions
+## Transformation Functions
 
 Provided transformation functions are listed below.
 
-### String functions
+### Control Functions
+* ```try```
+
+### String Functions
  * ```stripQuotes```
- * ```strlen```
+ * ```length```
  * ```trim```
  * ```capitalize```
  * ```lowercase```
  * ```regexReplace```
- * ```concat```
- * ```substr```
+ * ```concatenate```
+ * ```substring```
  * ```toString```
  
-### Date functions
+### Date Functions
  * ```now```
  * ```date```
- * ```datetime```
- * ```isodate``` 
- * ```isodatetime```
+ * ```dateTime```
+ * ```basicDate``` 
+ * ```basicDateTime```
  * ```basicDateTimeNoMillis```
  * ```dateHourMinuteSecondMillis```
  * ```millisToDate```
 
-### Geometry functions
+### Geometry Functions
   * ```point```
   * ```linestring```
   * ```polygon```
   * ```geometry```
   
 ### ID Functions
- * ```string2bytes```
+ * ```stringToBytes```
  * ```md5```
  * ```uuid```
  * ```base64```
  
-### Data Casting
- * ```::int```
+### Type Conversions
+ * ```::int``` or ```::integer```
  * ```::long```
  * ```::float```
  * ```::double```
  * ```::boolean```
  * ```::r```
+ * ```stringToInt``` or ```stringToInteger```
+ * ```stringToLong```
+ * ```stringToFloat```
+ * ```stringToDouble```
+ * ```stringToBoolean```
 
 ### List and Map Parsing
  * ```parseList```
@@ -97,123 +105,172 @@ Provided transformation functions are listed below.
 ### JSON/Avro Transformations
 
 See Parsing Json and Parsing Avro sections
-  
+
 ## Transformation Function Usage
 
-### String functions
-#### ```stripQuotes``` - Remove double quotes from a string
+### Control Functions
+
+#### try
+
+Description: Execute another function - if it fails, instead use a default value
+
+Usage: ```try($1, $2)```
+
+Example: ```try("1"::int, 0) = 1```
+
+Example: ```try("abcd"::int, 0) = 0```
+
+### String Functions
+
+#### stripQuotes
+
+Description: Remove double quotes from a string.
 
 Usage: ```stripQuotes($1)```
 
 Example: ```stripQuotes('fo"o') = foo```
 
-#### ```strlen``` - Returns length of a string
+#### length
 
-Usage: ```strlen($1)```
+Description: Returns the length of a string.
 
-Example: ```strlen('foo') = 3```
+Usage: ```length($1)```
 
-#### ```trim``` - Trim whitespace from around a string
+Example: ```length('foo') = 3```
+
+#### trim
+
+Description: Trim whitespace from around a string.
 
 Usage: ```trim($1)```
 
 Example: ```trim('  foo ') = foo```
 
-#### ```capitalize``` - Capitalize a string
+#### capitalize
+
+Description: Capitalize a string.
 
 Usage: ```capitalize($1)```
 
 Example: ```capitalize('foo') = Foo```
 
-#### ```lowercase``` - Lowercase a string
+#### lowercase
+
+Description: Lowercase a string.
 
 Usage: ```lowercase($1)```
 
 Example: ```lowercase('FOO') = foo```
 
-#### ```uppercase``` - Uppercase a string
+#### uppercase
+
+Description: Uppercase a string.
 
 Usage: ```uppercase($1)```
 
 Example: ```uppercase('foo') = FOO```
 
-#### ```regexReplace``` - Replace a given pattern with a target pattern in a string
+#### regexReplace
+
+Description: Replace a given pattern with a target pattern in a string.
 
 Usage: ```regexReplace($regex, $replacement, $1)```
 
 Example: ```regexReplace('foo'::r, 'bar', 'foobar') = barbar```
 
-#### ```concat``` - Concatenate two strings
+#### concatenate
 
-Usage: ```concat($0, $1)```
+Description: Concatenate two strings.
 
-Example: ```concat('foo', 'bar') = foobar```
+Usage: ```concatenate($0, $1)```
 
-#### ```substr``` - Return the substring of a string
+Example: ```concatenate('foo', 'bar') = foobar```
 
-Usage: ```substr($1, $startIndex, $endIndex)```
+#### substring
 
-Example: ```substr('foobarbaz', 2, 5) = oba```
+Description: Return the substring of a string.
 
-#### ```toString``` - Convert another datatype to a string
+Usage: ```substring($1, $startIndex, $endIndex)```
+
+Example: ```substring('foobarbaz', 2, 5) = oba```
+
+#### toString
+
+Description: Convert another data type to a string.
 
 Usage: ```toString($0)```
 
-Example: ```concat(toString(5), toString(6)) = '56'```
+Example: ```concatenate(toString(5), toString(6)) = '56'```
  
-### Date functions
+### Date Functions
 
-#### ```now``` - Use the current system time
+#### now
+
+Description: Use the current system time.
 
 Usage: ```now()```
 
+#### date
 
-#### ```date``` - Custom date parser
+Description: Custom date parser.
 
 Usage: ```date($format, $1)```
 
 Example: ```date('YYYY-MM-dd\'T\'HH:mm:ss.SSSSSS', '2015-01-01T00:00:00.000000')```
-  
-  
-#### ```datetime``` - A strict ISO 8601 Date parser for format yyyy-MM-dd'T'HH:mm:ss.SSSZZ
+
+#### dateTime
+
+Description: A strict ISO 8601 Date parser for format ```yyyy-MM-dd'T'HH:mm:ss.SSSZZ```.
  
-Usage: ```datetime($1)```
+Usage: ```dateTime($1)```
 
-Example: ```datetime('2015-01-01T00:00:00.000Z')```
+Example: ```dateTime('2015-01-01T00:00:00.000Z')```
 
-#### ```isodate``` -  A basic date format for yyyyMMdd
+#### basicDate
 
-Usage: ```isodate($1)```
+Description: A basic date format for ```yyyyMMdd```.
 
-Example: ```isodate('20150101')```
+Usage: ```basicDate($1)```
 
-#### ```isodatetime``` -  A basic format that combines a basic date and time for format yyyyMMdd'T'HHmmss.SSSZ
+Example: ```basicDate('20150101')```
 
-Usage: ```isodatetime($1)```
+#### basicDateTime
 
-Example: ```isodatetime('20150101T000000.000Z')```
+Description: A basic format that combines a basic date and time for format ```yyyyMMdd'T'HHmmss.SSSZ```.
 
-#### ```basicDateTimeNoMillis``` - A basic format that combines a basic date and time with no millis for format yyyyMMdd'T'HHmmssZ
+Usage: ```basicDateTime($1)```
+
+Example: ```basicDateTime('20150101T000000.000Z')```
+
+#### basicDateTimeNoMillis
+
+Description: A basic format that combines a basic date and time with no millis for format ```yyyyMMdd'T'HHmmssZ```.
 
 Usage: ```basicDateTimeNoMillis($1)```
 
 Example: ```basicDateTimeNoMillis('20150101T000000Z')```
 
-#### ```dateHourMinuteSecondMillis``` - Formatter for full date, and time keeping the first 3 fractional seconds for format yyyy-MM-dd'T'HH:mm:ss.SSS
+#### dateHourMinuteSecondMillis
+
+Description: Formatter for full date, and time keeping the first 3 fractional seconds for format ```yyyy-MM-dd'T'HH:mm:ss.SSS```.
 
 Usage: ```dateHourMinuteSecondMillis($1)```
 
 Example: ```dateHourMinuteSecondMillis('2015-01-01T00:00:00.000')``` 
 
-#### ```millisToDate``` - Create a new date from as long representing millis since 1970
+#### millisToDate
+
+Description: Create a new date from as long representing millis since 1970.
 
 Usage: ```millisToDate($1)```
 
-Example: ```millisToDate(1449675054462::long)``` 
+Example: ```millisToDate('1449675054462'::long)``` 
 
-### Geometry functions
+### Geometry Functions
 
-#### ```point``` - Parse a Point geometry from lon/lat or WKT
+#### point
+
+Description: Parse a Point geometry from lon/lat or WKT.
 
 Usage: ```point($lon, $lat)``` or ```point($wkt)```
 
@@ -252,19 +309,25 @@ Example: Parsing WKT as a point
     ID,wkt,date
     1,POINT(2 3),2015-01-02
 
-#### ```linestring``` - Parse a linestring from a WKT string
+#### linestring
+
+Description: Parse a linestring from a WKT string.
 
 Usage: ```linestring($0)```
 
 Example: ```linestring('LINESTRING(102 0, 103 1, 104 0, 105 1)')```
 
-#### ```polygon``` - Parse a polygon from a WKT string
+#### polygon
+
+Description: Parse a polygon from a WKT string.
 
 Usage: ```polygon($0)```
 
 Example: ```polygon('polygon((100 0, 101 0, 101 1, 100 1, 100 0))')```
   
-#### ```geometry``` - Parse a geometry from a WKT string or GeoJson
+#### geometry
+
+Description: Parse a geometry from a WKT string or GeoJson.
   
 Example: Parsing WKT as a geometry
 
@@ -290,34 +353,125 @@ Example: Parsing GeoJson geometry
     
 ### ID Functions
 
-#### ```string2bytes``` - Converts a string to a UTF-8 byte array
+#### stringToBytes
 
-#### ```md5``` - Creates an MD5 hash from a byte array
+Description: Converts a string to a UTF-8 byte array.
+
+#### md5
+
+Description: Creates an MD5 hash from a byte array.
 
 Usage: ```md5($0)```
 
-Example: ```md5(string2bytes('row,of,data'))```
+Example: ```md5(stringToBytes('row,of,data'))```
 
-#### ```uuid``` - Generates a random UUID
+#### uuid
+
+Description: Generates a random UUID.
 
 Usage: ```uuid()```
 
-#### ```base64``` - Encodes a byte array as a base-64 string
+#### base64
+
+Description: Encodes a byte array as a base-64 string.
 
 Usage; ```base64($0)```
 
-Example: ```base64(string2bytes('foo'))```
+Example: ```base64(stringToBytes('foo'))```
  
-### Data Casting
- * ```::int```
- * ```::long```
- * ```::float```
- * ```::double```
- * ```::boolean```
- * ```::r``` - Converts a string to a Regex object
+### Type Conversions
+
+#### ::int or ::integer
+
+Description: Converts a string into an integer. Invalid values will cause the record to fail.
+
+Example: ```'1'::int = 1```
+
+#### ::long
+
+Description: Converts a string into a long. Invalid values will cause the record to fail.
+
+Example: ```'1'::long = 1L```
+
+#### ::float
+
+Description: Converts a string into a float. Invalid values will cause the record to fail.
+
+Example: ```'1.0'::float = 1.0f```
+
+#### ::double
+
+Description: Converts a string into a double. Invalid values will cause the record to fail.
+
+Example: ```'1.0'::double = 1.0d```
+
+#### ::boolean
+
+Description: Converts a string into a boolean. Invalid values will cause the record to fail.
+
+Example: ```'true'::boolean = true```
+
+#### ::r
+
+Description: Converts a string into a Regex object.
+
+Example: ```'f.*'::r = f.*: scala.util.matching.Regex```
+
+#### stringToInt or stringToInteger
+
+Description: Converts a string into a integer, with a default value if conversion fails.
+
+Usage; ```stringToInt($1, $2)```
+
+Example: ```stringToInt('1', 0) = 1```
+
+Example: ```stringToInt('', 0) = 0```
+
+#### stringToLong
+
+Description: Converts a string into a long, with a default value if conversion fails.
+
+Usage; ```stringToLong($1, $2)```
+
+Example: ```stringToLong('1', 0L) = 1L```
+
+Example: ```stringToLong('', 0L) = 0L```
+
+#### stringToFloat
+
+Description: Converts a string into a float, with a default value if conversion fails.
+
+Usage; ```stringToFloat($1, $2)```
+
+Example: ```stringToFloat('1.0', 0.0f) = 1.0f```
+
+Example: ```stringToFloat('not a float', 0.0f) = 0.0f```
+
+#### stringToDouble
+
+Description: Converts a string into a double, with a default value if conversion fails.
+
+Usage; ```stringToDouble($1, $2)```
+
+Example: ```stringToDouble('1.0', 0.0) = 1.0d```
+
+Example: ```stringToDouble(null, 0.0) = 0.0d```
+
+#### stringToBoolean
+
+Description: Converts a string into a boolean, with a default value if conversion fails.
+
+Usage; ```stringToBoolean($1, $2)```
+
+Example: ```stringToBoolean('true', false) = true```
+
+Example: ```stringToBoolean('55', false) = false```
 
 ### List and Map Parsing
-#### ```parseList``` - Parse a List[T] type from a string
+
+#### parseList
+
+Description: Parse a ```List[T]``` type from a string.
  
 If your SimpleFeatureType config contains a list or map you can easily configure a transform function to parse it using
 the ```parseList``` function which takes either 2 or 3 args
@@ -341,7 +495,9 @@ And a transform to parse the quoted CSV field:
 
     { name = "friends", transform = "parseList('string', $5)" }
 
-#### ```parseMap```
+#### parseMap
+
+Description: Parse a ```Map[T,V]``` type from a string.
 
 Parsing Maps is similar. Take for example this CSV data with a quoted map field:
 
@@ -521,7 +677,9 @@ We can define a converter config to parse the avro:
 GeoMesa Convert allows users to define "avropaths" to the data similar to a jsonpath or xpath. This AvroPath allows you 
 to extract out fields from avro records into SFT fields.
 
-#### ```avroPath``` - Extract values from nested Avro structures 
+#### avroPath
+
+Description: Extract values from nested Avro structures. 
  
 Usage: ```avroPath($ref, $pathString)```
 
@@ -530,11 +688,11 @@ Usage: ```avroPath($ref, $pathString)```
   * ```$type=<typename>``` - interpret the field name as an avro schema type
   * ```[$<field>=<value>]``` - select records with a field named "field" and a value equal to "value"
 
-## Extending the converter library
+## Extending the Converter Library
 
 There are two ways to extend the converter library - adding new transformation functions and adding new data formats.
 
-### Adding new transformation functions
+### Adding New Transformation Functions
 
 To add new transformation functions, create a ```TransformationFunctionFactory``` and register it in 
 ```META-INF/services/org.locationtech.geomesa.convert.TransformationFunctionFactory```.  For example, here's how to add 
@@ -556,11 +714,11 @@ The ```sha256``` function can then be used in a field as shown.
 
 ```
    fields: [
-      { name = "hash", transform = "sha256(string2bytes($0))" }
+      { name = "hash", transform = "sha256(stringToBytes($0))" }
    ]
 ```
 
-### Adding new data formats
+### Adding New Data Formats
 
 To add new data formats, implement the ```SimpleFeatureConverterFactory``` and ```SimpleFeatureConverter``` interfaces 
 and register them in ```META-INF/services``` appropriately.  See 

--- a/geomesa-convert/geomesa-convert-all/pom.xml
+++ b/geomesa-convert/geomesa-convert-all/pom.xml
@@ -48,5 +48,10 @@
             <artifactId>specs2_2.10</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/geomesa-convert/geomesa-convert-all/src/test/resources/log4j.xml
+++ b/geomesa-convert/geomesa-convert-all/src/test/resources/log4j.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
-  ~ All rights reserved. This program and the accompanying materials
-  ~ are made available under the terms of the Apache License, Version 2.0 which
-  ~ accompanies this distribution and is available at
-  ~ http://www.opensource.org/licenses/apache2.0.php.
-  -->
+<!--********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*********************************************************************-->
 
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
@@ -29,9 +29,6 @@
         <priority value="warn"/>
     </category>
 
-    <category name="org.locationtech.geomesa.convert.text.DelimitedTextConverter">
-        <priority value="error"/>
-    </category>
     <!-- un-comment the following line to enable verbose log messages
          from the index query-planner; this can be helpful in debugging
          query plans -->
@@ -42,7 +39,7 @@
     -->
 
     <root>
-        <priority value="warn"/>
+        <priority value="info"/>
         <appender-ref ref="CONSOLE" />
     </root>
 </log4j:configuration>

--- a/geomesa-convert/geomesa-convert-avro/pom.xml
+++ b/geomesa-convert/geomesa-convert-avro/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>specs2_2.10</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/geomesa-convert/geomesa-convert-avro/src/main/scala/org/locationtech/geomesa/convert/avro/AvroPathFunctionFactory.scala
+++ b/geomesa-convert/geomesa-convert-avro/src/main/scala/org/locationtech/geomesa/convert/avro/AvroPathFunctionFactory.scala
@@ -18,7 +18,7 @@ class AvroPathFunctionFactory extends TransformerFunctionFactory {
 
   case class AvroPathFn() extends TransformerFn {
     override def getInstance: AvroPathFn = AvroPathFn()
-    val name = "avroPath"
+    override val names = Seq("avroPath")
 
     var path: AvroPath = null
     override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = {

--- a/geomesa-convert/geomesa-convert-avro/src/test/resources/log4j.xml
+++ b/geomesa-convert/geomesa-convert-avro/src/test/resources/log4j.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
-  ~ All rights reserved. This program and the accompanying materials
-  ~ are made available under the terms of the Apache License, Version 2.0 which
-  ~ accompanies this distribution and is available at
-  ~ http://www.opensource.org/licenses/apache2.0.php.
-  -->
+<!--********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*********************************************************************-->
 
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
@@ -28,7 +28,6 @@
     <category name="hsqldb">
         <priority value="warn"/>
     </category>
-
     <category name="org.locationtech.geomesa.convert.text.DelimitedTextConverter">
         <priority value="error"/>
     </category>
@@ -42,7 +41,7 @@
     -->
 
     <root>
-        <priority value="warn"/>
+        <priority value="info"/>
         <appender-ref ref="CONSOLE" />
     </root>
 </log4j:configuration>

--- a/geomesa-convert/geomesa-convert-avro/src/test/scala/org/locationtech/geomesa/convert/avro/AvroTransformersTest.scala
+++ b/geomesa-convert/geomesa-convert-avro/src/test/scala/org/locationtech/geomesa/convert/avro/AvroTransformersTest.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.convert.avro
 
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.convert.Transformers
-import org.locationtech.geomesa.convert.Transformers.EvaluationContext
+import org.locationtech.geomesa.convert.Transformers.{EvaluationContextImpl, EvaluationContext}
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -22,7 +22,7 @@ class AvroTransformersTest extends Specification with AvroUtils {
   sequential
 
   "Transformers" should {
-    implicit val ctx = new EvaluationContext(mutable.HashMap.empty[String, Int], null)
+    implicit val ctx = EvaluationContext.empty
     "handle Avro records" >> {
 
       "extract an inner value" >> {

--- a/geomesa-convert/geomesa-convert-common/pom.xml
+++ b/geomesa-convert/geomesa-convert-common/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>specs2_2.10</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/CompositeConverter.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/CompositeConverter.scala
@@ -9,9 +9,10 @@
 package org.locationtech.geomesa.convert
 
 import com.typesafe.config.Config
-import org.locationtech.geomesa.convert.Transformers.{DefaultCounter, Counter, EvaluationContext, Predicate}
+import org.locationtech.geomesa.convert.Transformers.{Counter, EvaluationContext, Predicate}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
+import scala.annotation.tailrec
 import scala.collection.JavaConversions._
 import scala.util.Try
 
@@ -27,46 +28,77 @@ class CompositeConverterFactory[I] extends SimpleFeatureConverterFactory[I] {
       }
     new CompositeConverter[I](sft, converters)
   }
+}
+
+class CompositeConverter[I](val targetSFT: SimpleFeatureType, converters: Seq[(Predicate, SimpleFeatureConverter[I])])
+    extends SimpleFeatureConverter[I] {
+
+  val predsWithIndex = converters.map(_._1).zipWithIndex.toIndexedSeq
+  val indexedConverters = converters.map(_._2).toIndexedSeq
+
+  override def createEvaluationContext(globalParams: Map[String, Any], counter: Counter): EvaluationContext = {
+    val delegates = converters.map(_._2.createEvaluationContext(globalParams, counter)).toIndexedSeq
+    new CompositeEvaluationContext(delegates)
+  }
+
+  override def processInput(is: Iterator[I], ec: EvaluationContext): Iterator[SimpleFeature] = {
+    val setEc: (Int) => Unit = ec match {
+      case c: CompositeEvaluationContext => (i) => c.setCurrent(i)
+      case _ => (_) => Unit
+    }
+    val toEval = Array.ofDim[Any](1)
+
+    def evalPred(pi: (Predicate, Int)): Boolean = {
+      setEc(pi._2)
+      Try(pi._1.eval(toEval)(ec)).getOrElse(false)
+    }
+
+    new Iterator[SimpleFeature] {
+      var iter: Iterator[SimpleFeature] = loadNext()
+
+      override def hasNext: Boolean = iter.hasNext
+      override def next(): SimpleFeature = {
+        val res = iter.next()
+        if (!iter.hasNext && is.hasNext) {
+          iter = loadNext()
+        }
+        res
+      }
+
+      @tailrec
+      def loadNext(): Iterator[SimpleFeature] = {
+        toEval(0) = is.next()
+        val i = predsWithIndex.find(evalPred).map(_._2).getOrElse(-1)
+        val res = if (i == -1) {
+          ec.counter.incLineCount()
+          ec.counter.incFailure()
+          Iterator.empty
+        } else {
+          indexedConverters(i).processInput(Iterator(toEval(0).asInstanceOf[I]), ec)
+        }
+
+        if (res.hasNext) {
+          res
+        } else if (!is.hasNext) {
+          Iterator.empty
+        } else {
+          loadNext()
+        }
+      }
+    }
+  }
+
 
 }
 
-class CompositeConverter[I](val targetSFT: SimpleFeatureType,
-                            converters: Seq[(Predicate, SimpleFeatureConverter[I])])
-  extends SimpleFeatureConverter[I] {
+case class CompositeEvaluationContext(contexts: IndexedSeq[EvaluationContext]) extends EvaluationContext {
 
-  val evaluationContexts = List.fill(converters.length)(new EvaluationContext(null, null))
+  var current: EvaluationContext = contexts.headOption.orNull
 
-  def processWithCallback(gParams: Map[String, Any] = Map.empty, counter: Counter = new DefaultCounter): (I) => Seq[SimpleFeature] = {
-    var count = 0
-    (input: I) => {
-      count += 1
-      converters.view.zipWithIndex.flatMap { case ((pred, conv), i) =>
-        implicit val ec = evaluationContexts(i)
-        ec.getCounter.setLineCount(count)
-        processIfValid(input, pred, conv, gParams)
-      }.headOption
-    }.toSeq
-  }
+  def setCurrent(i: Int): Unit = current = contexts(i)
 
-  override def processInput(is: Iterator[I],  gParams: Map[String, Any] = Map.empty, counter: Counter = new DefaultCounter): Iterator[SimpleFeature] =
-    is.flatMap(processWithCallback(gParams, counter))
-
-  override def processSingleInput(i: I, gParams: Map[String, Any] = Map.empty)(implicit ec: EvaluationContext): Seq[SimpleFeature] =
-    throw new UnsupportedOperationException("Single input processing is not enabled with composite converters...yet")
-
-  private val mutableArray = Array.ofDim[Any](1)
-
-  def processIfValid(input: I,
-                     pred: Predicate,
-                     conv: SimpleFeatureConverter[I],
-                     gParams: Map[String, Any])
-                    (implicit  ec: EvaluationContext) = {
-    val opt =
-      Try {
-        mutableArray(0) = input
-        pred.eval(mutableArray)
-      }.toOption.toSeq
-
-    opt.flatMap { v => if (v) conv.processSingleInput(input, gParams)(ec) else Seq.empty }
-  }
+  override def get(i: Int): Any = current.get(i)
+  override def set(i: Int, v: Any): Unit = current.set(i, v)
+  override def indexOf(n: String): Int = current.indexOf(n)
+  override def counter: Counter = current.counter
 }

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverterFactory.scala
@@ -8,6 +8,7 @@
 
 package org.locationtech.geomesa.convert
 
+import java.io.Closeable
 import javax.imageio.spi.ServiceRegistry
 
 import com.typesafe.config.Config
@@ -56,7 +57,6 @@ object SimpleFeatureConverters {
       (path.toSeq ++ Seq("converter", "input-converter"))
         .foldLeft(conf)( (c, p) => c.getConfigOpt(p).map(c.withFallback).getOrElse(c))
 
-
     providers
       .find(_.canProcess(converterConfig))
       .map(_.buildConverter(sft, converterConfig).asInstanceOf[SimpleFeatureConverter[I]])
@@ -64,16 +64,36 @@ object SimpleFeatureConverters {
   }
 }
 
-trait SimpleFeatureConverter[I] {
+trait SimpleFeatureConverter[I] extends Closeable {
+
+  /**
+   * Result feature type
+   */
   def targetSFT: SimpleFeatureType
-  def processInput(is: Iterator[I], globalParams: Map[String, Any] = Map.empty, counter: Counter = new DefaultCounter): Iterator[SimpleFeature]
-  def processWithCallback(gParams: Map[String, Any] = Map.empty, counter: Counter = new DefaultCounter): (I) => Seq[SimpleFeature]
-  def processSingleInput(i: I, globalParams: Map[String, Any] = Map.empty)(implicit ec: EvaluationContext): Seq[SimpleFeature]
-  def close(): Unit = {}
+
+  /**
+   * Stream process inputs into simple features
+   */
+  def processInput(is: Iterator[I], ec: EvaluationContext = createEvaluationContext()): Iterator[SimpleFeature]
+
+  /**
+   * Creates a context used for processing
+   */
+  def createEvaluationContext(globalParams: Map[String, Any] = Map.empty,
+                              counter: Counter = new DefaultCounter): EvaluationContext = {
+    val keys = globalParams.keys.toIndexedSeq
+    val values = keys.map(globalParams.apply).toArray
+    EvaluationContext(keys, values, counter)
+  }
+
+  override def close(): Unit = {}
 }
 
+/**
+ * Base trait to create a simple feature converter
+ */
 trait ToSimpleFeatureConverter[I] extends SimpleFeatureConverter[I] with Logging {
-  def logErrors: Boolean = false
+
   def targetSFT: SimpleFeatureType
   def inputFields: IndexedSeq[Field]
   def idBuilder: Expr
@@ -107,71 +127,59 @@ trait ToSimpleFeatureConverter[I] extends SimpleFeatureConverter[I] with Logging
   val sftIndices = requiredFields.map(f => targetSFT.indexOf(f.name))
   val inputFieldIndexes = mutable.HashMap.empty[String, Int] ++= requiredFields.map(_.name).zipWithIndex.toMap
 
-  var reuse: Array[Any] = null
-
-  def convert(t: Array[Any], reuse: Array[Any])(implicit ctx: EvaluationContext): SimpleFeature = {
-    ctx.computedFields = reuse
-
+  /**
+   * Convert input values into a simple feature with attributes
+   */
+  def convert(t: Array[Any], ec: EvaluationContext): SimpleFeature = {
     val sfValues = Array.ofDim[AnyRef](targetSFT.getAttributeCount)
 
     var i = 0
     while (i < nfields) {
-      reuse(i) = requiredFields(i).eval(t)
+      try {
+        ec.set(i, requiredFields(i).eval(t)(ec))
+      } catch {
+        case e: Exception =>
+          logger.warn(s"Failed to evaluate field '${requiredFields(i).name}' using values:\n" +
+              s"${t.headOption.orNull}\n[${t.tail.mkString(", ")}]", e) // head is the whole record
+          return null
+      }
       val sftIndex = sftIndices(i)
       if (sftIndex != -1) {
-        sfValues.update(sftIndex, reuse(i).asInstanceOf[AnyRef])
+        sfValues.update(sftIndex, ec.get(i).asInstanceOf[AnyRef])
       }
       i += 1
     }
 
-    val id = idBuilder.eval(t).asInstanceOf[String]
+    val id = idBuilder.eval(t)(ec).asInstanceOf[String]
     new ScalaSimpleFeature(id, targetSFT, sfValues)
   }
 
-  protected[this] def preProcess(i: I)(implicit ec: EvaluationContext): Option[I] = Some(i)
+  /**
+   * Process a single input (e.g. line)
+   */
+  def processSingleInput(i: I, ec: EvaluationContext): Seq[SimpleFeature] = {
+    ec.counter.incLineCount()
 
-  override def processSingleInput(i: I, gParams: Map[String, Any])(implicit ec: EvaluationContext): Seq[SimpleFeature] = {
-    val counter = ec.getCounter
-    if (reuse == null || ec.fieldNameMap == null) {
-      // initialize reuse and ec
-      ec.fieldNameMap = inputFieldIndexes
-      reuse = Array.ofDim[Any](nfields + gParams.size)
-      gParams.zipWithIndex.foreach { case ((k, v), idx) =>
-        val shiftedIdx = nfields + idx
-        reuse(shiftedIdx) = v
-        ec.fieldNameMap(k) = shiftedIdx
-      }
+    val attributes = try { fromInputType(i) } catch {
+      case e: Exception => logger.warn(s"Failed to parse input '$i'", e); Seq.empty
     }
-    try {
-      val attributeArrays = fromInputType(i)
-      attributeArrays.flatMap { attributes =>
-        try {
-          val res = convert(attributes, reuse)
-          counter.incSuccess()
-          Some(res)
-        } catch {
-          case e: Exception =>
-            logger.warn("Failed to convert input", e)
-            counter.incFailure()
-            None
-        }
-      }
-    } catch {
-      case e: Exception =>
-        logger.warn("Failed to parse input", e)
-        Seq.empty
+
+    val (failures, successes) = attributes.map(convert(_, ec)).partition(_ == null)
+    ec.counter.incSuccess(successes.length)
+    if (failures.nonEmpty) {
+      ec.counter.incFailure(failures.length)
     }
+    successes
   }
 
-  def processWithCallback(gParams: Map[String, Any] = Map.empty, counter: Counter = new DefaultCounter): (I) => Seq[SimpleFeature] = {
-    implicit val ctx = new EvaluationContext(inputFieldIndexes, null, counter)
-    (i: I) => {
-      counter.incLineCount()
-      preProcess(i).map(processSingleInput(_, gParams)).getOrElse(Seq.empty[SimpleFeature])
-    }
+  override def createEvaluationContext(globalParams: Map[String, Any], counter: Counter): EvaluationContext = {
+    val globalKeys = globalParams.keys.toSeq
+    val names = requiredFields.map(_.name) ++ globalKeys
+    val values = Array.ofDim[Any](names.length)
+    globalKeys.zipWithIndex.foreach { case (k, i) => values(requiredFields.length + i) = globalParams(k) }
+    new EvaluationContextImpl(names.toIndexedSeq, values, counter)
   }
 
-  def processInput(is: Iterator[I], gParams: Map[String, Any] = Map.empty, counter: Counter = new DefaultCounter): Iterator[SimpleFeature] =
-    is.flatMap(processWithCallback(gParams, counter))
-
+  override def processInput(is: Iterator[I], ec: EvaluationContext): Iterator[SimpleFeature] =
+    is.flatMap(i =>  processSingleInput(i, ec))
 }

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/Transformers.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/Transformers.scala
@@ -24,13 +24,15 @@ import org.locationtech.geomesa.utils.text.{EnhancedTokenParsers, WKTUtils}
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
+import scala.util.Try
 import scala.util.matching.Regex
 
 object Transformers extends EnhancedTokenParsers with Logging {
 
   val functionMap = mutable.HashMap[String, TransformerFn]()
+
   ServiceRegistry.lookupProviders(classOf[TransformerFunctionFactory]).foreach { factory =>
-    factory.functions.foreach { f => functionMap.put(f.name, f) }
+    factory.functions.foreach(f => f.names.foreach(functionMap.put(_, f)))
   }
 
   val EQ   = "Eq"
@@ -44,26 +46,32 @@ object Transformers extends EnhancedTokenParsers with Logging {
     private val OPEN_PAREN  = "("
     private val CLOSE_PAREN = ")"
 
-    def string      = quotedString ^^ { s => LitString(s) } //"'" ~> "[^']*".r <~ "'".r ^^ { s => LitString(s) }
-    def int         = wholeNumber ^^   { i => LitInt(i.toInt) }
-    def double      = decimalNumber ^^ { d => LitDouble(d.toDouble) }
-    def long        = wholeNumber ^^   { l => LitLong(l.toLong) }
-    def lit         = string | int | double
+    def decimal     = """\d*\.\d+""".r
+    def string      = quotedString ^^ { s => LitString(s) }
+    def int         = wholeNumber ^^ { i => LitInt(i.toInt) }
+    def double      = decimal <~ "[dD]?".r ^^ { d => LitDouble(d.toDouble) }
+    def long        = wholeNumber <~ "L" ^^   { l => LitLong(l.toLong) }
+    def float       = decimal <~ "[fF]".r ^^ { l => LitFloat(l.toFloat) }
+    def boolean     = "false|true".r ^^ { l => LitBoolean(l.toBoolean) }
+    def nulls       = "null" ^^ { _ => LitNull }
+    def lit         = string | float | double | long | int | boolean | nulls // order is important - most to least specific
     def wholeRecord = "$0" ^^ { _ => WholeRecord }
     def regexExpr   = string <~ "::r" ^^ { case LitString(s) => RegexExpr(s) }
     def column      = "$" ~> "[1-9][0-9]*".r ^^ { i => Col(i.toInt) }
 
-    def cast2int     = expr <~ "::int"     ^^ { e => Cast2Int(e)     }
-    def cast2long    = expr <~ "::long"    ^^ { e => Cast2Long(e)    }
-    def cast2float   = expr <~ "::float"   ^^ { e => Cast2Float(e)   }
-    def cast2double  = expr <~ "::double"  ^^ { e => Cast2Double(e)  }
-    def cast2boolean = expr <~ "::boolean" ^^ { e => Cast2Boolean(e) }
+    def cast2int     = expr <~ "::int" ~ "(eger)?".r ^^ { e => Cast2Int(e)     }
+    def cast2long    = expr <~ "::long"              ^^ { e => Cast2Long(e)    }
+    def cast2float   = expr <~ "::float"             ^^ { e => Cast2Float(e)   }
+    def cast2double  = expr <~ "::double"            ^^ { e => Cast2Double(e)  }
+    def cast2boolean = expr <~ "::bool" ~ "(ean)?".r ^^ { e => Cast2Boolean(e) }
 
     def fieldLookup = "$" ~> ident ^^ { i => FieldLookup(i) }
     def fnName      = ident ^^ { n => LitString(n) }
+    def tryFn       = ("try" ~ OPEN_PAREN) ~> (argument ~ "," ~ argument) <~ CLOSE_PAREN ^^ {
+      case arg ~ ","  ~ fallback => TryFunctionExpr(arg, fallback)
+    }
     def fn          = (fnName <~ OPEN_PAREN) ~ (repsep(argument, ",") <~ CLOSE_PAREN) ^^ {
-      case LitString(name) ~ e =>
-        FunctionExpr(functionMap(name).getInstance, e.toArray)
+      case LitString(name) ~ e => FunctionExpr(functionMap(name).getInstance, e.toArray)
     }
     def strEq       = ("strEq" ~ OPEN_PAREN) ~> (transformExpr ~ "," ~ transformExpr) <~ CLOSE_PAREN ^^ {
       case l ~ "," ~ r => strBinOps(EQ)(l, r)
@@ -78,11 +86,13 @@ object Transformers extends EnhancedTokenParsers with Logging {
 
     def binaryPred =
       strEq |
-      getBinPreds("int",    intBinOps)    |
-      getBinPreds("long",   longBinOps)   |
-      getBinPreds("float",  floatBinOps)  |
-      getBinPreds("double", doubleBinOps) |
-      getBinPreds("bool",   boolBinOps)
+      getBinPreds("int",     intBinOps)    |
+      getBinPreds("integer", intBinOps)    |
+      getBinPreds("long",    longBinOps)   |
+      getBinPreds("float",   floatBinOps)  |
+      getBinPreds("double",  doubleBinOps) |
+      getBinPreds("bool",    boolBinOps)   |
+      getBinPreds("boolean", boolBinOps)
 
     def andPred     = ("and" ~ OPEN_PAREN) ~> (pred ~ "," ~ pred) <~ CLOSE_PAREN ^^ {
       case l ~ "," ~ r => And(l, r)
@@ -95,50 +105,57 @@ object Transformers extends EnhancedTokenParsers with Logging {
     }
     def logicPred = andPred | orPred | notPred
     def pred: Parser[Predicate] = binaryPred | logicPred
-    def expr =
-      fn |
-        wholeRecord |
-        regexExpr |
-        fieldLookup |
-        column |
-        lit
+    def expr = tryFn | fn | wholeRecord | regexExpr | fieldLookup | column | lit
     def transformExpr: Parser[Expr] = cast2double | cast2int | cast2boolean | cast2float | cast2long | expr
     def argument = transformExpr | string
   }
 
   trait Counter {
-    def incSuccess(): Unit
+    def incSuccess(i: Int = 1): Unit
     def getSuccess: Int
 
-    def incFailure(): Unit
+    def incFailure(i: Int = 1): Unit
     def getFailure: Int
 
-    def incLineCount(): Unit
+    def incLineCount(i: Int = 1): Unit
     def getLineCount: Int
     def setLineCount(i: Int)
   }
 
   class DefaultCounter extends Counter {
-    private var c: Int = 0
     private var s: Int = 0
     private var f: Int = 0
-    private var skipped: Int = 0
+    private var c: Int = 0
 
-    override def incSuccess(): Unit = s +=1
+    override def incSuccess(i: Int = 1): Unit = s += i
     override def getSuccess: Int = s
 
-    override def incFailure(): Unit = f += 1
+    override def incFailure(i: Int = 1): Unit = f += i
     override def getFailure: Int = f
 
-    override def incLineCount = c += 1
+    override def incLineCount(i: Int = 1) = c += i
     override def getLineCount: Int = c
     override def setLineCount(i: Int) = c = i
   }
 
-  class EvaluationContext(var fieldNameMap: mutable.HashMap[String, Int], var computedFields: Array[Any], val counter: Counter = new DefaultCounter) {
-    def indexOf(n: String): Int = fieldNameMap.getOrElse(n, -1)
-    def lookup(i: Int) = if(i < 0) null else computedFields(i)
-    def getCounter = counter
+  trait EvaluationContext {
+    def get(i: Int): Any
+    def set(i: Int, v: Any): Unit
+    def indexOf(n: String): Int
+    def counter: Counter
+  }
+
+  object EvaluationContext {
+    def empty: EvaluationContext = apply(IndexedSeq.empty, Array.empty, new DefaultCounter)
+    def apply(names: IndexedSeq[String], values: Array[Any], counter: Counter): EvaluationContext =
+      new EvaluationContextImpl(names, values, counter)
+  }
+
+  class EvaluationContextImpl(names: IndexedSeq[String], values: Array[Any], val counter: Counter)
+      extends EvaluationContext {
+    def get(i: Int): Any = values(i)
+    def set(i: Int, v: Any): Unit = values(i) = v
+    def indexOf(n: String): Int = names.indexOf(n)
   }
 
   sealed trait Expr {
@@ -156,21 +173,27 @@ object Transformers extends EnhancedTokenParsers with Logging {
   case class LitFloat(value: java.lang.Float) extends Lit[java.lang.Float]
   case class LitDouble(value: java.lang.Double) extends Lit[java.lang.Double]
   case class LitBoolean(value: java.lang.Boolean) extends Lit[java.lang.Boolean]
+  case object LitNull extends Lit[AnyRef] { override def value = null }
 
   case class Cast2Int(e: Expr) extends Expr {
-    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = e.eval(args).asInstanceOf[String].toInt
+    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any =
+      e.eval(args).asInstanceOf[String].toInt
   }
   case class Cast2Long(e: Expr) extends Expr {
-    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = e.eval(args).asInstanceOf[String].toLong
+    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any =
+      e.eval(args).asInstanceOf[String].toLong
   }
   case class Cast2Float(e: Expr) extends Expr {
-    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = e.eval(args).asInstanceOf[String].toFloat
+    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any =
+      e.eval(args).asInstanceOf[String].toFloat
   }
   case class Cast2Double(e: Expr) extends Expr {
-    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = e.eval(args).asInstanceOf[String].toDouble
+    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any =
+      e.eval(args).asInstanceOf[String].toDouble
   }
   case class Cast2Boolean(e: Expr) extends Expr {
-    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = e.eval(args).asInstanceOf[String].toBoolean
+    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any =
+      e.eval(args).asInstanceOf[String].toBoolean
   }
 
   case object WholeRecord extends Expr {
@@ -184,8 +207,10 @@ object Transformers extends EnhancedTokenParsers with Logging {
   case class FieldLookup(n: String) extends Expr {
     var idx = -1
     override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = {
-      if(idx == -1) idx = ctx.indexOf(n)
-      ctx.lookup(idx)
+      if (idx == -1) {
+        idx = ctx.indexOf(n)
+      }
+      ctx.get(idx)
     }
   }
 
@@ -195,7 +220,14 @@ object Transformers extends EnhancedTokenParsers with Logging {
   }
 
   case class FunctionExpr(f: TransformerFn, arguments: Array[Expr]) extends Expr {
-    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = f.eval(arguments.map(_.eval(args)))
+    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any =
+      f.eval(arguments.map(_.eval(args)))
+  }
+
+  case class TryFunctionExpr(toTry: Expr, fallback: Expr) extends Expr {
+    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = {
+      Try(toTry.eval(args)).getOrElse(fallback.eval(args))
+    }
   }
 
   sealed trait Predicate {
@@ -256,7 +288,7 @@ object Transformers extends EnhancedTokenParsers with Logging {
 
   val strBinOps = Map[String, ExprToBinPred[String]](
       EQ  -> buildPred[String](_.equals(_)),
-      NEQ -> buildPred[String]( (a, b) => !(a.equals(b)))
+      NEQ -> buildPred[String]((a, b) => a != b)
     )
 
   case class Not(p: Predicate) extends Predicate {
@@ -267,7 +299,8 @@ object Transformers extends EnhancedTokenParsers with Logging {
     override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Boolean = f(l.eval(args), r.eval(args))
   }
 
-  def buildBinaryLogicPredicate(f: (Boolean, Boolean) => Boolean): (Predicate, Predicate) => BinaryLogicPredicate = new BinaryLogicPredicate(_, _, f)
+  def buildBinaryLogicPredicate(f: (Boolean, Boolean) => Boolean): (Predicate, Predicate) => BinaryLogicPredicate =
+    new BinaryLogicPredicate(_, _, f)
 
   val And = buildBinaryLogicPredicate(_ && _)
   val Or  = buildBinaryLogicPredicate(_ || _)
@@ -285,15 +318,14 @@ object Transformers extends EnhancedTokenParsers with Logging {
 }
 
 object TransformerFn {
-  def apply(n: String)(f: Seq[Any] => Any) =
-    new TransformerFn {
-      override def eval(args: Array[Any])(implicit ctx: Transformers.EvaluationContext): Any = f(args)
-      override def name: String = n
+  def apply(n: String*)(f: (Array[Any]) => Any) = new TransformerFn {
+    override def eval(args: Array[Any])(implicit ctx: Transformers.EvaluationContext): Any = f(args)
+    override def names: Seq[String] = n
   }
 }
 
 trait TransformerFn {
-  def name: String
+  def names: Seq[String]
   def eval(args: Array[Any])(implicit ctx: Transformers.EvaluationContext): Any
   // some transformers cache arguments that don't change, override getInstance in order
   // to return a new transformer that can cache args
@@ -309,42 +341,52 @@ class StringFunctionFactory extends TransformerFunctionFactory {
   override def functions: Seq[TransformerFn] =
     Seq(stripQuotes, strLen, trim, capitalize, lowercase, uppercase, regexReplace, concat,  substr, string)
 
+  val string       = TransformerFn("toString")     { args => args(0).toString }
   val stripQuotes  = TransformerFn("stripQuotes")  { args => args(0).asInstanceOf[String].replaceAll("\"", "") }
-  val strLen       = TransformerFn("strlen")       { args => args(0).asInstanceOf[String].length }
   val trim         = TransformerFn("trim")         { args => args(0).asInstanceOf[String].trim }
   val capitalize   = TransformerFn("capitalize")   { args => args(0).asInstanceOf[String].capitalize }
   val lowercase    = TransformerFn("lowercase")    { args => args(0).asInstanceOf[String].toLowerCase }
   val uppercase    = TransformerFn("uppercase")    { args => args(0).asInstanceOf[String].toUpperCase }
-  val regexReplace = TransformerFn("regexReplace") { args => args(0).asInstanceOf[Regex].replaceAllIn(args(2).asInstanceOf[String], args(1).asInstanceOf[String]) }
-  val concat       = TransformerFn("concat")       { args => s"${args(0)}${args(1)}" }
-  val substr       = TransformerFn("substr")       { args => args(0).asInstanceOf[String].substring(args(1).asInstanceOf[Int], args(2).asInstanceOf[Int]) }
-  val string       = TransformerFn("toString")     { args => args(0).toString }
+  val concat       = TransformerFn("concat", "concatenate") { args => s"${args(0)}${args(1)}" }
+  val regexReplace = TransformerFn("regexReplace") {
+    args => args(0).asInstanceOf[Regex].replaceAllIn(args(2).asInstanceOf[String], args(1).asInstanceOf[String])
+  }
+  val substr = TransformerFn("substr", "substring") {
+    args => args(0).asInstanceOf[String].substring(args(1).asInstanceOf[Int], args(2).asInstanceOf[Int])
+  }
+  val strLen = TransformerFn("strlen", "stringLength", "length") {
+    args => args(0).asInstanceOf[String].length
+  }
 }
 
 class DateFunctionFactory extends TransformerFunctionFactory {
 
   override def functions: Seq[TransformerFn] =
-    Seq(now, customFormatDateParser, datetime, isodate, isodatetime, basicDateTimeNoMillis, dateHourMinuteSecondMillis, millisToDate)
+    Seq(now, customFormatDateParser, datetime, isodate, isodatetime, basicDateTimeNoMillis,
+      dateHourMinuteSecondMillis, millisToDate)
 
-  val now                         = TransformerFn("now") { args => DateTime.now.toDate }
-  val customFormatDateParser      = CustomFormatDateParser()
-  val datetime                    = StandardDateParser("datetime", ISODateTimeFormat.dateTime().withZoneUTC())
-  val isodate                     = StandardDateParser("isodate", ISODateTimeFormat.basicDate().withZoneUTC())
-  val isodatetime                 = StandardDateParser("isodatetime", ISODateTimeFormat.basicDateTime().withZoneUTC())
-  val basicDateTimeNoMillis       = StandardDateParser("basicDateTimeNoMillis", ISODateTimeFormat.basicDateTimeNoMillis().withZoneUTC())
-  val dateHourMinuteSecondMillis  = StandardDateParser("dateHourMinuteSecondMillis", ISODateTimeFormat.dateHourMinuteSecondMillis().withZoneUTC())
-  val millisToDate                = TransformerFn("millisToDate") { args => new Date(args(0).asInstanceOf[Long]) }
+  val now                        = TransformerFn("now") { args => DateTime.now.toDate }
+  val millisToDate               = TransformerFn("millisToDate") { args => new Date(args(0).asInstanceOf[Long]) }
+  val customFormatDateParser     = CustomFormatDateParser()
+  val datetime                   = StandardDateParser("datetime", "dateTime")(ISODateTimeFormat.dateTime().withZoneUTC())
+  val isodate                    = StandardDateParser("isodate", "basicDate")(ISODateTimeFormat.basicDate().withZoneUTC())
+  val isodatetime                = StandardDateParser("isodatetime", "basicDateTime")(ISODateTimeFormat.basicDateTime().withZoneUTC())
+  val basicDateTimeNoMillis      = StandardDateParser("basicDateTimeNoMillis")(ISODateTimeFormat.basicDateTimeNoMillis().withZoneUTC())
+  val dateHourMinuteSecondMillis = StandardDateParser("dateHourMinuteSecondMillis")(ISODateTimeFormat.dateHourMinuteSecondMillis().withZoneUTC())
 
-  case class StandardDateParser(name: String, format: DateTimeFormatter) extends TransformerFn {
-    override def eval(args: Array[Any])(implicit ctx: Transformers.EvaluationContext): Any = format.parseDateTime(args(0).toString).toDate
+  case class StandardDateParser(names: String*)(format: DateTimeFormatter) extends TransformerFn {
+    override def eval(args: Array[Any])(implicit ctx: Transformers.EvaluationContext): Any =
+      format.parseDateTime(args(0).toString).toDate
   }
 
   case class CustomFormatDateParser(var format: DateTimeFormatter = null) extends TransformerFn {
-    val name = "date"
+    override val names = Seq("date")
     override def getInstance: CustomFormatDateParser = CustomFormatDateParser()
 
     override def eval(args: Array[Any])(implicit ctx: Transformers.EvaluationContext): Any = {
-      if(format == null) format = DateTimeFormat.forPattern(args(0).asInstanceOf[String]).withZoneUTC()
+      if (format == null) {
+        format = DateTimeFormat.forPattern(args(0).asInstanceOf[String]).withZoneUTC()
+      }
       format.parseDateTime(args(1).asInstanceOf[String]).toDate
     }
   }
@@ -393,24 +435,27 @@ class GeometryFunctionFactory extends TransformerFunctionFactory {
         throw new IllegalArgumentException(s"Invalid geometry conversion argument: ${args.toList}")
     }
   }
-
 }
 
 class IdFunctionFactory extends TransformerFunctionFactory {
-  override def functions = Seq(string2Bytes, MD5, uuidFn, base64)
+  override def functions = Seq(string2Bytes, md5, uuidFn, base64)
 
-  val string2Bytes = TransformerFn("string2bytes") { args => args(0).asInstanceOf[String].getBytes(StandardCharsets.UTF_8) }
-
-  case object MD5 extends TransformerFn {
-
-    override def name: String = "md5"
-    val hasher = Hashing.md5()
-    override def eval(args: Array[Any])(implicit ctx: Transformers.EvaluationContext): Any = hasher.hashBytes(args(0).asInstanceOf[Array[Byte]]).toString
+  val string2Bytes = TransformerFn("string2bytes", "stringToBytes") {
+    args => args(0).asInstanceOf[String].getBytes(StandardCharsets.UTF_8)
   }
-
   val uuidFn = TransformerFn("uuid")   { args => UUID.randomUUID().toString }
-  val base64 = TransformerFn("base64") { args => Base64.encodeBase64URLSafeString(args(0).asInstanceOf[Array[Byte]]) }
+  val base64 = TransformerFn("base64") {
+    args => Base64.encodeBase64URLSafeString(args(0).asInstanceOf[Array[Byte]])
+  }
+  val md5 = new MD5
 
+  class MD5 extends TransformerFn {
+    override val names = Seq("md5")
+    override def getInstance: MD5 = new MD5()
+    val hasher = Hashing.md5()
+    override def eval(args: Array[Any])(implicit ctx: Transformers.EvaluationContext): Any =
+      hasher.hashBytes(args(0).asInstanceOf[Array[Byte]]).toString
+  }
 }
 
 class LineNumberFunctionFactory extends TransformerFunctionFactory {
@@ -418,10 +463,9 @@ class LineNumberFunctionFactory extends TransformerFunctionFactory {
 
   case class LineNumberFn() extends TransformerFn {
     override def getInstance: LineNumberFn = LineNumberFn()
-    override def name: String = "lineNo"
-    def eval(args: Array[Any])(implicit ctx: Transformers.EvaluationContext): Any = ctx.getCounter.getLineCount
+    override val names = Seq("lineNo", "lineNumber")
+    def eval(args: Array[Any])(implicit ctx: Transformers.EvaluationContext): Any = ctx.counter.getLineCount
   }
-
 }
 
 class MapListFunctionFactory extends TransformerFunctionFactory {
@@ -444,9 +488,7 @@ class MapListFunctionFactory extends TransformerFunctionFactory {
 
   import scala.collection.JavaConverters._
 
-  val listFn = TransformerFn("list") { args =>
-    args.toList.asJava
-  }
+  val listFn = TransformerFn("list") { args => args.toList.asJava }
 
   def convert(value: Any, clazz: Class[_]) =
     Option(Converters.convert(value, clazz))
@@ -485,22 +527,36 @@ class MapListFunctionFactory extends TransformerFunctionFactory {
 }
 
 class CastFunctionFactory extends TransformerFunctionFactory {
-  override def functions = Seq(string2double, string2int, string2float, string2long, string2boolean, string2integer)
+  override def functions = Seq(stringToDouble, stringToInt, stringToFloat, stringToLong, stringToBoolean)
 
-  val string2double = TransformerFn("string2double") {
-    args => { try { args(0).asInstanceOf[String].toDouble } catch { case e: Exception => args(1) } }
+  val stringToDouble = TransformerFn("stringToDouble") {
+    args => tryConvert(args(0).asInstanceOf[String], (s) => s.toDouble, args(1))
   }
-  val string2int = TransformerFn("string2int") { str2intHelper() }
-  val string2integer = TransformerFn("string2integer") { str2intHelper() }
-  val string2float = TransformerFn("string2float") {
-    args => { try { args(0).asInstanceOf[String].toFloat } catch { case e: Exception => args(1) } }
+  val stringToInt = TransformerFn("stringToInt", "stringToInteger") {
+    args => tryConvert(args(0).asInstanceOf[String], (s) => s.toInt, args(1))
   }
-  val string2long = TransformerFn("string2long") {
-    args => { try { args(0).asInstanceOf[String].toLong } catch { case e: Exception => args(1) } }
+  val stringToFloat = TransformerFn("stringToFloat") {
+    args => tryConvert(args(0).asInstanceOf[String], (s) => s.toFloat, args(1))
   }
-  val string2boolean = TransformerFn("string2boolean") {
-    args => { try { args(0).asInstanceOf[String].toBoolean } catch { case e: Exception => args(1) } }
+  val stringToLong = TransformerFn("stringToLong") {
+    args => tryConvert(args(0).asInstanceOf[String], (s) => s.toLong, args(1))
+  }
+  val stringToBoolean = TransformerFn("stringToBool", "stringToBoolean") {
+    args => tryConvert(args(0).asInstanceOf[String], (s) => s.toBoolean, args(1))
   }
 
-  def str2intHelper() = (args: Seq[Any]) => { try { args(0).asInstanceOf[String].toInt } catch { case e: Exception => args(1) } }
+  def tryConvert(s: String, conversion: (String) => Any, default: Any): Any = {
+    if (s == null || s.isEmpty) {
+      return default
+    }
+    try { conversion(s) } catch { case e: Exception => default }
+  }
+}
+
+class OpFunctionFactory extends TransformerFunctionFactory {
+  override def functions = Seq(tri)
+
+  val tri = TransformerFn("try", "Try") {
+    args =>
+  }
 }

--- a/geomesa-convert/geomesa-convert-common/src/test/resources/log4j.xml
+++ b/geomesa-convert/geomesa-convert-common/src/test/resources/log4j.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
-  ~ All rights reserved. This program and the accompanying materials
-  ~ are made available under the terms of the Apache License, Version 2.0 which
-  ~ accompanies this distribution and is available at
-  ~ http://www.opensource.org/licenses/apache2.0.php.
-  -->
+<!--********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*********************************************************************-->
 
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
@@ -29,9 +29,6 @@
         <priority value="warn"/>
     </category>
 
-    <category name="org.locationtech.geomesa.convert.text.DelimitedTextConverter">
-        <priority value="error"/>
-    </category>
     <!-- un-comment the following line to enable verbose log messages
          from the index query-planner; this can be helpful in debugging
          query plans -->
@@ -42,7 +39,7 @@
     -->
 
     <root>
-        <priority value="warn"/>
+        <priority value="info"/>
         <appender-ref ref="CONSOLE" />
     </root>
 </log4j:configuration>

--- a/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert/common/TransformersTest.scala
+++ b/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert/common/TransformersTest.scala
@@ -16,12 +16,11 @@ import org.apache.commons.codec.binary.Base64
 import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.convert.Transformers
-import org.locationtech.geomesa.convert.Transformers.{EvaluationContext, Predicate}
+import org.locationtech.geomesa.convert.Transformers.EvaluationContext
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
-import scala.collection.mutable
 import scala.util.Random
 
 @RunWith(classOf[JUnitRunner])
@@ -29,7 +28,7 @@ class TransformersTest extends Specification {
 
   "Transformers" should {
 
-    implicit val ctx = new EvaluationContext(mutable.HashMap.empty[String, Int], null)
+    implicit val ctx = EvaluationContext.empty
 
     "handle transformations" >> {
 
@@ -38,76 +37,121 @@ class TransformersTest extends Specification {
           val exp = Transformers.parseTransform("'hello'")
           exp.eval(Array(null)) must be equalTo "hello"
         }
-
         "allow quoted strings" >> {
           val exp = Transformers.parseTransform("'he\\'llo'")
           exp.eval(Array(null)) must be equalTo "he'llo"
-        }
-
-        "not parse non-quoted things (this shouldn't be a string)" >> {
-          val exp = Transformers.parseTransform("5")
-          exp.eval(Array(null)) must be equalTo 5
         }
         "allow empty literal strings" >> {
           val exp = Transformers.parseTransform("''")
           exp.eval(Array(null)) must be equalTo ""
         }
-
+        "allow native ints" >> {
+          val res = Transformers.parseTransform("1").eval(Array(null))
+          res must beAnInstanceOf[java.lang.Integer]
+          res mustEqual 1
+        }
+        "allow native longs" >> {
+          val res = Transformers.parseTransform("1L").eval(Array(null))
+          res must beAnInstanceOf[java.lang.Long]
+          res mustEqual 1L
+        }
+        "allow native floats" >> {
+          val f = Transformers.parseTransform("1.0f").eval(Array(null))
+          f must beAnInstanceOf[java.lang.Float]
+          f mustEqual 1.0f
+          val F = Transformers.parseTransform("1.0F").eval(Array(null))
+          F must beAnInstanceOf[java.lang.Float]
+          F mustEqual 1.0f
+        }
+        "allow native doubles" >> {
+          val res = Transformers.parseTransform("1.0").eval(Array(null))
+          res must beAnInstanceOf[java.lang.Double]
+          res mustEqual 1.0d
+          val d = Transformers.parseTransform("1.0d").eval(Array(null))
+          d must beAnInstanceOf[java.lang.Double]
+          d mustEqual 1.0d
+          val D = Transformers.parseTransform("1.0D").eval(Array(null))
+          D must beAnInstanceOf[java.lang.Double]
+          D mustEqual 1.0d
+        }
+        "allow native booleans" >> {
+          Transformers.parseTransform("false").eval(Array(null)) mustEqual false
+          Transformers.parseTransform("true").eval(Array(null)) mustEqual true
+        }
+        "allow native nulls" >> {
+          Transformers.parseTransform("null").eval(Array(null)) must beNull
+        }
         "trim" >> {
           val exp = Transformers.parseTransform("trim($1)")
           exp.eval(Array("", "foo ", "bar")) must be equalTo "foo"
         }
-
         "capitalize" >> {
           val exp = Transformers.parseTransform("capitalize($1)")
           exp.eval(Array("", "foo", "bar")) must be equalTo "Foo"
         }
-
         "lowercase" >> {
           val exp = Transformers.parseTransform("lowercase($1)")
           exp.eval(Array("", "FOO", "bar")) must be equalTo "foo"
         }
-
         "uppercase" >> {
           val exp = Transformers.parseTransform("uppercase($1)")
           exp.eval(Array("", "FoO")) must be equalTo "FOO"
         }
-
         "regexReplace" >> {
           val exp = Transformers.parseTransform("regexReplace('foo'::r,'bar',$1)")
           exp.eval(Array("", "foobar")) must be equalTo "barbar"
         }
-
         "compound expression" >> {
           val exp = Transformers.parseTransform("regexReplace('foo'::r,'bar',trim($1))")
           exp.eval(Array("", " foobar ")) must be equalTo "barbar"
         }
-
         "substr" >> {
           val exp = Transformers.parseTransform("substr($1, 2, 5)")
           exp.eval(Array("", "foobarbaz")) must be equalTo "foobarbaz".substring(2, 5)
         }
-
+        "substring" >> {
+          val exp = Transformers.parseTransform("substring($1, 2, 5)")
+          exp.eval(Array("", "foobarbaz")) must be equalTo "foobarbaz".substring(2, 5)
+        }
         "strlen" >> {
           val exp = Transformers.parseTransform("strlen($1)")
           exp.eval(Array("", "FOO")) must be equalTo 3
         }
-
+        "length" >> {
+          val exp = Transformers.parseTransform("length($1)")
+          exp.eval(Array("", "FOO")) must be equalTo 3
+        }
         "toString" >> {
           val exp = Transformers.parseTransform("toString($1)")
           exp.eval(Array("", 5)) must be equalTo "5"
         }
-
         "concat with tostring" >> {
           val exp = Transformers.parseTransform("concat(toString($1), toString($2))")
           exp.eval(Array("", 5, 6)) must be equalTo "56"
         }
-
       }
 
-      "handle numeric literals" >> {
-        val exp = Transformers.parseTransform("$2")
-        exp.eval(Array("", "1", 2)) must be equalTo 2
+      "handle non-string literals" >> {
+        "input is an int" >> {
+          val exp = Transformers.parseTransform("$2")
+          exp.eval(Array("", "1", 2)) must be equalTo 2
+        }
+        "cast to int" >> {
+          val exp = Transformers.parseTransform("$1::int")
+          exp.eval(Array("", "1")) mustEqual 1
+        }
+        "cast to integer" >> {
+          val exp = Transformers.parseTransform("$1::integer")
+          exp.eval(Array("", "1")) mustEqual 1
+        }
+        "cast to bool" >> {
+          val exp = Transformers.parseTransform("$1::bool")
+          exp.eval(Array("", "true")) mustEqual true
+        }
+        "cast to boolean" >> {
+          val exp = Transformers.parseTransform("$1::boolean")
+          exp.eval(Array("", "false")) mustEqual false
+        }
       }
 
       "handle dates" >> {
@@ -117,43 +161,47 @@ class TransformersTest extends Specification {
           val exp = Transformers.parseTransform("date('yyyyMMdd', $1)")
           exp.eval(Array("", "20150101")).asInstanceOf[Date] must be equalTo testDate
         }
-
         "date with a realistic custom format" >> {
           val exp = Transformers.parseTransform("date('YYYY-MM-dd\\'T\\'HH:mm:ss.SSSSSS', $1)")
           exp.eval(Array("", "2015-01-01T00:00:00.000000")).asInstanceOf[Date] must be equalTo testDate
         }
-
         "datetime" >> {
           val exp = Transformers.parseTransform("datetime($1)")
           exp.eval(Array("", "2015-01-01T00:00:00.000Z")).asInstanceOf[Date] must be equalTo testDate
         }
-
+        "dateTime" >> {
+          val exp = Transformers.parseTransform("dateTime($1)")
+          exp.eval(Array("", "2015-01-01T00:00:00.000Z")).asInstanceOf[Date] must be equalTo testDate
+        }
         "isodate" >> {
           val exp = Transformers.parseTransform("isodate($1)")
           exp.eval(Array("", "20150101")).asInstanceOf[Date] must be equalTo testDate
         }
-
+        "basicDate" >> {
+          val exp = Transformers.parseTransform("basicDate($1)")
+          exp.eval(Array("", "20150101")).asInstanceOf[Date] must be equalTo testDate
+        }
         "isodatetime" >> {
           val exp = Transformers.parseTransform("isodatetime($1)")
           exp.eval(Array("", "20150101T000000.000Z")).asInstanceOf[Date] must be equalTo testDate
         }
-
+        "basicDateTime" >> {
+          val exp = Transformers.parseTransform("basicDateTime($1)")
+          exp.eval(Array("", "20150101T000000.000Z")).asInstanceOf[Date] must be equalTo testDate
+        }
         "basicDateTimeNoMillis" >> {
           val exp = Transformers.parseTransform("basicDateTimeNoMillis($1)")
           exp.eval(Array("", "20150101T000000Z")).asInstanceOf[Date] must be equalTo testDate
         }
-
         "dateHourMinuteSecondMillis" >> {
           val exp = Transformers.parseTransform("dateHourMinuteSecondMillis($1)")
           exp.eval(Array("", "2015-01-01T00:00:00.000")).asInstanceOf[Date] must be equalTo testDate
         }
-
         "millisToDate" >> {
           val millis = testDate.getTime
           val exp = Transformers.parseTransform("millisToDate($1)")
           exp.eval(Array("", millis)).asInstanceOf[Date] must be equalTo testDate
         }
-
       }
 
       "handle point geometries" >> {
@@ -213,12 +261,10 @@ class TransformersTest extends Specification {
           val hashedResult = exp.eval(Array(bytes)).asInstanceOf[String]
           hashedResult must be equalTo hasher.putBytes(bytes).hash().toString
         }
-
         "uuid" >> {
           val exp = Transformers.parseTransform("uuid()")
           exp.eval(Array(null)) must anInstanceOf[String]
         }
-
         "base64" >> {
           val exp = Transformers.parseTransform("base64($0)")
           exp.eval(Array(bytes)) must be equalTo Base64.encodeBase64URLSafeString(bytes)
@@ -226,11 +272,32 @@ class TransformersTest extends Specification {
       }
 
       "handle named values" >> {
-        val closure = Array.ofDim[Any](3)
-        closure(1) = "bar"
-        implicit val ctx = new EvaluationContext(mutable.HashMap("foo" -> 1), closure)
+        implicit val ctx = EvaluationContext(IndexedSeq(null, "foo", null), Array[Any](null, "bar", null), null)
         val exp = Transformers.parseTransform("capitalize($foo)")
         exp.eval(Array(null))(ctx) must be equalTo "Bar"
+      }
+
+      "handle exceptions to casting" >> {
+        val exp = Transformers.parseTransform("try($1::int, 0)")
+        exp.eval(Array("", "1")).asInstanceOf[Int] mustEqual 1
+        exp.eval(Array("", "")).asInstanceOf[Int] mustEqual 0
+        exp.eval(Array("", "abcd")).asInstanceOf[Int] mustEqual 0
+      }
+
+      "handle exceptions to conversions" >> {
+        val exp = Transformers.parseTransform("try(millisToDate($1), now())")
+        val millis = 100000L
+        exp.eval(Array("", millis)).asInstanceOf[Date] mustEqual new Date(millis)
+        exp.eval(Array("", "")).asInstanceOf[Date].getTime must beCloseTo(System.currentTimeMillis(), 100)
+        exp.eval(Array("", "abcd")).asInstanceOf[Date].getTime must beCloseTo(System.currentTimeMillis(), 100)
+      }
+
+      "handle exceptions with null defaults" >> {
+        val exp = Transformers.parseTransform("try(millisToDate($1), null)")
+        val millis = 100000L
+        exp.eval(Array("", millis)).asInstanceOf[Date] mustEqual new Date(millis)
+        exp.eval(Array("", "")).asInstanceOf[Date] must beNull
+        exp.eval(Array("", "abcd")).asInstanceOf[Date] must beNull
       }
     }
 
@@ -238,7 +305,6 @@ class TransformersTest extends Specification {
       "string equals" >> {
         val exp = Transformers.parsePred("strEq($1, $2)")
         exp.eval(Array("", "1", "2")) must beFalse
-
         exp.eval(Array("", "1", "1")) must beTrue
       }
 
@@ -248,13 +314,16 @@ class TransformersTest extends Specification {
           exp.eval(Array("", "1", "2")) must beFalse
           exp.eval(Array("", "1", "1")) must beTrue
         }
-
+        "integer equals" >> {
+          val exp = Transformers.parsePred("integerEq($1::int, $2::int)")
+          exp.eval(Array("", "1", "2")) must beFalse
+          exp.eval(Array("", "1", "1")) must beTrue
+        }
         "nested int equals" >> {
           val exp = Transformers.parsePred("intEq($1::int, strlen($2))")
           exp.eval(Array("", "3", "foo")) must beTrue
           exp.eval(Array("", "4", "foo")) must beFalse
         }
-
         "int lteq" >> {
           val exp = Transformers.parsePred("intLTEq($1::int, $2::int)")
           exp.eval(Array("", "1", "2")) must beTrue
@@ -283,7 +352,6 @@ class TransformersTest extends Specification {
           exp.eval(Array("", "1.0", "2.0")) must beFalse
           exp.eval(Array("", "1.0", "1.0")) must beTrue
         }
-
         "double lteq" >> {
           val exp = Transformers.parsePred("doubleLTEq($1::double, $2::double)")
           exp.eval(Array("", "1.0", "2.0")) must beTrue
@@ -309,97 +377,97 @@ class TransformersTest extends Specification {
         }
       }
 
-      "string2 functions" >> {
-        "string2double" >> {
-          "double string2double zero default" >> {
-            val exp = Transformers.parseTransform("string2double($1, '0.0'::double)")
+      "stringTo functions" >> {
+        "stringToDouble" >> {
+          "double stringToDouble zero default" >> {
+            val exp = Transformers.parseTransform("stringToDouble($1, 0.0)")
             exp.eval(Array("", "1.2")) mustEqual 1.2
             exp.eval(Array("", "")) mustEqual 0.0
             exp.eval(Array("", null)) mustEqual 0.0
-            exp.eval(Array("", 5L)) mustEqual 0.0
+            exp.eval(Array("", "notadouble")) mustEqual 0.0
           }
-          "double string2double null default" >> {
-            val exp = Transformers.parseTransform("string2double($1, $2)")
+          "double stringToDouble null default" >> {
+            val exp = Transformers.parseTransform("stringToDouble($1, $2)")
             exp.eval(Array("", "1.2", null)) mustEqual 1.2
             exp.eval(Array("", "", null)) mustEqual null
             exp.eval(Array("", null, null)) mustEqual null
-            exp.eval(Array("", 5L, null)) mustEqual null
+            exp.eval(Array("", "notadouble", null)) mustEqual null
           }
         }
-        "string2int" >> {
-          "int string2int zero default" >> {
-            val exp = Transformers.parseTransform("string2int($1, '0'::int)")
+        "stringToInt" >> {
+          "int stringToInt zero default" >> {
+            val exp = Transformers.parseTransform("stringToInt($1, 0)")
             exp.eval(Array("", "2")) mustEqual 2
             exp.eval(Array("", "")) mustEqual 0
             exp.eval(Array("", null)) mustEqual 0
             exp.eval(Array("", "1.2")) mustEqual 0
           }
-          "int string2int null default" >> {
-            val exp = Transformers.parseTransform("string2int($1, $2)")
+          "int stringToInt null default" >> {
+            val exp = Transformers.parseTransform("stringToInt($1, $2)")
             exp.eval(Array("", "2", null)) mustEqual 2
             exp.eval(Array("", "", null)) mustEqual null
             exp.eval(Array("", null, null)) mustEqual null
             exp.eval(Array("", "1.2", null)) mustEqual null
           }
         }
-        "string2integer" >> {
-          "int string2integer zero default" >> {
-            val exp = Transformers.parseTransform("string2integer($1, '0'::int)")
+        "stringToInteger" >> {
+          "int stringToInteger zero default" >> {
+            val exp = Transformers.parseTransform("stringToInteger($1, 0)")
             exp.eval(Array("", "2")) mustEqual 2
             exp.eval(Array("", "")) mustEqual 0
             exp.eval(Array("", null)) mustEqual 0
             exp.eval(Array("", "1.2")) mustEqual 0
           }
-          "int string2integer null default" >> {
-            val exp = Transformers.parseTransform("string2integer($1, $2)")
+          "int stringToInteger null default" >> {
+            val exp = Transformers.parseTransform("stringToInteger($1, $2)")
             exp.eval(Array("", "2", null)) mustEqual 2
             exp.eval(Array("", "", null)) mustEqual null
             exp.eval(Array("", null, null)) mustEqual null
             exp.eval(Array("", "1.2", null)) mustEqual null
           }
         }
-        "string2long" >> {
-          "long string2long zero default" >> {
-            val exp = Transformers.parseTransform("string2long($1, '0'::long)")
+        "stringToLong" >> {
+          "long stringToLong zero default" >> {
+            val exp = Transformers.parseTransform("stringToLong($1, 0L)")
             exp.eval(Array("", "22960000000")) mustEqual 22960000000L
             exp.eval(Array("", "")) mustEqual 0L
             exp.eval(Array("", null)) mustEqual 0L
             exp.eval(Array("", "1.2")) mustEqual 0L
           }
-          "long string2long null default" >> {
-            val exp = Transformers.parseTransform("string2long($1, $2)")
+          "long stringToLong null default" >> {
+            val exp = Transformers.parseTransform("stringToLong($1, $2)")
             exp.eval(Array("", "22960000000", null)) mustEqual 22960000000L
             exp.eval(Array("", "", null)) mustEqual null
             exp.eval(Array("", null, null)) mustEqual null
             exp.eval(Array("", "1.2", null)) mustEqual null
           }
         }
-        "string2float" >> {
-          "float string2float zero default" >> {
-            val exp = Transformers.parseTransform("string2float($1, '0.0'::float)")
+        "stringToFloat" >> {
+          "float stringToFloat zero default" >> {
+            val exp = Transformers.parseTransform("stringToFloat($1, 0.0f)")
             exp.eval(Array("", "1.2")) mustEqual 1.2f
             exp.eval(Array("", "")) mustEqual 0.0f
             exp.eval(Array("", null)) mustEqual 0.0f
-            exp.eval(Array("", 5L)) mustEqual 0.0f
+            exp.eval(Array("", "notafloat")) mustEqual 0.0f
           }
-          "float string2float zero default" >> {
-            val exp = Transformers.parseTransform("string2float($1, $2)")
+          "float stringToFloat zero default" >> {
+            val exp = Transformers.parseTransform("stringToFloat($1, $2)")
             exp.eval(Array("", "1.2", null)) mustEqual 1.2f
             exp.eval(Array("", "", null)) mustEqual null
             exp.eval(Array("", null, null)) mustEqual null
-            exp.eval(Array("", 5L, null)) mustEqual null
+            exp.eval(Array("", "notafloat", null)) mustEqual null
           }
         }
-        "string2boolean" >> {
-          "boolean string2boolean false default" >> {
-            val exp = Transformers.parseTransform("string2boolean($1,'false'::boolean)")
+        "stringToBoolean" >> {
+          "boolean stringToBoolean false default" >> {
+            val exp = Transformers.parseTransform("stringToBoolean($1, false)")
             exp.eval(Array("", "true")) mustEqual true
             exp.eval(Array("", "")) mustEqual false
             exp.eval(Array("", null)) mustEqual false
             exp.eval(Array("", "18")) mustEqual false
           }
-          "boolean string2boolean null default" >> {
-            val exp = Transformers.parseTransform("string2boolean($1,$2)")
+          "boolean stringToBoolean null default" >> {
+            val exp = Transformers.parseTransform("stringToBoolean($1,$2)")
             exp.eval(Array("", "true", null)) mustEqual true
             exp.eval(Array("", "", null)) mustEqual null
             exp.eval(Array("", null, null)) mustEqual null
@@ -413,12 +481,10 @@ class TransformersTest extends Specification {
           val exp = Transformers.parsePred("not(strEq($1, $2))")
           exp.eval(Array("", "1", "1")) must beFalse
         }
-
         "and" >> {
           val exp = Transformers.parsePred("and(strEq($1, $2), strEq(concat($3, $4), $1))")
           exp.eval(Array("", "foo", "foo", "f", "oo")) must beTrue
         }
-
         "or" >> {
           val exp = Transformers.parsePred("or(strEq($1, $2), strEq($3, $1))")
           exp.eval(Array("", "foo", "foo", "f", "oo")) must beTrue

--- a/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
+++ b/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>specs2_2.10</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/geomesa-convert/geomesa-convert-fixedwidth/src/test/resources/log4j.xml
+++ b/geomesa-convert/geomesa-convert-fixedwidth/src/test/resources/log4j.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
-  ~ All rights reserved. This program and the accompanying materials
-  ~ are made available under the terms of the Apache License, Version 2.0 which
-  ~ accompanies this distribution and is available at
-  ~ http://www.opensource.org/licenses/apache2.0.php.
-  -->
+<!--********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*********************************************************************-->
 
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
@@ -29,9 +29,6 @@
         <priority value="warn"/>
     </category>
 
-    <category name="org.locationtech.geomesa.convert.text.DelimitedTextConverter">
-        <priority value="error"/>
-    </category>
     <!-- un-comment the following line to enable verbose log messages
          from the index query-planner; this can be helpful in debugging
          query plans -->
@@ -42,7 +39,7 @@
     -->
 
     <root>
-        <priority value="warn"/>
+        <priority value="info"/>
         <appender-ref ref="CONSOLE" />
     </root>
 </log4j:configuration>

--- a/geomesa-convert/geomesa-convert-json/pom.xml
+++ b/geomesa-convert/geomesa-convert-json/pom.xml
@@ -37,12 +37,6 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
 </project>

--- a/geomesa-convert/geomesa-convert-json/src/main/scala/org/locationtech/geomesa/convert/json/JsonFunctionFactory.scala
+++ b/geomesa-convert/geomesa-convert-json/src/main/scala/org/locationtech/geomesa/convert/json/JsonFunctionFactory.scala
@@ -17,7 +17,7 @@ class JsonFunctionFactory extends TransformerFunctionFactory {
     override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any =
       args(0).asInstanceOf[JsonElement].toString
 
-    override def name: String = "json2string"
+    override val names = Seq("json2string", "jsonToString")
   }
 
   override val functions: Seq[TransformerFn] = Seq(json2string)

--- a/geomesa-convert/geomesa-convert-json/src/test/scala/org/locationtech/geomesa/convert/json/JsonConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-json/src/test/scala/org/locationtech/geomesa/convert/json/JsonConverterTest.scala
@@ -57,7 +57,6 @@ class JsonConverterTest extends Specification {
     """.stripMargin)
 
   val sft = SimpleFeatureTypes.createType(sftConfPoint)
-  implicit val ec = new EvaluationContext(null, null)
 
   "Json Converter" should {
 

--- a/geomesa-convert/geomesa-convert-text/pom.xml
+++ b/geomesa-convert/geomesa-convert-text/pom.xml
@@ -40,5 +40,10 @@
             <artifactId>specs2_2.10</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
+++ b/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
@@ -16,7 +16,7 @@ import com.typesafe.config.Config
 import org.apache.commons.csv.{CSVFormat, QuoteMode}
 import org.locationtech.geomesa.convert.Transformers.{EvaluationContext, Expr}
 import org.locationtech.geomesa.convert.{Field, SimpleFeatureConverterFactory, ToSimpleFeatureConverter}
-import org.opengis.feature.simple.SimpleFeatureType
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.JavaConversions._
 
@@ -44,9 +44,9 @@ class DelimitedTextConverterFactory extends SimpleFeatureConverterFactory[String
     val opts = {
       import org.locationtech.geomesa.utils.conf.ConfConversions._
       val o = "options"
-      var dOpts = new DelimitedOptions()
-      dOpts = conf.getIntOpt(s"$o.skip-lines").map(s => dOpts.copy(skipLines = s)).getOrElse(dOpts)
-      dOpts = conf.getIntOpt(s"$o.pipe-size").map(p => dOpts.copy(pipeSize = p)).getOrElse(dOpts)
+      val dOpts = new DelimitedOptions()
+      conf.getIntOpt(s"$o.skip-lines").foreach(s => dOpts.skipLines = s)
+      conf.getIntOpt(s"$o.pipe-size").foreach(p => dOpts.pipeSize = p)
       dOpts
     }
 
@@ -56,8 +56,7 @@ class DelimitedTextConverterFactory extends SimpleFeatureConverterFactory[String
   }
 }
 
-case class DelimitedOptions(skipLines: Int = 0,
-                            pipeSize: Int = 16*1024)
+class DelimitedOptions(var skipLines: Int = 0, var pipeSize: Int = 16 * 1024)
 
 class DelimitedTextConverter(format: CSVFormat,
                              val targetSFT: SimpleFeatureType,
@@ -82,7 +81,6 @@ class DelimitedTextConverter(format: CSVFormat,
     override def run(): Unit = {
       while (true) {
         val s = q.take()
-
         // make sure the input is not null and is nonempty...if it is empty the threads will deadlock
         if (s != null && s.nonEmpty) {
           writer.write(s)
@@ -93,9 +91,16 @@ class DelimitedTextConverter(format: CSVFormat,
     }
   })
 
+  override def processInput(is: Iterator[String], ec: EvaluationContext): Iterator[SimpleFeature] = {
+    ec.counter.incLineCount(options.skipLines)
+    super.processInput(is.drop(options.skipLines), ec)
+  }
+
   override def fromInputType(string: String): Seq[Array[Any]] = {
     // empty strings cause deadlock
-    if (string == null || string.isEmpty) throw new IllegalArgumentException("Invalid input (empty)")
+    if (string == null || string.isEmpty) {
+      throw new IllegalArgumentException("Invalid input (empty)")
+    }
     q.put(string)
     val rec = parser.next()
     val len = rec.size()
@@ -108,13 +113,6 @@ class DelimitedTextConverter(format: CSVFormat,
     }
     Seq(ret)
   }
-
-  private var skipLines = options.skipLines
-  override def preProcess(i: String)(implicit ec: EvaluationContext): Option[String] =
-    if (skipLines > 0) {
-      skipLines -= 1
-      None
-    } else Some(i)
 
   override def close(): Unit = {
     es.shutdownNow()

--- a/geomesa-convert/geomesa-convert-text/src/test/resources/log4j.xml
+++ b/geomesa-convert/geomesa-convert-text/src/test/resources/log4j.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
-  ~ All rights reserved. This program and the accompanying materials
-  ~ are made available under the terms of the Apache License, Version 2.0 which
-  ~ accompanies this distribution and is available at
-  ~ http://www.opensource.org/licenses/apache2.0.php.
-  -->
+<!--********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*********************************************************************-->
 
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
@@ -28,7 +28,6 @@
     <category name="hsqldb">
         <priority value="warn"/>
     </category>
-
     <category name="org.locationtech.geomesa.convert.text.DelimitedTextConverter">
         <priority value="error"/>
     </category>
@@ -42,7 +41,7 @@
     -->
 
     <root>
-        <priority value="warn"/>
+        <priority value="info"/>
         <appender-ref ref="CONSOLE" />
     </root>
 </log4j:configuration>

--- a/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/CompositeTextConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/CompositeTextConverterTest.scala
@@ -42,8 +42,8 @@ class CompositeTextConverterTest extends Specification {
       |       fields = [
       |         { name = "phrase", transform = "concat($1, $2)" },
       |         { name = "lineNr", transform = "lineNo()" },
-      |         { name = "lat",    transform = "string2double($3, '0.0'::double)" },
-      |         { name = "lon",    transform = "string2double($4, '0.0'::double)" },
+      |         { name = "lat",    transform = "stringToDouble($3, '0.0'::double)" },
+      |         { name = "lon",    transform = "stringToDouble($4, '0.0'::double)" },
       |         { name = "geom",   transform = "point($lat, $lon)" }
       |       ]
       |     }
@@ -56,8 +56,8 @@ class CompositeTextConverterTest extends Specification {
       |       id-field     = "concat('second', trim($1))",
       |       fields = [
       |         { name = "phrase", transform = "concat($1, $2)" },
-      |         { name = "lat",    transform = "string2double($3, '0.0'::double)" },
-      |         { name = "lon",    transform = "string2double($4, '0.0'::double)" },
+      |         { name = "lat",    transform = "stringToDouble($3, '0.0'::double)" },
+      |         { name = "lon",    transform = "stringToDouble($4, '0.0'::double)" },
       |         { name = "geom",   transform = "point($lat, $lon)" }
       |         { name = "lineNr", transform = "lineNo()" }
       |       ]

--- a/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterTest.scala
@@ -121,7 +121,8 @@ class DelimitedTextConverterTest extends Specification {
       val converter = SimpleFeatureConverters.build[String](sft, conf)
       converter must not beNull
       val input = data.split("\n").toIterator.filterNot( s => "^\\s*$".r.findFirstIn(s).size > 0).map(_.replaceAll(",", "\t"))
-      val res = converter.processInput(input, Map("filename"-> "/some/file/path/testfile.txt")).toList
+      val ec = converter.createEvaluationContext(Map("filename"-> "/some/file/path/testfile.txt"))
+      val res = converter.processInput(input, ec).toList
       converter.close()
       res.size must be equalTo 2
       res(0).getAttribute("phrase").asInstanceOf[String] must be equalTo "1hello"
@@ -154,7 +155,8 @@ class DelimitedTextConverterTest extends Specification {
       val converter = SimpleFeatureConverters.build[String](sft, conf)
       converter must not beNull
       val input = data.split("\n").toIterator.filterNot( s => "^\\s*$".r.findFirstIn(s).size > 0).map(_.replaceAll(",", "\t"))
-      val res = converter.processInput(input, Map("filename"-> "/some/file/path/testfile.txt")).toList
+      val ec = converter.createEvaluationContext(Map("filename"-> "/some/file/path/testfile.txt"))
+      val res = converter.processInput(input, ec).toList
       converter.close()
       res.size must be equalTo 2
       res(0).getAttribute("phrase").asInstanceOf[String] must be equalTo "1hello"
@@ -322,7 +324,8 @@ class DelimitedTextConverterTest extends Specification {
         val converter = SimpleFeatureConverters.build[String](wktSft, trueConf)
 
         val counter = new DefaultCounter
-        val res = converter.processInput(trueData.split("\n").toIterator.filterNot( s => "^\\s*$".r.findFirstIn(s).size > 0), counter = counter).toList
+        val ec = converter.createEvaluationContext(counter = counter)
+        val res = converter.processInput(trueData.split("\n").toIterator.filterNot( s => "^\\s*$".r.findFirstIn(s).size > 0), ec).toList
         res.length mustEqual 2
         converter.close()
 
@@ -345,7 +348,8 @@ class DelimitedTextConverterTest extends Specification {
         val converter = SimpleFeatureConverters.build[String](wktSft, falseConf)
 
         val counter = new DefaultCounter
-        val res = converter.processInput(falseData.split("\n").toIterator.filterNot( s => "^\\s*$".r.findFirstIn(s).size > 0), counter = counter).toList
+        val ec = converter.createEvaluationContext(counter = counter)
+        val res = converter.processInput(falseData.split("\n").toIterator.filterNot( s => "^\\s*$".r.findFirstIn(s).size > 0), ec).toList
         res.length mustEqual 2
         converter.close()
 
@@ -370,7 +374,8 @@ class DelimitedTextConverterTest extends Specification {
         val converter = SimpleFeatureConverters.build[String](wktSft, falseConf)
 
         val counter = new DefaultCounter
-        val res = converter.processInput(falseData.split("\n").toIterator.filterNot( s => "^\\s*$".r.findFirstIn(s).size > 0), counter = counter).toList
+        val ec = converter.createEvaluationContext(counter = counter)
+        val res = converter.processInput(falseData.split("\n").toIterator.filterNot( s => "^\\s*$".r.findFirstIn(s).size > 0), ec).toList
         res.length mustEqual 2
         converter.close()
 

--- a/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlFunctionFactory.scala
+++ b/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlFunctionFactory.scala
@@ -26,7 +26,7 @@ class XmlFunctionFactory extends TransformerFunctionFactory {
   val xml2string = new TransformerFn {
     private val transformers = new SoftThreadLocal[Transformer]
 
-    override def name = "xml2string"
+    override val names = Seq("xml2string", "xmlToString")
 
     override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = {
       val element = args.head.asInstanceOf[Element]

--- a/geomesa-convert/geomesa-convert-xml/src/test/resources/log4j.properties
+++ b/geomesa-convert/geomesa-convert-xml/src/test/resources/log4j.properties
@@ -1,4 +1,0 @@
-log4j.rootLogger=DEBUG,out
-log4j.appender.out=org.apache.log4j.ConsoleAppender
-log4j.appender.out.layout=org.apache.log4j.PatternLayout
-log4j.appender.out.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n

--- a/geomesa-convert/geomesa-convert-xml/src/test/resources/log4j.xml
+++ b/geomesa-convert/geomesa-convert-xml/src/test/resources/log4j.xml
@@ -28,10 +28,10 @@
     <category name="hsqldb">
         <priority value="warn"/>
     </category>
-
-    <category name="org.locationtech.geomesa.convert.text.DelimitedTextConverter">
+    <category name="org.locationtech.geomesa.convert.xml.XMLConverter">
         <priority value="error"/>
     </category>
+
     <!-- un-comment the following line to enable verbose log messages
          from the index query-planner; this can be helpful in debugging
          query plans -->
@@ -42,7 +42,7 @@
     -->
 
     <root>
-        <priority value="warn"/>
+        <priority value="info"/>
         <appender-ref ref="CONSOLE" />
     </root>
 </log4j:configuration>

--- a/geomesa-convert/geomesa-convert-xml/src/test/scala/org/locationtech/geomesa/convert/xml/XMLConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-xml/src/test/scala/org/locationtech/geomesa/convert/xml/XMLConverterTest.scala
@@ -23,7 +23,6 @@ class XMLConverterTest extends Specification {
     """.stripMargin)
 
   val sft = SimpleFeatureTypes.createType(sftConf)
-  implicit val ec = new EvaluationContext(null, null)
 
   "XML Converter" should {
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/ScaldingConverterIngestJob.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/ScaldingConverterIngestJob.scala
@@ -13,13 +13,14 @@ import java.nio.charset.StandardCharsets
 import com.twitter.scalding.{Args, Hdfs, Job, Local, Mode}
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.slf4j.Logging
-import org.geotools.data.{DataStoreFinder, Transaction}
+import org.geotools.data.{DataUtilities, DataStoreFinder, Transaction}
 import org.geotools.factory.Hints
 import org.geotools.filter.identity.FeatureIdImpl
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStoreFactory.{params => dsp}
 import org.locationtech.geomesa.convert.SimpleFeatureConverters
 import org.locationtech.geomesa.convert.Transformers.DefaultCounter
+import org.locationtech.geomesa.convert.text.DelimitedTextConverter
 import org.locationtech.geomesa.jobs.scalding.MultipleUsefulTextLineFiles
 import org.locationtech.geomesa.tools.Utils.IngestParams
 
@@ -52,7 +53,14 @@ class ScaldingConverterIngestJob(args: Args) extends Job(args) with Logging {
     val sft = ds.getSchema(featureName)
     lazy val fw = ds.getFeatureWriterAppend(featureName, Transaction.AUTO_COMMIT)
     val converter = SimpleFeatureConverters.build[String](sft, ConfigFactory.parseString(converterConfig))
-    val callback = converter.processWithCallback(counter = counter)
+    converter match {
+      case d: DelimitedTextConverter if d.options.skipLines > 0 =>
+        logger.warn("SkipLines not supported - setting to 0")
+        d.options.skipLines = 0
+      case _ =>
+    }
+
+    val ec = converter.createEvaluationContext(counter = counter)
     def release(): Unit = {
       logger.trace("Releasing ingest resources")
       converter.close()
@@ -87,15 +95,18 @@ class ScaldingConverterIngestJob(args: Args) extends Job(args) with Logging {
   }
 
   private def processLine(resources: Resources, s: String) =
-    resources.callback(s)
-      .foreach { sf =>
-        val toWrite = resources.fw.next()
-        toWrite.setAttributes(sf.getAttributes)
-        toWrite.getIdentifier.asInstanceOf[FeatureIdImpl].setID(sf.getID)
-        toWrite.getUserData.putAll(sf.getUserData)
-        toWrite.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+    resources.converter.processInput(Iterator(s), resources.ec).foreach { sf =>
+      val toWrite = resources.fw.next()
+      toWrite.setAttributes(sf.getAttributes)
+      toWrite.getIdentifier.asInstanceOf[FeatureIdImpl].setID(sf.getID)
+      toWrite.getUserData.putAll(sf.getUserData)
+      toWrite.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+      try {
         resources.fw.write()
+      } catch {
+        case e: Exception => logger.error(s"Failed to write '${DataUtilities.encodeFeature(toWrite)}'", e)
       }
+    }
 
   def runTestIngest(lines: Iterator[String]) = {
     val ds = DataStoreFinder.getDataStore(dsConfig).asInstanceOf[AccumuloDataStore]

--- a/geomesa-tools/src/test/resources/examples/example1.conf
+++ b/geomesa-tools/src/test/resources/examples/example1.conf
@@ -13,7 +13,7 @@ converter = {
   type = "delimited-text",
   format = "CSV",
   options {
-    skip-lines = 1
+    skip-lines = 0 // don't skip lines in distributed ingest
   },
   id-field = "toString($id)",
   fields = [


### PR DESCRIPTION
Note: stacks on top of #740, please consider only the subsequent commits.

* Standardized converter function names
* Added converter support for native ints, longs, booleans, floats, doubles
* Added converter support for json longs and booleans
* Simplified SimpleFeatureConverter interface
* Improved erorr logging for converters
* Updated converter docs

Signed-off-by: Emilio Lahr-Vivaz elahrvivaz@ccri.com