### PR TITLE
GEOMESA-1115 Adding metrics for geoserver instrumentation

### DIFF
--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -37,6 +37,9 @@ com.typesafe:config	1.2.1	compile
 com.typesafe.scala-logging:scala-logging_2.11	3.1.0	compile
 com.vividsolutions:jts	1.13	compile
 eu.medsea.mimeutil:mime-util	2.1.3	compile
+io.dropwizard.metrics:metrics-core	3.1.2	compile
+io.dropwizard.metrics:metrics-ganglia	3.1.2	compile
+io.dropwizard.metrics:metrics-graphite	3.1.2	compile
 io.netty:netty-all	4.0.23.Final	compile
 it.geosolutions.jaiext.affine:jt-affine	1.0.8	compile
 it.geosolutions.jaiext.algebra:jt-algebra	1.0.8	compile

--- a/docs/bin/import-module-readme.sh
+++ b/docs/bin/import-module-readme.sh
@@ -6,11 +6,12 @@
 # IMPORTANT: update these to match your system!
 # (I had two copies of the geomesa repo because they were checked out on different branches)
 GM_DOCS=/opt/devel/src/geomesa
-GM_MASTER=/opt/devel/src/geomesa2
+GM_MASTER=/opt/devel/src/geomesa
 MODULES="
 geomesa-compute
 geomesa-convert
 geomesa-jobs
+geomesa-metrics
 geomesa-process
 geomesa-raster
 geomesa-stream

--- a/docs/developer/modules.rst
+++ b/docs/developer/modules.rst
@@ -10,9 +10,9 @@ distribution in more detail.
    modules/geomesa-compute
    modules/geomesa-convert
    modules/geomesa-jobs
+   modules/geomesa-metrics
    modules/geomesa-process
    modules/geomesa-raster
    modules/geomesa-stream
    modules/geomesa-utils
    modules/geomesa-web-data
-

--- a/docs/developer/modules/geomesa-metrics.rst
+++ b/docs/developer/modules/geomesa-metrics.rst
@@ -1,0 +1,288 @@
+.. _geomesa-metrics:
+
+geomesa-metrics
+===============
+
+GeoMesa provides integration with the `DropWizard
+Metrics <http://metrics.dropwizard.io/>`__ library for real-time
+reporting.
+
+Instrumentation of GeoServer
+----------------------------
+
+GeoMesa metrics provides a servlet filter that will instrument GeoServer
+requests.
+
+Installation
+~~~~~~~~~~~~
+
+Copy the following jars into geoserver's ``WEB-INF/lib`` directory:
+
+-  geomesa-metrics-.jar
+-  metrics-core-3.1.2.jar
+-  metrics-graphite-3.1.2.jar
+-  metrics-ganglia-3.1.2.jar
+
+Also copy the following jars if not already present:
+
+-  scala-library-2.11.7.jar
+-  scala-logging\_2.11-3.1.0.jar
+-  scala-reflect-2.11.7.jar
+-  config-1.2.1.jar
+-  joda-time-2.3.jar
+
+Ganglia Reporting
+^^^^^^^^^^^^^^^^^
+
+To enable ganglia reporters, also copy the following jars:
+
+-  gmetric4j-1.0.7.jar
+-  oncrpc-1.0.7.jar
+
+Delimited File Reporting
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+To enable TSV/CSV reporters, also copy the following jars:
+
+-  commons-csv-1.0.jar
+
+Configuration
+~~~~~~~~~~~~~
+
+To configure instrumentation, add the metrics filter to GeoServer's
+``WEB-INF/web.xml``:
+
+.. code:: xml
+
+    <filter>
+      <filter-name>metricsFilter</filter-name>
+      <filter-class>org.locationtech.geomesa.metrics.servlet.AggregatedMetricsFilter</filter-class>
+      <!-- name used for registering metrics - can also be specified in the config, but this takes priority -->
+      <init-param>
+        <param-name>name-prefix</param-name>
+        <param-value>geoserver</param-value>
+      </init-param>
+      <! -- can embed configuration directly, otherwise will load default
+            configurations and look under 'geomesa.metrics.servlet' -->
+      <init-param>
+        <param-name>config</param-name>
+        <param-value>
+        {
+          // name used for registering metrics - init-param takes precedence
+          name-prefix = "geoserver"
+          // will only instrument matching urls
+          // example string matched against: '/geoserver/<workspace>/ows'
+          url-patterns = [ "(?i).*/(ows|wfs|wms)" ]
+          // match request mappings based on just the workspace:layer name, or the whole url
+          // if you are instrumenting non-wfs/wms requests, layer names will never match
+          map-by-layer = true
+          // mappings of urls to metric groups, based on regexes
+          // any urls not mapped will end up under 'other'
+          request-mappings = [
+            {
+              name = "qs"
+              regex = ".*:AccumuloQuickStart"
+            }
+          ]
+          // metrics reporters - see configuration details below
+          reporters = {
+            console = {
+              type = "console"
+              units = "MINUTES"
+              interval = 10
+            }
+          }
+        }
+        </param-value>
+      </init-param>
+    </filter>
+
+    <filter-mapping>
+      <filter-name>metricsFilter</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+Configuration of Reporters
+--------------------------
+
+Use ``org.locationtech.geomesa.metrics.config.MetricsConfig.reporters``
+to configure reporters via TypeSafe Config. Reporters should be defined
+as objects under the path ``geomesa.metrics.reporters``:
+
+::
+
+    geomesa = {
+      metrics = {
+        reporters = {
+          console = {
+            type     = "console"
+            units    = "MILLISECONDS"
+            interval = 60
+          }
+          slf4j = {
+            type     = "slf4j"
+            units    = "MILLISECONDS"
+            interval = 60
+            logger   = "org.locationtech.geomesa"
+            level    = "debug"
+          }
+          delimited-text = {
+            type      = "delimited-text"
+            units     = "MILLISECONDS"
+            interval  = 60
+            tabs      = true
+            aggregate = true
+            output    = ${java.io.tmpdir}/"geoserver-metrics"
+          }
+          graphite = {
+            type     = "graphite"
+            units    = "MILLISECONDS"
+            interval = 60
+            url      = "graphite.example.com:80"
+            prefix   = "org.locationtech.geomesa"
+          }
+          ganglia = {
+            type            = "ganglia"
+            units           = "MILLISECONDS"
+            interval        = 60
+            group           = "ganglia.example.com"
+            port            = 8649
+            addressing-mode = "MULTICAST"
+            ttl             = 1
+            ganglia311      = true
+          }
+          accumulo = {
+            type       = "accumulo"
+            units      = "MILLISECONDS"
+            interval   = -1
+            instanceId = "mycloud"
+            zookeepers = "zoo1,zoo2,zoo3"
+            user       = "myuser"
+            password   = "mypassword"
+            tableName  = "geomesa_metrics"
+          }      
+        }
+      }
+    }
+
+Standard Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+The following fields are common among all reporters:
+
++----------------------+-----------+---------------------------------------------------------------------------------------------------------------+
+| Field                | Type      | Description                                                                                                   |
++======================+===========+===============================================================================================================+
+| ``rate-units``       | String    | The type of units used to report the rate of a metric. Corresponds to ``java.util.concurrent.TimeUnit``       |
++----------------------+-----------+---------------------------------------------------------------------------------------------------------------+
+| ``duration-units``   | String    | The type of units used to report the duration of a metric. Corresponds to ``java.util.concurrent.TimeUnit``   |
++----------------------+-----------+---------------------------------------------------------------------------------------------------------------+
+| ``units``            | String    | If rate or duration units are not specified, this will be used instead.                                       |
++----------------------+-----------+---------------------------------------------------------------------------------------------------------------+
+| ``interval``         | Integer   | How often the reporter will run, in seconds. If less than 1, reporter will not run automatically.             |
++----------------------+-----------+---------------------------------------------------------------------------------------------------------------+
+| ``type``             | String    | The type of reporter. Types are documented below.                                                             |
++----------------------+-----------+---------------------------------------------------------------------------------------------------------------+
+
+Console Reporter
+~~~~~~~~~~~~~~~~
+
+Writes metrics to the console.
+
++------------+----------+---------------------+
+| Field      | Type     | Description         |
++============+==========+=====================+
+| ``type``   | String   | Must be ``console``   |
++------------+----------+---------------------+
+
+Slf4j Reporter
+~~~~~~~~~~~~~~
+
+Writes metrics using an slf4j logger.
+
++--------------+----------+---------------------------------------------------------------------------------------------------------------------------------+
+| Field        | Type     | Description                                                                                                                     |
++==============+==========+=================================================================================================================================+
+| ``type``     | String   | Must be ``slf4j``                                                                                                               |
++--------------+----------+---------------------------------------------------------------------------------------------------------------------------------+
+| ``logger``   | String   | The name of the logger that will be used for logging.                                                                           |
++--------------+----------+---------------------------------------------------------------------------------------------------------------------------------+
+| ``level``    | String   | (optional) Level to use for logger messages. One of ``trace``, ``debug``, ``info``, ``warn``, ``error``. Default is ``debug``   |
++--------------+----------+---------------------------------------------------------------------------------------------------------------------------------+
+
+Delimited Text Reporter
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Writes metrics to tab or comma-delimited files.
+
++-----------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Field           | Type      | Description                                                                                                                                                   |
++=================+===========+===============================================================================================================================================================+
+| ``type``        | String    | Must be ``delimited-text``                                                                                                                                    |
++-----------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``output``      | String    | The path to output metrics to. Will be passed into ``new java.io.File(output)``                                                                               |
++-----------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``aggregate``   | Boolean   | (optional) Aggregate output files by type. If true, there will be one file per metric type; if false there will be one file per metric. Default is ``true``   |
++-----------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``tabs``        | Boolean   | (optional) If true, delimit entries with tabs, else delimit entries with commas. Default is ``true``                                                          |
++-----------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Graphite Reporter
+~~~~~~~~~~~~~~~~~
+
+Writes metrics to Graphite.
+
++--------------+----------+--------------------------------------------------------------------+
+| Field        | Type     | Description                                                        |
++==============+==========+====================================================================+
+| ``type``     | String   | Must be ``graphite``                                               |
++--------------+----------+--------------------------------------------------------------------+
+| ``url``      | String   | The URL to the graphite server, in the form of ``<host>:<port>``   |
++--------------+----------+--------------------------------------------------------------------+
+| ``prefix``   | String   | (optional) The graphite prefix to use                              |
++--------------+----------+--------------------------------------------------------------------+
+
+Ganglia Reporter
+~~~~~~~~~~~~~~~~
+
+Writes metrics to Ganglia.
+
++-----------------------+-----------+----------------------------------------------------------------------------------+
+| Field                 | Type      | Description                                                                      |
++=======================+===========+==================================================================================+
+| ``type``              | String    | Must be ``ganglia``                                                              |
++-----------------------+-----------+----------------------------------------------------------------------------------+
+| ``group``             | String    | The group (url) used for connecting to the ganglia server                        |
++-----------------------+-----------+----------------------------------------------------------------------------------+
+| ``port``              | Int       | The port used for connecting to the ganglia server                               |
++-----------------------+-----------+----------------------------------------------------------------------------------+
+| ``ttl``               | Int       | Time-to-live for broadcast packets, in the range of 0-255                        |
++-----------------------+-----------+----------------------------------------------------------------------------------+
+| ``addressing-mode``   | String    | (optional) Addressing mode to use. Must be one of ``unicast`` or ``multicast``   |
++-----------------------+-----------+----------------------------------------------------------------------------------+
+| ``ganglia311``        | Boolean   | (optional) To use protocol version 3.1 (true) or 3.0 (false). Default is 3.1     |
++-----------------------+-----------+----------------------------------------------------------------------------------+
+
+Accumulo Reporter
+~~~~~~~~~~~~~~~~~
+
+Writes metrics to Accumulo.
+
++--------------------+----------+------------------------------------------------------------+
+| Field              | Type     | Description                                                |
++====================+==========+============================================================+
+| ``type``           | String   | Must be ``accumulo``                                       |
++--------------------+----------+------------------------------------------------------------+
+| ``instanceId``     | String   | The instance ID for the accumulo cluster                   |
++--------------------+----------+------------------------------------------------------------+
+| ``zookeepers``     | String   | The zookeeper connection string for the accumulo cluster   |
++--------------------+----------+------------------------------------------------------------+
+| ``user``           | String   | The accumulo user to connect with                          |
++--------------------+----------+------------------------------------------------------------+
+| ``password``       | String   | The password for the accumulo user                         |
++--------------------+----------+------------------------------------------------------------+
+| ``tableName``      | String   | The table metrics will be written to                       |
++--------------------+----------+------------------------------------------------------------+
+| ``visibilities``   | String   | (optional) Visibilities applied to written data            |
++--------------------+----------+------------------------------------------------------------+
+

