### PR TITLE
GEOMESA-977,GEOMESA-1002 Discoverable simple feature types and converters

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
@@ -108,15 +108,15 @@ class AccumuloDataStoreFactory extends DataStoreFactorySpi {
       zookeepersParam,
       userParam,
       passwordParam,
+      tableNameParam,
       authsParam,
       visibilityParam,
-      tableNameParam,
-      statsParam,
-      cachingParam,
       queryTimeoutParam,
       queryThreadsParam,
       recordThreadsParam,
-      writeThreadsParam
+      writeThreadsParam,
+      statsParam,
+      cachingParam
     )
 
   def canProcess(params: JMap[String,Serializable]) = AccumuloDataStoreFactory.canProcess(params)

--- a/geomesa-tools/README.md
+++ b/geomesa-tools/README.md
@@ -30,43 +30,48 @@ Now, you should be able to use GeoMesa from any directory on your computer. To t
 
 This should print out the following usage text: 
 
-    bash$ geomesa
+    $ geomesa
     Usage: geomesa [command] [command options]
       Commands:
-        create       Create a feature definition in a GeoMesa catalog
-        delete       Delete a feature's data and definition from a GeoMesa catalog
-        deleteraster Delete a raster table
-        describe     Describe the attributes of a given feature in GeoMesa
-        explain      Explain how a GeoMesa query will be executed
-        export       Export a GeoMesa feature
-        help         Show help
-        ingest       Ingest a file of various formats into GeoMesa
-        ingestraster Ingest a raster file or raster files in a directory into GeoMesa
-        list         List GeoMesa features for a given catalog
-        querystats   Export queries and statistics about the last X number of queries to a CSV file.
-        tableconf    Perform table configuration operations
-                
+        create           Create a feature definition in a GeoMesa catalog
+        deletecatalog    Delete a GeoMesa catalog completely (and all features in it)
+        deleteraster     Delete a GeoMesa Raster Table
+        describe         Describe the attributes of a given feature in GeoMesa
+        env              Examine the current GeoMesa environment
+        explain          Explain how a GeoMesa query will be executed
+        export           Export a GeoMesa feature
+        getsft           Get the SimpleFeatureType of a feature
+        help             Show help
+        ingest           Ingest/convert various file formats into GeoMesa
+        ingestraster     Ingest a raster file or raster files in a directory into GeoMesa
+        list             List GeoMesa features for a given catalog
+        querystats       Export queries and statistics about the last X number of queries to a CSV file.
+        removeschema     Remove a schema and associated features from a GeoMesa catalog
+        tableconf        Perform table configuration operations
+        version          GeoMesa Version
+
+
 This usage text lists the available commands. To see help for an individual command run `geomesa help <command-name>` which for example
 will give you something like this:
 
-    bash$ geomesa help list
+    $ geomesa help list
     List GeoMesa features for a given catalog
     Usage: list [options]
       Options:
-        -a, --auths
+        --auths
            Accumulo authorizations
       * -c, --catalog
            Catalog table name for GeoMesa
         -i, --instance
            Accumulo instance name
-        -mc, --mock
+        --mock
            Run everything with a mock accumulo instance instead of a real one
            Default: false
         -p, --password
            Accumulo password (will prompt if not supplied)
       * -u, --user
            Accumulo user name
-        -v, --visibilities
+        --visibilities
            Accumulo scan visibilities
         -z, --zookeepers
            Zookeepers (host[:port], comma separated)
@@ -80,7 +85,7 @@ A test script is included under `geomesa\bin\test-geomesa` that runs each comman
 by including your Accumulo username, password, test catalog table, test feature name, and test SFT specification. Default values
 are already included in the script. Then, run the script from the command line to ensure there are no errors in the output text. 
 
-In all commands below, one can add `--instance-name`, `--zookeepers`, `--auths`, and `--visibilities` (or in short form `-i, -z, -a, -v`) arguments
+In all commands below, one can add `--instance-name`, `--zookeepers`, `--auths`, and `--visibilities` (or in short form `-i, -z`) arguments
 to properly configure the Accumulo data store connector. The Accumulo instance name and Zookeepers string can usually
 be automatically assigned as long as Accumulo is configured correctly. The Auths and Visibilities strings will have to
 be added as arguments to each command, if needed.
@@ -102,7 +107,7 @@ Optionally there is a script bundled as `$GEOMESA_HOME/bin/install-jai` that wil
 the jai libraries
 
 
-###Enabling Raster Ingest
+### Enabling Raster Ingest
 Due to licensing restrictions, a number of necessary dependencies required for raster ingest must be manually installed:
 
     <dependency>
@@ -157,110 +162,108 @@ To create a new feature on a specified catalog table, use the `create` command.
 
 #### Usage (required options denoted with star):
     $ geomesa help create
-    Create a feature definition in a GeoMesa catalog
-    Usage: create [options]
-      Options:
-        -a, --auths
-           Accumulo authorizations
-      * -c, --catalog
-           Catalog table name for GeoMesa
-        -dt, --dtg
-           DateTime field name to use as the default dtg
-      * -fn, --feature-name
-           Simple Feature Type name on which to operate
-        -i, --instance
-           Accumulo instance name
-        -mc, --mock
-           Run everything with a mock accumulo instance instead of a real one
-           Default: false
-        -p, --password
-           Accumulo password (will prompt if not supplied)
-        -sh, --shards
-           Number of shards to use for the storage tables (defaults to number of
-           tservers)
-      * -s, --spec
-           SimpleFeatureType specification
-        -st, --use-shared-tables
-           Use shared tables in Accumulo for feature storage (true/false)
-           Default: true
-      * -u, --user
-           Accumulo user name
-        -v, --visibilities
-           Accumulo scan visibilities
-        -z, --zookeepers
-           Zookeepers (host[:port], comma separated)
+      Create a feature definition in a GeoMesa catalog
+      Usage: create [options]
+        Options:
+          --auths
+             Accumulo authorizations
+        * -c, --catalog
+             Catalog table name for GeoMesa
+          --dtg
+             DateTime field name to use as the default dtg
+        * -f, --feature-name
+             Simple Feature Type name on which to operate
+          -i, --instance
+             Accumulo instance name
+          --mock
+             Run everything with a mock accumulo instance instead of a real one
+             Default: false
+          -p, --password
+             Accumulo password (will prompt if not supplied)
+          -s, --spec
+             SimpleFeatureType specification as a GeoTools spec string, SFT config, or
+             file with either
+          --use-shared-tables
+             Use shared tables in Accumulo for feature storage (true/false)
+             Default: true
+        * -u, --user
+             Accumulo user name
+          --visibilities
+             Accumulo scan visibilities
+          -z, --zookeepers
+             Zookeepers (host[:port], comma separated)
+
 
 #### Example command:
-    geomesa create -u username -p password -c test_create -i instname -z zoo1,zoo2,zoo3 -fn testing -s fid:String:index=true,dtg:Date,geom:Point:srid=4326 -dt dtg
+    geomesa create -u username -p password -c test_create -i instance -z zoo1,zoo2,zoo3 -f testing -s fid:String:index=true,dtg:Date,geom:Point:srid=4326 --dtg dtg
 
 ### removeschema
 To remove a feature type and it's associated data from a catalog table, use the `removeschema` command.
 
-####Usage (required options denoted with star):
+#### Usage (required options denoted with star):
     $ geomesa help removeschema
+    Remove a schema and associated features from a GeoMesa catalog
     Usage: removeschema [options]
       Options:
-        -a, --auths
+        --auths
            Accumulo authorizations
       * -c, --catalog
            Catalog table name for GeoMesa
-        -fn, --feature-name
+        -f, --feature-name
            Simple Feature Type name on which to operate
-        -f, --force
+        --force
            Force deletion without prompt
            Default: false
         -i, --instance
            Accumulo instance name
-        -mc, --mock
+        --mock
            Run everything with a mock accumulo instance instead of a real one
-           (true/false)
            Default: false
         -p, --password
            Accumulo password (will prompt if not supplied)
-        -pt, --pattern
+        --pattern
            Regular expression to select items to delete
       * -u, --user
            Accumulo user name
-        -v, --visibilities
+        --visibilities
            Accumulo scan visibilities
         -z, --zookeepers
            Zookeepers (host[:port], comma separated)
 
 
-    
 ####Example:
-    geomesa removeschema -u username -p password -i instname -z zoo1,zoo2,zoo3 -c test_catalog -fn testfeature1
-    geomesa removeschema -u username -p password -i instname -z zoo1,zoo2,zoo3 -c test_catalog -pt 'testfeatures\d+'
+    geomesa removeschema -u username -p password -i instance -z zoo1,zoo2,zoo3 -c test_catalog -f testfeature1
+    geomesa removeschema -u username -p password -i instance -z zoo1,zoo2,zoo3 -c test_catalog --pattern 'testfeatures\d+'
     
     
 ### deleteraster
 To delete a specific raster table use the `deleteraster` command.
 
