### PR TITLE
GEOMESA-1049 Adding CQL functions to tranformer functions

### DIFF
--- a/geomesa-convert/README.md
+++ b/geomesa-convert/README.md
@@ -122,7 +122,20 @@ function hello(s) {
 ```
 
 you can reference that function in a transform expression as ```js:hello($2)```
- 
+
+### CQL Functions
+
+Most of the basic CQL functions are available as transformations. To use one,
+invoke it like a regular function, prefixed with the `cql` namespace. For example,
+you can use the CQL buffer function to turn a point into a polygon:
+
+```
+cql:buffer($1, 2.0)
+```
+
+For more information on the various CQL functions, see the GeoServer
+[filter function reference](http://docs.geoserver.org/stable/en/user/filter/function_reference.html#filter-function-reference)
+
 ### JSON/Avro Transformations
 
 See Parsing Json and Parsing Avro sections

--- a/geomesa-convert/README.md
+++ b/geomesa-convert/README.md
@@ -134,7 +134,7 @@ cql:buffer($1, 2.0)
 ```
 
 For more information on the various CQL functions, see the GeoServer
-[filter function reference](http://docs.geoserver.org/stable/en/user/filter/function_reference.html#filter-function-reference)
+[filter function reference](http://docs.geoserver.org/stable/en/user/filter/function_reference.html#filter-function-reference).
 
 ### JSON/Avro Transformations
 

--- a/geomesa-convert/geomesa-convert-common/pom.xml
+++ b/geomesa-convert/geomesa-convert-common/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>config</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-parser-combinators_2.11</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-feature-all</artifactId>
         </dependency>
@@ -34,6 +38,14 @@
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.media</groupId>
+            <artifactId>jai_core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.media</groupId>
+            <artifactId>jai_imageio</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>

--- a/geomesa-convert/geomesa-convert-common/pom.xml
+++ b/geomesa-convert/geomesa-convert-common/pom.xml
@@ -44,10 +44,6 @@
             <artifactId>jai_core</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.media</groupId>
-            <artifactId>jai_imageio</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.specs2</groupId>
             <artifactId>specs2_2.11</artifactId>
             <scope>test</scope>

--- a/geomesa-convert/geomesa-convert-common/src/main/resources/META-INF/services/org.geotools.filter.expression.PropertyAccessorFactory
+++ b/geomesa-convert/geomesa-convert-common/src/main/resources/META-INF/services/org.geotools.filter.expression.PropertyAccessorFactory
@@ -1,0 +1,1 @@
+org.locationtech.geomesa.convert.cql.ArrayPropertyAccessorFactory

--- a/geomesa-convert/geomesa-convert-common/src/main/resources/META-INF/services/org.locationtech.geomesa.convert.TransformerFunctionFactory
+++ b/geomesa-convert/geomesa-convert-common/src/main/resources/META-INF/services/org.locationtech.geomesa.convert.TransformerFunctionFactory
@@ -5,3 +5,4 @@ org.locationtech.geomesa.convert.IdFunctionFactory
 org.locationtech.geomesa.convert.LineNumberFunctionFactory
 org.locationtech.geomesa.convert.MapListFunctionFactory
 org.locationtech.geomesa.convert.CastFunctionFactory
+org.locationtech.geomesa.convert.cql.CqlFunctionFactory

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/Transformers.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/Transformers.scala
@@ -334,14 +334,21 @@ object Transformers extends EnhancedTokenParsers with LazyLogging {
 
   def parseTransform(s: String): Expr = {
     logger.trace(s"Parsing transform $s")
-    parse(TransformerParser.transformExpr, s).get
+    parse(TransformerParser.transformExpr, s) match {
+      case Success(r, _) => r
+      case Failure(e, _) => throw new IllegalArgumentException(s"Error parsing expression '$s': $e")
+      case Error(e, _)   => throw new RuntimeException(s"Error parsing expression '$s': $e")
+    }
   }
 
   def parsePred(s: String): Predicate = {
     logger.trace(s"Parsing predicate $s")
-    parse(TransformerParser.pred, s).get
+    parse(TransformerParser.pred, s) match {
+      case Success(p, _) => p
+      case Failure(e, _) => throw new IllegalArgumentException(s"Error parsing predicate '$s': $e")
+      case Error(e, _)   => throw new RuntimeException(s"Error parsing predicate '$s': $e")
+    }
   }
-
 }
 
 object TransformerFn {
@@ -578,13 +585,5 @@ class CastFunctionFactory extends TransformerFunctionFactory {
       return default
     }
     try { conversion(s) } catch { case e: Exception => default }
-  }
-}
-
-class OpFunctionFactory extends TransformerFunctionFactory {
-  override def functions = Seq(tri)
-
-  val tri = TransformerFn("try", "Try") {
-    args =>
   }
 }

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/cql/CqlFunctionFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/cql/CqlFunctionFactory.scala
@@ -1,0 +1,92 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.convert.cql
+
+import com.typesafe.scalalogging.LazyLogging
+import org.geotools.factory.{CommonFactoryFinder, Hints}
+import org.geotools.feature.NameImpl
+import org.geotools.filter.expression.{PropertyAccessor, PropertyAccessorFactory}
+import org.geotools.util.Converters
+import org.locationtech.geomesa.convert.{TransformerFn, TransformerFunctionFactory}
+
+import scala.collection.JavaConversions._
+
+class CqlFunctionFactory extends TransformerFunctionFactory with LazyLogging {
+
+  private val ff = CommonFactoryFinder.getFilterFactory2
+
+  private val names = CommonFactoryFinder.getFunctionFactories(null).toSeq.flatMap { factory =>
+    try {
+      // only import default cql functions (without namespaces)
+      // exclude 'categorize', as it doesn't parse into a function correctly
+      factory.getFunctionNames.filter(f => f.getFunctionName.getNamespaceURI == null && f.getName != "Categorize")
+    } catch {
+      // if CQL classes aren't on the classpath, these functions won't be available
+      case e: NoClassDefFoundError =>
+        logger.warn(s"Couldn't create cql function factory '${factory.getClass.getName}': ${e.toString}")
+        Seq.empty
+    }
+  }
+
+  val cqlFunctions = names.flatMap { f =>
+    val name = f.getFunctionName.toString
+    // use alphas for the array indices, as used by the ArrayPropertyAccessor, below
+    val arguments = (0 until f.getArguments.length).map(i => ('a' + i).toChar.toString)
+    val expressions = arguments.map(a => ff.property(new NameImpl(a))).toArray
+    try {
+      val fn = ff.function(name, expressions: _*)
+      Some(TransformerFn(s"cql:$name") { args => fn.evaluate(args) })
+    } catch {
+      case e: Exception =>
+        logger.warn(s"Couldn't create cql function '$name': ${e.toString}")
+        None
+    }
+  }
+
+  override def functions = cqlFunctions
+}
+
+/**
+ * For accessing 'properties' of arrays (instead of simple features)
+ */
+class ArrayPropertyAccessorFactory extends PropertyAccessorFactory {
+  override def createPropertyAccessor(typ: Class[_],
+                                      xpath: String,
+                                      target: Class[_],
+                                      hints: Hints): PropertyAccessor = {
+    if (typ.isArray) new ArrayPropertyAccessor else null
+  }
+}
+
+/**
+ * Accessing properties of an array. Indices are expected to be lower-case letters,
+ * where 'a' indicates the first element, b the second, etc. We use alphas because
+ * integers are interpreted as literals, not properties.
+ */
+class ArrayPropertyAccessor extends PropertyAccessor {
+
+  override def canHandle(obj: Any, xpath: String, target: Class[_]): Boolean = {
+    val i = toIndex(xpath)
+    i >=0 && i < obj.asInstanceOf[Array[Any]].length
+  }
+
+  override def set[T](obj: Any, xpath: String, value: T, target: Class[T]): Unit =
+    obj.asInstanceOf[Array[Any]].update(toIndex(xpath), Converters.convert(value, target))
+
+  override def get[T](obj: Any, xpath: String, target: Class[T]): T =
+    Converters.convert(obj.asInstanceOf[Array[Any]].apply(toIndex(xpath)), target)
+
+  private def toIndex(xpath: String): Int = {
+    if (xpath.length == 1) {
+      xpath.charAt(0) - 'a'
+    } else {
+      -1
+    }
+  }
+}

--- a/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert/common/TransformersTest.scala
+++ b/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert/common/TransformersTest.scala
@@ -513,6 +513,18 @@ class TransformersTest extends Specification {
           exp.eval(Array("", "foo", "foo", "f", "oo")) must beTrue
         }
       }
+
+      "support cql functions" >> {
+        "buffer" >> {
+          val exp = Transformers.parseTransform("cql:buffer($1, $2)")
+          val buf = exp.eval(Array(null, "POINT(1 1)", 2.0))
+          buf must beAnInstanceOf[Polygon]
+          buf.asInstanceOf[Polygon].getCentroid.getX must beCloseTo(1, 0.0001)
+          buf.asInstanceOf[Polygon].getCentroid.getY must beCloseTo(1, 0.0001)
+          // note: area is not particularly close as there aren't very many points in the polygon
+          buf.asInstanceOf[Polygon].getArea must beCloseTo(math.Pi * 4.0, 0.2)
+        }
+      }
     }
 
     import scala.collection.JavaConversions._


### PR DESCRIPTION
* CQL functions are namespaced with 'cql', e.g. 'cql:buffer($1, 2.0)'

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>