--- a/docs/developer/modules/geomesa-metrics.rst
+++ b/docs/developer/modules/geomesa-metrics.rst
@@ -88,7 +88,8 @@ To configure instrumentation, add the metrics filter to GeoServer's
           reporters = {
             console = {
               type = "console"
-              units = "MINUTES"
+              rate-units = "MINUTES"
+              duration-units = "MILLISECONDS"
               interval = 10
             }
           }
@@ -101,6 +102,61 @@ To configure instrumentation, add the metrics filter to GeoServer's
       <filter-name>metricsFilter</filter-name>
       <url-pattern>/*</url-pattern>
     </filter-mapping>
+
+Session Tracking
+^^^^^^^^^^^^^^^^
+
+The metrics servlet doesn't track active user sessions by default.
+GeoServer mostly doesn't create sessions for OWS requests, and blatantly
+warns you against doing so. However, if you are willing to incur the
+cost of session management, you may enable session tracking in the
+metrics servlet.
+
+Update the configuration for the metrics servlet (either in
+``application.conf`` or ``web.xml``) with the following attribute:
+
+.. code:: json
+
+    // how often to update metrics for expired sessions, in seconds
+    // if set to &lt; 1, sessions will not be tracked
+    // use in conjunction with the session listener defined below
+    session-removal-interval = 60
+
+Add the following listener to GeoServer's ``WEB-INF/web.xml``:
+
+.. warning::
+
+    Failure to add this listener when session tracking is
+    enabled will cause incorrect metrics reports and eventually lead to
+    out-of-memory errors
+
+.. code:: xml
+
+    <!-- listener for sessions events
+         if you enable session tracking and this is not defined, sessions will never
+         be expired from the metrics cache and you will eventually run out of memory -->
+    <listener>
+      <listener-class>org.locationtech.geomesa.metrics.servlet.SessionMetricsListener</listenerclass>
+    </listener>
+
+In order to suppress GeoServer's warnings about session creation,
+comment out the following filter in GeoServer's ``WEB-INF/web.xml``:
+
+.. code:: xml
+
+    <!--
+    <filter>
+      <filter-name>SessionDebugger</filter-name>
+      <filter-class>org.geoserver.filters.SessionDebugFilter</filter-class>
+    </filter>
+    -->
+    ...
+    <!--
+    <filter-mapping>
+      <filter-name>SessionDebugger</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    -->
 
 Configuration of Reporters
 --------------------------
@@ -189,11 +245,11 @@ Console Reporter
 
 Writes metrics to the console.
 
-+------------+----------+---------------------+
-| Field      | Type     | Description         |
-+============+==========+=====================+
++------------+----------+-----------------------+
+| Field      | Type     | Description           |
++============+==========+=======================+
 | ``type``   | String   | Must be ``console``   |
-+------------+----------+---------------------+
++------------+----------+-----------------------+
 
 Slf4j Reporter
 ~~~~~~~~~~~~~~

--- a/geomesa-metrics/README.md
+++ b/geomesa-metrics/README.md
@@ -1,0 +1,230 @@
+# GeoMesa Metrics
+
+GeoMesa provides integration with the [DropWizard Metrics](http://metrics.dropwizard.io/) library for real-time reporting.
+
+## Instrumentation of GeoServer
+
+GeoMesa metrics provides a servlet filter that will instrument GeoServer requests.
+
+### Installation
+
+Copy the following jars into geoserver's `WEB-INF/lib` directory:
+
+* geomesa-metrics-<version>.jar
+* metrics-core-3.1.2.jar
+* metrics-graphite-3.1.2.jar
+* metrics-ganglia-3.1.2.jar
+
+Also copy the following jars if not already present:
+
+* scala-library-2.11.7.jar
+* scala-logging_2.11-3.1.0.jar
+* scala-reflect-2.11.7.jar
+* config-1.2.1.jar
+* joda-time-2.3.jar
+
+#### Ganglia Reporting
+
+To enable ganglia reporters, also copy the following jars:
+
+* gmetric4j-1.0.7.jar
+* oncrpc-1.0.7.jar
+
+#### Delimited File Reporting
+
+To enable TSV/CSV reporters, also copy the following jars:
+
+* commons-csv-1.0.jar
+
+### Configuration
+
+To configure instrumentation, add the metrics filter to GeoServer's `WEB-INF/web.xml`:
+
+```xml
+<filter>
+  <filter-name>metricsFilter</filter-name>
+  <filter-class>org.locationtech.geomesa.metrics.servlet.AggregatedMetricsFilter</filter-class>
+  <!-- name used for registering metrics - can also be specified in the config, but this takes priority -->
+  <init-param>
+    <param-name>name-prefix</param-name>
+    <param-value>geoserver</param-value>
+  </init-param>
+  <! -- can embed configuration directly, otherwise will load default
+        configurations and look under 'geomesa.metrics.servlet' -->
+  <init-param>
+    <param-name>config</param-name>
+    <param-value>
+    {
+      // name used for registering metrics - init-param takes precedence
+      name-prefix = "geoserver"
+      // will only instrument matching urls
+      // example string matched against: '/geoserver/<workspace>/ows'
+      url-patterns = [ "(?i).*/(ows|wfs|wms)" ]
+      // match request mappings based on just the workspace:layer name, or the whole url
+      // if you are instrumenting non-wfs/wms requests, layer names will never match
+      map-by-layer = true
+      // mappings of urls to metric groups, based on regexes
+      // any urls not mapped will end up under 'other'
+      request-mappings = [
+        {
+          name = "qs"
+          regex = ".*:AccumuloQuickStart"
+        }
+      ]
+      // metrics reporters - see configuration details below
+      reporters = {
+        console = {
+          type = "console"
+          units = "MINUTES"
+          interval = 10
+        }
+      }
+    }
+    </param-value>
+  </init-param>
+</filter>
+
+<filter-mapping>
+  <filter-name>metricsFilter</filter-name>
+  <url-pattern>/*</url-pattern>
+</filter-mapping>
+```
+
+## Configuration of Reporters
+
+Use `org.locationtech.geomesa.metrics.config.MetricsConfig.reporters` to configure reporters via TypeSafe Config.
+Reporters should be defined as objects under the path `geomesa.metrics.reporters`:
+
+```
+geomesa = {
+  metrics = {
+    reporters = {
+      console = {
+        type     = "console"
+        units    = "MILLISECONDS"
+        interval = 60
+      }
+      slf4j = {
+        type     = "slf4j"
+        units    = "MILLISECONDS"
+        interval = 60
+        logger   = "org.locationtech.geomesa"
+        level    = "debug"
+      }
+      delimited-text = {
+        type      = "delimited-text"
+        units     = "MILLISECONDS"
+        interval  = 60
+        tabs      = true
+        aggregate = true
+        output    = ${java.io.tmpdir}/"geoserver-metrics"
+      }
+      graphite = {
+        type     = "graphite"
+        units    = "MILLISECONDS"
+        interval = 60
+        url      = "graphite.example.com:80"
+        prefix   = "org.locationtech.geomesa"
+      }
+      ganglia = {
+        type            = "ganglia"
+        units           = "MILLISECONDS"
+        interval        = 60
+        group           = "ganglia.example.com"
+        port            = 8649
+        addressing-mode = "MULTICAST"
+        ttl             = 1
+        ganglia311      = true
+      }
+      accumulo = {
+        type       = "accumulo"
+        units      = "MILLISECONDS"
+        interval   = -1
+        instanceId = "mycloud"
+        zookeepers = "zoo1,zoo2,zoo3"
+        user       = "myuser"
+        password   = "mypassword"
+        tableName  = "geomesa_metrics"
+      }      
+    }
+  }
+}
+```
+
+### Standard Configuration
+
+The following fields are common among all reporters:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `rate-units` | String | The type of units used to report the rate of a metric. Corresponds to `java.util.concurrent.TimeUnit` |
+| `duration-units` | String | The type of units used to report the duration of a metric. Corresponds to `java.util.concurrent.TimeUnit` |
+| `units` | String | If rate or duration units are not specified, this will be used instead. |
+| `interval` | Integer | How often the reporter will run, in seconds. If less than 1, reporter will not run automatically. |
+| `type` | String | The type of reporter. Types are documented below. |
+
+### Console Reporter
+
+Writes metrics to the console.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `type` | String | Must be `console` |
+
+### Slf4j Reporter
+
+Writes metrics using an slf4j logger.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `type` | String | Must be `slf4j` |
+| `logger` | String | The name of the logger that will be used for logging. |
+| `level` | String | (optional) Level to use for logger messages. One of `trace`, `debug`, `info`, `warn`, `error`. Default is `debug` |
+
+### Delimited Text Reporter
+
+Writes metrics to tab or comma-delimited files.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `type` | String | Must be `delimited-text` |
+| `output` | String | The path to output metrics to. Will be passed into `new java.io.File(output)` |
+| `aggregate` | Boolean | (optional) Aggregate output files by type. If true, there will be one file per metric type; if false there will be one file per metric. Default is `true` |
+| `tabs` | Boolean | (optional) If true, delimit entries with tabs, else delimit entries with commas. Default is `true` |
+
+### Graphite Reporter
+
+Writes metrics to Graphite.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `type` | String | Must be `graphite` |
+| `url` | String | The URL to the graphite server, in the form of `<host>:<port>` |
+| `prefix` | String | (optional) The graphite prefix to use |
+
+### Ganglia Reporter
+
+Writes metrics to Ganglia.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `type` | String | Must be `ganglia` |
+| `group` | String | The group (url) used for connecting to the ganglia server |
+| `port` | Int | The port used for connecting to the ganglia server |
+| `ttl` | Int | Time-to-live for broadcast packets, in the range of 0-255 |
+| `addressing-mode` | String | (optional) Addressing mode to use. Must be one of `unicast` or `multicast` |
+| `ganglia311` | Boolean | (optional) To use protocol version 3.1 (true) or 3.0 (false). Default is 3.1 |
+
+### Accumulo Reporter
+
+Writes metrics to Accumulo.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `type` | String | Must be `accumulo` |
+| `instanceId` | String | The instance ID for the accumulo cluster |
+| `zookeepers` | String | The zookeeper connection string for the accumulo cluster |
+| `user` | String | The accumulo user to connect with |
+| `password` | String | The password for the accumulo user |
+| `tableName` | String | The table metrics will be written to |
+| `visibilities` | String | (optional) Visibilities applied to written data |

--- a/geomesa-metrics/pom.xml
+++ b/geomesa-metrics/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.locationtech.geomesa</groupId>
+        <artifactId>geomesa</artifactId>
+        <version>1.2.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-metrics</artifactId>
+    <name>GeoMesa Metrics</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <metrics.version>3.1.2</metrics.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>info.ganglia.gmetric4j</groupId>
+                <artifactId>gmetric4j</artifactId>
+                <version>1.0.7</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${metrics.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-graphite</artifactId>
+            <version>${metrics.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-ganglia</artifactId>
+            <version>${metrics.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging_2.11</artifactId>
+        </dependency>
+
+        <!-- provided dependencies -->
+        <dependency>
+            <groupId>org.apache.accumulo</groupId>
+            <artifactId>accumulo-core</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2_2.11</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/geomesa-metrics/src/main/scala/org/locationtech/geomesa/metrics/config/MetricsConfig.scala
+++ b/geomesa-metrics/src/main/scala/org/locationtech/geomesa/metrics/config/MetricsConfig.scala
@@ -1,0 +1,149 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.metrics.config
+
+import java.net.InetSocketAddress
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics.Slf4jReporter.LoggingLevel
+import com.codahale.metrics.ganglia.GangliaReporter
+import com.codahale.metrics.graphite.{Graphite, GraphiteReporter}
+import com.codahale.metrics.{MetricRegistry, _}
+import com.typesafe.config.{ConfigFactory, Config}
+import com.typesafe.scalalogging.LazyLogging
+import info.ganglia.gmetric4j.gmetric.GMetric
+import info.ganglia.gmetric4j.gmetric.GMetric.UDPAddressingMode
+import org.locationtech.geomesa.metrics.reporters.{DelimitedFileReporter, AccumuloReporter}
+import org.slf4j.LoggerFactory
+
+object MetricsConfig extends LazyLogging {
+
+  val ConfigPath = "geomesa.metrics.reporters"
+
+  def reporters(config: Config,
+                registry: MetricRegistry,
+                path: Option[String] = Some(ConfigPath),
+                start: Boolean = true): Seq[ScheduledReporter] = {
+    val reporters = path match {
+      case Some(p) => if (config.hasPath(p)) config.getConfig(p) else ConfigFactory.empty()
+      case None    => config
+    }
+
+    import scala.collection.JavaConversions._
+    reporters.root.keys.toSeq.flatMap { path =>
+      try {
+        Some(createReporter(reporters.getConfig(path), registry, start))
+      } catch {
+        case e: Exception =>
+          logger.warn("Invalid reporter config", e)
+          None
+      }
+    }
+  }
+
+  private def createReporter(config: Config, registry: MetricRegistry, start: Boolean): ScheduledReporter = {
+    val rate = timeUnit(config.getString(if (config.hasPath("rate-units")) "rate-units" else "units"))
+    val duration = timeUnit(config.getString(if (config.hasPath("duration-units")) "duration-units" else "units"))
+    val interval = if (config.hasPath("interval")) config.getInt("interval") else -1
+    val typ = config.getString("type").toLowerCase(Locale.US)
+
+    val reporter = if (typ == "console") {
+      ConsoleReporter.forRegistry(registry)
+          .convertRatesTo(rate)
+          .convertDurationsTo(duration)
+          .build()
+    } else if (typ == "slf4j") {
+      val logger = LoggerFactory.getLogger(config.getString("logger"))
+      val level = if (config.hasPath("level")) {
+        LoggingLevel.valueOf(config.getString("level").toUpperCase)
+      } else {
+        LoggingLevel.DEBUG
+      }
+      Slf4jReporter.forRegistry(registry)
+          .outputTo(logger)
+          .convertRatesTo(rate)
+          .convertDurationsTo(duration)
+          .withLoggingLevel(level)
+          .build()
+    } else if (typ == "delimited-text") {
+      val path = config.getString("output")
+      val aggregate = if (config.hasPath("aggregate")) config.getBoolean("aggregate") else true
+      val tabs = if (config.hasPath("tabs")) config.getBoolean("tabs") else true
+
+      val builder = DelimitedFileReporter.forRegistry(registry)
+          .convertRatesTo(rate)
+          .convertDurationsTo(duration)
+          .aggregate(aggregate)
+      if (tabs) {
+        builder.withTabs()
+      } else {
+        builder.withCommas()
+      }
+      builder.build(path)
+    } else if (typ == "graphite") {
+      val url +: Nil :+ port = config.getString("url").split(":").toList
+      val graphite = new Graphite(new InetSocketAddress(url, port.toInt))
+      val prefix = if (config.hasPath("prefix")) config.getString("prefix") else null
+
+      GraphiteReporter.forRegistry(registry)
+          .prefixedWith(prefix)
+          .convertRatesTo(rate)
+          .convertDurationsTo(duration)
+          .build(graphite)
+    } else if (typ == "ganglia") {
+      val group = config.getString("group")
+      val port = config.getInt("port")
+      val mode = if (config.hasPath("addressing-mode") &&
+          config.getString("addressing-mode").equalsIgnoreCase("unicast")) {
+        UDPAddressingMode.UNICAST
+      } else {
+        UDPAddressingMode.MULTICAST
+      }
+      val ttl = config.getInt("ttl")
+      val is311 = if (config.hasPath("ganglia311")) config.getBoolean("ganglia311") else true
+      val ganglia = new GMetric(group, port.toInt, mode, ttl, is311)
+
+      GangliaReporter.forRegistry(registry)
+          .convertRatesTo(rate)
+          .convertDurationsTo(duration)
+          .build(ganglia)
+    } else if (typ == "accumulo") {
+      val instance = config.getString("instanceId")
+      val zoos = config.getString("zookeepers")
+      val user = config.getString("user")
+      val password = config.getString("password")
+      val table = config.getString("tableName")
+
+      val builder = AccumuloReporter.forRegistry(registry)
+          .convertRatesTo(rate)
+          .convertDurationsTo(duration)
+          .writeToTable(table)
+      if (config.hasPath("visibilities")) {
+        builder.withVisibilities(config.getString("visibilities"))
+      }
+      if (config.hasPath("mock") && config.getBoolean("mock")) {
+        builder.mock(true)
+      }
+      builder.build(instance, zoos, user, password)
+    } else {
+      throw new RuntimeException(s"No reporter type '$typ' defined")
+    }
+
+    if (start && interval > 0) {
+      reporter.start(interval, TimeUnit.SECONDS)
+    }
+
+    reporter
+  }
+
+  // convert string to timeunit enum using reflection
+  private def timeUnit(unit: String): TimeUnit =
+    classOf[TimeUnit].getField(unit.toUpperCase(Locale.US)).get(null).asInstanceOf[TimeUnit]
+}

--- a/geomesa-metrics/src/main/scala/org/locationtech/geomesa/metrics/reporters/AccumuloReporter.scala
+++ b/geomesa-metrics/src/main/scala/org/locationtech/geomesa/metrics/reporters/AccumuloReporter.scala
@@ -1,0 +1,230 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.metrics.reporters
+
+
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics._
+import com.google.common.base.Charsets
+import org.apache.accumulo.core.client._
+import org.apache.accumulo.core.client.admin.TimeType
+import org.apache.accumulo.core.client.mock.MockInstance
+import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.data.{Mutation, Value}
+import org.apache.accumulo.core.security.ColumnVisibility
+import org.apache.hadoop.io.Text
+import org.joda.time.format.DateTimeFormat
+
+import scala.collection.JavaConversions._
+import scala.language.implicitConversions
+
+/**
+ * Reporter for dropwizard metrics that will write to accumulo
+ */
+object AccumuloReporter {
+
+  object Keys {
+    val count =  new Text("count")
+    val value =  new Text("value")
+
+    val max =    new Text("max")
+    val mean =   new Text("mean")
+    val min =    new Text("min")
+    val stddev = new Text("stddev")
+
+    val p50 =  new Text("p50")
+    val p75 =  new Text("p75")
+    val p95 =  new Text("p95")
+    val p98 =  new Text("p98")
+    val p99 =  new Text("p99")
+    val p999 = new Text("p999")
+
+    val mean_rate =     new Text("mean_rate")
+    val m1_rate =       new Text("m1_rate")
+    val m5_rate =       new Text("m5_rate")
+    val m15_rate =      new Text("m15_rate")
+    val rate_unit =     new Text("rate_unit")
+    val duration_unit = new Text("duration_unit")
+
+    val empty = new Text(Array.empty[Byte])
+  }
+
+  def forRegistry(registry: MetricRegistry): Builder = new Builder(registry)
+
+  class Builder private[metrics] (registry: MetricRegistry) {
+
+    private var locale: Locale = Locale.getDefault
+    private var rateUnit: TimeUnit = TimeUnit.SECONDS
+    private var durationUnit: TimeUnit = TimeUnit.MILLISECONDS
+    private var clock: Clock = Clock.defaultClock
+    private var filter: MetricFilter = MetricFilter.ALL
+    private var table: String = "metrics"
+    private var visibilities: String = null
+    private var mock: Boolean = false
+
+    def formatFor(locale: Locale): Builder = { this.locale = locale; this }
+
+    def convertRatesTo(rateUnit: TimeUnit): Builder = { this.rateUnit = rateUnit; this }
+
+    def convertDurationsTo(durationUnit: TimeUnit): Builder = { this.durationUnit = durationUnit; this }
+
+    def withClock(clock: Clock): Builder = { this.clock = clock; this }
+
+    def filter(filter: MetricFilter): Builder = { this.filter = filter; this }
+
+    def writeToTable(table: String): Builder = { this.table = table; this }
+
+    def withVisibilities(visibilities: String): Builder = { this.visibilities = visibilities; this }
+
+    def mock(mock: Boolean): Builder = { this.mock = mock; this }
+
+    def build(instanceId: String, zookeepers: String, user: String, password: String): AccumuloReporter = {
+      val instance = if (mock) new MockInstance(instanceId) else new ZooKeeperInstance(instanceId, zookeepers)
+      val connector = instance.getConnector(user, new PasswordToken(password))
+      new AccumuloReporter(registry, connector, table, Option(visibilities),
+        clock, locale, filter, rateUnit, durationUnit)
+    }
+  }
+
+  private def mutationFor(name: String, timestamp: Option[String] = None) =
+    new Mutation(timestamp.map(t => s"$name-$t").getOrElse(name))
+}
+
+/**
+ * Reporter for dropwizard metrics that will write to accumulo
+ */
+class AccumuloReporter private (registry: MetricRegistry,
+                                connector: Connector,
+                                table: String,
+                                visibilities: Option[String],
+                                clock: Clock,
+                                locale: Locale,
+                                filter: MetricFilter,
+                                rateUnit: TimeUnit,
+                                durationUnit: TimeUnit)
+    extends ScheduledReporter(registry, "AccumuloReporter", filter, rateUnit, durationUnit) {
+
+  import AccumuloReporter.{Keys, mutationFor}
+
+  if (!connector.tableOperations().exists(table)) {
+    try { connector.tableOperations().create(table, true, TimeType.LOGICAL) } catch {
+      case e: TableExistsException => // no-op
+    }
+  }
+  private val writer = connector.createBatchWriter(table, new BatchWriterConfig)
+  private val timeEncoder = DateTimeFormat.forPattern("yyyyMMddHHmmss").withZoneUTC()
+  private val visibility = visibilities.map(new ColumnVisibility(_))
+
+  override def stop(): Unit = {
+    writer.close()
+    super.stop()
+  }
+
+  override def report(gauges: java.util.SortedMap[String, Gauge[_]],
+                      counters: java.util.SortedMap[String, Counter],
+                      histograms: java.util.SortedMap[String, Histogram],
+                      meters: java.util.SortedMap[String, Meter],
+                      timers: java.util.SortedMap[String, Timer]) = {
+    lazy val timestamp = timeEncoder.print(clock.getTime)
+    addMutations(gauges.toSeq.map { case (name, metric) => gaugeToMutation(name, timestamp, metric) })
+    addMutations(counters.toSeq.map { case (name, metric) => counterToMutation(name, timestamp, metric) })
+    addMutations(histograms.toSeq.map { case (name, metric) => histogramToMutation(name, metric) })
+    addMutations(meters.toSeq.map { case (name, metric) => meterToMutation(name, metric) })
+    addMutations(timers.toSeq.map { case (name, metric) => timerToMutation(name, metric) })
+  }
+
+  def flush(): Unit = writer.flush()
+
+  private def addMutations(mutations: Seq[Mutation]): Unit =
+    if (mutations.nonEmpty) { writer.addMutations(mutations) }
+
+  // gauges are stored with the timestamp in the row key, so history is kept
+  private def gaugeToMutation(name: String, timestamp: String, gauge: Gauge[_]): Mutation = {
+    val m = mutationFor(name, Some(timestamp))
+    put(m, Keys.value, "%s", gauge.getValue)
+    m
+  }
+
+  // counters are stored with the timestamp in the row key, so history is kept
+  private def counterToMutation(name: String, timestamp: String, counter: Counter): Mutation = {
+    val m = mutationFor(name, Some(timestamp))
+    put(m, Keys.count, "%d", counter.getCount)
+    m
+  }
+
+  // histograms will overwrite existing data
+  private def histogramToMutation(name: String, histogram: Histogram): Mutation = {
+    val m = mutationFor(name)
+    val snapshot = histogram.getSnapshot
+
+    put(m, Keys.count,  "%d", histogram.getCount)
+    put(m, Keys.max,    "%d", snapshot.getMax)
+    put(m, Keys.mean,   "%f", snapshot.getMean)
+    put(m, Keys.min,    "%d", snapshot.getMin)
+    put(m, Keys.stddev, "%f", snapshot.getStdDev)
+    put(m, Keys.p50,    "%f", snapshot.getMedian)
+    put(m, Keys.p75,    "%f", snapshot.get75thPercentile)
+    put(m, Keys.p95,    "%f", snapshot.get95thPercentile)
+    put(m, Keys.p98,    "%f", snapshot.get98thPercentile)
+    put(m, Keys.p99,    "%f", snapshot.get99thPercentile)
+    put(m, Keys.p999,   "%f", snapshot.get999thPercentile)
+
+    m
+  }
+
+  // meters will overwrite existing data
+  private def meterToMutation(name: String, meter: Meter): Mutation = {
+    val m = mutationFor(name)
+
+    put(m, Keys.count,     "%d", meter.getCount)
+    put(m, Keys.mean_rate, "%f", convertRate(meter.getMeanRate))
+    put(m, Keys.m1_rate,   "%f", convertRate(meter.getOneMinuteRate))
+    put(m, Keys.m5_rate,   "%f", convertRate(meter.getFiveMinuteRate))
+    put(m, Keys.m15_rate,  "%f", convertRate(meter.getFifteenMinuteRate))
+    put(m, Keys.rate_unit, "events/%s", getRateUnit)
+
+    m
+  }
+
+  // timers will overwrite existing data
+  private def timerToMutation(name: String, timer: Timer): Mutation = {
+    val m = mutationFor(name)
+    val snapshot = timer.getSnapshot
+
+    put(m, Keys.count,         "%d", timer.getCount)
+    put(m, Keys.max,           "%f", convertDuration(snapshot.getMax))
+    put(m, Keys.mean,          "%f", convertDuration(snapshot.getMean))
+    put(m, Keys.min,           "%f", convertDuration(snapshot.getMin))
+    put(m, Keys.stddev,        "%f", convertDuration(snapshot.getStdDev))
+    put(m, Keys.p50,           "%f", convertDuration(snapshot.getMedian))
+    put(m, Keys.p75,           "%f", convertDuration(snapshot.get75thPercentile))
+    put(m, Keys.p95,           "%f", convertDuration(snapshot.get95thPercentile))
+    put(m, Keys.p98,           "%f", convertDuration(snapshot.get98thPercentile))
+    put(m, Keys.p99,           "%f", convertDuration(snapshot.get99thPercentile))
+    put(m, Keys.p999,          "%f", convertDuration(snapshot.get999thPercentile))
+    put(m, Keys.mean_rate,     "%f", convertRate(timer.getMeanRate))
+    put(m, Keys.m1_rate,       "%f", convertRate(timer.getOneMinuteRate))
+    put(m, Keys.m5_rate,       "%f", convertRate(timer.getFiveMinuteRate))
+    put(m, Keys.m15_rate,      "%f", convertRate(timer.getFifteenMinuteRate))
+    put(m, Keys.duration_unit, "%s", getDurationUnit)
+    put(m, Keys.rate_unit,     "calls/%s", getRateUnit)
+
+    m
+  }
+
+  private def put(m: Mutation, cf: Text, format: String, value: Any): Unit = {
+    val v = new Value(format.formatLocal(locale, value).getBytes(Charsets.UTF_8))
+    visibility match {
+      case None      => m.put(cf, Keys.empty, v)
+      case Some(vis) => m.put(cf, Keys.empty, vis, v)
+    }
+  }
+}