-####Usage (required options denoted with star):
+#### Usage (required options denoted with star):
     $ geomesa help deleteraster
-    Delete a GeoMesa Raster Store 
-    Usage: deleteraster [options]
-      Options:
-        -a, --auths
-           Accumulo authorizations
-        -f, --force
-           Force deletion of feature without prompt
-           Default: false
-        -i, --instance
-           Accumulo instance name
-        -mc, --mock
-           Run everything with a mock accumulo instance instead of a real one
-           Default: false
-        -p, --password
-           Accumulo password (will prompt if not supplied)
-      * -t, --raster-table
-           Accumulo table for storing raster data
-      * -u, --user
-           Accumulo user name
-        -v, --visibilities
-           Accumulo scan visibilities
-        -z, --zookeepers
-           Zookeepers (host[:port], comma separated)
+      Delete a GeoMesa Raster Table
+      Usage: deleteraster [options]
+        Options:
+          --auths
+             Accumulo authorizations
+          -f, --force
+             Force deletion of feature without prompt
+             Default: false
+          -i, --instance
+             Accumulo instance name
+          --mock
+             Run everything with a mock accumulo instance instead of a real one
+             Default: false
+          -p, --password
+             Accumulo password (will prompt if not supplied)
+        * -t, --raster-table
+             Accumulo table for storing raster data
+        * -u, --user
+             Accumulo user name
+          --visibilities
+             Accumulo scan visibilities
+          -z, --zookeepers
+             Zookeepers (host[:port], comma separated)
 
 
 ####Example:
@@ -270,142 +273,159 @@ To delete a specific raster table use the `deleteraster` command.
 ### deletecatalog
 To delete a GeoMesa catalog completely (and all features in it) use the `deletecatalog` command.
 
-####Usage (required options denoted with star):
-    geomesa help deletecatalog
+#### Usage (required options denoted with star):
+    $ geomesa help deletecatalog
     Delete a GeoMesa catalog completely (and all features in it)
     Usage: deletecatalog [options]
       Options:
-        -a, --auths
+        --auths
            Accumulo authorizations
       * -c, --catalog
            Catalog table name for GeoMesa
-        -f, --force
+        --force
            Force deletion without prompt
            Default: false
         -i, --instance
            Accumulo instance name
-        -mc, --mock
+        --mock
            Run everything with a mock accumulo instance instead of a real one
-           (true/false)
            Default: false
         -p, --password
            Accumulo password (will prompt if not supplied)
       * -u, --user
            Accumulo user name
-        -v, --visibilities
+        --visibilities
            Accumulo scan visibilities
         -z, --zookeepers
            Zookeepers (host[:port], comma separated)
+
     
 ####Example:
-    geomesa deletecatalog -u username -p password -i instname -z zoo1,zoo2,zoo3 -c test_catalog
+    geomesa deletecatalog -u username -p password -i instance -z zoo1,zoo2,zoo3 -c test_catalog
     
 ### describe
 To describe the attributes of a feature on a specified catalog table, use the `describe` command.  
 
-####Usage (required options denoted with star):
+#### Usage (required options denoted with star):
     $ geomesa help describe
     Describe the attributes of a given feature in GeoMesa
     Usage: describe [options]
       Options:
-        -a, --auths
+        --auths
            Accumulo authorizations
       * -c, --catalog
            Catalog table name for GeoMesa
-      * -fn, --feature-name
+      * -f, --feature-name
            Simple Feature Type name on which to operate
         -i, --instance
            Accumulo instance name
-        -mc, --mock
-           Run everything with a mock accumulo instance instead of a real one (true/false)
+        --mock
+           Run everything with a mock accumulo instance instead of a real one
            Default: false
         -p, --password
            Accumulo password (will prompt if not supplied)
       * -u, --user
            Accumulo user name
-        -v, --visibilities
+        --visibilities
            Accumulo scan visibilities
         -z, --zookeepers
            Zookeepers (host[:port], comma separated)
 
       
 #### Example command:
-    geomesa describe -u username -p password -c test_delete -fn testing
- 
+    geomesa describe -u username -p password -c test_delete -f testing
+
+### env
+Prints out simple feature types and simple feature converters that are available on the current classpath.
+Available types can be used for ingestion - see the `ingest` command.
+
+#### Usage (required options denoted with star):
+    $ geomesa help env
+    Examine the current GeoMesa environment
+    Usage: env [options]
+      Options:
+        -c, --converters
+           Examine GeoMesa converters
+        -s, --sfts
+           Examine simple feature types
+
+#### Example command:
+    geomesa env
+
 ### explain
 To ask GeoMesa how it intends to satisfy a given query, use the `explain` command.
 
-####Usage (required options denoted with star):
+#### Usage (required options denoted with star):
     $ geomesa help explain
     Explain how a GeoMesa query will be executed
     Usage: explain [options]
       Options:
-        -a, --auths
+        --auths
            Accumulo authorizations
       * -c, --catalog
            Catalog table name for GeoMesa
       * -q, --cql
            CQL predicate
-      * -fn, --feature-name
+      * -f, --feature-name
            Simple Feature Type name on which to operate
         -i, --instance
            Accumulo instance name
-        -mc, --mock
+        --mock
            Run everything with a mock accumulo instance instead of a real one
            Default: false
         -p, --password
            Accumulo password (will prompt if not supplied)
       * -u, --user
            Accumulo user name
-        -v, --visibilities
+        --visibilities
            Accumulo scan visibilities
         -z, --zookeepers
            Zookeepers (host[:port], comma separated)
 
 
 #### Example command:
-    geomesa explain -u username -p password -c test_catalog -fn test_feature -q "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
+    geomesa explain -u username -p password -c test_catalog -f test_feature -q "INTERSECTS(geom, POLYGON ((41 28, 42 28, 42 29, 41 29, 41 28)))"
 
 ### export
 To export features, use the `export` command.  
 
-####Usage (required options denoted with star):
+#### Usage (required options denoted with star):
     $ geomesa help export
     Export a GeoMesa feature
     Usage: export [options]
       Options:
-        -at, --attributes
+        -a, --attributes
            Attributes from feature to export (comma-separated)...Comma-separated
            expressions with each in the format attribute[=filter_function_expression]|derived-attribute=filter_function_expression.
            filter_function_expression is an expression of filter function applied to attributes, literals and
            filter functions, i.e. can be nested
-        -a, --auths
+        --auths
            Accumulo authorizations
       * -c, --catalog
            Catalog table name for GeoMesa
         -q, --cql
            CQL predicate
-        -dt, --dt-attribute
+        --dt-attribute
            name of the date attribute to export
-      * -fn, --feature-name
+      * -f, --feature-name
            Simple Feature Type name on which to operate
-        -fmt, --format
+        -F, --format
            Format to export (csv|tsv|gml|json|shp|bin)
            Default: csv
-        -id, --id-attribute
+        --id-attribute
            name of the id attribute to export
         -i, --instance
            Accumulo instance name
-        -lat, --lat-attribute
+        --label-attribute
+           name of the attribute to use as a bin file label
+        --lat-attribute
            name of the latitude attribute to export
-        -lon, --lon-attribute
+        --lon-attribute
            name of the longitude attribute to export
-        -lbl, --label-attribute
-           name of the label attribute to export
-        -max, --max-features
+        -m, --max-features
            Maximum number of features to return. default: Long.MaxValue
            Default: 2147483647
-        -mc, --mock
+        --mock
            Run everything with a mock accumulo instance instead of a real one
            Default: false
         -o, --output
@@ -414,10 +434,11 @@ To export features, use the `export` command.
            Accumulo password (will prompt if not supplied)
       * -u, --user
            Accumulo user name
-        -v, --visibilities
+        --visibilities
            Accumulo scan visibilities
         -z, --zookeepers
            Zookeepers (host[:port], comma separated)
+
 
 <b>attribute expressions</b>
 Attribute expressions are comma-separated expressions with each in the format 
@@ -427,11 +448,43 @@ Attribute expressions are comma-separated expressions with each in the format
 `filter_function_expression` is an expression of filter function applied to attributes, literals and filter functions, i.e. can be nested
 
 #### Example commands:
-    geomesa export -u username -p password -c test_catalog -fn test_feature -at "geom,text,user_name" -fmt csv -q "include" -m 100
-    geomesa export -u username -p password -c test_catalog -fn test_feature -at "geom,text,user_name" -fmt gml -q "user_name='JohnSmith'"
-    geomesa export -u username -p password -c test_catalog -fn test_feature -at "user_name,buf=buffer(geom\, 2)" \
-        -fmt csv -q "[[ user_name like `John%' ] AND [ bbox(geom, 22.1371589, 44.386463, 40.228581, 52.379581, 'EPSG:4326') ]]"
-    
+    geomesa export -u username -p password -c test_catalog -f test_feature -a "geom,text,user_name" --format csv -q "include" -m 100
+    geomesa export -u username -p password -c test_catalog -f test_feature -a "geom,text,user_name" --format gml -q "user_name='JohnSmith'"
+    geomesa export -u username -p password -c test_catalog -f test_feature -a "user_name,buf=buffer(geom\, 2)" \
+        --format csv -q "[[ user_name like `John%' ] AND [ bbox(geom, 22.1371589, 44.386463, 40.228581, 52.379581, 'EPSG:4326') ]]"
+
+### getsft
+Gets an existing simple feature type as an encoded string.
+
+#### Usage (required options denoted with star):
+    $ geomesa help getsft
+    Get the SimpleFeatureType of a feature
+    Usage: getsft [options]
+      Options:
+        --auths
+           Accumulo authorizations
+      * -c, --catalog
+           Catalog table name for GeoMesa
+      * -f, --feature-name
+           Simple Feature Type name on which to operate
+        -i, --instance
+           Accumulo instance name
+        --mock
+           Run everything with a mock accumulo instance instead of a real one
+           Default: false
+        -p, --password
+           Accumulo password (will prompt if not supplied)
+      * -u, --user
+           Accumulo user name
+        --visibilities
+           Accumulo scan visibilities
+        -z, --zookeepers
+           Zookeepers (host[:port], comma separated)
+
+
+#### Example command:
+    geomesa getsft -u username -p password -c test_catalog -f test_feature -i instance
+
 ### ingest
 Ingests line-oriented delimited text (csv, tsv) and SHP files from the local file system and HDFS. CSV and TSV files  
 can be ingested either with explicit latitude and longitude columns or with a column of WKT geometries.
@@ -440,41 +493,38 @@ columns in the file such as: `*geom:Point`. The file type is inferred from the e
 the formatting of the file matches the extension of the file and that the extension is present.
 *Note* the header if present is not parsed by Ingest for information, it is assumed that all lines are valid entries.
 
-####Usage (required options denoted with star):
+#### Usage (required options denoted with star):
     $ geomesa help ingest
-    Ingest a file of various formats into GeoMesa
+    Ingest/convert various file formats into GeoMesa
     Usage: ingest [options] <file>...
       Options:
-        -a, --auths
+        --auths
            Accumulo authorizations
       * -c, --catalog
            Catalog table name for GeoMesa
-        -conf, --conf
-           GeoMesa configuration file for SFT and/or convert
-        -fn, --feature-name
+        -C, --converter
+           GeoMesa converter specification as a config string or name of an
+           available converter
+        -f, --feature-name
            Simple Feature Type name on which to operate
-        -fmt, --format
+        -F, --format
            indicate non-converter ingest (shp)
-        -is, --index-schema
-           GeoMesa index schema format string
         -i, --instance
            Accumulo instance name
-        -mc, --mock
+        --mock
            Run everything with a mock accumulo instance instead of a real one
-           (true/false)
            Default: false
         -p, --password
            Accumulo password (will prompt if not supplied)
         -s, --spec
-           SimpleFeatureType specification as a GeoTools spec string, SFT config, or
-           file with either
+           SimpleFeatureType specification as a GeoTools spec, SFT config, or name
+           of an available type
       * -u, --user
            Accumulo user name
-        -v, --visibilities
+        --visibilities
            Accumulo scan visibilities
         -z, --zookeepers
            Zookeepers (host[:port], comma separated)
-
 
 
 #### Example commands:
@@ -487,41 +537,46 @@ the formatting of the file matches the extension of the file and that the extens
     26236,Hermione,25,2015-06-07,"Edward, Bill, Harry",40.232,-53.2356
     3233,Severus,30,2015-10-23,"Tom, Riddle, Voldemort",3,-62.23
         