--- a/geomesa-metrics/src/main/scala/org/locationtech/geomesa/metrics/reporters/DelimitedFileReporter.scala
+++ b/geomesa-metrics/src/main/scala/org/locationtech/geomesa/metrics/reporters/DelimitedFileReporter.scala
@@ -1,0 +1,246 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.metrics.reporters
+
+import java.io._
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics._
+import org.apache.commons.csv.{CSVFormat, CSVPrinter}
+import org.joda.time.format.DateTimeFormat
+
+import scala.language.implicitConversions
+
+/**
+ * Reporter for dropwizard metrics that will write to delimited files. In contrast to the
+ * dropwizard CSVReporter, allows for either CSV or TSV files and for aggregating metrics by type.
+ */
+object DelimitedFileReporter {
+
+  val gaugeCols = Array(("value", "%s"))
+
+  val counterCols = Array(("count", "%d"))
+
+  val histogramCols = Array(
+    ("count", "%d"),
+    ("min", "%d"),
+    ("max", "%d"),
+    ("mean", "%2.2f"),
+    ("stdDev", "%2.2f"),
+    ("median", "%2.2f"),
+    ("75thPercentile", "%2.2f"),
+    ("95thPercentile", "%2.2f"),
+    ("98thPercentile", "%2.2f"),
+    ("99thPercentile", "%2.2f"),
+    ("999thPercentile", "%2.2f")
+  )
+
+  val meterCols = Array(
+    ("count", "%d"),
+    ("meanRate", "%2.2f"),
+    ("oneMinuteRate", "%2.2f"),
+    ("fiveMinuteRate", "%2.2f"),
+    ("fifteenMinuteRate", "%2.2f"),
+    ("rateUnit", "events/%s")
+  )
+
+  val timerCols = Array(
+    ("count", "%d"),
+    ("min", "%2.2f"),
+    ("max", "%2.2f"),
+    ("mean", "%2.2f"),
+    ("stdDev", "%2.2f"),
+    ("median", "%2.2f"),
+    ("75thPercentile", "%2.2f"),
+    ("95thPercentile", "%2.2f"),
+    ("98thPercentile", "%2.2f"),
+    ("99thPercentile", "%2.2f"),
+    ("999thPercentile", "%2.2f"),
+    ("meanRate", "%2.2f"),
+    ("oneMinuteRate", "%2.2f"),
+    ("fiveMinuteRate", "%2.2f"),
+    ("fifteenMinuteRate", "%2.2f"),
+    ("rateUnit", "calls/%s"),
+    ("durationUnit", "%s")
+  )
+
+  def forRegistry(registry: MetricRegistry): Builder = new Builder(registry)
+
+  class Builder private[metrics] (registry: MetricRegistry) {
+
+    private var locale: Locale = Locale.getDefault
+    private var rateUnit: TimeUnit = TimeUnit.SECONDS
+    private var durationUnit: TimeUnit = TimeUnit.MILLISECONDS
+    private var clock: Clock = Clock.defaultClock
+    private var filter: MetricFilter = MetricFilter.ALL
+    private var aggregate: Boolean = true
+    private var format: CSVFormat = CSVFormat.TDF
+
+    def formatFor(locale: Locale): Builder = { this.locale = locale; this }
+
+    def convertRatesTo(rateUnit: TimeUnit): Builder = { this.rateUnit = rateUnit; this }
+
+    def convertDurationsTo(durationUnit: TimeUnit): Builder = { this.durationUnit = durationUnit; this }
+
+    def withClock(clock: Clock): Builder = { this.clock = clock; this }
+
+    def filter(filter: MetricFilter): Builder = { this.filter = filter; this }
+
+    def aggregate(aggregate: Boolean): Builder = { this.aggregate = aggregate; this }
+
+    def withCommas(): Builder = { this.format = CSVFormat.DEFAULT; this }
+
+    def withTabs(): Builder = { this.format = CSVFormat.TDF; this }
+
+    def build(path: String): DelimitedFileReporter = {
+      new DelimitedFileReporter(registry, path, aggregate, format, clock, locale, filter, rateUnit, durationUnit)
+    }
+  }
+}
+
+/**
+ * Reporter for dropwizard metrics that will write to accumulo
+ */
+class DelimitedFileReporter private (registry: MetricRegistry,
+                                     path: String,
+                                     aggregate: Boolean,
+                                     format: CSVFormat,
+                                     clock: Clock,
+                                     locale: Locale,
+                                     filter: MetricFilter,
+                                     rateUnit: TimeUnit,
+                                     durationUnit: TimeUnit)
+    extends ScheduledReporter(registry, "DelimitedFileReporter", filter, rateUnit, durationUnit) {
+
+  import DelimitedFileReporter._
+
+  private val writers = scala.collection.mutable.Map.empty[String, CSVPrinter]
+  private val folder = new File(path)
+  if (folder.exists()) {
+    require(folder.isDirectory, s"Path refers to a file - must be a folder: $path")
+  } else {
+    require(folder.mkdirs(), s"Can't create folder at $path")
+  }
+
+  private val timeEncoder = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS").withZoneUTC()
+
+  def flush(): Unit = writers.synchronized(writers.values.foreach(_.flush()))
+
+  override def stop(): Unit = {
+    writers.synchronized(writers.values.foreach { w => w.flush(); w.close() })
+    super.stop()
+  }
+
+  override def report(gauges: java.util.SortedMap[String, Gauge[_]],
+                      counters: java.util.SortedMap[String, Counter],
+                      histograms: java.util.SortedMap[String, Histogram],
+                      meters: java.util.SortedMap[String, Meter],
+                      timers: java.util.SortedMap[String, Timer]) = {
+    import scala.collection.JavaConversions._
+    lazy val timestamp = timeEncoder.print(clock.getTime)
+    gauges.foreach { case (name, metric) => writeGauge(name, timestamp, metric) }
+    counters.foreach { case (name, metric) => writeCounter(name, timestamp, metric) }
+    histograms.foreach { case (name, metric) => writeHistogram(name, timestamp, metric) }
+    meters.foreach { case (name, metric) => writeMeter(name, timestamp, metric) }
+    timers.foreach { case (name, metric) => writeTimer(name, timestamp, metric) }
+  }
+
+  private def writeGauge(name: String, timestamp: String, gauge: Gauge[_]): Unit =
+    write("gauges", gaugeCols, name, timestamp, Array[Any](gauge.getValue))
+
+  private def writeCounter(name: String, timestamp: String, counter: Counter): Unit =
+    write("counters", counterCols, name, timestamp, Array[Any](counter.getCount))
+
+  private def writeHistogram(name: String, timestamp: String, histogram: Histogram): Unit = {
+    val snapshot = histogram.getSnapshot
+    val values = Array[Any](
+      histogram.getCount,
+      snapshot.getMin,
+      snapshot.getMax,
+      snapshot.getMean,
+      snapshot.getStdDev,
+      snapshot.getMedian,
+      snapshot.get75thPercentile,
+      snapshot.get95thPercentile,
+      snapshot.get98thPercentile,
+      snapshot.get99thPercentile,
+      snapshot.get999thPercentile
+    )
+    write("histograms", histogramCols, name, timestamp, values)
+  }
+
+  private def writeMeter(name: String, timestamp: String, meter: Meter): Unit = {
+    val values = Array[Any](
+      meter.getCount,
+      convertRate(meter.getMeanRate),
+      convertRate(meter.getOneMinuteRate),
+      convertRate(meter.getFiveMinuteRate),
+      convertRate(meter.getFifteenMinuteRate),
+      getRateUnit)
+    write("meters", meterCols, name, timestamp, values)
+  }
+
+  private def writeTimer(name: String, timestamp: String, timer: Timer): Unit = {
+    val snapshot = timer.getSnapshot
+    val values = Array[Any](
+      timer.getCount,
+      convertDuration(snapshot.getMin),
+      convertDuration(snapshot.getMax),
+      convertDuration(snapshot.getMean),
+      convertDuration(snapshot.getStdDev),
+      convertDuration(snapshot.getMedian),
+      convertDuration(snapshot.get75thPercentile),
+      convertDuration(snapshot.get95thPercentile),
+      convertDuration(snapshot.get98thPercentile),
+      convertDuration(snapshot.get99thPercentile),
+      convertDuration(snapshot.get999thPercentile),
+      convertRate(timer.getMeanRate),
+      convertRate(timer.getOneMinuteRate),
+      convertRate(timer.getFiveMinuteRate),
+      convertRate(timer.getFifteenMinuteRate),
+      getRateUnit,
+      getDurationUnit
+    )
+    write("timers", timerCols, name, timestamp, values)
+  }
+
+  private def write(metric: String,
+                    cols: Array[(String, String)],
+                    name: String,
+                    timestamp: String,
+                    values: Array[Any]): Unit = writers.synchronized {
+    val key = if (aggregate) metric else name
+    val writer = writers.getOrElseUpdate(key, {
+      val fileName = s"$key.${if (format == CSVFormat.TDF) "t" else "c"}sv"
+      val file = new File(folder, fileName)
+      val writer = format.print(new FileWriter(file, true))
+      // write the header row if the file is empty
+      if (!file.exists() || file.length() == 0) {
+        writer.print("time")
+        if (aggregate) {
+          writer.print("name")
+        }
+        cols.foreach { case (header, _) => writer.print(header) }
+        writer.println()
+      }
+      writer
+    })
+    writer.print(timestamp)
+    if (aggregate) {
+      writer.print(name)
+    }
+    var i = 0
+    while (i < cols.length) {
+      writer.print(cols(i)._2.formatLocal(locale, values(i)))
+      i += 1
+    }
+    writer.println()
+  }
+}