-    # cat example1.conf
-    {
-      sft = {
-        type-name = "renegades"
-        attributes = [
-          {name = "id", type = "Integer", index = false},
-          {name = "name", type = "String", index = true},
-          {name = "age", type = "Integer", index = false},
-          {name = "lastseen", type = "Date", index = true},
-          {name = "friends", type = "List[String]", index = true},
-          {name = "geom", type = "Point", index = true, srid = 4326, default = true}
-        ]
-      },
-      converter = {
-        type = "delimited-text",
-        format = "CSV",
-        options {
-          skip-lines = 1
-        },
-        id-field = "toString($id)",
-        fields = [
-          {name = "id", transform = "$1::int"},
-          {name = "name", transform = "$2::string"},
-          {name = "age", transform = "$3::int"},
-          {name = "lastseen", transform = "$4::date"},
-          {name = "friends", transform = "parseList('string', $5)"},
-          {name = "lon", transform = "$6::double"},
-          {name = "lat", transform = "$7::double"},
-          {name = "geom", transform = "point($lon, $lat)"}
-        ]
-      }
+    # cat $GEOMESA_HOME/conf/application.conf
+    geomesa {
+      sfts = [
+        {
+          type-name = "renegades"
+          attributes = [
+            {name = "id", type = "Integer", index = false},
+            {name = "name", type = "String", index = true},
+            {name = "age", type = "Integer", index = false},
+            {name = "lastseen", type = "Date", index = true},
+            {name = "friends", type = "List[String]", index = true},
+            {name = "geom", type = "Point", index = true, srid = 4326, default = true}
+          ]
+        }
+      ],
+      converters = [
+        {
+          name = "renegades-csv"
+          type = "delimited-text",
+          format = "CSV",
+          options {
+            skip-lines = 0 // don't skip lines in distributed ingest
+          },
+          id-field = "toString($id)",
+          fields = [
+            {name = "id", transform = "$1::int"},
+            {name = "name", transform = "$2::string"},
+            {name = "age", transform = "$3::int"},
+            {name = "lastseen", transform = "$4::date"},
+            {name = "friends", transform = "parseList('string', $5)"},
+            {name = "lon", transform = "$6::double"},
+            {name = "lat", transform = "$7::double"},
+            {name = "geom", transform = "point($lon, $lat)"}
+          ]
+        }
+      ]
     }
 
     # ingest command
-    geomesa ingest -u username -p password -c geomesa_catalog -i inst -conf example1.conf hdfs:///some/hdfs/path/to/file.csv
+    geomesa ingest -u username -p password -c geomesa_catalog -i instance -s renegades -C renegades-csv hdfs:///some/hdfs/path/to/file.csv
 
 ##### Converter Config
 
@@ -544,43 +599,42 @@ directory from where they are ingested.
 EPSG:4326 raster files before ingestion. An example of doing conversion with GDAL utility is `gdalwarp -t_srs EPSG:4326
 input_file out_file`.
 
-####Usage (required options denoted with star):
+#### Usage (required options denoted with star):
     $ geomesa help ingestraster
-    Ingest a raster file or files in a directory into GeoMesa
+    Ingest a raster file or raster files in a directory into GeoMesa
     Usage: ingestraster [options]
       Options:
-        -a, --auths
+        --auths
            Accumulo authorizations
       * -f, --file
            Single raster file or directory of raster files to be ingested
-        -fmt, --format
+        -F, --format
            Format of incoming raster data (geotiff | DTED) to override file
            extension recognition
         -i, --instance
            Accumulo instance name
-        -mc, --mock
+        --mock
            Run everything with a mock accumulo instance instead of a real one
-           (true/false)
            Default: false
-        -par, --parallel-level
+        -P, --parallel-level
            Maximum number of local threads for ingesting multiple raster files
            (default to 1)
            Default: 1
         -p, --password
            Accumulo password (will prompt if not supplied)
-        -qt, --query-threads
+        --query-threads
            Threads for quering raster data
       * -t, --raster-table
            Accumulo table for storing raster data
-        -tm, --timestamp
+        -T, --timestamp
            Ingestion time (default to current time)
       * -u, --user
            Accumulo user name
-        -v, --visibilities
+        --visibilities
            Accumulo scan visibilities
-        -wm, --write-memory
+        --write-memory
            Memory allocation for ingestion operation
-        -wt, --write-threads
+        --write-threads
            Threads for writing raster data
         -z, --zookeepers
            Zookeepers (host[:port], comma separated)
@@ -589,30 +643,28 @@ input_file out_file`.
 #### Example commands:
     geomesa ingestraster -u username -p password -t geomesa_raster -f /some/local/path/to/raster.tif
 
-    geomesa ingestraster -u username -p password -t geomesa_raster -ck -cs 1000 -m distributed -f /some/path/to/raster.tif
-
 ### list
 To list the features on a specified catalog table, use the `list` command.  
 
-####Usage (required options denoted with star):
+#### Usage (required options denoted with star):
     $ geomesa help list
     List GeoMesa features for a given catalog
     Usage: list [options]
       Options:
-        -a, --auths
+        --auths
            Accumulo authorizations
       * -c, --catalog
            Catalog table name for GeoMesa
         -i, --instance
            Accumulo instance name
-        -mc, --mock
+        --mock
            Run everything with a mock accumulo instance instead of a real one
            Default: false
         -p, --password
            Accumulo password (will prompt if not supplied)
       * -u, --user
            Accumulo user name
-        -v, --visibilities
+        --visibilities
            Accumulo scan visibilities
         -z, --zookeepers
            Zookeepers (host[:port], comma separated)
@@ -624,20 +676,19 @@ To list the features on a specified catalog table, use the `list` command.
 ### querystats
 Export queries and statistics logged for raster tables by using the `querystats` command.
 
-####Usage (required options denoted with star):
-    $ geomesa help querystats
+#### Usage (required options denoted with star):
+    $ geomesa help queryrasterstats
     Export queries and statistics about the last X number of queries to a CSV file.
     Usage: querystats [options]
       Options:
-        -a, --auths
+        --auths
            Accumulo authorizations
         -i, --instance
            Accumulo instance name
-        -mc, --mock
+        --mock
            Run everything with a mock accumulo instance instead of a real one
-           (true/false)
            Default: false
-        -num, --number-of-records
+        -n, --number-of-records
            Number of query records to export from Accumulo
            Default: 1000
         -o, --output
@@ -648,19 +699,19 @@ Export queries and statistics logged for raster tables by using the `querystats`
            Accumulo table for storing raster data
       * -u, --user
            Accumulo user name
-        -v, --visibilities
+        --visibilities
            Accumulo scan visibilities
         -z, --zookeepers
            Zookeepers (host[:port], comma separated)
 
 
 #### Example command:
-    geomesa querystats -u username -p password -t somerastertable -num 10
+    geomesa queryrasterstats -u username -p password -t somerastertable -num 10
     
 ### tableconf
 To list, describe, and update the configuration parameters on a specified table, use the `tableconf` command. 
 
-####Usage (required options denoted with star):
+#### Usage (required options denoted with star):
     $ geomesa help tableconf
     Perform table configuration operations
     Usage: tableconf [options] [command] [command options]
@@ -668,15 +719,15 @@ To list, describe, and update the configuration parameters on a specified table,
         list      List the configuration parameters for a geomesa table
           Usage: list [options]
             Options:
-              -a, --auths
+              --auths
                  Accumulo authorizations
             * -c, --catalog
                  Catalog table name for GeoMesa
-            * -fn, --feature-name
+            * -f, --feature-name
                  Simple Feature Type name on which to operate
               -i, --instance
                  Accumulo instance name
-              -mc, --mock
+              --mock
                  Run everything with a mock accumulo instance instead of a real one
                  Default: false
               -p, --password
@@ -685,7 +736,7 @@ To list, describe, and update the configuration parameters on a specified table,
                  Table suffix to operate on (attr_idx, st_idx, or records)
             * -u, --user
                  Accumulo user name
-              -v, --visibilities
+              --visibilities
                  Accumulo scan visibilities
               -z, --zookeepers
                  Zookeepers (host[:port], comma separated)
@@ -693,18 +744,18 @@ To list, describe, and update the configuration parameters on a specified table,
         describe      Describe a given configuration parameter for a table
           Usage: describe [options]
             Options:
-              -a, --auths
+              --auths
                  Accumulo authorizations
             * -c, --catalog
                  Catalog table name for GeoMesa
-            * -fn, --feature-name
+            * -f, --feature-name
                  Simple Feature Type name on which to operate
               -i, --instance
                  Accumulo instance name
-              -mc, --mock
+              --mock
                  Run everything with a mock accumulo instance instead of a real one
                  Default: false
-            *     --param
+            * -P, --param
                  Accumulo table configuration param name (e.g. table.bloom.enabled)
               -p, --password
                  Accumulo password (will prompt if not supplied)
@@ -712,7 +763,7 @@ To list, describe, and update the configuration parameters on a specified table,
                  Table suffix to operate on (attr_idx, st_idx, or records)
             * -u, --user
                  Accumulo user name
-              -v, --visibilities
+              --visibilities
                  Accumulo scan visibilities
               -z, --zookeepers
                  Zookeepers (host[:port], comma separated)
@@ -720,20 +771,20 @@ To list, describe, and update the configuration parameters on a specified table,
         update      Update a given table configuration parameter
           Usage: update [options]
             Options:
-              -a, --auths
+              --auths
                  Accumulo authorizations
             * -c, --catalog
                  Catalog table name for GeoMesa
-            * -fn, --feature-name
+            * -f, --feature-name
                  Simple Feature Type name on which to operate
               -i, --instance
                  Accumulo instance name
-              -mc, --mock
+              --mock
                  Run everything with a mock accumulo instance instead of a real one
                  Default: false
             * -n, --new-value
                  New value of the property
-            *     --param
+            * -P, --param
                  Accumulo table configuration param name (e.g. table.bloom.enabled)
               -p, --password
                  Accumulo password (will prompt if not supplied)
@@ -741,23 +792,34 @@ To list, describe, and update the configuration parameters on a specified table,
                  Table suffix to operate on (attr_idx, st_idx, or records)
             * -u, --user
                  Accumulo user name
-              -v, --visibilities
+              --visibilities
                  Accumulo scan visibilities
               -z, --zookeepers
                  Zookeepers (host[:port], comma separated)
 
 
 #### Example commands:
-    geomesa tableconf list -u username -p password -c test_catalog -fn test_feature -t st_idx
-    geomesa tableconf describe -u username -p password -c test_catalog -fn test_feature -t attr_idx --param table.bloom.enabled
-    geomesa tableconf update -u username -p password -c test_catalog -fn test_feature -t records --param table.bloom.enabled -n true
+    geomesa tableconf list -u username -p password -c test_catalog -f test_feature -t st_idx
+    geomesa tableconf describe -u username -p password -c test_catalog -f test_feature -t attr_idx --param table.bloom.enabled
+    geomesa tableconf update -u username -p password -c test_catalog -f test_feature -t records --param table.bloom.enabled -n true
+
+### version
+Prints out the version, git branch, and commit ID that the tools were built with.
+
+#### Usage:
+    $geomesa help version
+    GeoMesa Version
+    Usage: version
+
+#### Example commands:
+    geomesa version
 
 ### repl
 To drop into an interactive REPL, use the `repl` command. The REPL is the scala console with GeoMesa-specific
 functionality. In addition to normal GeoMesa usage, the scalding REPL is included. More details on the
 features exposed by scalding can be read here: [Scalding-REPL](https://github.com/twitter/scalding/wiki/Scalding-REPL)
 
-####Usage:
+#### Usage:
     $ geomesa repl
     # Launches the REPL. Enter commands just as you would at the scala repl.
     $ geomesa repl hdfs

--- a/geomesa-tools/bin/geomesa
+++ b/geomesa-tools/bin/geomesa
@@ -166,7 +166,7 @@ function findJars() {
 
 # Start constructing GEOMESA_CP (classpath)
 # include geomesa first so that the correct log4j.properties is picked up
-GEOMESA_CP="${GEOMESA_CONF_DIR}\log4j.properties:$(findJars $GEOMESA_LIB)"
+GEOMESA_CP="${GEOMESA_CONF_DIR}:$(findJars $GEOMESA_LIB)"
 GEOMESA_CP="${GEOMESA_CP}:${ACCUMULO_CONF_DIR}:${HADOOP_CONF_DIR}"
 ACCUMULO_CP="$(findJars $ACCUMULO_LIB)"
 

--- a/geomesa-tools/bin/test-geomesa
+++ b/geomesa-tools/bin/test-geomesa
@@ -27,25 +27,25 @@ INST=INSTANCE
 ZOO=zoo1,zoo2,zoo3
 ACC_OPTS="-u $USER -p $PASS -i $INST -z $ZOO"
 
-geomesa create $ACC_OPTS -c ${CREATE_CATALOG} -fn ${CREATE_FEATURENAME} -s ${SPEC} -dt dtg
+geomesa create $ACC_OPTS -c ${CREATE_CATALOG} -f ${CREATE_FEATURENAME} -s ${SPEC} --dtg dtg
 geomesa list $ACC_OPTS -c ${CATALOG}
-geomesa describe $ACC_OPTS -c ${CATALOG} -fn ${FEATURENAME}
-geomesa explain $ACC_OPTS -c ${CATALOG} -fn ${FEATURENAME} -q include
+geomesa describe $ACC_OPTS -c ${CATALOG} -f ${FEATURENAME}
+geomesa explain $ACC_OPTS -c ${CATALOG} -f ${FEATURENAME} -q include
 
 # export to std out in various formats
-geomesa export $ACC_OPTS -c ${CATALOG} -fn ${FEATURENAME} -fmt csv -max ${MAXFEATURES}
-geomesa export $ACC_OPTS -c ${CATALOG} -fn ${FEATURENAME} -fmt tsv -max ${MAXFEATURES}
-geomesa export $ACC_OPTS -c ${CATALOG} -fn ${FEATURENAME} -fmt json -max ${MAXFEATURES}
-geomesa export $ACC_OPTS -c ${CATALOG} -fn ${FEATURENAME} -fmt gml -max ${MAXFEATURES}
+geomesa export $ACC_OPTS -c ${CATALOG} -f ${FEATURENAME} --format csv ---max-features ${MAXFEATURES}
+geomesa export $ACC_OPTS -c ${CATALOG} -f ${FEATURENAME} --format tsv --max-features ${MAXFEATURES}
+geomesa export $ACC_OPTS -c ${CATALOG} -f ${FEATURENAME} --format json --max-features ${MAXFEATURES}
+geomesa export $ACC_OPTS -c ${CATALOG} -f ${FEATURENAME} --format gml --max-features ${MAXFEATURES}
 
 # export to files (includes shape file)
-geomesa export $ACC_OPTS -c ${CATALOG} -fn ${FEATURENAME} -fmt csv -max ${MAXFEATURES} -o /tmp/csv.out
-geomesa export $ACC_OPTS -c ${CATALOG} -fn ${FEATURENAME} -fmt tsv -max ${MAXFEATURES} -o /tmp/tsv.out
-geomesa export $ACC_OPTS -c ${CATALOG} -fn ${FEATURENAME} -fmt json -max ${MAXFEATURES} -o /tmp/json.out
-geomesa export $ACC_OPTS -c ${CATALOG} -fn ${FEATURENAME} -fmt gml -max ${MAXFEATURES} -o /tmp/gml.out
-geomesa export $ACC_OPTS -c ${CATALOG} -fn ${FEATURENAME} -fmt shp -max ${MAXFEATURES} -o /tmp/out.shp
+geomesa export $ACC_OPTS -c ${CATALOG} -f ${FEATURENAME} --format csv --max-features ${MAXFEATURES} -o /tmp/csv.out
+geomesa export $ACC_OPTS -c ${CATALOG} -f ${FEATURENAME} --format tsv --max-features ${MAXFEATURES} -o /tmp/tsv.out
+geomesa export $ACC_OPTS -c ${CATALOG} -f ${FEATURENAME} --format json --max-features ${MAXFEATURES} -o /tmp/json.out
+geomesa export $ACC_OPTS -c ${CATALOG} -f ${FEATURENAME} --format gml --max-features ${MAXFEATURES} -o /tmp/gml.out
+geomesa export $ACC_OPTS -c ${CATALOG} -f ${FEATURENAME} --format shp --max-features ${MAXFEATURES} -o /tmp/out.shp
 
 # clean up previous temp feature
-geomesa delete $ACC_OPTS --force -c ${CREATE_CATALOG} -fn ${CREATE_FEATURENAME}
+geomesa delete $ACC_OPTS --force -c ${CREATE_CATALOG} -f ${CREATE_FEATURENAME}
 geomesa list $ACC_OPTS -c ${CREATE_CATALOG}
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ConverterConfigParser.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ConverterConfigParser.scala
@@ -12,6 +12,7 @@ import java.io.File
 import com.beust.jcommander.ParameterException
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.slf4j.Logging
+import org.locationtech.geomesa.convert.SimpleFeatureConverters
 
 import scala.util.{Failure, Success, Try}
 
@@ -20,32 +21,26 @@ import scala.util.{Failure, Success, Try}
  * as a filename containing the converter config
  */
 object ConverterConfigParser extends Logging {
-  type ConfigParser = String => Option[Config]
 
   /**
    * @throws ParameterException if the config cannot be parsed
    * @return the converter config parsed from the args
    */
   @throws[ParameterException]
-  def getConfig(configArg: String): Config =
-    Seq(parseString, parseFile)
-      .view.flatMap(_(configArg))
-      .headOption
-      .getOrElse(throw new ParameterException(s"Unable to parse Converter config from argument $configArg"))
+  def getConfig(configArg: String): Config = {
+    getLoadedConf(configArg).orElse(parseString(configArg)).getOrElse {
+      throw new ParameterException(s"Unable to parse Converter config from argument $configArg")
+    }
+  }
 
-  private[ConverterConfigParser] val parseString: ConfigParser = (configArg: String) =>
+  private[ConverterConfigParser] def getLoadedConf(configArg: String): Option[Config] =
+    SimpleFeatureConverters.confs.find(_._1 == configArg).map(_._2)
+
+  private[ConverterConfigParser] def parseString(configArg: String): Option[Config] =
     Try(ConfigFactory.parseString(configArg)) match {
       case Success(config) => Some(config)
       case Failure(ex) =>
         logger.debug(s"Unable to parse config from string $configArg")
-        None
-    }
-
-  private[ConverterConfigParser] val parseFile: ConfigParser = (configArg: String) =>
-    Try(ConfigFactory.parseFile(new File(configArg))) match {
-      case Success(config) => Some(config)
-      case Failure(ex) =>
-        logger.debug(s"Unable to parse config from file $configArg")
         None
     }
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/FeatureCreator.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/FeatureCreator.scala
@@ -21,7 +21,7 @@ object FeatureCreator extends Logging {
     val ds = new DataStoreHelper(params).getDataStore()
     createFeature(
       ds,
-      SftArgParser.getSft(params.spec, params.featureName, convert),
+      SftArgParser.getSft(params.spec, params.featureName),
       params.featureName,
       Option(params.dtgField),
       Option(params.useSharedTables),

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Runner.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Runner.scala
@@ -26,6 +26,7 @@ object Runner extends Logging {
       new DeleteCatalogCommand(jc),
       new DeleteRasterCommand(jc),
       new DescribeCommand(jc),
+      new EnvironmentCommand(jc),
       new ExplainCommand(jc),
       new ExportCommand(jc),
       new HelpCommand(jc),
@@ -51,8 +52,7 @@ object Runner extends Logging {
         sys.exit(-1)
     }
 
-    val command: Command =
-      commandMap.get(jc.getParsedCommand).getOrElse(new DefaultCommand(jc))
+    val command: Command = commandMap.getOrElse(jc.getParsedCommand, new DefaultCommand(jc))
 
     try {
       command.execute()

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/SftArgParser.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/SftArgParser.scala
@@ -13,7 +13,9 @@ import com.beust.jcommander.ParameterException
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.slf4j.Logging
 import org.apache.commons.io.IOUtils
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.geotools.data.DataUtilities
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder
+import org.locationtech.geomesa.utils.geotools.{SimpleFeatureTypeLoader, SimpleFeatureTypes}
 import org.opengis.feature.simple.SimpleFeatureType
 
 import scala.util.{Failure, Success, Try}
@@ -21,62 +23,56 @@ import scala.util.{Failure, Success, Try}
 /**
  * Parsers SimpleFeatureType specification from a variety of arguments
  * including sft strings (e.g. name:String,age:Integer,*geom:Point)
- * and typesafe config. Will handle string arguments or filename args.
+ * and typesafe config.
  */
 object SftArgParser extends Logging {
-  type SpecParser = () => Option[SimpleFeatureType]
 
   /**
    * @throws ParameterException if the SFT cannot be parsed
    * @return the SFT parsed from the Args
    */
   @throws[ParameterException]
-  def getSft(specArg: String, featureName: String = null, convertArg: String = null): SimpleFeatureType = {
-    val configParsers =
-      Seq(Option(specArg), Option(convertArg))
-        .flatten
-        .flatMap(s => List(readFile(s),Some(s)).flatten)
-        .map(s => getConfParser(s))
-
-    (configParsers ++ Seq(getSpecParser(specArg, Option(featureName))))
-      .view.map(_())
-      .find(_.nonEmpty)
-      .getOrElse(throw new ParameterException("Unable to parse Simple Feature type from sft config or string"))
-      .get
-  }
-
-  private[SftArgParser] def getSpecParser (specArg: String, nameOpt: Option[String]) : SpecParser = () => {
-    nameOpt.map[Option[SimpleFeatureType]] { featureName =>
-        Try { SimpleFeatureTypes.createType(featureName, specArg) }
-        match {
-          case Success(sft) => Some(sft)
-          case Failure(ex)  =>
-            logger.debug(s"Unable to parse sft spec from string $specArg with error ${ex.getMessage}")
-            None
+  def getSft(specArg: String, featureName: String = null): SimpleFeatureType =
+    getLoadedSft(specArg, featureName)
+        .orElse(parseSpecString(specArg, featureName))
+        .orElse(parseSpecConf(specArg, featureName))
+        .getOrElse {
+          throw new ParameterException("Unable to parse Simple Feature type from sft config or string")
         }
-      }.getOrElse(Option.empty)
+
+  // gets an sft from simple feature type providers on the classpath
+  private[SftArgParser] def getLoadedSft(specArg: String, name: String): Option[SimpleFeatureType] = {
+    SimpleFeatureTypeLoader.sfts.find(_.getTypeName == specArg).map { sft =>
+      if (name == null || name == sft.getTypeName) sft else renameSft(sft, name)
+    }
   }
 
-  private[SftArgParser] def getConfParser(str: String): SpecParser = () =>
-    Try { SimpleFeatureTypes.createType(ConfigFactory.parseString(str)) }
-    match {
-      case Success(sft) => Some(sft)
-      case Failure(ex)  =>
-        logger.debug(s"Unable to parse sft conf from string $str with error ${ex.getMessage}")
-        Option.empty
+  // gets an sft based on a spec string
+  private[SftArgParser] def parseSpecString(specArg: String, name: String): Option[SimpleFeatureType] =
+    Option(name).flatMap { featureName =>
+      Try(SimpleFeatureTypes.createType (featureName, specArg)) match {
+        case Success(sft) => Some(sft)
+        case Failure(e) =>
+          logger.debug(s"Unable to parse sft spec from string $specArg with error ${e.getMessage}")
+          None
+      }
     }
 
-  def readFile(s: String): Option[String] = {
-    val f = new File(s)
-    if (f.exists && f.canRead && f.isFile) {
-      val reader = new BufferedReader(new InputStreamReader(new FileInputStream(f)))
-      val contents = try {
-        IOUtils.toString(reader)
-      } finally {
-        reader.close()
-      }
-      Some(contents)
-    } else None
+  // gets an sft based on a spec conf string
+  private[SftArgParser] def parseSpecConf(specArg: String, name: String): Option[SimpleFeatureType] = {
+    Try(SimpleFeatureTypes.createType(ConfigFactory.parseString(specArg))) match {
+      case Success(sft) if name == null || name == sft.getTypeName => Some(sft)
+      case Success(sft) => Some(renameSft(sft, name))
+      case Failure(e) =>
+        logger.debug(s"Unable to parse sft spec from string $specArg as conf with error ${e.getMessage}")
+        None
+    }
   }
 
+  private[SftArgParser] def renameSft(sft: SimpleFeatureType, name: String) = {
+    val builder = new SimpleFeatureTypeBuilder()
+    builder.init(sft)
+    builder.setName(name)
+    builder.buildFeatureType()
+  }
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/AccumuloParams.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/AccumuloParams.scala
@@ -24,13 +24,13 @@ class AccumuloParams {
   @Parameter(names = Array("-z", "--zookeepers"), description = "Zookeepers (host[:port], comma separated)")
   var zookeepers: String = null
 
-  @Parameter(names = Array("-a", "--auths"), description = "Accumulo authorizations")
+  @Parameter(names = Array("--auths"), description = "Accumulo authorizations")
   var auths: String = null
 
-  @Parameter(names = Array("-v", "--visibilities"), description = "Accumulo scan visibilities")
+  @Parameter(names = Array("--visibilities"), description = "Accumulo scan visibilities")
   var visibilities: String = null
 
-  @Parameter(names = Array("-mc", "--mock"), description = "Run everything with a mock accumulo instance instead of a real one (true/false)", arity = 1)
+  @Parameter(names = Array("--mock"), description = "Run everything with a mock accumulo instance instead of a real one")
   var useMock: Boolean = false
 }
 
@@ -40,12 +40,12 @@ class GeoMesaParams extends AccumuloParams {
 }
 
 class FeatureParams extends GeoMesaParams {
-  @Parameter(names = Array("-fn", "--feature-name"), description = "Simple Feature Type name on which to operate", required = true)
+  @Parameter(names = Array("-f", "--feature-name"), description = "Simple Feature Type name on which to operate", required = true)
   var featureName: String = null
 }
 
 class OptionalFeatureParams extends GeoMesaParams {
-  @Parameter(names = Array("-fn", "--feature-name"), description = "Simple Feature Type name on which to operate", required = false)
+  @Parameter(names = Array("-f", "--feature-name"), description = "Simple Feature Type name on which to operate", required = false)
   var featureName: String = null
 }
 
@@ -63,20 +63,20 @@ class CreateFeatureParams extends FeatureParams {
   @Parameter(names = Array("-s", "--spec"), description = "SimpleFeatureType specification as a GeoTools spec string, SFT config, or file with either")
   var spec: String = null
 
-  @Parameter(names = Array("-dt", "--dtg"), description = "DateTime field name to use as the default dtg")
+  @Parameter(names = Array("--dtg"), description = "DateTime field name to use as the default dtg")
   var dtgField: String = null
 
-  @Parameter(names = Array("-st", "--use-shared-tables"), description = "Use shared tables in Accumulo for feature storage (true/false)", arity = 1)
+  @Parameter(names = Array("--use-shared-tables"), description = "Use shared tables in Accumulo for feature storage (true/false)", arity = 1)
   var useSharedTables: Boolean = true //default to true in line with datastore
 }
 
 class ForceParams {
-  @Parameter(names = Array("-f", "--force"), description = "Force deletion without prompt", required = false)
+  @Parameter(names = Array("--force"), description = "Force deletion without prompt", required = false)
   var force: Boolean = false
 }
 
 class PatternParams {
-  @Parameter(names = Array("-pt", "--pattern"), description = "Regular expression to select items to delete", required = false)
+  @Parameter(names = Array("--pattern"), description = "Regular expression to select items to delete", required = false)
   var pattern: Pattern = null
 }
 
@@ -86,12 +86,12 @@ class RasterParams extends AccumuloParams {
 }
 
 class CreateRasterParams extends RasterParams {
-  @Parameter(names = Array("-wm", "--write-memory"), description = "Memory allocation for ingestion operation")
+  @Parameter(names = Array("--write-memory"), description = "Memory allocation for ingestion operation")
   var writeMemory: String = null
 
-  @Parameter(names = Array("-wt", "--write-threads"), description = "Threads for writing raster data")
+  @Parameter(names = Array("--write-threads"), description = "Threads for writing raster data")
   var writeThreads: Integer = null
 
-  @Parameter(names = Array("-qt", "--query-threads"), description = "Threads for quering raster data")
+  @Parameter(names = Array("--query-threads"), description = "Threads for quering raster data")
   var queryThreads: Integer = null
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/DeleteRasterCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/DeleteRasterCommand.scala
@@ -53,7 +53,7 @@ object DeleteRasterCommand {
 
   @Parameters(commandDescription = "Delete a GeoMesa Raster Table")
   class DeleteRasterParams extends RasterParams {
-    @Parameter(names = Array("-f", "--force"), description = "Force deletion of feature without prompt", required = false)
+    @Parameter(names = Array("--force"), description = "Force deletion of feature without prompt", required = false)
     var forceDelete: Boolean = false
   }
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/EnvironmentCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/EnvironmentCommand.scala
@@ -1,0 +1,76 @@
+/***********************************************************************
+* Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0 which
+* accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+package org.locationtech.geomesa.tools.commands
+
+import com.beust.jcommander.{JCommander, Parameter, Parameters}
+import com.typesafe.config.{Config, ConfigRenderOptions}
+import com.typesafe.scalalogging.slf4j.Logging
+import org.locationtech.geomesa.convert.SimpleFeatureConverters
+import org.locationtech.geomesa.tools.commands.EnvironmentCommand.EnvironmentParameters
+import org.locationtech.geomesa.utils.geotools.{SimpleFeatureTypeLoader, SimpleFeatureTypes}
+
+import scala.collection.JavaConversions._
+
+class EnvironmentCommand(parent: JCommander) extends Command(parent) with Logging {
+  override val command = "env"
+  override val params = new EnvironmentParameters()
+
+  // TODO accumulo environment?
+  override def execute(): Unit = {
+    if (params.sfts == null && params.converters == null) {
+      // default - list all
+      listSfts()
+      println
+      listConverters()
+    } else if (params.sfts != null) {
+      // only list specified
+      listSfts(params.sfts.toList)
+      if (params.converters != null) {
+        println
+        listConverters(params.converters.toList)
+      }
+    } else {
+      listConverters(params.converters.toList)
+    }
+  }
+
+  def listSfts(names: List[String] = List.empty): Unit = {
+    val all = SimpleFeatureTypeLoader.sfts
+    val filtered = if (names.isEmpty) all else names.flatMap(n => all.find(_.getTypeName == n))
+    println("Simple Feature Types:")
+    if (filtered.isEmpty) {
+      println("\tNone available")
+    } else {
+      filtered.map(s => s"\t${s.getTypeName} = ${SimpleFeatureTypes.encodeType(s)}").foreach(println)
+    }
+  }
+
+  def listConverters(names: List[String] = List.empty): Unit = {
+    val all = SimpleFeatureConverters.confs
+    val filtered = if (names.isEmpty) all else names.flatMap(n => all.find(_._1 == n))
+    println("Simple Feature Type Converters:")
+    if (filtered.isEmpty) {
+      println("\tNone available")
+    } else {
+      val options = ConfigRenderOptions.defaults().setJson(false).setOriginComments(false)
+      def render(c: Config) = c.root().render(options).replaceAll("\n", "\n\t")
+      filtered.map { case (name, conf)=> s"\t${render(conf)}\n"}.foreach(println)
+    }
+  }
+}
+
+object EnvironmentCommand {
+  @Parameters(commandDescription = "Examine the current GeoMesa environment")
+  class EnvironmentParameters {
+    @Parameter(names = Array("-s", "--sfts"), description = "Examine simple feature types", variableArity = true)
+    var sfts: java.util.List[String] = null
+
+    @Parameter(names = Array("-c", "--converters"), description = "Examine GeoMesa converters", variableArity = true)
+    var converters: java.util.List[String] = null
+  }
+}

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/ExportCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/ExportCommand.scala
@@ -119,32 +119,32 @@ class ExportCommand(parent: JCommander) extends CommandWithCatalog(parent) with 
 object ExportCommand {
   @Parameters(commandDescription = "Export a GeoMesa feature")
   class ExportParameters extends OptionalCqlFilterParameters {
-    @Parameter(names = Array("-fmt", "--format"), description = "Format to export (csv|tsv|gml|json|shp|bin)")
+    @Parameter(names = Array("-F", "--format"), description = "Format to export (csv|tsv|gml|json|shp|bin)")
     var format: String = "csv"
 
-    @Parameter(names = Array("-max", "--max-features"), description = "Maximum number of features to return. default: Long.MaxValue")
+    @Parameter(names = Array("-m", "--max-features"), description = "Maximum number of features to return. default: Long.MaxValue")
     var maxFeatures: Integer = Int.MaxValue
 
-    @Parameter(names = Array("-at", "--attributes"), description = "Attributes from feature to export " +
+    @Parameter(names = Array("-a", "--attributes"), description = "Attributes from feature to export " +
       "(comma-separated)...Comma-separated expressions with each in the format " +
       "attribute[=filter_function_expression]|derived-attribute=filter_function_expression. " +
       "filter_function_expression is an expression of filter function applied to attributes, literals " +
       "and filter functions, i.e. can be nested")
     var attributes: String = null
 
-    @Parameter(names = Array("-id", "--id-attribute"), description = "name of the id attribute to export")
+    @Parameter(names = Array("--id-attribute"), description = "name of the id attribute to export")
     var idAttribute: String = null
 
-    @Parameter(names = Array("-lat", "--lat-attribute"), description = "name of the latitude attribute to export")
+    @Parameter(names = Array("--lat-attribute"), description = "name of the latitude attribute to export")
     var latAttribute: String = null
 
-    @Parameter(names = Array("-lon", "--lon-attribute"), description = "name of the longitude attribute to export")
+    @Parameter(names = Array("--lon-attribute"), description = "name of the longitude attribute to export")
     var lonAttribute: String = null
 
-    @Parameter(names = Array("-dt", "--dt-attribute"), description = "name of the date attribute to export")
+    @Parameter(names = Array("--dt-attribute"), description = "name of the date attribute to export")
     var dateAttribute: String = null
 
-    @Parameter(names = Array("-lbl", "--label-attribute"), description = "name of the attribute to use as a bin file label")
+    @Parameter(names = Array("--label-attribute"), description = "name of the attribute to use as a bin file label")
     var labelAttribute: String = null
 
     @Parameter(names = Array("-o", "--output"), description = "name of the file to output to instead of std out")

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestCommand.scala
@@ -32,22 +32,18 @@ class IngestCommand(parent: JCommander) extends Command(parent) with Logging {
       new DelimitedIngest(params).run()
     }
   }
-
 }
 
 object IngestCommand {
   @Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")
   class IngestParameters extends OptionalFeatureParams {
-    @Parameter(names = Array("-s", "--spec"), description = "SimpleFeatureType specification as a GeoTools spec string, SFT config, or file with either")
+    @Parameter(names = Array("-s", "--spec"), description = "SimpleFeatureType specification as a GeoTools spec, SFT config, or name of an available type")
     var spec: String = null
 
-    @Parameter(names = Array("-conf", "--conf"), description = "GeoMesa configuration file for SFT and/or converter config")
+    @Parameter(names = Array("-C", "--converter"), description = "GeoMesa converter specification as a config string or name of an available converter")
     var config: String = null
 
-    @Parameter(names = Array("-is", "--index-schema"), description = "GeoMesa index schema format string")
-    var indexSchema: String = null
-
-    @Parameter(names = Array("-fmt", "--format"), description = "indicate non-converter ingest (shp)")
+    @Parameter(names = Array("-F", "--format"), description = "indicate non-converter ingest (shp)")
     var format: String = null
 
     @Parameter(description = "<file>...", required = true)

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestRasterCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/IngestRasterCommand.scala
@@ -81,7 +81,7 @@ class PathValidator extends IParameterValidator {
 object IngestRasterCommand {
   @Parameters(commandDescription = "Ingest a raster file or raster files in a directory into GeoMesa")
   class IngestRasterParameters extends CreateRasterParams {
-    @Parameter(names = Array("-fmt", "--format"), description = "Format of incoming raster data " +
+    @Parameter(names = Array("-F", "--format"), description = "Format of incoming raster data " +
       "(geotiff | DTED) to override file extension recognition")
     var format: String = null
 
@@ -89,10 +89,10 @@ object IngestRasterCommand {
       "raster files to be ingested", validateWith = classOf[PathValidator], required = true)
     var file: String = null
 
-    @Parameter(names = Array("-tm", "--timestamp"), description = "Ingestion time (default to current time)")
+    @Parameter(names = Array("-T", "--timestamp"), description = "Ingestion time (default to current time)")
     var timeStamp: String = null
 
-    @Parameter(names = Array("-par", "--parallel-level"), description = "Maximum number of local " +
+    @Parameter(names = Array("-P", "--parallel-level"), description = "Maximum number of local " +
       "threads for ingesting multiple raster files (default to 1)")
     var parLevel: Integer = 1
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/QueryStatsCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/QueryStatsCommand.scala
@@ -17,7 +17,7 @@ import org.locationtech.geomesa.tools.AccumuloProperties
 import org.locationtech.geomesa.tools.commands.QueryStatsCommand.QueryStatsParameters
 
 class QueryStatsCommand(parent: JCommander) extends Command(parent) with AccumuloProperties {
-  override val command: String = "querystats"
+  override val command: String = "queryrasterstats"
   override val params = new QueryStatsParameters()
 
   override def execute() = {
@@ -55,7 +55,7 @@ class QueryStatsCommand(parent: JCommander) extends Command(parent) with Accumul
 object QueryStatsCommand {
   @Parameters(commandDescription = "Export queries and statistics about the last X number of queries to a CSV file.")
   class QueryStatsParameters extends RasterParams {
-    @Parameter(names = Array("-num", "--number-of-records"), description = "Number of query records to export from Accumulo")
+    @Parameter(names = Array("-n", "--number-of-records"), description = "Number of query records to export from Accumulo")
     var numRecords: Int = 1000
 
     @Parameter(names = Array("-o", "--output"), description = "Name of the file to output to")

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/TableConfCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/TableConfCommand.scala
@@ -116,7 +116,7 @@ object TableConfCommand {
 
   @Parameters(commandDescription = "Describe a given configuration parameter for a table")
   class DescribeParams extends ListParams {
-    @Parameter(names = Array("--param"), description = "Accumulo table configuration param name (e.g. table.bloom.enabled)", required = true)
+    @Parameter(names = Array("-P", "--param"), description = "Accumulo table configuration param name (e.g. table.bloom.enabled)", required = true)
     var param: String = null
   }
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/DelimitedIngest.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/DelimitedIngest.scala
@@ -31,7 +31,7 @@ import scala.collection.JavaConversions._
 
 class DelimitedIngest(params: IngestParameters) extends AccumuloProperties {
 
-  val sft = SftArgParser.getSft(params.spec, params.featureName, params.config)
+  val sft = SftArgParser.getSft(params.spec, params.featureName)
   val converterConfig = ConverterConfigParser.getConfig(params.config)
 
   def run(): Unit = {
@@ -53,7 +53,7 @@ class DelimitedIngest(params: IngestParameters) extends AccumuloProperties {
 
     validateFileArgs(mode, params)
 
-    val arguments = Mode.putMode(mode, getScaldingArgs())
+    val arguments = Mode.putMode(mode, buildScaldingArgs())
     val job = new ScaldingConverterIngestJob(arguments)
     val flow = job.buildFlow
 
@@ -90,7 +90,7 @@ class DelimitedIngest(params: IngestParameters) extends AccumuloProperties {
       () => ClassPathUtils.getJarsFromClasspath(classOf[AccumuloDataStore]),
       () => ClassPathUtils.getJarsFromClasspath(classOf[Connector]))
 
-  def getScaldingArgs(): Args = {
+  def buildScaldingArgs(): Args = {
     val singleArgs = List(classOf[ScaldingConverterIngestJob].getCanonicalName, getModeFlag(params.files(0)))
 
     val sftString = SimpleFeatureTypes.encodeType(sft)
@@ -112,8 +112,7 @@ class DelimitedIngest(params: IngestParameters) extends AccumuloProperties {
 
     val optionalKvArgs: Map[String, List[String]] = List(
       Option(params.auths)        .map(IngestParams.AUTHORIZATIONS   -> List(_)),
-      Option(params.visibilities) .map(IngestParams.VISIBILITIES     -> List(_)),
-      Option(params.indexSchema)  .map(IngestParams.INDEX_SCHEMA_FMT -> List(_))).flatten.toMap
+      Option(params.visibilities) .map(IngestParams.VISIBILITIES     -> List(_))).flatten.toMap
 
     val kvArgs = (requiredKvArgs ++ optionalKvArgs).flatMap { case (k,v) => List(s"--$k") ++ v }
     Args(singleArgs ++ kvArgs)

--- a/geomesa-tools/src/test/resources/examples/example1.conf
+++ b/geomesa-tools/src/test/resources/examples/example1.conf
@@ -1,29 +1,36 @@
-sft = {
-  type-name = "renegades"
-  attributes = [
-    {name = "id", type = "Integer", index = false},
-    {name = "name", type = "String", index = true},
-    {name = "age", type = "Integer", index = false},
-    {name = "lastseen", type = "Date", index = true},
-    {name = "friends", type = "List[String]", index = true},
-    {name = "geom", type = "Point", index = true, srid = 4326, default = true}
-  ]
-},
-converter = {
-  type = "delimited-text",
-  format = "CSV",
-  options {
-    skip-lines = 0 // don't skip lines in distributed ingest
-  },
-  id-field = "toString($id)",
-  fields = [
-    {name = "id", transform = "$1::int"},
-    {name = "name", transform = "$2::string"},
-    {name = "age", transform = "$3::int"},
-    {name = "lastseen", transform = "$4::date"},
-    {name = "friends", transform = "parseList('string', $5)"},
-    {name = "lon", transform = "$6::double"},
-    {name = "lat", transform = "$7::double"},
-    {name = "geom", transform = "point($lon, $lat)"}
+geomesa {
+  sfts = [
+    {
+      type-name = "renegades"
+      attributes = [
+        {name = "id", type = "Integer", index = false},
+        {name = "name", type = "String", index = true},
+        {name = "age", type = "Integer", index = false},
+        {name = "lastseen", type = "Date", index = true},
+        {name = "friends", type = "List[String]", index = true},
+        {name = "geom", type = "Point", index = true, srid = 4326, default = true}
+      ]
+    }
+  ],
+  converters = [
+    {
+      name = "renegades-csv"
+      type = "delimited-text",
+      format = "CSV",
+      options {
+        skip-lines = 0 // don't skip lines in distributed ingest
+      },
+      id-field = "toString($id)",
+      fields = [
+        {name = "id", transform = "$1::int"},
+        {name = "name", transform = "$2::string"},
+        {name = "age", transform = "$3::int"},
+        {name = "lastseen", transform = "$4::date"},
+        {name = "friends", transform = "parseList('string', $5)"},
+        {name = "lon", transform = "$6::double"},
+        {name = "lat", transform = "$7::double"},
+        {name = "geom", transform = "point($lon, $lat)"}
+      ]
+    }
   ]
 }

--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/commands/convert/JPatternConverterTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/commands/convert/JPatternConverterTest.scala
@@ -22,7 +22,7 @@ class JPatternConverterTest extends Specification {
       val jc = new JCommander()
       jc.addConverterFactory(new GeoMesaIStringConverterFactory)
       jc.addObject(params)
-      jc.parse(Array("-pt", "foobar\\d+").toArray: _*)
+      jc.parse(Array("--pattern", "foobar\\d+").toArray: _*)
       params.pattern.pattern() mustEqual "foobar\\d+"
       params.pattern.matcher("foobar3").matches mustEqual true
     }

--- a/geomesa-utils/src/main/java/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypeProvider.java
+++ b/geomesa-utils/src/main/java/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypeProvider.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0 which
+ * accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ */
+
+package org.locationtech.geomesa.utils.geotools;
+
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import java.util.List;
+
+public interface SimpleFeatureTypeProvider {
+    public List<SimpleFeatureType> loadTypes();
+}

--- a/geomesa-utils/src/main/resources/META-INF/services/org.locationtech.geomesa.utils.geotools.SimpleFeatureTypeProvider
+++ b/geomesa-utils/src/main/resources/META-INF/services/org.locationtech.geomesa.utils.geotools.SimpleFeatureTypeProvider
@@ -1,0 +1,1 @@
+org.locationtech.geomesa.utils.geotools.ConfigSftProvider

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/ConfigSftProvider.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/ConfigSftProvider.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2013-2015 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0 which
+ * accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ */
+
+package org.locationtech.geomesa.utils.geotools
+
+import javax.imageio.spi.ServiceRegistry
+
+import com.typesafe.config.{ConfigFactory, ConfigRenderOptions}
+import com.typesafe.scalalogging.slf4j.Logging
+import org.opengis.feature.simple.SimpleFeatureType
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+/**
+ * Provides simple feature types based on configs on the classpath
+ */
+class ConfigSftProvider extends SimpleFeatureTypeProvider with Logging {
+  override def loadTypes(): java.util.List[SimpleFeatureType] = {
+    val config = ConfigFactory.load()
+    val path = sys.props.getOrElse(ConfigSftProvider.ConfigPathProperty, "geomesa.sfts")
+    if (!config.hasPath(path)) {
+      return List.empty[SimpleFeatureType]
+    }
+    config.getConfigList(path).flatMap { sft =>
+      try {
+        Some(SimpleFeatureTypes.createType(sft, None))
+      } catch {
+        case e: Exception =>
+          logger.error("Error loading simple feature type from config " +
+              s"${sft.root().render(ConfigRenderOptions.concise())}", e)
+          None
+      }
+    }.asJava
+  }
+}
+
+object ConfigSftProvider {
+  val ConfigPathProperty = "org.locationtech.geomesa.sft.config.path"
+}
+
+object SimpleFeatureTypeLoader {
+  val sfts: List[SimpleFeatureType] =
+    ServiceRegistry.lookupProviders(classOf[SimpleFeatureTypeProvider]).flatMap(_.loadTypes()).toList
+}

--- a/geomesa-web/geomesa-web-data/pom.xml
+++ b/geomesa-web/geomesa-web-data/pom.xml
@@ -80,7 +80,7 @@
             <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
-                <version>1.32</version>
+                <version>1.48</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -966,7 +966,7 @@
             <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
-                <version>1.32</version>
+                <version>1.48</version>
             </dependency>
 
             <!-- test dependencies -->


### PR DESCRIPTION
Note: stacks on top of #743 - please consider only last commit(s)

* Ingest command will now accept named values for simple feature types and converters that will be loaded from the classpath
* Simple feature types can be added by placing an application.conf file on the classpath with the types under 'geomesa.sfts' as an array
* Simple feature type converters can be added by placing an application.conf file on the classpath with the converters under 'geomesa.co
* Simple feature type converters should add a 'name' attribute in order to be identifiable.
* New command line method 'env' will list available simple feature types and converters.

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>