--- a/geomesa-metrics/src/main/scala/org/locationtech/geomesa/metrics/servlet/AggregatedMetricsFilter.scala
+++ b/geomesa-metrics/src/main/scala/org/locationtech/geomesa/metrics/servlet/AggregatedMetricsFilter.scala
@@ -8,9 +8,10 @@
 
 package org.locationtech.geomesa.metrics.servlet
 
+import java.util.concurrent.{ScheduledExecutorService, Executors, TimeUnit}
 import java.util.regex.Pattern
 import javax.servlet._
-import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+import javax.servlet.http.{HttpSessionEvent, HttpSessionListener, HttpServletRequest, HttpServletResponse}
 
 import com.codahale.metrics._
 import com.typesafe.config.ConfigFactory
@@ -27,12 +28,13 @@ class AggregatedMetricsFilter extends Filter with LazyLogging {
   var reporters: Seq[ScheduledReporter] = Seq.empty
   var urlPatterns: Seq[Pattern] = null // urls to operate on
   var mappings: List[Pattern] = null // url patterns to match
-  var metrics: (Int) => (Counter, Timer, Map[Int, Meter]) = null // metrics per url pattern
+  var metrics: (Int) => (Counter, Counter, Timer, Map[Int, Meter]) = null // metrics per url pattern
   var getUri: (HttpServletRequest) => String = null // uri to evaluate mappings against
+  var trackSession: (HttpServletRequest, Int, Counter) => Unit = null
+  var executor: ScheduledExecutorService = null
 
   override def init(filterConfig: FilterConfig): Unit = {
     import AggregatedMetricsFilter.Params._
-
     try {
       // config can be passed in directly, or we use global typesafe config with defined path
       val configString = filterConfig.getInitParameter(ServletConfig)
@@ -79,19 +81,70 @@ class AggregatedMetricsFilter extends Filter with LazyLogging {
         List((Pattern.compile(".*"), "other"))
       }
 
+      val sessionExpiration = if (config.hasPath(SessionRemoval)) config.getInt(SessionRemoval) else -1
+      val trackSessions = sessionExpiration > 0
+
       // index of mappings and metrics are lined up
       mappings = regexAndNames.map(_._1)
       // lazily create the metrics as they are requested, otherwise you get a bunch of empty reports
-      val array = Array.ofDim[(Counter, Timer, Map[Int, Meter])](mappings.length)
+      val array = Array.ofDim[(Counter, Counter, Timer, Map[Int, Meter])](mappings.length)
       metrics = (i) => {
         val metric = array(i)
         if (metric != null) {
           metric
         } else {
-          val created = createMetrics(registry, s"$prefix.${regexAndNames(i)._2}")
+          val created = createMetrics(registry, s"$prefix.${regexAndNames(i)._2}", trackSessions)
           array(i) = created
           created
         }
+      }
+
+      // handle session expiration
+      if (trackSessions) {
+        executor = Executors.newSingleThreadScheduledExecutor()
+
+        val mappedSessions = Array.fill(mappings.length)(scala.collection.mutable.Set.empty[String])
+
+        val expiredSessions = scala.collection.mutable.Set.empty[String]
+        AggregatedMetricsFilter.expiredSessions.put(this, expiredSessions)
+
+        trackSession = (request, i, counter) => {
+          // note: we are forcing creation of a session in order to track users
+          val session = request.getSession(true).getId
+          val sessions = mappedSessions(i)
+          if (sessions.synchronized(sessions.add(session))) {
+            counter.inc()
+          }
+        }
+
+        // as the session listener is a separate class, we periodically poll the sessions that have
+        // expired and decrement our session metric for each mapping
+        val sessionRemoval = new Runnable {
+          override def run(): Unit = {
+            val expired = expiredSessions.synchronized {
+              val copy = expiredSessions.toSeq
+              expiredSessions.clear()
+              copy
+            }
+            var i = 0
+            while (i < mappedSessions.length) {
+              val sessions = mappedSessions(i)
+              val count = sessions.synchronized {
+                val initial = sessions.size
+                sessions --= expired
+                initial - sessions.size
+              }
+              if (count > 0) {
+                metrics(i)._2.dec(count)
+              }
+              i += 1
+            }
+          }
+        }
+
+        executor.scheduleWithFixedDelay(sessionRemoval, sessionExpiration, sessionExpiration, TimeUnit.SECONDS)
+      } else {
+        trackSession = (_, _, _) => {}
       }
     } catch {
       // initialization exceptions get swallowed - print them out to help debugging and re-throw
@@ -115,12 +168,13 @@ class AggregatedMetricsFilter extends Filter with LazyLogging {
 
   private def doFilter(request: HttpServletRequest, response: HttpServletResponse, chain: FilterChain): Unit = {
     val uri = getUri(request) // get the uri or layer name
-    val i = mappings.indexWhere(_.matcher(uri).matches())
-    val (activeRequests, timer, status) = metrics(i) // we have a fallback matcher so we know i is valid
+    val i = mappings.indexWhere(_.matcher(uri).matches()) // we have a fallback matcher so we know i is valid
+    val (activeRequests, activeSessions, timer, status) = metrics(i)
 
     val wrappedResponse = new StatusExposingServletResponse(response)
 
     activeRequests.inc()
+    trackSession(request, i, activeSessions)
     val context = timer.time()
     try {
       chain.doFilter(request, wrappedResponse)
@@ -131,7 +185,24 @@ class AggregatedMetricsFilter extends Filter with LazyLogging {
     }
   }
 
-  override def destroy(): Unit = reporters.foreach(_.stop())
+  override def destroy(): Unit = {
+    if (executor != null) {
+      executor.shutdown()
+    }
+    reporters.foreach(_.stop())
+  }
+}
+
+class SessionMetricsListener extends HttpSessionListener {
+
+  import AggregatedMetricsFilter.expiredSessions
+
+  override def sessionCreated(se: HttpSessionEvent): Unit = {}
+
+  override def sessionDestroyed(se: HttpSessionEvent): Unit = {
+    val session = se.getSession.getId
+    expiredSessions.values.foreach(sessions => sessions.synchronized(sessions.add(session)))
+  }
 }
 
 object AggregatedMetricsFilter {
@@ -144,6 +215,7 @@ object AggregatedMetricsFilter {
     val RequestMappings   = "request-mappings"
     val MapByLayer        = "map-by-layer"
     val UrlPatterns       = "url-patterns"
+    val SessionRemoval    = "session-removal-interval"
   }
 
   val LayerParameters = Seq("typeNames", "typeName", "layers")
@@ -159,12 +231,19 @@ object AggregatedMetricsFilter {
     500 -> "responseCodes.serverError"
   ).withDefaultValue("responseCodes.other")
 
-  private def createMetrics(registry: MetricRegistry, name: String): (Counter, Timer, Map[Int, Meter]) = {
-    val activeRequests = registry.counter(s"$name.activeRequests")
+  // static variable to track our sessions - this allows interaction between the sessions listener and the filter
+  // the values should be manually synchronized
+  val expiredSessions =
+    scala.collection.mutable.Map.empty[AggregatedMetricsFilter, scala.collection.mutable.Set[String]]
+
+  private def createMetrics(registry: MetricRegistry,
+                            name: String,
+                            trackSessions: Boolean): (Counter, Counter, Timer, Map[Int, Meter]) = {
+    val requests = registry.counter(s"$name.activeRequests")
+    val sessions = if (trackSessions) registry.counter(s"$name.activeSessions") else null.asInstanceOf[Counter]
     val timer = registry.timer(s"$name.requests")
-    // use an invalid code to get default name
     val status = MeterNamesByStatus.mapValues(status => registry.meter(s"$name.$status"))
-          .withDefaultValue(registry.meter(s"$name.${MeterNamesByStatus(-1)}"))
-    (activeRequests, timer, status)
+          .withDefault(i => registry.meter(s"$name.${MeterNamesByStatus(i)}"))
+    (requests, sessions, timer, status)
   }
 }

--- a/geomesa-metrics/src/main/scala/org/locationtech/geomesa/metrics/servlet/AggregatedMetricsFilter.scala
+++ b/geomesa-metrics/src/main/scala/org/locationtech/geomesa/metrics/servlet/AggregatedMetricsFilter.scala
@@ -1,0 +1,170 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.metrics.servlet
+
+import java.util.regex.Pattern
+import javax.servlet._
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+import com.codahale.metrics._
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.LazyLogging
+import org.locationtech.geomesa.metrics.config.MetricsConfig
+
+/**
+ * Filter that will track request metrics, aggregated based on url patterns.
+ */
+class AggregatedMetricsFilter extends Filter with LazyLogging {
+
+  import AggregatedMetricsFilter.{LayerParameters, createMetrics}
+
+  var reporters: Seq[ScheduledReporter] = Seq.empty
+  var urlPatterns: Seq[Pattern] = null // urls to operate on
+  var mappings: List[Pattern] = null // url patterns to match
+  var metrics: (Int) => (Counter, Timer, Map[Int, Meter]) = null // metrics per url pattern
+  var getUri: (HttpServletRequest) => String = null // uri to evaluate mappings against
+
+  override def init(filterConfig: FilterConfig): Unit = {
+    import AggregatedMetricsFilter.Params._
+
+    try {
+      // config can be passed in directly, or we use global typesafe config with defined path
+      val configString = filterConfig.getInitParameter(ServletConfig)
+      val config = if (configString != null && configString.trim.nonEmpty) {
+        ConfigFactory.parseString(configString)
+      } else {
+        ConfigFactory.load().getConfig(ServletConfigPath)
+      }
+
+      val registry = new MetricRegistry
+      reporters = MetricsConfig.reporters(config, registry, Some(Reporters))
+
+      // metric name prefix can be set based on filter param, typesafe config, or fallback to class name
+      val prefix = Option(filterConfig.getInitParameter(NamePrefix)).map(_.trim).filterNot(_.isEmpty).getOrElse {
+        if (config.hasPath(NamePrefix)) config.getString(NamePrefix) else this.getClass.getName
+      }
+
+      // validate urls against the full url, or just the layer name (pulled from the request)
+      // note: layer names will only be relevant for wfs/wms requests
+      val mapByLayer = if (config.hasPath(MapByLayer)) config.getBoolean(MapByLayer) else false
+      getUri = if (mapByLayer) {
+        (r) => LayerParameters.map(r.getParameter).find(_ != null).getOrElse("unknown")
+      } else {
+        (r) => { val qs = r.getQueryString; if (qs.isEmpty) r.getRequestURI else s"${r.getRequestURI}?$qs" }
+      }
+
+      // filter for requests to handle - if not defined, handle all
+      urlPatterns = if (config.hasPath(UrlPatterns)) {
+        import scala.collection.JavaConversions._
+        config.getStringList(UrlPatterns).map(Pattern.compile)
+      } else {
+        Seq(Pattern.compile(".*"))
+      }
+
+      // mappings that we group our metrics by - add a fallback option last so we always match something
+      val regexAndNames = if (config.hasPath(RequestMappings)) {
+        import scala.collection.JavaConversions._
+        config.getConfigList(RequestMappings).map { c =>
+          val name = c.getString("name")
+          val regex = Pattern.compile(c.getString("regex"))
+          (regex, name)
+        }.toList ++ List((Pattern.compile(".*"), "other"))
+      } else {
+        List((Pattern.compile(".*"), "other"))
+      }
+
+      // index of mappings and metrics are lined up
+      mappings = regexAndNames.map(_._1)
+      // lazily create the metrics as they are requested, otherwise you get a bunch of empty reports
+      val array = Array.ofDim[(Counter, Timer, Map[Int, Meter])](mappings.length)
+      metrics = (i) => {
+        val metric = array(i)
+        if (metric != null) {
+          metric
+        } else {
+          val created = createMetrics(registry, s"$prefix.${regexAndNames(i)._2}")
+          array(i) = created
+          created
+        }
+      }
+    } catch {
+      // initialization exceptions get swallowed - print them out to help debugging and re-throw
+      case t: Throwable => t.printStackTrace(); throw t
+    }
+  }
+
+  override def doFilter(req: ServletRequest, resp: ServletResponse, chain: FilterChain): Unit = {
+    (req, resp) match {
+      case (request: HttpServletRequest, response: HttpServletResponse) =>
+        val uri = request.getRequestURI
+        if (urlPatterns.exists(_.matcher(uri).matches())) {
+          doFilter(request, response, chain)
+        } else {
+          logger.trace(s"Skipping metrics for request '$uri'")
+          chain.doFilter(request, response)
+        }
+      case _ => throw new ServletException("UserMetricsFilter only supports HTTP requests")
+    }
+  }
+
+  private def doFilter(request: HttpServletRequest, response: HttpServletResponse, chain: FilterChain): Unit = {
+    val uri = getUri(request) // get the uri or layer name
+    val i = mappings.indexWhere(_.matcher(uri).matches())
+    val (activeRequests, timer, status) = metrics(i) // we have a fallback matcher so we know i is valid
+
+    val wrappedResponse = new StatusExposingServletResponse(response)
+
+    activeRequests.inc()
+    val context = timer.time()
+    try {
+      chain.doFilter(request, wrappedResponse)
+    } finally {
+      context.stop()
+      activeRequests.dec()
+      status(wrappedResponse.status).mark()
+    }
+  }
+
+  override def destroy(): Unit = reporters.foreach(_.stop())
+}
+
+object AggregatedMetricsFilter {
+
+  object Params {
+    val ServletConfig     = "config"
+    val ServletConfigPath = "geomesa.metrics.servlet"
+    val NamePrefix        = "name-prefix"
+    val Reporters         = "reporters"
+    val RequestMappings   = "request-mappings"
+    val MapByLayer        = "map-by-layer"
+    val UrlPatterns       = "url-patterns"
+  }
+
+  val LayerParameters = Seq("typeNames", "typeName", "layers")
+
+  val MeterNamesByStatus = Map(
+    200 -> "responseCodes.ok",
+    201 -> "responseCodes.created",
+    204 -> "responseCodes.noContext",
+    400 -> "responseCodes.badRequest",
+    401 -> "responseCodes.unauthenticated",
+    403 -> "responseCodes.unauthorized",
+    404 -> "responseCodes.notFound",
+    500 -> "responseCodes.serverError"
+  ).withDefaultValue("responseCodes.other")
+
+  private def createMetrics(registry: MetricRegistry, name: String): (Counter, Timer, Map[Int, Meter]) = {
+    val activeRequests = registry.counter(s"$name.activeRequests")
+    val timer = registry.timer(s"$name.requests")
+    // use an invalid code to get default name
+    val status = MeterNamesByStatus.mapValues(status => registry.meter(s"$name.$status"))
+          .withDefaultValue(registry.meter(s"$name.${MeterNamesByStatus(-1)}"))
+    (activeRequests, timer, status)
+  }
+}

--- a/geomesa-metrics/src/main/scala/org/locationtech/geomesa/metrics/servlet/StatusExposingServletResponse.scala
+++ b/geomesa-metrics/src/main/scala/org/locationtech/geomesa/metrics/servlet/StatusExposingServletResponse.scala
@@ -1,0 +1,36 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.metrics.servlet
+
+import javax.servlet.http.{HttpServletResponseWrapper, HttpServletResponse}
+
+/**
+ * Exposes the servlet response so we can track it. Copied from dropwizard metrics-servlet.
+ */
+class StatusExposingServletResponse(response: HttpServletResponse)
+    extends HttpServletResponseWrapper(response) {
+
+  // The Servlet spec says: calling setStatus is optional, if no status is set, the default is 200.
+  var status: Int = 200
+
+  override def sendError(sc: Int): Unit = {
+    status = sc
+    super.sendError(sc)
+  }
+
+  override def sendError(sc: Int, msg: String): Unit = {
+    status = sc
+    super.sendError(sc, msg)
+  }
+
+  override def setStatus(sc: Int): Unit = {
+    status = sc
+    super.setStatus(sc)
+  }
+}

--- a/geomesa-metrics/src/test/resources/config-test.conf
+++ b/geomesa-metrics/src/test/resources/config-test.conf
@@ -1,0 +1,50 @@
+geomesa.metrics.reporters = {
+  console = {
+    type     = "console"
+    units    = "MILLISECONDS"
+    interval = 60
+  }
+  slf4j = {
+    type     = "slf4j"
+    units    = "MILLISECONDS"
+    interval = 60
+    logger   = "org.locationtech.geomesa"
+    level    = "debug"
+  }
+  delimited-text = {
+    type      = "delimited-text"
+    units     = "MILLISECONDS"
+    interval  = 60
+    tabs      = true
+    output    = "geomesa-metrics-test" // we override this in the config test
+    aggregate = true
+  }
+  ganglia = {
+    type            = "ganglia"
+    units           = "MILLISECONDS"
+    interval        = 60
+    group           = "localhost"
+    port            = 8649
+    addressing-mode = "MULTICAST"
+    ttl             = 1
+    ganglia311      = true
+  }
+  graphite = {
+    type     = "graphite"
+    units    = "MILLISECONDS"
+    interval = 60
+    url      = "localhost:80"
+    prefix   = "org.locationtech.geomesa"
+  }
+  accumulo = {
+    type       = "accumulo"
+    units      = "MILLISECONDS"
+    interval   = -1
+    instanceId = "mycloud"
+    zookeepers = "zoo1,zoo2,zoo3"
+    user       = "myuser"
+    password   = "mypassword"
+    tableName  = "geomesa_metrics"
+    mock       = true
+  }
+}

--- a/geomesa-metrics/src/test/resources/log4j.xml
+++ b/geomesa-metrics/src/test/resources/log4j.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="[%d] %5p %c: %m%n"/>
+        </layout>
+    </appender>
+
+    <category name="org.apache.zookeeper">
+        <priority value="warn"/>
+    </category>
+    <category name="org.apache.accumulo">
+        <priority value="warn"/>
+    </category>
+    <category name="org.apache.hadoop">
+        <priority value="warn"/>
+    </category>
+    <category name="hsqldb">
+        <priority value="warn"/>
+    </category>
+
+    <root>
+        <priority value="info"/>
+        <appender-ref ref="CONSOLE" />
+    </root>
+</log4j:configuration>
+

--- a/geomesa-metrics/src/test/scala/org/locationtech/geomesa/metrics/config/MetricsConfigTest.scala
+++ b/geomesa-metrics/src/test/scala/org/locationtech/geomesa/metrics/config/MetricsConfigTest.scala
@@ -1,0 +1,114 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.metrics.config
+
+import java.nio.file.Files
+
+import com.codahale.metrics.ganglia.GangliaReporter
+import com.codahale.metrics.graphite.GraphiteReporter
+import com.codahale.metrics.{ConsoleReporter, MetricRegistry, Slf4jReporter}
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import org.apache.commons.io.FileUtils
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.metrics.reporters.{AccumuloReporter, DelimitedFileReporter}
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class MetricsConfigTest extends Specification {
+
+  val folder = Files.createTempDirectory("geomesa-metrics-config").toFile
+  val config = ConfigFactory.load("config-test")
+      .withValue("geomesa.metrics.reporters.delimited-text.output",
+        ConfigValueFactory.fromAnyRef(folder.getAbsolutePath))
+
+  "MetricsConfig" should {
+    "configure console reporter" >> {
+      val c = config.getConfig(s"${MetricsConfig.ConfigPath}.console").atKey("console")
+      val reporters = MetricsConfig.reporters(c, new MetricRegistry, None, start = false)
+      try {
+        reporters must haveLength(1)
+        reporters.head must beAnInstanceOf[ConsoleReporter]
+      } finally {
+        reporters.foreach(_.stop())
+      }
+    }
+
+    "configure slf4j reporter" >> {
+      val c = config.getConfig(s"${MetricsConfig.ConfigPath}.slf4j").atKey("slf4j")
+      val reporters = MetricsConfig.reporters(c, new MetricRegistry, None, start = false)
+      try {
+        reporters must haveLength(1)
+        reporters.head must beAnInstanceOf[Slf4jReporter]
+      } finally {
+        reporters.foreach(_.stop())
+      }
+    }
+
+    "configure delimited text reporter" >> {
+      val c = config.getConfig(s"${MetricsConfig.ConfigPath}.delimited-text").atKey("delimited-text")
+      val reporters = MetricsConfig.reporters(c, new MetricRegistry, None, start = false)
+      try {
+        reporters must haveLength(1)
+        reporters.head must beAnInstanceOf[DelimitedFileReporter]
+      } finally {
+        reporters.foreach(_.stop())
+      }
+    }
+
+    "configure ganglia reporter" >> {
+      val c = config.getConfig(s"${MetricsConfig.ConfigPath}.ganglia").atKey("ganglia")
+      val reporters = MetricsConfig.reporters(c, new MetricRegistry, None, start = false)
+      try {
+        reporters must haveLength(1)
+        reporters.head must beAnInstanceOf[GangliaReporter]
+      } finally {
+        reporters.foreach(_.stop())
+      }
+    }
+
+    "configure graphite reporter" >> {
+      val c = config.getConfig(s"${MetricsConfig.ConfigPath}.graphite").atKey("graphite")
+      val reporters = MetricsConfig.reporters(c, new MetricRegistry, None, start = false)
+      try {
+        reporters must haveLength(1)
+        reporters.head must beAnInstanceOf[GraphiteReporter]
+      } finally {
+        reporters.foreach(_.stop())
+      }
+    }
+
+    "configure accumulo reporter" >> {
+      val c = config.getConfig(s"${MetricsConfig.ConfigPath}.accumulo").atKey("accumulo")
+      val reporters = MetricsConfig.reporters(c, new MetricRegistry, None, start = false)
+      try {
+        reporters must haveLength(1)
+        reporters.head must beAnInstanceOf[AccumuloReporter]
+      } finally {
+        reporters.foreach(_.stop())
+      }
+    }
+
+    "configure multiple reporters" >> {
+      val reporters = MetricsConfig.reporters(config, new MetricRegistry, start = false)
+      try {
+        reporters must haveLength(6)
+        reporters.map(_.getClass) must containTheSameElementsAs(Seq(classOf[ConsoleReporter],
+          classOf[Slf4jReporter], classOf[DelimitedFileReporter], classOf[GangliaReporter],
+          classOf[GraphiteReporter], classOf[AccumuloReporter]))
+      } finally {
+        reporters.foreach(_.stop())
+      }
+    }
+  }
+
+  step {
+    FileUtils.deleteDirectory(folder) // recursive delete
+  }
+}

--- a/geomesa-metrics/src/test/scala/org/locationtech/geomesa/metrics/reporters/AccumuloReporterTest.scala
+++ b/geomesa-metrics/src/test/scala/org/locationtech/geomesa/metrics/reporters/AccumuloReporterTest.scala
@@ -1,0 +1,191 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.metrics.reporters
+
+import java.util.Map.Entry
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics._
+import org.apache.accumulo.core.client.mock.MockInstance
+import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.data.{Key, Value}
+import org.apache.accumulo.core.security.Authorizations
+import org.apache.hadoop.io.Text
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.metrics.reporters.AccumuloReporter.Keys
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class AccumuloReporterTest extends Specification {
+
+  sequential
+
+  val registry = new MetricRegistry()
+  val connector = new MockInstance("AccumuloReporterTest").getConnector("root", new PasswordToken(""))
+  val reporter = AccumuloReporter.forRegistry(registry)
+      .mock(true)
+      .writeToTable("metrics")
+      .convertDurationsTo(TimeUnit.MILLISECONDS)
+      .convertRatesTo(TimeUnit.SECONDS)
+      .build("AccumuloReporterTest", "", "root", "")
+
+  def scan(prefix: String): List[Entry[Key, Value]] = {
+    val scanner = connector.createScanner("metrics", new Authorizations)
+    scanner.setRange(org.apache.accumulo.core.data.Range.prefix(prefix))
+    try {
+      scanner.toList
+    } finally {
+      scanner.close()
+    }
+  }
+
+  def entry(entries: List[Entry[Key, Value]], cf: Text): Option[Double] =
+    entries.find(_.getKey.getColumnFamily == cf).map(_.getValue.toString.toDouble)
+
+  "AccumuloReporter" should {
+    "report gauges" >> {
+      val name = "mygauge"
+
+      registry.register(name, new Gauge[String] {
+        override def getValue: String = "value1"
+      })
+
+      reporter.report()
+      reporter.flush()
+      registry.remove(name)
+
+      val entries = scan(name)
+
+      entries must haveLength(1)
+      entries.head.getKey.getRow.toString must startWith(name)
+      entries.head.getKey.getColumnFamily mustEqual Keys.value
+      entries.head.getValue.toString mustEqual "value1"
+    }
+
+    "report counters" >> {
+      val name = "mycounter"
+
+      val metric = registry.counter(name)
+      metric.inc(10)
+
+      reporter.report()
+      reporter.flush()
+      registry.remove(name)
+
+      val entries = scan(name)
+
+      entries must haveLength(1)
+      entries.head.getKey.getColumnFamily mustEqual Keys.count
+      entries.head.getValue.toString mustEqual "10"
+    }
+
+    "report histograms" >> {
+      val name = "myhistogram"
+
+      val metric = registry.histogram(name)
+      (0 until 10).foreach(metric.update)
+
+      reporter.report()
+      reporter.flush()
+      registry.remove(name)
+
+      val entries = scan(name)
+
+      entries must haveLength(11)
+      forall(entries)(_.getKey.getRow.toString mustEqual name)
+
+      entry(entries, Keys.count) must beSome(10.0)
+      entry(entries, Keys.max) must beSome(9.0)
+      entry(entries, Keys.mean) must beSome(4.5)
+      entry(entries, Keys.min) must beSome(0.0)
+      entry(entries, Keys.stddev) must beSome(2.872281)
+      entry(entries, Keys.p50) must beSome(5.0)
+      entry(entries, Keys.p75) must beSome(7.0)
+      entry(entries, Keys.p95) must beSome(9.0)
+      entry(entries, Keys.p98) must beSome(9.0)
+      entry(entries, Keys.p99) must beSome(9.0)
+      entry(entries, Keys.p999) must beSome(9.0)
+    }
+
+    "report meters" >> {
+      val name = "mymeter"
+
+      var tick: Long = 0
+      val clock = new Clock { override def getTick: Long = tick * 1000 } // tick is in nanos - we use millis
+
+      val metric = registry.register(name, new Meter(clock))
+      (0 until 10).foreach { i => tick += i; metric.mark() }
+
+      reporter.report()
+      reporter.flush()
+      registry.remove(name)
+
+      val entries = scan(name)
+
+      entries must haveLength(6)
+      forall(entries)(_.getKey.getRow.toString mustEqual name)
+
+      entry(entries, Keys.count) must beSome(10.0)
+      entry(entries, Keys.mean_rate) must beSome(222222.222222)
+      entry(entries, Keys.m1_rate) must beSome(0.0)
+      entry(entries, Keys.m5_rate) must beSome(0.0)
+      entry(entries, Keys.m15_rate) must beSome(0.0)
+      entries.find(_.getKey.getColumnFamily == Keys.rate_unit).map(_.getValue.toString) must beSome("events/second")
+    }
+
+    "report timers" >> {
+      val name = "mytimer"
+
+      var tick: Long = 0
+      val clock = new Clock { override def getTick: Long = tick * 1000 } // tick is in nanos - we use millis
+
+      val metric = registry.register(name, new Timer(new ExponentiallyDecayingReservoir(), clock))
+      (0 until 10).foreach { i =>
+        tick += i
+        val c = metric.time()
+        tick += i
+        c.stop()
+      }
+
+      reporter.report()
+      reporter.flush()
+      registry.remove(name)
+
+      val entries = scan(name)
+
+      entries must haveLength(17)
+      forall(entries)(_.getKey.getRow.toString mustEqual name)
+
+      entry(entries, Keys.count) must beSome(10.0)
+      entry(entries, Keys.max) must beSome(0.009)
+      entry(entries, Keys.mean) must beSome(0.0045)
+      entry(entries, Keys.min) must beSome(0.0)
+      entry(entries, Keys.stddev) must beSome(0.002872)
+      entry(entries, Keys.p50) must beSome(0.005)
+      entry(entries, Keys.p75) must beSome(0.007)
+      entry(entries, Keys.p95) must beSome(0.009)
+      entry(entries, Keys.p98) must beSome(0.009)
+      entry(entries, Keys.p99) must beSome(0.009)
+      entry(entries, Keys.p999) must beSome(0.009)
+      entry(entries, Keys.mean_rate) must beSome(111111.111111)
+      entry(entries, Keys.m1_rate) must beSome(0.0)
+      entry(entries, Keys.m5_rate) must beSome(0.0)
+      entry(entries, Keys.m15_rate) must beSome(0.0)
+      entries.find(_.getKey.getColumnFamily == Keys.rate_unit).map(_.getValue.toString) must beSome("calls/second")
+      entries.find(_.getKey.getColumnFamily == Keys.duration_unit).map(_.getValue.toString) must beSome("milliseconds")
+    }
+  }
+
+  step {
+    reporter.stop()
+  }
+}

--- a/geomesa-metrics/src/test/scala/org/locationtech/geomesa/metrics/reporters/DelimitedFileReporterTest.scala
+++ b/geomesa-metrics/src/test/scala/org/locationtech/geomesa/metrics/reporters/DelimitedFileReporterTest.scala
@@ -1,0 +1,182 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.metrics.reporters
+
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics._
+import org.apache.commons.io.FileUtils
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.io.Source
+
+@RunWith(classOf[JUnitRunner])
+class DelimitedFileReporterTest extends Specification {
+  sequential
+
+  val registry = new MetricRegistry()
+  val folder = Files.createTempDirectory("geomesa-metrics").toFile
+  val reporter = DelimitedFileReporter.forRegistry(registry)
+      .aggregate(true)
+      .withTabs()
+      .convertDurationsTo(TimeUnit.MILLISECONDS)
+      .convertRatesTo(TimeUnit.SECONDS)
+      .build(folder.getAbsolutePath)
+
+  def read(metric: String, name: String): Seq[Array[String]] = {
+    val source = Source.fromFile(new File(folder, s"$metric.tsv"))
+    try {
+      source.getLines().toList.map(_.split("\t")).filter(_.apply(1) == name).map(_.drop(2)) // drop name and timestamp
+    } finally {
+      source.close()
+    }
+  }
+
+  "AccumuloReporter" should {
+    "report gauges" >> {
+      val name = "mygauge"
+
+      registry.register(name, new Gauge[String] {
+        override def getValue: String = "value1"
+      })
+
+      reporter.report()
+      reporter.flush()
+      registry.remove(name)
+
+      val entries = read("gauges", name)
+
+      entries must haveLength(1)
+      entries.head must haveLength(1)
+      entries.head(0) mustEqual "value1"
+    }
+
+    "report counters" >> {
+      val name = "mycounter"
+
+      val metric = registry.counter(name)
+      metric.inc(10)
+
+      reporter.report()
+      reporter.flush()
+      registry.remove(name)
+
+      val entries = read("counters", name)
+
+      entries must haveLength(1)
+      entries.head must haveLength(1)
+      entries.head(0) mustEqual "10"
+    }
+
+    "report histograms" >> {
+      val name = "myhistogram"
+
+      val metric = registry.histogram(name)
+      (0 until 10).foreach(metric.update)
+
+      reporter.report()
+      reporter.flush()
+      registry.remove(name)
+
+      val entries = read("histograms", name)
+
+      entries must haveLength(1)
+      entries.head must haveLength(11)
+
+      entries.head(0).toDouble mustEqual 10.0 // count
+      entries.head(1).toDouble mustEqual 0.0 // min
+      entries.head(2).toDouble mustEqual 9.0 // max
+      entries.head(3).toDouble mustEqual 4.5 // mean
+      entries.head(4).toDouble mustEqual 2.87 // std dev
+      entries.head(5).toDouble mustEqual 5.0 // median
+      entries.head(6).toDouble mustEqual 7.0 // 75th
+      entries.head(7).toDouble mustEqual 9.0 // 95th
+      entries.head(8).toDouble mustEqual 9.0 // 98th
+      entries.head(9).toDouble mustEqual 9.0 // 99th
+      entries.head(10).toDouble mustEqual 9.0 // 999th
+    }
+
+    "report meters" >> {
+      val name = "mymeter"
+
+      var tick: Long = 0
+      val clock = new Clock { override def getTick: Long = tick * 1000 } // tick is in nanos - we use millis
+
+      val metric = registry.register(name, new Meter(clock))
+      (0 until 10).foreach { i => tick += i; metric.mark() }
+
+      reporter.report()
+      reporter.flush()
+      registry.remove(name)
+
+      val entries = read("meters", name)
+
+      entries must haveLength(1)
+      entries.head must haveLength(6)
+
+      entries.head(0).toDouble mustEqual 10.0
+      entries.head(1).toDouble mustEqual 222222.22
+      entries.head(2).toDouble mustEqual 0.0
+      entries.head(3).toDouble mustEqual 0.0
+      entries.head(4).toDouble mustEqual 0.0
+      entries.head(5) mustEqual "events/second"
+    }
+
+    "report timers" >> {
+      val name = "mytimer"
+
+      var tick: Long = 0
+      val clock = new Clock { override def getTick: Long = tick * 1000000 } // tick is in nanos - we use seconds
+
+      val metric = registry.register(name, new Timer(new ExponentiallyDecayingReservoir(), clock))
+      (0 until 10).foreach { i =>
+        tick += i
+        val c = metric.time()
+        tick += i
+        c.stop()
+      }
+
+      reporter.report()
+      reporter.flush()
+      registry.remove(name)
+
+      val entries = read("timers", name)
+
+      entries must haveLength(1)
+      entries.head must haveLength(17)
+
+      entries.head(0).toDouble mustEqual 10.0
+      entries.head(1).toDouble mustEqual 0.0
+      entries.head(2).toDouble mustEqual 9.0
+      entries.head(3).toDouble mustEqual 4.5
+      entries.head(4).toDouble mustEqual 2.87
+      entries.head(5).toDouble mustEqual 5.0
+      entries.head(6).toDouble mustEqual 7.0
+      entries.head(7).toDouble mustEqual 9.0
+      entries.head(8).toDouble mustEqual 9.0
+      entries.head(9).toDouble mustEqual 9.0
+      entries.head(10).toDouble mustEqual 9.0
+      entries.head(11).toDouble mustEqual 111.11
+      entries.head(12).toDouble mustEqual 0.0
+      entries.head(13).toDouble mustEqual 0.0
+      entries.head(14).toDouble mustEqual 0.0
+      entries.head(15) mustEqual "calls/second"
+      entries.head(16) mustEqual "milliseconds"
+    }
+  }
+
+  step {
+    reporter.stop()
+    FileUtils.deleteDirectory(folder) // recursive delete of contents
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <module>geomesa-hbase</module>
         <module>geomesa-blobstore</module>
         <module>geomesa-cassandra</module>
+        <module>geomesa-metrics</module>
         <module>docs</module>
     </modules>
 
@@ -1456,6 +1457,11 @@
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
                 <artifactId>geomesa-convert-xml</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.locationtech.geomesa</groupId>
+                <artifactId>geomesa-metrics</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
* Serlvet filter to instrument requests, with grouping by layer in geoserver
* Extend dropwizard metrics with reporters for Accumulo and TSV
* Configuration of metrics/reporters via typesafe config

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>