### PR TITLE
GEOMESA-1122 Remove dependency on deprecated AbstractDataStore

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -10,8 +10,9 @@
 package org.locationtech.geomesa.accumulo.data
 
 import java.io.IOException
-import java.util.NoSuchElementException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.{Lock, ReentrantLock}
+import java.util.{List => jList, NoSuchElementException}
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.accumulo.core.client._
@@ -20,14 +21,11 @@ import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreMutex
 import org.apache.curator.retry.ExponentialBackoffRetry
 import org.geotools.data._
-import org.geotools.data.simple.SimpleFeatureSource
 import org.geotools.factory.Hints
-import org.geotools.feature.NameImpl
-import org.geotools.geometry.jts.ReferencedEnvelope
-import org.geotools.referencing.crs.DefaultGeographicCRS
-import org.joda.time.Interval
+import org.geotools.feature.{FeatureTypes, NameImpl}
 import org.locationtech.geomesa.CURRENT_SCHEMA_VERSION
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore._
+import org.locationtech.geomesa.accumulo.data.stats.GeoMesaMetadataStats
 import org.locationtech.geomesa.accumulo.data.tables._
 import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType.StrategyType
 import org.locationtech.geomesa.accumulo.index._
@@ -40,76 +38,510 @@ import org.locationtech.geomesa.security.{AuditProvider, AuthorizationsProvider}
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.{FeatureSpec, NonGeomAttributeSpec}
-import org.locationtech.geomesa.utils.time.Time._
 import org.opengis.feature.`type`.Name
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
-import org.opengis.referencing.crs.CoordinateReferenceSystem
 
 import scala.collection.JavaConversions._
-import scala.collection.mutable
-import scala.concurrent.Lock
-import scala.util.{Failure, Success, Try}
+
 
 /**
+ * This class handles DataStores which are stored in Accumulo Tables. To be clear, one table may
+ * contain multiple features addressed by their featureName.
  *
  * @param connector Accumulo connector
  * @param catalogTable Table name in Accumulo to store metadata about featureTypes. For pre-catalog
  *                     single-table stores this equates to the spatiotemporal table name
- * @param authorizationsProvider Provides the authorizations used to access data
- * @param writeVisibilities   Visibilities applied to any data written by this store
- *
- *  This class handles DataStores which are stored in Accumulo Tables.  To be clear, one table may
- *  contain multiple features addressed by their featureName.
+ * @param authProvider Provides the authorizations used to access data
+ * @param auditProvider Provides access to the current user for auditing purposes
+ * @param defaultVisibilities default visibilities applied to any data written
+ * @param config configuration values
  */
 class AccumuloDataStore(val connector: Connector,
                         val catalogTable: String,
-                        val authorizationsProvider: AuthorizationsProvider,
+                        val authProvider: AuthorizationsProvider,
                         val auditProvider: AuditProvider,
-                        val writeVisibilities: String,
+                        val defaultVisibilities: String,
                         val config: AccumuloDataStoreConfig)
-    extends AbstractDataStore(true) with AccumuloConnectorCreator with StrategyHintsProvider with LazyLogging {
-
-  // having at least as many shards as tservers provides optimal parallelism in queries
-  val DEFAULT_MAX_SHARD = connector.instanceOperations().getTabletServers.size()
-
-  protected[data] val queryTimeoutMillis: Option[Long] = config.queryTimeout
-      .orElse(GeomesaSystemProperties.QueryProperties.QUERY_TIMEOUT_MILLIS.option.map(_.toLong))
-
-  // equivalent to: s"%~#s%$maxShard#r%${name}#cstr%0,3#gh%yyyyMMddHH#d::%~#s%3,2#gh::%~#s%#id"
-  def buildDefaultSpatioTemporalSchema(name: String, maxShard: Int = DEFAULT_MAX_SHARD): String =
-    new IndexSchemaBuilder("~")
-      .randomNumber(maxShard)
-      .indexOrDataFlag()
-      .constant(name)
-      .geoHash(0, 3)
-      .date("yyyyMMddHH")
-      .nextPart()
-      .geoHash(3, 2)
-      .nextPart()
-      .id()
-      .build()
+    extends DataStore with AccumuloConnectorCreator with HasGeoMesaMetadata
+            with GeoMesaMetadataStats with StrategyHintsProvider with LazyLogging {
 
   Hints.putSystemDefault(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, true)
 
-  private val validated = new mutable.HashMap[String, String]()
-                              with mutable.SynchronizedMap[String, String]
+  // having at least as many shards as tservers provides optimal parallelism in queries
+  private val defaultMaxShard = connector.instanceOperations().getTabletServers.size()
 
-  private[data] val metadata: GeoMesaMetadata =
-    new AccumuloBackedMetadata(connector, catalogTable, writeVisibilities, authorizationsProvider)
-
-  private val visibilityCheckCache = new mutable.HashMap[(String, String), Boolean]()
-                                         with mutable.SynchronizedMap[(String, String), Boolean]
+  private val queryTimeoutMillis: Option[Long] = config.queryTimeout
+      .orElse(GeomesaSystemProperties.QueryProperties.QUERY_TIMEOUT_MILLIS.option.map(_.toLong))
 
   private val defaultBWConfig = GeoMesaBatchWriterConfig().setMaxWriteThreads(config.writeThreads)
 
+  override val metadata: GeoMesaMetadata = new AccumuloBackedMetadata(connector, catalogTable, authProvider)
+
   private val tableOps = connector.tableOperations()
+
+  // methods from org.geotools.data.DataStore
+
+  /**
+   * @see org.geotools.data.DataStore#getTypeNames()
+   * @return existing simple feature type names
+   */
+  override def getTypeNames: Array[String] = metadata.getFeatureTypes
+
+  /**
+   * @see org.geotools.data.DataAccess#getNames()
+   * @return existing simple feature type names
+   */
+  override def getNames: jList[Name] = getTypeNames.map(new NameImpl(_)).toList
+
+  /**
+   * Compute the GeoMesa SpatioTemporal Schema, create tables, and write metadata to catalog.
+   * If the schema already exists, log a message and continue without error.
+   * This method uses distributed locking to ensure a schema is only created once.
+   *
+   * @see org.geotools.data.DataAccess#createSchema(org.opengis.feature.type.FeatureType)
+   * @param sft type to create
+   */
+  override def createSchema(sft: SimpleFeatureType): Unit = {
+    if (getSchema(sft.getTypeName) == null) {
+      val lock = acquireDistributedLock()
+      try {
+        // check a second time now that we have the lock
+        if (getSchema(sft.getTypeName) == null) {
+          // inspect, warn and set SF_PROPERTY_START_TIME if appropriate
+          // do this before anything else so appropriate tables will be created
+          TemporalIndexCheck.validateDtgField(sft)
+          // set the schema version, required for table checks
+          sft.setSchemaVersion(CURRENT_SCHEMA_VERSION)
+          // get the requested index schema or build the default
+          val spatioTemporalSchema = Option(sft.getStIndexSchema) match {
+            case None         => buildDefaultSpatioTemporalSchema(sft.getTypeName)
+            case Some(schema) => schema
+          }
+          checkSchemaRequirements(sft, spatioTemporalSchema)
+          writeMetadata(sft, SerializationType.KRYO, spatioTemporalSchema)
+
+          // reload the SFT then copy over any additional keys that were in the original sft
+          val reloadedSft = getSchema(sft.getTypeName)
+          (sft.getUserData.keySet -- reloadedSft.getUserData.keySet)
+              .foreach(k => reloadedSft.getUserData.put(k, sft.getUserData.get(k)))
+
+          // create the tables in accumulo
+          GeoMesaTable.getTables(reloadedSft).foreach { table =>
+            val name = table.formatTableName(catalogTable, reloadedSft)
+            AccumuloVersion.ensureTableExists(connector, name)
+            table.configureTable(reloadedSft, name, tableOps)
+          }
+        }
+      } finally {
+        lock.release()
+      }
+    }
+  }
+
+  /**
+   * @see org.geotools.data.DataStore#getSchema(java.lang.String)
+   * @param typeName feature type name
+   * @return feature type, or null if it does not exist
+   */
+  override def getSchema(typeName: String): SimpleFeatureType = getSchema(new NameImpl(typeName))
+
+  /**
+   * @see org.geotools.data.DataAccess#getSchema(org.opengis.feature.type.Name)
+   * @param name feature type name
+   * @return feature type, or null if it does not exist
+   */
+  override def getSchema(name: Name): SimpleFeatureType = {
+    val typeName = name.getLocalPart
+    metadata.read(typeName, ATTRIBUTES_KEY).map { attributes =>
+      val sft = SimpleFeatureTypes.createType(name.getURI, attributes)
+
+      // IMPORTANT: set data that we want to pass around with the sft
+      metadata.read(typeName, DTGFIELD_KEY).foreach(sft.setDtgField)
+      val version = metadata.readRequired(typeName, VERSION_KEY).toInt
+      if (version > CURRENT_SCHEMA_VERSION) {
+        logger.error(s"Trying to access schema ${sft.getTypeName} with version $version " +
+            s"but client can only handle up to version $CURRENT_SCHEMA_VERSION.")
+        throw new IllegalStateException(s"The schema ${sft.getTypeName} was written with a newer " +
+            "version of GeoMesa than this client can handle. Please ensure that you are using the " +
+            "same GeoMesa jar versions across your entire workflow. For more information, see " +
+            "http://www.geomesa.org/documentation/user/installation_and_configuration.html#upgrading")
+      } else {
+        sft.setSchemaVersion(version)
+      }
+      sft.setStIndexSchema(metadata.read(typeName, SCHEMA_KEY).orNull)
+      // If no data is written, we default to 'false' in order to support old tables.
+      if (metadata.read(typeName, SHARED_TABLES_KEY).exists(_.toBoolean)) {
+        sft.setTableSharing(true)
+        // use schema id if available or fall back to old type name for backwards compatibility
+        val prefix = metadata.read(typeName, SCHEMA_ID_KEY).getOrElse(s"${sft.getTypeName}~")
+        sft.setTableSharingPrefix(prefix)
+      } else {
+        sft.setTableSharing(false)
+        sft.setTableSharingPrefix("")
+      }
+      metadata.read(typeName, TABLES_ENABLED_KEY).foreach(sft.setEnabledTables)
+
+      sft
+    }.orNull
+  }
+
+  /**
+   * @see org.geotools.data.DataStore#updateSchema(java.lang.String, org.opengis.feature.simple.SimpleFeatureType)
+   * @param typeName simple feature type name
+   * @param sft new simple feature type
+   */
+  override def updateSchema(typeName: String, sft: SimpleFeatureType): Unit =
+    updateSchema(new NameImpl(typeName), sft)
+
+  /**
+   * @see org.geotools.data.DataAccess#updateSchema(org.opengis.feature.type.Name, org.opengis.feature.type.FeatureType)
+   * @param typeName simple feature type name
+   * @param sft new simple feature type
+   */
+  override def updateSchema(typeName: Name, sft: SimpleFeatureType): Unit =
+    throw new UnsupportedOperationException("AccumuloDataStore does not support updateSchema")
+
+  /**
+   * Deletes all features from the accumulo index tables and deletes metadata from the catalog.
+   * If the feature type shares tables with another, this is fairly expensive,
+   * proportional to the number of features. Otherwise, it is fairly cheap.
+   *
+   * @see org.geotools.data.DataStore#removeSchema(java.lang.String)
+   * @param typeName simple feature type name
+   */
+  override def removeSchema(typeName: String) = {
+    val lock = acquireDistributedLock()
+    try {
+      Option(getSchema(typeName)).foreach { sft =>
+        if (sft.isTableSharing && getTypeNames.filter(_ != typeName).map(getSchema).exists(_.isTableSharing)) {
+          deleteSharedTables(sft)
+        } else {
+          deleteStandAloneTables(sft)
+        }
+      }
+      metadata.delete(typeName, 1)
+      metadata.expireCache(typeName)
+    } finally {
+      lock.release()
+    }
+  }
+
+  /**
+   * @see org.geotools.data.DataAccess#removeSchema(org.opengis.feature.type.Name)
+   * @param typeName simple feature type name
+   */
+  override def removeSchema(typeName: Name): Unit = removeSchema(typeName.getLocalPart)
+
+  /**
+   * @see org.geotools.data.DataStore#getFeatureSource(org.opengis.feature.type.Name)
+   * @param typeName simple feature type name
+   * @return featureStore, suitable for reading and writing
+   */
+  override def getFeatureSource(typeName: Name): AccumuloFeatureStore = {
+    checkSchema(typeName.getLocalPart)
+    if (config.caching) {
+      new AccumuloFeatureStore(this, typeName) with CachingFeatureSource
+    } else {
+      new AccumuloFeatureStore(this, typeName)
+    }
+  }
+
+  /**
+   * @see org.geotools.data.DataStore#getFeatureSource(java.lang.String)
+   * @param typeName simple feature type name
+   * @return featureStore, suitable for reading and writing
+   */
+  override def getFeatureSource(typeName: String): AccumuloFeatureStore =
+    getFeatureSource(new NameImpl(typeName))
+
+  /**
+   * @see org.geotools.data.DataStore#getFeatureReader(org.geotools.data.Query, org.geotools.data.Transaction)
+   * @param query query to execute
+   * @param transaction transaction to use (currently ignored)
+   * @return feature reader
+   */
+  override def getFeatureReader(query: Query, transaction: Transaction): AccumuloFeatureReader = {
+    val sw = Some(this).collect { case w: StatWriter => w }
+    val qp = getQueryPlanner(query.getTypeName)
+    AccumuloFeatureReader(query, qp, queryTimeoutMillis, sw, auditProvider)
+  }
+
+  /**
+   * Create a general purpose writer that is capable of updates and deletes.
+   * Does <b>not</b> allow inserts. Will return all existing features.
+   *
+   * @see org.geotools.data.DataStore#getFeatureWriter(java.lang.String, org.geotools.data.Transaction)
+   * @param typeName feature type name
+   * @param transaction transaction (currently ignored)
+   * @return feature writer
+   */
+  override def getFeatureWriter(typeName: String, transaction: Transaction): AccumuloFeatureWriter =
+    getFeatureWriter(typeName, Filter.INCLUDE, transaction)
+
+  /**
+   * Create a general purpose writer that is capable of updates and deletes.
+   * Does <b>not</b> allow inserts.
+   *
+   * @see org.geotools.data.DataStore#getFeatureWriter(java.lang.String, org.opengis.filter.Filter,
+   *        org.geotools.data.Transaction)
+   * @param typeName feature type name
+   * @param filter cql filter to select features for update/delete
+   * @param transaction transaction (currently ignored)
+   * @return feature writer
+   */
+  override def getFeatureWriter(typeName: String, filter: Filter, transaction: Transaction): AccumuloFeatureWriter = {
+    checkSchema(typeName)
+    val sft = getSchema(typeName)
+    val fe = SimpleFeatureSerializers(sft, getFeatureEncoding(sft))
+    new ModifyAccumuloFeatureWriter(sft, fe, this, defaultVisibilities, filter)
+  }
+
+  /**
+   * Creates a feature writer only for writing - does not allow updates or deletes.
+   *
+   * @see org.geotools.data.DataStore#getFeatureWriterAppend(java.lang.String, org.geotools.data.Transaction)
+   * @param typeName feature type name
+   * @param transaction transaction (currently ignored)
+   * @return feature writer
+   */
+  override def getFeatureWriterAppend(typeName: String, transaction: Transaction): AccumuloFeatureWriter = {
+    checkSchema(typeName)
+    val sft = getSchema(typeName)
+    val fe = SimpleFeatureSerializers(sft, getFeatureEncoding(sft))
+    new AppendAccumuloFeatureWriter(sft, fe, this, defaultVisibilities)
+  }
+
+  /**
+   * @see org.geotools.data.DataAccess#getInfo()
+   * @return service info
+   */
+  override def getInfo: ServiceInfo = {
+    val info = new DefaultServiceInfo()
+    info.setDescription("Features from AccumuloDataStore")
+    info.setSchema(FeatureTypes.DEFAULT_NAMESPACE)
+    info
+  }
+
+  /**
+   * We always return null, which indicates that we are handling transactions ourselves.
+   *
+   * @see org.geotools.data.DataStore#getLockingManager()
+   * @return locking manager - null
+   */
+  override def getLockingManager: LockingManager = null
+
+  /**
+   * Cleanup any open connections, etc. Equivalent to java.io.Closeable.close()
+   *
+   * @see org.geotools.data.DataAccess#dispose()
+   */
+  override def dispose(): Unit = {}
+
+  // end methods from org.geotools.data.DataStore
+
+  // methods from AccumuloConnectorCreator
+
+  /**
+   * @see org.locationtech.geomesa.accumulo.data.AccumuloConnectorCreator#getScanner(java.lang.String)
+   * @param table table to scan
+   * @return scanner
+   */
+  override def getScanner(table: String): Scanner =
+    connector.createScanner(table, authProvider.getAuthorizations)
+
+  /**
+   * @see org.locationtech.geomesa.accumulo.data.AccumuloConnectorCreator#getBatchScanner(java.lang.String, int)
+   * @param table table to scan
+   * @param threads number of threads to use in scanning
+   * @return batch scanner
+   */
+  override def getBatchScanner(table: String, threads: Int): BatchScanner =
+    connector.createBatchScanner(table, authProvider.getAuthorizations, threads)
+
+  /**
+   * @see org.locationtech.geomesa.accumulo.data.AccumuloConnectorCreator#getTableName(java.lang.String,
+   *          org.locationtech.geomesa.accumulo.data.tables.GeoMesaTable)
+   * @param featureName feature type name
+   * @param table table
+   * @return accumulo table name
+   */
+  override def getTableName(featureName: String, table: GeoMesaTable): String = {
+    val key = table match {
+      case RecordTable         => RECORD_TABLE_KEY
+      case Z3Table             => Z3_TABLE_KEY
+      case AttributeTable      => ATTR_IDX_TABLE_KEY
+      // noinspection ScalaDeprecation
+      case AttributeTableV5    => ATTR_IDX_TABLE_KEY
+      case SpatioTemporalTable => ST_IDX_TABLE_KEY
+      case _ => throw new NotImplementedError("Unknown table")
+    }
+    metadata.readRequired(featureName, key)
+  }
+
+  /**
+   * @see org.locationtech.geomesa.accumulo.data.AccumuloConnectorCreator#getSuggestedThreads(java.lang.String,
+   *          org.locationtech.geomesa.accumulo.data.tables.GeoMesaTable)
+   * @param featureName feature type name
+   * @param table table
+   * @return threads to use in scanning
+   */
+  override def getSuggestedThreads(featureName: String, table: GeoMesaTable): Int = {
+    table match {
+      case RecordTable         => config.recordThreads
+      case Z3Table             => config.queryThreads
+      case AttributeTable      => config.queryThreads
+      // noinspection ScalaDeprecation
+      case AttributeTableV5    => 1
+      case SpatioTemporalTable => config.queryThreads
+      case _ => throw new NotImplementedError("Unknown table")
+    }
+  }
+
+  // end methods from AccumuloConnectorCreator
+
+  /**
+   * Method from StatWriter - allows us to mixin stat writing
+   *
+   * @see org.locationtech.geomesa.accumulo.stats.StatWriter.getStatTable
+   */
+  def getStatTable(stat: Stat): String = {
+    stat match {
+      case qs: QueryStat =>
+        metadata.read(stat.typeName, QUERIES_TABLE_KEY).getOrElse {
+          // For backwards compatibility with existing tables that do not have queries table metadata
+          val queriesTableValue = formatQueriesTableName(catalogTable)
+          metadata.insert(stat.typeName, QUERIES_TABLE_KEY, queriesTableValue) // side effect
+          queriesTableValue
+        }
+      case _ => throw new NotImplementedError()
+    }
+  }
+
+  /**
+   * Method from StrategyHintsProvider
+   *
+   * @see org.locationtech.geomesa.accumulo.index.StrategyHintsProvider#strategyHints(org.opengis.feature.simple.SimpleFeatureType)
+   * @param sft feature type
+   * @return hints
+   */
+  override def strategyHints(sft: SimpleFeatureType) = new UserDataStrategyHints()
+
+  // other public methods
+
+  /**
+   * Optimized method to delete everything (all tables) associated with this datastore
+   * (index tables and catalog table)
+   * NB: We are *not* currently deleting the query table and/or query information.
+   */
+  def delete() = {
+    val indexTables = getTypeNames.map(getSchema).flatMap(GeoMesaTable.getTableNames(_, this)).distinct
+    // Delete index tables first then catalog table in case of error
+    indexTables.filter(tableOps.exists).foreach(tableOps.delete)
+    if (tableOps.exists(catalogTable)) {
+      tableOps.delete(catalogTable)
+    }
+  }
+
+  /**
+   * Reads the serialization type (feature encoding) from the metadata.
+   *
+   * @param sft simple feature type
+   * @return serialization type
+   * @throws RuntimeException if the feature encoding is missing or invalid
+   */
+  @throws[RuntimeException]
+  def getFeatureEncoding(sft: SimpleFeatureType): SerializationType = {
+    val name = metadata.readRequired(sft.getTypeName, FEATURE_ENCODING_KEY)
+    try {
+      SerializationType.withName(name)
+    } catch {
+      case e: NoSuchElementException => throw new RuntimeException(s"Invalid Feature Encoding '$name'.")
+    }
+  }
+
+  /**
+   * Reads the index schema format out of the metadata
+   *
+   * @param typeName simple feature type name
+   * @return index schema format string
+   */
+  def getIndexSchemaFmt(typeName: String): String =
+    metadata.read(typeName, SCHEMA_KEY).getOrElse(EMPTY_STRING)
+
+  /**
+   * Used to update the attributes that are marked as indexed - partial implementation of updateSchema.
+   *
+   * @param typeName feature type name
+   * @param attributes attribute string, as is passed to SimpleFeatureTypes.createType
+   */
+  def updateIndexedAttributes(typeName: String, attributes: String): Unit = {
+    val FeatureSpec(existing, _) = SimpleFeatureTypes.parse(metadata.read(typeName, ATTRIBUTES_KEY).getOrElse(""))
+    val FeatureSpec(updated, _)  = SimpleFeatureTypes.parse(attributes)
+    // check that the only changes are to non-geometry index flags
+    val ok = existing.length == updated.length &&
+        existing.zip(updated).forall { case (e, u) => e == u ||
+            (e.isInstanceOf[NonGeomAttributeSpec] &&
+                u.isInstanceOf[NonGeomAttributeSpec] &&
+                e.clazz == u.clazz &&
+                e.name == u.name) }
+    if (!ok) {
+      throw new IllegalArgumentException("Attribute spec is not consistent with existing spec")
+    }
+
+    metadata.insert(typeName, ATTRIBUTES_KEY, attributes)
+
+    // reconfigure the splits on the attribute table
+    val sft = getSchema(typeName)
+    val table = getTableName(typeName, AttributeTable)
+    AttributeTable.configureTable(sft, table, tableOps)
+  }
+
+  /**
+   * Gets the query plan for a given query. The query plan consists of the tables, ranges, iterators etc
+   * required to run a query against accumulo.
+   *
+   * @param query query to execute
+   * @param strategy hint on the index to use to satisfy the query
+   * @return query plans
+   */
+  def getQueryPlan(query: Query,
+                   strategy: Option[StrategyType] = None,
+                   explainer: ExplainerOutputType = ExplainNull): Seq[QueryPlan] = {
+    require(query.getTypeName != null, "Type name is required in the query")
+    getQueryPlanner(query.getTypeName).planQuery(query, None, explainer)
+  }
+
+  /**
+   * Gets a query planner. Also has side-effect of setting transforms in the query.
+   */
+  protected[data] def getQueryPlanner(featureName: String): QueryPlanner = {
+    checkSchema(featureName)
+    val sft = getSchema(featureName)
+    val indexSchemaFmt = getIndexSchemaFmt(featureName)
+    val featureEncoding = getFeatureEncoding(sft)
+    val hints = strategyHints(sft)
+    new QueryPlanner(sft, featureEncoding, indexSchemaFmt, this, hints)
+  }
+
+  // end public methods
+
+  // equivalent to: s"%~#s%$maxShard#r%${name}#cstr%0,3#gh%yyyyMMddHH#d::%~#s%3,2#gh::%~#s%#id"
+  private def buildDefaultSpatioTemporalSchema(name: String, maxShard: Int = defaultMaxShard): String =
+    new IndexSchemaBuilder("~")
+        .randomNumber(maxShard)
+        .indexOrDataFlag()
+        .constant(name)
+        .geoHash(0, 3)
+        .date("yyyyMMddHH")
+        .nextPart()
+        .geoHash(3, 2)
+        .nextPart()
+        .id()
+        .build()
 
   /**
    * Computes and writes the metadata for this feature type
-   *
-   * @param sft
-   * @param fe
    */
   private def writeMetadata(sft: SimpleFeatureType,
                             fe: SerializationType,
@@ -134,7 +566,6 @@ class AccumuloDataStore(val connector: Connector,
         ATTRIBUTES_KEY        -> attributesValue,
         SCHEMA_KEY            -> spatioTemporalSchemaValue,
         FEATURE_ENCODING_KEY  -> featureEncodingValue,
-        VISIBILITIES_KEY      -> writeVisibilities,
         Z3_TABLE_KEY          -> z3TableValue,
         ST_IDX_TABLE_KEY      -> spatioTemporalIdxTableValue,
         ATTR_IDX_TABLE_KEY    -> attrIdxTableValue,
@@ -147,12 +578,6 @@ class AccumuloDataStore(val connector: Connector,
 
     val featureName = sft.getTypeName
     metadata.insert(featureName, attributeMap)
-
-    // write out a visibilities protected entry that we can use to validate that a user can see
-    // data in this store
-    if (!writeVisibilities.isEmpty) {
-      metadata.insert(featureName, VISIBILITIES_CHECK_KEY, writeVisibilities, writeVisibilities)
-    }
 
     // write a schema ID out - ensure that it is unique in this catalog
     // IMPORTANT: this method needs to stay inside a zookeeper distributed locking block
@@ -167,129 +592,10 @@ class AccumuloDataStore(val connector: Connector,
     metadata.insert(featureName, SCHEMA_ID_KEY, new String(Array(schemaId.asInstanceOf[Byte]), "UTF-8"))
   }
 
-  /**
-   * Used to update the attributes that are marked as indexed
-   *
-   * @param featureName
-   * @param attributes
-   */
-  def updateIndexedAttributes(featureName: String, attributes: String): Unit = {
-    val FeatureSpec(existing, _) = SimpleFeatureTypes.parse(getAttributes(featureName).getOrElse(""))
-    val FeatureSpec(updated, _)  = SimpleFeatureTypes.parse(attributes)
-    // check that the only changes are to non-geometry index flags
-    val ok = existing.length == updated.length &&
-      existing.zip(updated).forall { case (e, u) => e == u ||
-        (e.isInstanceOf[NonGeomAttributeSpec] &&
-         u.isInstanceOf[NonGeomAttributeSpec] &&
-         e.clazz == u.clazz &&
-         e.name == u.name) }
-    if (!ok) {
-      throw new IllegalArgumentException("Attribute spec is not consistent with existing spec")
-    }
-
-    metadata.insert(featureName, ATTRIBUTES_KEY, attributes)
-
-    // reconfigure the splits on the attribute table
-    val sft = getSchema(featureName)
-    val table = getTableName(featureName, AttributeTable)
-    AttributeTable.configureTable(sft, table, tableOps)
-  }
-
-  /**
-   * Implements method from StatWriter
-   */
-  def getStatTable(stat: Stat): String = {
-    stat match {
-      case qs: QueryStat => getQueriesTableName(qs.typeName)
-      case _ => throw new NotImplementedError()
-    }
-  }
-
-  /**
-   * Read Queries table name from store metadata
-   */
-  def getQueriesTableName(featureName: String): String =
-    Try(metadata.readRequired(featureName, QUERIES_TABLE_KEY)) match {
-      case Success(queriesTableName) => queriesTableName
-      // For backwards compatibility with existing tables that do not have queries table metadata
-      case Failure(t) if t.getMessage.contains("Unable to find required metadata property") =>
-        writeAndReturnMissingQueryTableMetadata(featureName)
-      case Failure(t) => throw t
-    }
-
-  /**
-   * Here just to write missing query metadata (for backwards compatibility with preexisting data).
-   */
-  private[this] def writeAndReturnMissingQueryTableMetadata(featureName: String): String = {
-    val queriesTableValue = formatQueriesTableName(catalogTable)
-    metadata.insert(featureName, QUERIES_TABLE_KEY, queriesTableValue)
-    queriesTableValue
-  }
-
-
-  /**
-   * Read SpatioTemporal Index table name from store metadata
-   */
-  def getSpatioTemporalMaxShard(sft: SimpleFeatureType): Int = {
-    val indexSchemaFmt = metadata.read(sft.getTypeName, SCHEMA_KEY)
-      .getOrElse(throw new RuntimeException(s"Unable to find required metadata property for $SCHEMA_KEY"))
-    IndexSchema.maxShard(indexSchemaFmt)
-  }
-
-  def createTablesForType(sft: SimpleFeatureType): Unit = {
-    GeoMesaTable.getTables(sft).foreach { table =>
-      val name = table.formatTableName(catalogTable, sft)
-      AccumuloVersion.ensureTableExists(connector, name)
-      table.configureTable(sft, name, tableOps)
-    }
-  }
-
-  // Retrieves or computes the indexSchema
-  def computeSpatioTemporalSchema(sft: SimpleFeatureType): String = {
-    Option(sft.getStIndexSchema) match {
-      case None         => buildDefaultSpatioTemporalSchema(sft.getTypeName)
-      case Some(schema) => schema
-    }
-  }
-
-  /**
-   * Compute the GeoMesa SpatioTemporal Schema, create tables, and write metadata to catalog.
-   * If the schema already exists, log a message and continue without error.
-   * This method uses distributed locking to ensure a schema is only created once.
-   *
-   * @param sft
-   */
-  override def createSchema(sft: SimpleFeatureType) =
-    if (getSchema(sft.getTypeName) == null) {
-      val lock = acquireDistributedLock()
-      try {
-        // check a second time now that we have the lock
-        if (getSchema(sft.getTypeName) == null) {
-          // inspect, warn and set SF_PROPERTY_START_TIME if appropriate
-          // do this before anything else so appropriate tables will be created
-          TemporalIndexCheck.validateDtgField(sft)
-          // set the schema version, required for table checks
-          sft.setSchemaVersion(CURRENT_SCHEMA_VERSION)
-          val spatioTemporalSchema = computeSpatioTemporalSchema(sft)
-          checkSchemaRequirements(sft, spatioTemporalSchema)
-          writeMetadata(sft, SerializationType.KRYO, spatioTemporalSchema)
-
-          // reload the SFT then copy over any additional keys that were in the original sft
-          val reloadedSft = getSchema(sft.getTypeName)
-          (sft.getUserData.keySet -- reloadedSft.getUserData.keySet)
-            .foreach(k => reloadedSft.getUserData.put(k, sft.getUserData.get(k)))
-
-          createTablesForType(reloadedSft)
-        }
-      } finally {
-        lock.release()
-      }
-    }
-
   // This function enforces the shared ST schema requirements.
-  //  For a shared ST table, the IndexSchema must start with a partition number and a constant string.
-  //  TODO: This function should check if the constant is equal to the featureType.getTypeName
-  def checkSchemaRequirements(featureType: SimpleFeatureType, schema: String) {
+  // For a shared ST table, the IndexSchema must start with a partition number and a constant string.
+  // TODO: This function should check if the constant is equal to the featureType.getTypeName
+  private def checkSchemaRequirements(featureType: SimpleFeatureType, schema: String) {
     if (featureType.isTableSharing) {
       val (rowf, _,_) = IndexSchema.parse(IndexSchema.formatter, schema).get
       rowf.lf match {
@@ -301,43 +607,8 @@ class AccumuloDataStore(val connector: Connector,
     }
   }
 
-  /**
-   * Deletes the tables from Accumulo created from the Geomesa SpatioTemporal Schema, and deletes
-   * metadata from the catalog. If the table is an older 0.10.x table, we throw an exception.
-   *
-   * This version overrides the default geotools removeSchema function and uses 1 thread for
-   * querying during metadata deletion.
-   *
-   * @param featureName the name of the feature
-   */
-  override def removeSchema(featureName: String) = removeSchema(featureName, 1)
-
-  /**
-   * Deletes the tables from Accumulo created from the Geomesa SpatioTemporal Schema, and deletes
-   * metadata from the catalog.
-   *
-   * @param featureName the name of the feature
-   * @param numThreads the number of concurrent threads to spawn for querying during metadata deletion
-   */
-  def removeSchema(featureName: String, numThreads: Int = 1) = {
-    val lock = acquireDistributedLock()
-    try {
-      Option(getSchema(featureName)).foreach { sft =>
-        if (sft.isTableSharing && getTypeNames.length > 1) {
-          deleteSharedTables(sft)
-        } else {
-          deleteStandAloneTables(sft)
-        }
-      }
-      metadata.delete(featureName, numThreads)
-      metadata.expireCache(featureName)
-    } finally {
-      lock.release()
-    }
-  }
-
   private def deleteSharedTables(sft: SimpleFeatureType) = {
-    val auths = authorizationsProvider.getAuthorizations
+    val auths = authProvider.getAuthorizations
     GeoMesaTable.getTables(sft).par.foreach { table =>
       val name = getTableName(sft.getTypeName, table)
       if (tableOps.exists(name)) {
@@ -357,445 +628,17 @@ class AccumuloDataStore(val connector: Connector,
     GeoMesaTable.getTableNames(sft, this).filter(tableOps.exists).foreach(tableOps.delete)
 
   /**
-   * Delete everything (all tables) associated with this datastore (index tables and catalog table)
-   * NB: We are *not* currently deleting the query table and/or query information.
-   */
-  def delete() = {
-    val indexTables = getTypeNames.map(getSchema).flatMap(GeoMesaTable.getTableNames(_, this)).distinct
-    // Delete index tables first then catalog table in case of error
-    indexTables.filter(tableOps.exists).foreach(tableOps.delete)
-    if (tableOps.exists(catalogTable)) {
-      tableOps.delete(catalogTable)
-    }
-  }
-
-  /**
-   * Validates the configuration of this data store instance against the stored configuration in
-   * Accumulo, if any. This is used to ensure that the visibilities (in particular) do not change
-   * from one instance to the next. This will fill in any missing metadata that may occur in an
-   * older (0.1.0) version of a table.
-   */
-  protected def validateMetadata(featureName: String): Unit = {
-    metadata.read(featureName, ATTRIBUTES_KEY)
-      .getOrElse(throw new IOException(s"Feature '$featureName' has not been initialized. Please call 'createSchema' first."))
-
-    val ok = validated.getOrElseUpdate(featureName, checkMetadata(featureName))
-
-    if (!ok.isEmpty) {
-      throw new RuntimeException("Configuration of this DataStore does not match the schema values: " + ok)
-    }
-  }
-
-  /**
-   * Wraps the functionality of checking the metadata against this config
+   * Verifies that the schema exists
    *
-   * @param featureName
-   * @return string with errors, or empty string
+   * @param typeName simple feature type
+   * @throws IOException if schema does not exist
    */
-  private def checkMetadata(featureName: String): String = {
-
-    // check the different metadata options
-    val checks = List(checkVisibilitiesMetadata(featureName))
-
-    val errors = checks.flatten.mkString(", ")
-
-    // if no errors, check the feature encoding
-    if (errors.isEmpty) {
-      checkFeatureEncodingMetadata(featureName)
-    }
-
-    errors
-  }
-
-  /**
-   * Checks the visibility stored in the metadata table against the configuration of this data store.
-   *
-   * @param featureName
-   * @return
-   */
-  private def checkVisibilitiesMetadata(featureName: String): Option[String] = {
-    // validate that visibilities have not changed
-    val storedVisibilities = metadata.read(featureName, VISIBILITIES_KEY).getOrElse("")
-    if (storedVisibilities != writeVisibilities) {
-      Some(s"$VISIBILITIES_KEY = '$writeVisibilities', should be '$storedVisibilities'")
-    } else {
-      None
+  @throws[IOException]
+  private def checkSchema(typeName: String): Unit = {
+    metadata.read(typeName, ATTRIBUTES_KEY).getOrElse {
+      throw new IOException(s"Schema '$typeName' has not been initialized. Please call 'createSchema' first.")
     }
   }
-
-  /**
-   * Checks the feature encoding in the metadata against the configuration of this data store.
-   *
-   * @param featureName
-   */
-  def checkFeatureEncodingMetadata(featureName: String): Unit = {
-    // for feature encoding, we are more lenient - we will use whatever is stored in the table
-    if (metadata.read(featureName, FEATURE_ENCODING_KEY).getOrElse("").isEmpty) {
-      throw new RuntimeException(s"No '$FEATURE_ENCODING_KEY' found for feature '$featureName'.")
-    }
-  }
-
-  /**
-   * Checks whether the current user can write - based on whether they can read data in this
-   * data store.
-   *
-   * @param featureName
-   */
-  protected def checkWritePermissions(featureName: String): Unit = {
-    val visibilities = metadata.read(featureName, VISIBILITIES_KEY).getOrElse("")
-    // if no visibilities set, no need to check
-    if (!visibilities.isEmpty) {
-      // create a key for the user's auths that we will use to check the cache
-      val authString = authorizationsProvider.getAuthorizations.getAuthorizations
-                      .map(a => new String(a)).sorted.mkString(",")
-      if (!checkWritePermissions(featureName, authString)) {
-        throw new RuntimeException(s"The current user does not have the required authorizations to " +
-          s"write $featureName features. Required authorizations: '$visibilities', " +
-          s"actual authorizations: '$authString'")
-      }
-    }
-  }
-
-  /**
-   * Wraps logic for checking write permissions for a given set of auths
-   *
-   * @param featureName
-   * @param authString
-   * @return
-   */
-  private def checkWritePermissions(featureName: String, authString: String) = {
-    // if cache contains an entry, use that
-    visibilityCheckCache.getOrElse((featureName, authString), {
-      // check the 'visibilities check' metadata - it has visibilities applied, so if the user
-      // can read that row, then they can read any data in the data store
-      val visCheck = metadata.readNoCache(featureName, VISIBILITIES_CHECK_KEY)
-                      .isInstanceOf[Some[String]]
-      visibilityCheckCache.put((featureName, authString), visCheck)
-      visCheck
-    })
-  }
-
-  /**
-   * Implementation of AbstractDataStore getTypeNames
-   *
-   * @return
-   */
-  override def getTypeNames: Array[String] = metadata.getFeatureTypes
-
-  // NB:  By default, AbstractDataStore is "isWriteable".  This means that createFeatureSource returns
-  // a featureStore
-  override def getFeatureSource(typeName: Name): SimpleFeatureSource = {
-    validateMetadata(typeName.getLocalPart)
-    if (config.caching) {
-      new AccumuloFeatureStore(this, typeName) with CachingFeatureSource
-    } else {
-      new AccumuloFeatureStore(this, typeName)
-    }
-  }
-
-  override def getFeatureSource(typeName: String): SimpleFeatureSource =
-    getFeatureSource(new NameImpl(typeName))
-
-  /**
-   * Reads the index schema format out of the metadata
-   *
-   * @param featureName
-   * @return
-   */
-  def getIndexSchemaFmt(featureName: String) =
-    metadata.read(featureName, SCHEMA_KEY).getOrElse(EMPTY_STRING)
-
-  /**
-   * Updates the index schema format - WARNING don't use this unless you know what you're doing.
-   * @param sft
-   * @param schema
-   */
-  def setIndexSchemaFmt(sft: String, schema: String) = {
-    metadata.insert(sft, SCHEMA_KEY, schema)
-    metadata.expireCache(sft)
-  }
-
-  /**
-   * Update the geomesa version
-   *
-   * @param sft
-   * @param version
-   */
-  def setGeomesaVersion(sft: String, version: Int): Unit = {
-    metadata.insert(sft, VERSION_KEY, version.toString)
-    metadata.expireCache(sft)
-  }
-
-  /**
-   * Reads the attributes out of the metadata
-   *
-   * @param featureName
-   * @return
-   */
-  private def getAttributes(featureName: String) = metadata.read(featureName, ATTRIBUTES_KEY)
-
-  /**
-   * Reads the feature encoding from the metadata.
-   *
-   * @throws RuntimeException if the feature encoding is missing or invalid
-   */
-  def getFeatureEncoding(sft: SimpleFeatureType): SerializationType = {
-    val name = metadata.readRequired(sft.getTypeName, FEATURE_ENCODING_KEY)
-    try {
-      SerializationType.withName(name)
-    } catch {
-      case e: NoSuchElementException => throw new RuntimeException(s"Invalid Feature Encoding '$name'.")
-    }
-  }
-
-  // We assume that they want the bounds for everything.
-  override def getBounds(query: Query): ReferencedEnvelope = {
-    val env = metadata.read(query.getTypeName, SPATIAL_BOUNDS_KEY).getOrElse(WHOLE_WORLD_BOUNDS)
-    val minMaxXY = env.split(":")
-    val curBounds = minMaxXY.size match {
-      case 4 => env
-      case _ => WHOLE_WORLD_BOUNDS
-    }
-    val sft = getSchema(query.getTypeName)
-    val crs = sft.getCoordinateReferenceSystem
-    stringToReferencedEnvelope(curBounds, crs)
-  }
-
-  def getTimeBounds(typeName: String): Interval = {
-    metadata.read(typeName, TEMPORAL_BOUNDS_KEY)
-      .map(stringToTimeBounds)
-      .getOrElse(ALL_TIME_BOUNDS)
-  }
-
-  def getRecordTableSize(featureName: String): Long = {
-    metadata.getTableSize(getTableName(featureName, RecordTable))
-  }
-
-  def stringToTimeBounds(value: String): Interval = {
-    val longs = value.split(":").map(java.lang.Long.parseLong)
-    require(longs(0) <= longs(1))
-    require(longs.length == 2)
-    new Interval(longs(0), longs(1))
-  }
-
-  private def stringToReferencedEnvelope(string: String,
-                                         crs: CoordinateReferenceSystem): ReferencedEnvelope = {
-    val minMaxXY = string.split(":")
-    require(minMaxXY.size == 4)
-    new ReferencedEnvelope(minMaxXY(0).toDouble, minMaxXY(1).toDouble, minMaxXY(2).toDouble,
-                            minMaxXY(3).toDouble, crs)
-  }
-
-  /**
-   * Writes spatial bounds for this feature
-   *
-   * @param featureName
-   * @param bounds
-   */
-  def writeSpatialBounds(featureName: String, bounds: ReferencedEnvelope) {
-    // prepare to write out properties to the Accumulo SHP-file table
-    val newbounds = metadata.read(featureName, SPATIAL_BOUNDS_KEY) match {
-      case Some(env) => getNewBounds(env, bounds)
-      case None      => bounds
-    }
-
-    val minMaxXY = List(newbounds.getMinX, newbounds.getMaxX, newbounds.getMinY, newbounds.getMaxY)
-    val encoded = minMaxXY.mkString(":")
-
-    metadata.insert(featureName, SPATIAL_BOUNDS_KEY, encoded)
-  }
-
-  private def getNewBounds(env: String, bounds: ReferencedEnvelope) = {
-    val oldBounds = stringToReferencedEnvelope(env, DefaultGeographicCRS.WGS84)
-    oldBounds.expandToInclude(bounds)
-    oldBounds
-  }
-
-  /**
-   * Writes temporal bounds for this feature
-   *
-   * @param featureName
-   * @param timeBounds
-   */
-  def writeTemporalBounds(featureName: String, timeBounds: Interval) {
-    val newTimeBounds = metadata.read(featureName, TEMPORAL_BOUNDS_KEY) match {
-      case Some(currentTimeBoundsString) => getNewTimeBounds(currentTimeBoundsString, timeBounds)
-      case None                          => Some(timeBounds)
-    }
-
-    // Only write expanded bounds.
-    newTimeBounds.foreach { newBounds =>
-      val encoded = s"${newBounds.getStartMillis}:${newBounds.getEndMillis}"
-      metadata.insert(featureName, TEMPORAL_BOUNDS_KEY, encoded)
-    }
-  }
-
-  def getNewTimeBounds(current: String, newBounds: Interval): Option[Interval] = {
-    val currentTimeBounds = stringToTimeBounds(current)
-    val expandedTimeBounds = currentTimeBounds.expandByInterval(newBounds)
-    if (!currentTimeBounds.equals(expandedTimeBounds)) {
-      Some(expandedTimeBounds)
-    } else {
-      None
-    }
-  }
-
-  /**
-   * Implementation of abstract method
-   *
-   * @param featureName
-   * @return the corresponding feature type (schema) for this feature name,
-   *         or NULL if this feature name does not appear to exist
-   */
-  override def getSchema(featureName: String): SimpleFeatureType = getSchema(new NameImpl(featureName))
-
-  override def getSchema(name: Name): SimpleFeatureType = {
-    val featureName = name.getLocalPart
-    getAttributes(featureName).map { attributes =>
-      val sft = SimpleFeatureTypes.createType(name.getURI, attributes)
-      // IMPORTANT: set data that we want to pass around with the sft
-      metadata.read(featureName, DTGFIELD_KEY).foreach(sft.setDtgField)
-      val version = metadata.readRequired(featureName, VERSION_KEY).toInt
-      if (version > CURRENT_SCHEMA_VERSION) {
-        logger.error(s"Trying to access schema ${sft.getTypeName} with version $version " +
-            s"but client can only handle up to version $CURRENT_SCHEMA_VERSION.")
-        throw new IllegalStateException(s"The schema ${sft.getTypeName} was written with a newer " +
-            "version of GeoMesa than this client can handle. Please ensure that you are using the " +
-            "same GeoMesa jar versions across your entire workflow. For more information, see " +
-            "http://www.geomesa.org/documentation/user/installation_and_configuration.html#upgrading")
-      } else {
-        sft.setSchemaVersion(version)
-      }
-
-      sft.setStIndexSchema(metadata.read(featureName, SCHEMA_KEY).orNull)
-      // If no data is written, we default to 'false' in order to support old tables.
-      if (metadata.read(featureName, SHARED_TABLES_KEY).exists(_.toBoolean)) {
-        sft.setTableSharing(true)
-        // use schema id if available or fall back to old type name for backwards compatibility
-        val prefix = metadata.read(featureName, SCHEMA_ID_KEY).getOrElse(s"${sft.getTypeName}~")
-        sft.setTableSharingPrefix(prefix)
-      } else {
-        sft.setTableSharing(false)
-        sft.setTableSharingPrefix("")
-      }
-
-      metadata.read(featureName, TABLES_ENABLED_KEY).foreach { enabledTablesStr =>
-        sft.setEnabledTables(enabledTablesStr)
-      }
-
-      sft
-    }.orNull
-  }
-
-  // Implementation of Abstract method
-  def getFeatureReader(featureName: String): AccumuloFeatureReader =
-    getFeatureReader(featureName, new Query(featureName))
-
-  // This override is important as it allows us to optimize and plan our search with the Query.
-  override def getFeatureReader(featureName: String, query: Query): AccumuloFeatureReader = {
-    val sw = Some(this).collect { case w: StatWriter => w }
-    AccumuloFeatureReader(query, getQueryPlanner(featureName), queryTimeoutMillis, sw, auditProvider)
-  }
-
-  // override the abstract data store method - we already handle all projections, transformations, etc
-  override def getFeatureReader(query: Query, transaction: Transaction): AccumuloFeatureReader =
-    getFeatureReader(query.getTypeName, query)
-
-  /**
-   * Gets the query plan for a given query. The query plan consists of the tables, ranges, iterators etc
-   * required to run a query against accumulo.
-   */
-  def getQueryPlan(query: Query, strategy: Option[StrategyType] = None): Seq[QueryPlan] = {
-    require(query.getTypeName != null, "Type name is required in the query")
-    planQuery(query.getTypeName, query, strategy, ExplainNull)
-  }
-
-  /**
-   * Prints the query plan for a given query to the provided output.
-   */
-  def explainQuery(query: Query, o: ExplainerOutputType = new ExplainPrintln): Unit = {
-    require(query.getTypeName != null, "Type name is required in the query")
-    planQuery(query.getTypeName, query, None, o)
-  }
-
-  /**
-   * Plan the query, but don't execute it
-   */
-  private def planQuery(featureName: String,
-                        query: Query,
-                        strategy: Option[StrategyType],
-                        o: ExplainerOutputType): Seq[QueryPlan] =
-    getQueryPlanner(featureName).planQuery(query, None, o)
-
-  /**
-   * Gets a query planner. Also has side-effect of setting transforms in the query.
-   */
-  protected[data] def getQueryPlanner(featureName: String): QueryPlanner = {
-    validateMetadata(featureName)
-    val sft = getSchema(featureName)
-    val indexSchemaFmt = getIndexSchemaFmt(featureName)
-    val featureEncoding = getFeatureEncoding(sft)
-    val hints = strategyHints(sft)
-    new QueryPlanner(sft, featureEncoding, indexSchemaFmt, this, hints)
-  }
-
-  /* create a general purpose writer that is capable of insert, deletes, and updates */
-  override def getFeatureWriter(typeName: String, filter: Filter, transaction: Transaction): SFFeatureWriter = {
-    validateMetadata(typeName)
-    checkWritePermissions(typeName)
-    val sft = getSchema(typeName)
-    val fe = SimpleFeatureSerializers(sft, getFeatureEncoding(sft))
-    new ModifyAccumuloFeatureWriter(sft, fe, this, writeVisibilities, filter)
-  }
-
-  /* optimized for GeoTools API to return writer ONLY for appending (aka don't scan table) */
-  override def getFeatureWriterAppend(typeName: String,
-                                      transaction: Transaction): SFFeatureWriter = {
-    validateMetadata(typeName)
-    checkWritePermissions(typeName)
-    val sft = getSchema(typeName)
-    val fe = SimpleFeatureSerializers(sft, getFeatureEncoding(sft))
-    new AppendAccumuloFeatureWriter(sft, fe, this, writeVisibilities)
-  }
-
-  override def getUnsupportedFilter(featureName: String, filter: Filter): Filter = Filter.INCLUDE
-
-  override def getScanner(table: String): Scanner =
-    connector.createScanner(table, authorizationsProvider.getAuthorizations)
-
-  override def getBatchScanner(table: String, threads: Int): BatchScanner =
-    connector.createBatchScanner(table, authorizationsProvider.getAuthorizations, threads)
-
-  override def getTableName(featureName: String, table: GeoMesaTable): String = {
-    val key = table match {
-      case RecordTable         => RECORD_TABLE_KEY
-      case Z3Table             => Z3_TABLE_KEY
-      case AttributeTable      => ATTR_IDX_TABLE_KEY
-      case AttributeTableV5    => ATTR_IDX_TABLE_KEY
-      case SpatioTemporalTable => ST_IDX_TABLE_KEY
-      case _ => throw new NotImplementedError("Unknown table")
-    }
-    metadata.readRequired(featureName, key)
-  }
-
-  override def getSuggestedThreads(featureName: String, table: GeoMesaTable): Int = {
-    table match {
-      case RecordTable         => config.recordThreads
-      case Z3Table             => config.queryThreads
-      case AttributeTable      => config.queryThreads
-      case AttributeTableV5    => 1
-      case SpatioTemporalTable => config.queryThreads
-      case _ => throw new NotImplementedError("Unknown table")
-    }
-  }
-
-  /**
-   * Read Queries table name from store metadata
-   */
-  def getQueriesTableName(featureType: SimpleFeatureType): String =
-    getQueriesTableName(featureType.getTypeName)
-
-  override def strategyHints(sft: SimpleFeatureType) = new UserDataStrategyHints()
 
   /**
    * Gets and acquires a distributed lock for all accumulo data stores sharing this catalog table.
@@ -804,10 +647,10 @@ class AccumuloDataStore(val connector: Connector,
   private def acquireDistributedLock(): Releasable = {
     if (connector.isInstanceOf[MockConnector]) {
       // for mock connections use a jvm-level lock
-      val lock = mockLocks.synchronized(mockLocks.getOrElseUpdate(catalogTable, new Lock))
-      lock.acquire()
+      val lock = mockLocks.synchronized(mockLocks.getOrElseUpdate(catalogTable, new ReentrantLock()))
+      lock.lock()
       new Releasable {
-        override def release(): Unit = lock.release()
+        override def release(): Unit = lock.unlock()
       }
     } else {
       val backoff = new ExponentialBackoffRetry(1000, 3)
@@ -838,8 +681,9 @@ object AccumuloDataStore {
   /**
    * Format queries table name for Accumulo...table name is stored in metadata for other usage
    * and provide compatibility moving forward if table names change
-   * @param catalogTable
-   * @return
+   *
+   * @param catalogTable table
+   * @return formatted name
    */
   def formatQueriesTableName(catalogTable: String): String =
     GeoMesaTable.concatenateNameParts(catalogTable, "queries")

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
@@ -60,7 +60,7 @@ class AccumuloDataStoreFactory extends DataStoreFactorySpi {
     // TODO would it be safer to default to no auths?
     val auths: List[String] = if (configuredAuths.nonEmpty) configuredAuths.toList else masterAuthsStrings.toList
 
-    val authorizationsProvider = security.getAuthorizationsProvider(params, auths)
+    val authProvider = security.getAuthorizationsProvider(params, auths)
     val auditProvider = security.getAuditProvider(params).getOrElse {
       val provider = new ParamsAuditProvider
       provider.configure(params)
@@ -82,19 +82,9 @@ class AccumuloDataStoreFactory extends DataStoreFactorySpi {
     val collectStats = !useMock && statsParam.lookupWithDefault[Boolean](params)
 
     if (collectStats) {
-      new AccumuloDataStore(connector,
-        tableName,
-        authorizationsProvider,
-        auditProvider,
-        visibility,
-        config) with StatWriter
+      new AccumuloDataStore(connector, tableName, authProvider, auditProvider, visibility, config) with StatWriter
     } else {
-      new AccumuloDataStore(connector,
-        tableName,
-        authorizationsProvider,
-        auditProvider,
-        visibility,
-        config)
+      new AccumuloDataStore(connector, tableName, authProvider, auditProvider, visibility, config)
     }
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureSource.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureSource.scala
@@ -8,17 +8,22 @@
 
 package org.locationtech.geomesa.accumulo.data
 
+import java.awt.RenderingHints.Key
+import java.net.URI
+import java.util
+import java.util.Collections
 import java.util.concurrent.atomic.AtomicBoolean
 
 import com.google.common.cache.{CacheBuilder, CacheLoader}
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.data._
-import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureIterator}
+import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureIterator, SimpleFeatureSource}
 import org.geotools.data.store.DataFeatureCollection
 import org.geotools.feature.collection.SortedSimpleFeatureCollection
 import org.geotools.feature.visitor.{BoundsVisitor, MaxVisitor, MinVisitor}
+import org.geotools.geometry.jts.ReferencedEnvelope
 import org.locationtech.geomesa.accumulo.GeomesaSystemProperties
-import org.locationtech.geomesa.accumulo.index.QueryHints.{RichHints, _}
+import org.locationtech.geomesa.accumulo.index.QueryHints.RichHints
 import org.locationtech.geomesa.accumulo.index.QueryPlanner
 import org.locationtech.geomesa.accumulo.process.knn.KNNVisitor
 import org.locationtech.geomesa.accumulo.process.proximity.ProximityVisitor
@@ -26,7 +31,6 @@ import org.locationtech.geomesa.accumulo.process.query.QueryVisitor
 import org.locationtech.geomesa.accumulo.process.stats.StatsVisitor
 import org.locationtech.geomesa.accumulo.process.tube.TubeVisitor
 import org.locationtech.geomesa.accumulo.process.unique.AttributeVisitor
-import org.locationtech.geomesa.accumulo.util.TryLoggingFailure
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.opengis.feature.FeatureVisitor
 import org.opengis.feature.`type`.Name
@@ -34,25 +38,20 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 import org.opengis.filter.expression.{Expression, PropertyName}
 import org.opengis.filter.sort.SortBy
+import org.opengis.referencing.crs.CoordinateReferenceSystem
 import org.opengis.util.ProgressListener
 
-trait AccumuloAbstractFeatureSource extends AbstractFeatureSource with LazyLogging with TryLoggingFailure {
-  self =>
+import scala.util.Try
+import scala.collection.JavaConversions._
+
+abstract class AccumuloFeatureSource(val dataStore: AccumuloDataStore, val featureName: Name)
+    extends SimpleFeatureSource with LazyLogging {
 
   import org.locationtech.geomesa.utils.geotools.Conversions._
 
-  val dataStore: AccumuloDataStore
-  val featureName: Name
+  private[data] val typeName = featureName.getLocalPart
 
-  def addFeatureListener(listener: FeatureListener) {}
-
-  def removeFeatureListener(listener: FeatureListener) {}
-
-  def getSchema: SimpleFeatureType = getDataStore.getSchema(featureName)
-
-  def getDataStore: AccumuloDataStore = dataStore
-
-  def longCount = dataStore.getRecordTableSize(featureName.getLocalPart)
+  lazy private val hints = Collections.unmodifiableSet(Set.empty[Key])
 
   // The default behavior for getCount is to use Accumulo to look up the number of entries in
   //  the record table for a feature.
@@ -62,47 +61,63 @@ trait AccumuloAbstractFeatureSource extends AbstractFeatureSource with LazyLoggi
   // Since users may want *actual* counts, there are two ways to force exact counts.
   //  First, one can set the System property "geomesa.force.count".
   //  Second, there is an EXACT_COUNT query hint.
-  override def getCount(query: Query) = {
-    val exactCount = if(query.getHints.get(EXACT_COUNT) != null) {
-      query.getHints.get(EXACT_COUNT).asInstanceOf[Boolean]
-    } else {
-      GeomesaSystemProperties.QueryProperties.QUERY_EXACT_COUNT.get.toBoolean
-    }
+  override def getCount(query: Query): Int = {
+    import GeomesaSystemProperties.QueryProperties.QUERY_EXACT_COUNT
 
-    if (exactCount || longCount == -1) {
+    val useExactCount = query.getHints.isExactCount.getOrElse(QUERY_EXACT_COUNT.get.toBoolean)
+    lazy val estimatedCount = dataStore.estimateCount(query)
+
+    if (useExactCount || estimatedCount == -1) {
       getFeaturesNoCache(query).features().size
+    } else if (estimatedCount > Int.MaxValue.toLong) {
+      Int.MaxValue
     } else {
-      longCount match {
-        case _ if longCount > Int.MaxValue      => Int.MaxValue
-        case _                                  => longCount.toInt
-      }
+      estimatedCount.toInt
     }
   }
 
-  override def getQueryCapabilities = new QueryCapabilities() {
+  override def getBounds: ReferencedEnvelope = getBounds(new Query(typeName, Filter.INCLUDE))
+
+  override def getBounds(query: Query): ReferencedEnvelope = dataStore.estimateBounds(query)
+
+  override def getQueryCapabilities = AccumuloQueryCapabilities
+
+  override def getFeatures(query: Query): SimpleFeatureCollection = getFeaturesNoCache(query)
+
+  override def getFeatures(filter: Filter): SimpleFeatureCollection =
+    getFeatures(new Query(typeName, filter))
+
+  override def getFeatures: SimpleFeatureCollection = getFeatures(Filter.INCLUDE)
+
+  override def getName: Name = featureName
+
+  override def getDataStore: AccumuloDataStore = dataStore
+
+  override def getSchema: SimpleFeatureType = dataStore.getSchema(featureName)
+
+  override def getSupportedHints: java.util.Set[Key] = hints
+
+  override def getInfo: ResourceInfo = new DelegatingResourceInfo(this)
+
+  override def addFeatureListener(listener: FeatureListener): Unit = {}
+
+  override def removeFeatureListener(listener: FeatureListener): Unit = {}
+
+  private def getFeaturesNoCache(query: Query): SimpleFeatureCollection =
+    new AccumuloFeatureCollection(this, query)
+
+  object AccumuloQueryCapabilities extends QueryCapabilities {
     override def isOffsetSupported = false
     override def isReliableFIDSupported = true
     override def isUseProvidedFIDSupported = true
     override def supportsSorting(sortAttributes: Array[SortBy]) = true
   }
-
-  protected def getFeaturesNoCache(query: Query): SimpleFeatureCollection =
-    new AccumuloFeatureCollection(self, query)
-
-  override def getFeatures(query: Query): SimpleFeatureCollection =
-    tryLoggingFailures(getFeaturesNoCache(query))
-
-  override def getFeatures(filter: Filter): SimpleFeatureCollection =
-    getFeatures(new Query(getSchema().getTypeName, filter))
 }
-
-class AccumuloFeatureSource(val dataStore: AccumuloDataStore, val featureName: Name)
-  extends AccumuloAbstractFeatureSource
 
 /**
  * Feature collection implementation
  */
-class AccumuloFeatureCollection(source: AccumuloAbstractFeatureSource, query: Query)
+class AccumuloFeatureCollection(source: AccumuloFeatureSource, query: Query)
   extends DataFeatureCollection {
 
   private val ds = source.getDataStore
@@ -126,12 +141,9 @@ class AccumuloFeatureCollection(source: AccumuloAbstractFeatureSource, query: Qu
   override def accepts(visitor: FeatureVisitor, progress: ProgressListener): Unit =
     visitor match {
       // TODO GEOMESA-421 implement min/max iterators
-      case v: MinVisitor if isTime(v.getExpression) =>
-        v.setValue(ds.getTimeBounds(query.getTypeName).getStart.toDate)
-      case v: MaxVisitor if isTime(v.getExpression) =>
-        v.setValue(ds.getTimeBounds(query.getTypeName).getEnd.toDate)
-
-      case v: BoundsVisitor          => v.reset(ds.getBounds(query))
+      case v: MinVisitor if isTime(v.getExpression) => v.setValue(ds.estimateTimeBounds(query).getStart.toDate)
+      case v: MaxVisitor if isTime(v.getExpression) => v.setValue(ds.estimateTimeBounds(query).getEnd.toDate)
+      case v: BoundsVisitor          => v.reset(ds.estimateBounds(query))
       case v: TubeVisitor            => v.setValue(v.tubeSelect(source, query))
       case v: ProximityVisitor       => v.setValue(v.proximitySearch(source, query))
       case v: QueryVisitor           => v.setValue(v.query(source, query))
@@ -142,12 +154,12 @@ class AccumuloFeatureCollection(source: AccumuloAbstractFeatureSource, query: Qu
     }
 
   private def isTime(e: Expression) = e match {
-    case p: PropertyName => getSchema.getDtgField.exists(_ == p.getPropertyName)
+    case p: PropertyName => getSchema.getDtgField.contains(p.getPropertyName)
     case _ => false
   }
 
   override def reader(): FeatureReader[SimpleFeatureType, SimpleFeature] = {
-    val reader = ds.getFeatureReader(query.getTypeName, query)
+    val reader = ds.getFeatureReader(query, Transaction.AUTO_COMMIT)
     val maxFeatures = query.getMaxFeatures
     if (maxFeatures != Integer.MAX_VALUE) {
       new MaxFeatureReader[SimpleFeatureType, SimpleFeature](reader, maxFeatures)
@@ -161,7 +173,7 @@ class AccumuloFeatureCollection(source: AccumuloAbstractFeatureSource, query: Qu
   override def getBounds = source.getBounds(query)
 }
 
-class CachingAccumuloFeatureCollection(source: AccumuloAbstractFeatureSource, query: Query)
+class CachingAccumuloFeatureCollection(source: AccumuloFeatureSource, query: Query)
     extends AccumuloFeatureCollection(source, query) {
 
   lazy val featureList = {
@@ -186,17 +198,16 @@ class CachingAccumuloFeatureCollection(source: AccumuloAbstractFeatureSource, qu
   override def size = featureList.length
 }
 
-trait CachingFeatureSource extends AccumuloAbstractFeatureSource {
-  self: AccumuloAbstractFeatureSource =>
+trait CachingFeatureSource extends AccumuloFeatureSource {
 
   private val featureCache =
     CacheBuilder.newBuilder().build(
       new CacheLoader[Query, SimpleFeatureCollection] {
         override def load(query: Query): SimpleFeatureCollection =
-          new CachingAccumuloFeatureCollection(self, query)
+          new CachingAccumuloFeatureCollection(CachingFeatureSource.this, query)
       })
 
-  override def getFeatures(query: Query): SimpleFeatureCollection = {
+  abstract override def getFeatures(query: Query): SimpleFeatureCollection = {
     // geotools bug in Query.hashCode
     if (query.getStartIndex == null) {
       query.setStartIndex(0)
@@ -208,5 +219,26 @@ trait CachingFeatureSource extends AccumuloAbstractFeatureSource {
       new SortedSimpleFeatureCollection(featureCache.get(query), query.getSortBy)
   }
 
-  override def getCount(query: Query): Int = getFeatures(query).size()
+  abstract override def getCount(query: Query): Int = getFeatures(query).size()
+}
+
+class DelegatingResourceInfo(source: SimpleFeatureSource) extends ResourceInfo {
+
+  import scala.collection.JavaConversions._
+
+  private val keywords = Collections.unmodifiableSet(Set("features", getName))
+
+  override def getName: String = source.getSchema.getTypeName
+
+  override def getTitle: String = source.getSchema.getName.getLocalPart
+
+  override def getDescription: String = null
+
+  override def getKeywords: util.Set[String] = keywords
+
+  override def getSchema: URI = Try(new URI(source.getSchema.getName.getNamespaceURI)).getOrElse(null)
+
+  override def getCRS: CoordinateReferenceSystem = source.getSchema.getCoordinateReferenceSystem
+
+  override def getBounds: ReferencedEnvelope = source.getBounds
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureStore.scala
@@ -8,106 +8,131 @@
 
 package org.locationtech.geomesa.accumulo.data
 
-import java.util.{List => JList}
+import java.util.{List => jList}
 
-import com.google.common.collect.Lists
 import org.geotools.data._
-import org.geotools.factory.Hints
+import org.geotools.data.simple.SimpleFeatureStore
 import org.geotools.feature._
-import org.geotools.filter.identity.FeatureIdImpl
-import org.geotools.geometry.jts.ReferencedEnvelope
-import org.locationtech.geomesa.security.SecurityUtils
-import org.locationtech.geomesa.utils.geotools.MinMaxTimeVisitor
-import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-import org.opengis.feature.`type`.Name
+import org.locationtech.geomesa.utils.geotools.FeatureUtils
+import org.opengis.feature.`type`.{AttributeDescriptor, Name}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import org.opengis.filter.Filter
 import org.opengis.filter.identity.FeatureId
 
-class AccumuloFeatureStore(val dataStore: AccumuloDataStore, val featureName: Name)
-    extends AbstractFeatureStore with AccumuloAbstractFeatureSource {
-  override def addFeatures(collection: FeatureCollection[SimpleFeatureType, SimpleFeature]): JList[FeatureId] =
-    addFeatures(collection, None)
+import scala.collection.JavaConversions._
 
 
-  def addFeatures(collection: FeatureCollection[SimpleFeatureType, SimpleFeature],
-                  featureVis: Option[String]): JList[FeatureId] = {
-    val fids = Lists.newArrayList[FeatureId]()
-    if (collection.size > 0) {
-      writeBounds(collection.getBounds)
+class AccumuloFeatureStore(dataStore: AccumuloDataStore, featureName: Name)
+    extends AccumuloFeatureSource(dataStore, featureName) with SimpleFeatureStore {
 
-      val minMaxVisitorO = collection.getSchema.getDtgField.map { new MinMaxTimeVisitor(_) }
-      val fw = dataStore.getFeatureWriterAppend(featureName.getLocalPart, Transaction.AUTO_COMMIT)
+  private var transaction: Transaction = Transaction.AUTO_COMMIT
 
-      val updateTimeBounds: SimpleFeature => Unit = { feature => minMaxVisitorO.foreach { _.visit(feature) } }
-
-      val write: SimpleFeature => FeatureId =
-        if (minMaxVisitorO.isDefined) { feature =>
-          updateTimeBounds(feature)
-          writeFeature(fw, feature)
-        }
-        else { feature =>
-          writeFeature(fw, feature)
-        }
-
-      val iter = collection.features()
-      while (iter.hasNext) {
-        val f = iter.next()
-        for (fv <- featureVis) SecurityUtils.setFeatureVisibility(f, fv)
-        val id = write(f) // keep side effecting code separate for clarity
-        fids.add(id)
-      }
-      iter.close()
-      fw.close()
-
-      for {
-        mmv <- minMaxVisitorO
-        bounds <- Option(mmv.getBounds)
-      } dataStore.writeTemporalBounds(featureName.getLocalPart, bounds)
+  override def addFeatures(collection: FeatureCollection[SimpleFeatureType, SimpleFeature]): jList[FeatureId] = {
+    if (collection.isEmpty) {
+      return List.empty[FeatureId]
     }
+
+    val features = collection.features
+    val writer = getDataStore.getFeatureWriterAppend(typeName, transaction)
+
+    val fids = new java.util.ArrayList[FeatureId](collection.size())
+
+    try {
+      while (features.hasNext) {
+        val toWrite = FeatureUtils.copyToWriter(writer, features.next())
+        writer.write()
+        fids.add(toWrite.getIdentifier)
+      }
+    } finally {
+      features.close()
+      writer.close()
+    }
+
+    dataStore.writeSpatialBounds(typeName, collection.getBounds)
+
     fids
   }
 
-  def writeFeature(fw: SFFeatureWriter, feature: SimpleFeature): FeatureId = {
-    val newFeature = fw.next()
+  override def setFeatures(reader: FeatureReader[SimpleFeatureType, SimpleFeature]): Unit = {
+    val remover = getDataStore.getFeatureWriter(typeName, transaction)
+    val writer = getDataStore.getFeatureWriterAppend(typeName, transaction)
 
     try {
-      newFeature.setAttributes(feature.getAttributes)
-      newFeature.getUserData.putAll(feature.getUserData)
-    } catch {
-      case ex: Exception =>
-        throw new DataSourceException(s"Could not create ${featureName.getLocalPart} out of provided feature: ${feature.getID}", ex)
-    }
-
-    val useExisting = java.lang.Boolean.TRUE.equals(feature.getUserData.get(Hints.USE_PROVIDED_FID).asInstanceOf[java.lang.Boolean])
-    if (getQueryCapabilities().isUseProvidedFIDSupported && useExisting) {
-      newFeature.getIdentifier.asInstanceOf[FeatureIdImpl].setID(feature.getID)
-    }
-
-    fw.write()
-    newFeature.getIdentifier
-  }
-
-  def updateTimeBounds(collection: FeatureCollection[SimpleFeatureType, SimpleFeature]) = {
-    val sft = collection.getSchema
-    val dateField = sft.getDtgField
-
-    dateField.flatMap { dtg =>
-      val minMax = new MinMaxTimeVisitor(dtg)
-      collection.accepts(minMax, null)
-      Option(minMax.getBounds)
+      while (remover.hasNext) {
+        remover.next()
+        remover.remove()
+      }
+      while (reader.hasNext) {
+        FeatureUtils.copyToWriter(writer, reader.next())
+        writer.write()
+      }
+    } finally {
+      remover.close()
+      writer.close()
+      reader.close()
     }
   }
 
-  def writeTimeBounds(collection: FeatureCollection[SimpleFeatureType, SimpleFeature]) {
-    updateTimeBounds(collection).foreach { dataStore.writeTemporalBounds(featureName.getLocalPart, _) }
+  override def modifyFeatures(attributes: Array[String], values: Array[AnyRef], filter: Filter): Unit =
+    modifyFeatures(attributes.map(new NameImpl(_).asInstanceOf[Name]), values, filter)
+
+  override def modifyFeatures(attributes: Array[AttributeDescriptor], values: Array[AnyRef], filter: Filter): Unit =
+    modifyFeatures(attributes.map(_.getName), values, filter)
+
+  override def modifyFeatures(attribute: String, value: AnyRef, filter: Filter): Unit =
+    modifyFeatures(Array[Name](new NameImpl(attribute)), Array(value), filter)
+
+  override def modifyFeatures(attribute: AttributeDescriptor, value: AnyRef, filter: Filter): Unit =
+    modifyFeatures(attribute.getName, value, filter)
+
+  override def modifyFeatures(attribute: Name, value: AnyRef, filter: Filter): Unit =
+    modifyFeatures(Array(attribute), Array(value), filter)
+
+  override def modifyFeatures(attributes: Array[Name], values: Array[AnyRef], filter: Filter): Unit = {
+    val sft = getSchema
+
+    require(filter != null, "Filter must not be null")
+    attributes.foreach(a => require(sft.getDescriptor(a) != null, s"$a is not an attribute of ${sft.getName}"))
+    require(attributes.length == values.length, "Modified names and values don't match")
+
+    val writer = getDataStore.getFeatureWriter(sft.getTypeName, filter, transaction)
+    try {
+      while (writer.hasNext) {
+        val sf = writer.next()
+        var i = 0
+        while (i < attributes.length) {
+          try {
+            sf.setAttribute(attributes(i), values(i))
+          } catch {
+            case e: Exception =>
+              throw new DataSourceException("Error updating feature " +
+                  s"'${sf.getID}' with ${attributes(i)}=${values(i)}", e)
+          }
+          i += 1
+        }
+        writer.write()
+      }
+    } finally {
+      writer.close()
+    }
   }
 
-  def writeBounds(envelope: ReferencedEnvelope) {
-    if(envelope != null)
-      dataStore.writeSpatialBounds(featureName.getLocalPart, envelope)
+  override def removeFeatures(filter: Filter): Unit = {
+    val writer = getDataStore.getFeatureWriter(typeName, filter, transaction)
+    try {
+      while (writer.hasNext) {
+        writer.next()
+        writer.remove()
+      }
+    } finally {
+      writer.close()
+    }
   }
-}
 
-object MapReduceAccumuloFeatureStore {
-  val MAPRED_CLASSPATH_USER_PRECEDENCE_KEY = "mapreduce.task.classpath.user.precedence"
+  override def setTransaction(transaction: Transaction): Unit = {
+    require(transaction != null, "Transaction can't be null - did you mean Transaction.AUTO_COMMIT?")
+    this.transaction = transaction
+  }
+
+  override def getTransaction: Transaction = transaction
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriter.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriter.scala
@@ -8,6 +8,7 @@
 
 package org.locationtech.geomesa.accumulo.data
 
+import java.io.Flushable
 import java.util.concurrent.atomic.AtomicLong
 
 import com.typesafe.scalalogging.LazyLogging
@@ -17,7 +18,7 @@ import org.apache.accumulo.core.security.ColumnVisibility
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapred.RecordWriter
 import org.geotools.data.simple.SimpleFeatureWriter
-import org.geotools.data.{DataUtilities, Query}
+import org.geotools.data.{Query, Transaction}
 import org.geotools.factory.Hints
 import org.geotools.filter.identity.FeatureIdImpl
 import org.locationtech.geomesa.accumulo.GeomesaSystemProperties.FeatureIdProperties.FEATURE_ID_GENERATOR
@@ -119,7 +120,8 @@ object AccumuloFeatureWriter extends LazyLogging {
 abstract class AccumuloFeatureWriter(sft: SimpleFeatureType,
                                      encoder: SimpleFeatureSerializer,
                                      ds: AccumuloDataStore,
-                                     defaultVisibility: String) extends SimpleFeatureWriter with LazyLogging {
+                                     defaultVisibility: String)
+    extends SimpleFeatureWriter with Flushable with LazyLogging {
 
   protected val multiBWWriter = ds.connector.createMultiTableBatchWriter(GeoMesaBatchWriterConfig())
   protected val binEncoder = BinEncoder(sft)
@@ -144,15 +146,16 @@ abstract class AccumuloFeatureWriter(sft: SimpleFeatureType,
 
   override def getFeatureType: SimpleFeatureType = sft
 
-  override def close(): Unit = multiBWWriter.close()
-
-  override def remove(): Unit = {}
-
   override def hasNext: Boolean = false
 
-  def flush(): Unit = multiBWWriter.flush()
+  override def flush(): Unit = multiBWWriter.flush()
+
+  override def close(): Unit = multiBWWriter.close()
 }
 
+/**
+ * Appends new features - can't modify or delete existing features.
+ */
 class AppendAccumuloFeatureWriter(sft: SimpleFeatureType,
                                   encoder: SimpleFeatureSerializer,
                                   ds: AccumuloDataStore,
@@ -167,12 +170,18 @@ class AppendAccumuloFeatureWriter(sft: SimpleFeatureType,
       currentFeature = null
     }
 
+  override def remove(): Unit =
+    throw new UnsupportedOperationException("Use getFeatureWriter instead of getFeatureWriterAppend")
+
   override def next(): SimpleFeature = {
     currentFeature = new ScalaSimpleFeature(nextFeatureId, sft)
     currentFeature
   }
 }
 
+/**
+ * Modifies or deletes existing features. Per the data store api, does not allow appending new features.
+ */
 class ModifyAccumuloFeatureWriter(sft: SimpleFeatureType,
                                   encoder: SimpleFeatureSerializer,
                                   ds: AccumuloDataStore,
@@ -180,7 +189,7 @@ class ModifyAccumuloFeatureWriter(sft: SimpleFeatureType,
                                   filter: Filter)
   extends AccumuloFeatureWriter(sft, encoder, ds, defaultVisibility) {
 
-  val reader = ds.getFeatureReader(sft.getTypeName, new Query(sft.getTypeName, filter))
+  val reader = ds.getFeatureReader(new Query(sft.getTypeName, filter), Transaction.AUTO_COMMIT)
 
   var live: SimpleFeature = null      /* feature to let user modify   */
   var original: SimpleFeature = null  /* feature returned from reader */
@@ -214,16 +223,11 @@ class ModifyAccumuloFeatureWriter(sft: SimpleFeatureType,
     }
 
   override def next: SimpleFeature = {
-    original = null
-    live = if (hasNext) {
-      original = reader.next()
-      // set the use provided FID hint - allows user to update fid if desired,
-      // but if not we'll use the existing one
-      original.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
-      ScalaSimpleFeatureFactory.copyFeature(sft, original, original.getID) // this copies user data as well
-    } else {
-      ScalaSimpleFeatureFactory.buildFeature(sft, Seq.empty, nextFeatureId)
-    }
+    original = reader.next()
+    // set the use provided FID hint - allows user to update fid if desired,
+    // but if not we'll use the existing one
+    original.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+    live = ScalaSimpleFeatureFactory.copyFeature(sft, original, original.getID) // this copies user data as well
     live
   }
 
@@ -231,5 +235,4 @@ class ModifyAccumuloFeatureWriter(sft: SimpleFeatureType,
     super.close() // closes writer
     reader.close()
   }
-
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/GeoMesaMetadata.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/GeoMesaMetadata.scala
@@ -46,9 +46,12 @@ trait GeoMesaMetadata {
   def getTableSize(tableName: String): Long
 }
 
+trait HasGeoMesaMetadata {
+  def metadata: GeoMesaMetadata
+}
+
 class AccumuloBackedMetadata(connector: Connector,
                              catalogTable: String,
-                             writeVisibilities: String,
                              authorizationsProvider: AuthorizationsProvider)
     extends GeoMesaMetadata with LazyLogging {
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/package.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/package.scala
@@ -38,8 +38,6 @@ package object data {
   val SCHEMA_KEY             = "schema"
   val DTGFIELD_KEY           = "dtgfield"
   val FEATURE_ENCODING_KEY   = "featureEncoding"
-  val VISIBILITIES_KEY       = "visibilities"
-  val VISIBILITIES_CHECK_KEY = "visibilitiesCheck"
   val ST_IDX_TABLE_KEY       = "tables.idx.st.name"
   val ATTR_IDX_TABLE_KEY     = "tables.idx.attr.name"
   val RECORD_TABLE_KEY       = "tables.record.name"
@@ -61,8 +59,6 @@ package object data {
   val EMPTY_COLQ           = new Text(EMPTY_STRING)
   val EMPTY_VIZ            = new Text(EMPTY_STRING)
   val EMPTY_TEXT           = new Text()
-  val WHOLE_WORLD_BOUNDS   = "-180.0:180.0:-90.0:90.0"
-  val ALL_TIME_BOUNDS      = new Interval(new DateTime(0l), new DateTime())  // Epoch till now
   val DEFAULT_ENCODING     = SerializationType.KRYO
 
   // SimpleFeature Hints

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/stats/GeoMesaStats.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/stats/GeoMesaStats.scala
@@ -149,8 +149,7 @@ object GeoMesaStats {
 
   def decodeTimeBounds(value: String): Interval = {
     val longs = value.split(":").map(java.lang.Long.parseLong)
-    require(longs(0) <= longs(1))
-    require(longs.length == 2)
+    require(longs.length == 2 && longs(0) <= longs(1), s"Unexpected time bounds value found: $value")
     new Interval(longs(0), longs(1), DateTimeZone.UTC)
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/stats/GeoMesaStats.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/stats/GeoMesaStats.scala
@@ -1,0 +1,167 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.accumulo.data.stats
+
+import com.vividsolutions.jts.geom.Envelope
+import org.geotools.data.Query
+import org.geotools.geometry.jts.ReferencedEnvelope
+import org.joda.time.{DateTimeZone, Interval}
+import org.locationtech.geomesa.accumulo.data._
+import org.locationtech.geomesa.accumulo.data.tables.RecordTable
+import org.locationtech.geomesa.utils.geotools.{CRS_EPSG_4326, wholeWorldEnvelope}
+
+/**
+ * Tracks stats for a schema - spatial/temporal bounds, number of records, etc. Persistence of
+ * stats is not part of this trait, as different implementations will likely have different method signatures.
+ */
+trait GeoMesaStats {
+
+  /**
+   * Get rough bounds for a query
+   *
+   * @param query query
+   * @return bounds
+   */
+  def estimateBounds(query: Query): ReferencedEnvelope
+
+  /**
+   * Get rough time bounds for a query
+   *
+   * @param query query
+   * @return time bounds
+   */
+  def estimateTimeBounds(query: Query): Interval
+
+  /**
+   * Rough estimate of number of features
+   *
+   * @param query query
+   * @return count of features
+   */
+  def estimateCount(query: Query): Long
+}
+
+/**
+ * Tracks stats via entries stored in metadata
+ */
+trait GeoMesaMetadataStats extends GeoMesaStats {
+
+  this: AccumuloConnectorCreator with HasGeoMesaMetadata =>
+
+  import GeoMesaStats.{allTimeBounds, decodeSpatialBounds, decodeTimeBounds, encode}
+
+  /**
+   * Get rough bounds for a query
+   * Note: we don't currently filter by the cql
+   *
+   * @param query query
+   * @return bounds
+   */
+  override def estimateBounds(query: Query): ReferencedEnvelope =
+    readSpatialBounds(query.getTypeName)
+        .map(new ReferencedEnvelope(_, CRS_EPSG_4326))
+        .getOrElse(wholeWorldEnvelope)
+
+  /**
+   * Get rough time bounds for a query
+   * Note: we don't currently filter by the cql
+   *
+   * @param query query
+   * @return time bounds
+   */
+  override def estimateTimeBounds(query: Query): Interval =
+    readTimeBounds(query.getTypeName).getOrElse(allTimeBounds)
+
+  /**
+   * Rough estimate of number of features
+   * Note: we don't currently filter by the cql
+   *
+   * @param query query
+   * @return count of features
+   */
+  override def estimateCount(query: Query): Long =
+    metadata.getTableSize(getTableName(query.getTypeName, RecordTable))
+
+  /**
+   * Clears any existing spatial bounds
+   *
+   * @param typeName simple feature type
+   */
+  def clearSpatialBounds(typeName: String): Unit = metadata.insert(typeName, SPATIAL_BOUNDS_KEY, "")
+
+  /**
+   * Clears any existing temporal bounds
+   *
+   * @param typeName simple feature type
+   */
+  def clearTemporalBounds(typeName: String): Unit = metadata.insert(typeName, TEMPORAL_BOUNDS_KEY, "")
+
+  /**
+   * Writes spatial bounds for this feature
+   *
+   * @param typeName simple feature type
+   * @param bounds partial bounds - existing bounds will be expanded to include this
+   */
+  def writeSpatialBounds(typeName: String, bounds: Envelope): Unit = {
+    val toWrite = readSpatialBounds(typeName) match {
+      case None => Some(bounds)
+      case Some(current) =>
+        val expanded = new Envelope(current)
+        expanded.expandToInclude(bounds)
+        if (current == expanded) None else Some(expanded)
+    }
+    toWrite.foreach(b => metadata.insert(typeName, SPATIAL_BOUNDS_KEY, encode(b)))
+  }
+
+  /**
+   * Writes temporal bounds for this feature
+   *
+   * @param typeName simple feature type
+   * @param bounds partial bounds - existing bounds will be expanded to include this
+   */
+  def writeTemporalBounds(typeName: String, bounds: Interval): Unit = {
+    import org.locationtech.geomesa.utils.time.Time.RichInterval
+    val toWrite = readTimeBounds(typeName) match {
+      case None => Some(bounds)
+      case Some(current) =>
+        val expanded = current.expandByInterval(bounds)
+        if (current == expanded) None else Some(expanded)
+    }
+    toWrite.foreach(b => metadata.insert(typeName, TEMPORAL_BOUNDS_KEY, encode(b)))
+  }
+
+  private def readTimeBounds(typeName: String): Option[Interval] =
+    metadata.readNoCache(typeName, TEMPORAL_BOUNDS_KEY).filterNot(_.isEmpty).map(decodeTimeBounds)
+
+  private def readSpatialBounds(typeName: String): Option[Envelope] =
+    metadata.readNoCache(typeName, SPATIAL_BOUNDS_KEY).filterNot(_.isEmpty).map(decodeSpatialBounds)
+}
+
+object GeoMesaStats {
+
+  def allTimeBounds = new Interval(0L, System.currentTimeMillis(), DateTimeZone.UTC) // Epoch till now
+
+  def decodeTimeBounds(value: String): Interval = {
+    val longs = value.split(":").map(java.lang.Long.parseLong)
+    require(longs(0) <= longs(1))
+    require(longs.length == 2)
+    new Interval(longs(0), longs(1), DateTimeZone.UTC)
+  }
+
+  def decodeSpatialBounds(string: String): Envelope = {
+    val minMaxXY = string.split(":")
+    require(minMaxXY.size == 4)
+    new Envelope(minMaxXY(0).toDouble, minMaxXY(1).toDouble, minMaxXY(2).toDouble, minMaxXY(3).toDouble)
+  }
+
+  def encode(bounds: Interval): String = s"${bounds.getStartMillis}:${bounds.getEndMillis}"
+
+  def encode(bounds: Envelope): String =
+    Seq(bounds.getMinX, bounds.getMaxX, bounds.getMinY, bounds.getMaxY).mkString(":")
+}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/index.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/index.scala
@@ -82,6 +82,7 @@ package object index {
         Option(hints.get(TRANSFORM_SCHEMA).asInstanceOf[SimpleFeatureType])
       def getTransform: Option[(String, SimpleFeatureType)] =
         hints.getTransformDefinition.flatMap(d => hints.getTransformSchema.map((d, _)))
+      def isExactCount: Option[Boolean] = Option(hints.get(EXACT_COUNT).asInstanceOf[Boolean])
     }
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/java/org/locationtech/geomesa/accumulo/iterators/TimestampSetIteratorTest.java
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/java/org/locationtech/geomesa/accumulo/iterators/TimestampSetIteratorTest.java
@@ -8,7 +8,8 @@
 
 package org.locationtech.geomesa.accumulo.iterators;
 
-import junit.framework.Assert;
+
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TimestampSetIteratorTest {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithDataStore.scala
@@ -89,7 +89,7 @@ trait TestWithDataStore extends Specification {
 
   def explain(query: Query): String = {
     val o = new ExplainString
-    ds.explainQuery(query, o)
+    ds.getQueryPlan(query, explainer = o)
     o.toString()
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithMultipleSfts.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithMultipleSfts.scala
@@ -56,13 +56,11 @@ trait TestWithMultipleSfts extends Specification {
 
   def createNewSchema(spec: String,
                       dtgField: Option[String] = Some("dtg"),
-                      tableSharing: Boolean = true,
-                      numShards: Option[Int] = None): SimpleFeatureType = synchronized {
+                      tableSharing: Boolean = true): SimpleFeatureType = synchronized {
     val sftName = sftBaseName + sftCounter.getAndIncrement()
     val sft = SimpleFeatureTypes.createType(sftName, spec)
     dtgField.foreach(sft.setDtgField)
     sft.setTableSharing(tableSharing)
-    numShards.map(ds.buildDefaultSpatioTemporalSchema(sftName, _)).foreach(sft.setStIndexSchema)
     ds.createSchema(sft)
     sfts += ds.getSchema(sftName) // reload the sft from the ds to ensure all user data is set properly
     sfts.last
@@ -94,7 +92,7 @@ trait TestWithMultipleSfts extends Specification {
 
   def explain(query: Query): String = {
     val o = new ExplainString
-    ds.explainQuery(query, o)
+    ds.getQueryPlan(query, explainer = o)
     o.toString()
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreAuthTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreAuthTest.scala
@@ -72,9 +72,9 @@ class AccumuloDataStoreAuthTest extends Specification with TestWithDataStore {
           "tableName" -> sftName,
           "auths"     -> "user")).asInstanceOf[AccumuloDataStore]
         ds must not beNull;
-        ds.authorizationsProvider must beAnInstanceOf[FilteringAuthorizationsProvider]
-        ds.authorizationsProvider.asInstanceOf[FilteringAuthorizationsProvider].wrappedProvider must beAnInstanceOf[DefaultAuthorizationsProvider]
-        ds.authorizationsProvider.asInstanceOf[AuthorizationsProvider].getAuthorizations mustEqual new Authorizations("user")
+        ds.authProvider must beAnInstanceOf[FilteringAuthorizationsProvider]
+        ds.authProvider.asInstanceOf[FilteringAuthorizationsProvider].wrappedProvider must beAnInstanceOf[DefaultAuthorizationsProvider]
+        ds.authProvider.asInstanceOf[AuthorizationsProvider].getAuthorizations mustEqual new Authorizations("user")
       }
 
       "by comma-delimited static auths" >> {
@@ -84,9 +84,9 @@ class AccumuloDataStoreAuthTest extends Specification with TestWithDataStore {
           "tableName" -> sftName,
           "auths"     -> "user,admin,test")).asInstanceOf[AccumuloDataStore]
         ds must not beNull;
-        ds.authorizationsProvider must beAnInstanceOf[FilteringAuthorizationsProvider]
-        ds.authorizationsProvider.asInstanceOf[FilteringAuthorizationsProvider].wrappedProvider must beAnInstanceOf[DefaultAuthorizationsProvider]
-        ds.authorizationsProvider.asInstanceOf[AuthorizationsProvider].getAuthorizations mustEqual new Authorizations("user", "admin", "test")
+        ds.authProvider must beAnInstanceOf[FilteringAuthorizationsProvider]
+        ds.authProvider.asInstanceOf[FilteringAuthorizationsProvider].wrappedProvider must beAnInstanceOf[DefaultAuthorizationsProvider]
+        ds.authProvider.asInstanceOf[AuthorizationsProvider].getAuthorizations mustEqual new Authorizations("user", "admin", "test")
       }
 
       "fail when auth provider system property does not match an actual class" >> {
@@ -123,25 +123,6 @@ class AccumuloDataStoreAuthTest extends Specification with TestWithDataStore {
 
       written must not beNull;
       written.length mustEqual 1
-    }
-
-    "restrict users with insufficient auths from writing data" >> {
-      // create the data store
-      val ds = DataStoreFinder.getDataStore(Map(
-        "connector"    -> connector,
-        "tableName"    -> sftName,
-        "auths"        -> "user",
-        "visibilities" -> "user&admin")).asInstanceOf[AccumuloDataStore]
-      ds must not beNull
-
-      val sft = SimpleFeatureTypes.createType("cantwrite", spec)
-      ds.createSchema(sft)
-
-      // write some data
-      val fs = ds.getFeatureSource("cantwrite").asInstanceOf[AccumuloFeatureStore]
-      val feat = new ScalaSimpleFeature("1", sft)
-      feat.setAttribute("geom", "POINT(45 55)")
-      fs.addFeatures(new ListFeatureCollection(sft, List(feat))) must throwA[RuntimeException]
     }
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreDeleteTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreDeleteTest.scala
@@ -31,8 +31,8 @@ class AccumuloDataStoreDeleteTest extends Specification with TestWithMultipleSft
 
   lazy val tableOps = ds.connector.tableOperations()
 
-  def createFeature(tableSharing: Boolean, numShards: Option[Int] = None) = {
-    val sft = createNewSchema("name:String:index=true,*geom:Point:srid=4326,dtg:Date", Some("dtg"), tableSharing, numShards)
+  def createFeature(tableSharing: Boolean) = {
+    val sft = createNewSchema("name:String:index=true,*geom:Point:srid=4326,dtg:Date", Some("dtg"), tableSharing)
 
     // create a feature
     val builder = new SimpleFeatureBuilder(sft)
@@ -56,7 +56,7 @@ class AccumuloDataStoreDeleteTest extends Specification with TestWithMultipleSft
       forall(tableNames)(tableOps.exists(_) must beTrue)
 
       // tests that metadata exists in the catalog before being deleted
-      ds.getFeatureReader(typeName) must not(beNull)
+      ds.getFeatureReader(new Query(typeName), Transaction.AUTO_COMMIT) must not(beNull)
       ds.metadata.getFeatureTypes.toSeq must contain(typeName)
 
       // delete the schema
@@ -89,8 +89,8 @@ class AccumuloDataStoreDeleteTest extends Specification with TestWithMultipleSft
       forall(tableNames2)(tableOps.exists(_) must beTrue)
 
       // tests that metadata exists in the catalog before being deleted
-      ds.getFeatureReader(typeName1) should not(beNull)
-      ds.getFeatureReader(typeName2) should not(beNull)
+      ds.getFeatureReader(new Query(typeName1), Transaction.AUTO_COMMIT) should not(beNull)
+      ds.getFeatureReader(new Query(typeName2), Transaction.AUTO_COMMIT) should not(beNull)
       ds.metadata.getFeatureTypes.toSeq must contain(typeName1)
       ds.metadata.getFeatureTypes.toSeq must contain(typeName2)
 
@@ -135,8 +135,8 @@ class AccumuloDataStoreDeleteTest extends Specification with TestWithMultipleSft
     }
 
     "delete entries on a shared table" in {
-      val sft1 = createFeature(tableSharing = true, Some(10))
-      val sft2 = createFeature(tableSharing = true, Some(10))
+      val sft1 = createFeature(tableSharing = true)
+      val sft2 = createFeature(tableSharing = true)
 
       val builder1 = new SimpleFeatureBuilder(sft1)
       val builder2 = new SimpleFeatureBuilder(sft2)
@@ -165,8 +165,8 @@ class AccumuloDataStoreDeleteTest extends Specification with TestWithMultipleSft
       forall(tableNames2)(tableOps.exists(_) must beTrue)
 
       // tests that metadata exists in the catalog before being deleted
-      ds.getFeatureReader(typeName1) should not(beNull)
-      ds.getFeatureReader(typeName2) should not(beNull)
+      ds.getFeatureReader(new Query(typeName1), Transaction.AUTO_COMMIT) should not(beNull)
+      ds.getFeatureReader(new Query(typeName2), Transaction.AUTO_COMMIT) should not(beNull)
       ds.metadata.getFeatureTypes.toSeq must contain(typeName1)
       ds.metadata.getFeatureTypes.toSeq must contain(typeName2)
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
@@ -130,12 +130,12 @@ class AccumuloDataStoreQueryTest extends Specification with TestWithMultipleSfts
 
       val explainNull = {
         val o = new ExplainString
-        ds.explainQuery(queryNull, o)
+        ds.getQueryPlan(queryNull, explainer = o)
         o.toString()
       }
       val explainEmpty = {
         val o = new ExplainString
-        ds.explainQuery(queryEmpty, o)
+        ds.getQueryPlan(queryEmpty, explainer = o)
         o.toString()
       }
 
@@ -310,7 +310,7 @@ class AccumuloDataStoreQueryTest extends Specification with TestWithMultipleSfts
 
       def expectStrategy(strategy: String) = {
         val explain = new ExplainString
-        ds.explainQuery(query, explain)
+        ds.getQueryPlan(query, explainer = explain)
         explain.toString().split("\n").map(_.trim).filter(_.startsWith("Strategy 1 of 1:")) mustEqual Array(s"Strategy 1 of 1: $strategy")
         val res = ds.getFeatureSource(defaultSft.getTypeName).getFeatures(query).features().map(_.getID).toList
         res must containTheSameElementsAs(Seq("fid-1"))
@@ -355,7 +355,7 @@ class AccumuloDataStoreQueryTest extends Specification with TestWithMultipleSfts
       val query = new Query(defaultSft.getTypeName, filter)
 
       val out = new ExplainString()
-      ds.explainQuery(query, out)
+      ds.getQueryPlan(query, explainer = out)
 
       val explanation = out.toString()
       explanation must not be null

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTransformsTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTransformsTest.scala
@@ -121,7 +121,8 @@ class AccumuloDataStoreTransformsTest extends Specification with TestWithMultipl
       val sft = createNewSchema(spec)
       val sftName = sft.getTypeName
 
-      ds.setGeomesaVersion(sftName, 2)
+      ds.metadata.insert(sftName, VERSION_KEY, "2")
+      ds.metadata.expireCache(sftName)
 
       addFeatures(sft, createFeature(sft))
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
@@ -100,7 +100,7 @@ class AccumuloFeatureWriterTest extends Specification with TestWithDataStore wit
       c.add(AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("karen", 50.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid4"))
       c.add(AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("bob", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid5"))
 
-      val writer = ds.getFeatureWriter(sftName, Transaction.AUTO_COMMIT)
+      val writer = ds.getFeatureWriterAppend(sftName, Transaction.AUTO_COMMIT)
 
       c.foreach {f =>
         val writerCreatedFeature = writer.next()

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/BackCompatibilityTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/BackCompatibilityTest.scala
@@ -56,7 +56,8 @@ class BackCompatibilityTest extends Specification with TestWithMultipleSfts {
 
   def runVersionTest(version: Int) = {
     val sft = createNewSchema(spec)
-    ds.setGeomesaVersion(sft.getTypeName, version)
+    ds.metadata.insert(sft.getTypeName, VERSION_KEY, version.toString)
+    ds.metadata.expireCache(sft.getTypeName)
     addFeatures(sft, getTestFeatures(sft))
 
     val fs = ds.getFeatureSource(sft.getTypeName).asInstanceOf[AccumuloFeatureStore]

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/VisibilitiesTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/VisibilitiesTest.scala
@@ -82,7 +82,7 @@ class VisibilitiesTest extends Specification {
     "nonpriv should only be able to read a subset of features" in {
 
       "using ALL queries" in {
-        val reader = unprivDS.getFeatureReader(sftName, Query.ALL)
+        val reader = unprivDS.getFeatureReader(new Query(sftName), Transaction.AUTO_COMMIT)
         val readFeatures = reader.getIterator.toList
 
         readFeatures.size must be equalTo 3
@@ -108,7 +108,7 @@ class VisibilitiesTest extends Specification {
     "priv should be able to read all 6 features" in {
 
       "using ALL queries" in {
-        val reader = ds.getFeatureReader(sftName, Query.ALL)
+        val reader = ds.getFeatureReader(new Query(sftName), Transaction.AUTO_COMMIT)
         val readFeatures = reader.getIterator.toList
         readFeatures.size must be equalTo 6
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/AttributeIndexFilteringIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/AttributeIndexFilteringIteratorTest.scala
@@ -50,7 +50,7 @@ class AttributeIndexFilteringIteratorTest extends Specification with TestWithDat
 
   def checkStrategies[T](query: Query, clas: Class[T]) = {
     val out = new ExplainString
-    ds.explainQuery(query, out)
+    ds.getQueryPlan(query, explainer = out)
     val lines = out.toString().split("\n").map(_.trim).filter(_.startsWith("Strategy 1 of 1:"))
     lines must haveLength(1)
     lines.head must contain(clas.getSimpleName)

--- a/geomesa-features/geomesa-feature-kryo/src/test/java/org/locationtech/geomesa/features/interop/SerializationOptionsTest.java
+++ b/geomesa-features/geomesa-feature-kryo/src/test/java/org/locationtech/geomesa/features/interop/SerializationOptionsTest.java
@@ -9,8 +9,8 @@
 package org.locationtech.geomesa.features.interop;
 
 import com.vividsolutions.jts.geom.Point;
-import org.junit.Assert;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.junit.Assert;
 import org.junit.Test;
 import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer;
 import org.locationtech.geomesa.utils.interop.SimpleFeatureTypes;

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/index/AttributeIndexJob.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/index/AttributeIndexJob.scala
@@ -145,7 +145,7 @@ class AttributeMapper extends Mapper[Text, SimpleFeature, Text, Mutation] {
       d.setIndexCoverage(if (attributes.contains(d.getLocalName)) coverage else IndexCoverage.NONE)
     }
 
-    visibilities = ds.writeVisibilities
+    visibilities = ds.defaultVisibilities
     val encoding = ds.getFeatureEncoding(sft)
     featureEncoder = SimpleFeatureSerializers(sft, encoding)
     indexValueEncoder = IndexValueEncoder(sft)

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaOutputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaOutputFormat.scala
@@ -127,7 +127,7 @@ class GeoMesaRecordWriter(params: Map[String, String], delegate: RecordWriter[Te
     val encoder = encoderCache.getOrElseUpdate(sftName, SimpleFeatureSerializers(sft, ds.getFeatureEncoding(sft)))
     val ive = indexEncoderCache.getOrElseUpdate(sftName, IndexValueEncoder(sft))
     val binEncoder = binEncoderCache.getOrElseUpdate(sftName, BinEncoder(sft))
-    val featureToWrite = new FeatureToWrite(withFid, ds.writeVisibilities, encoder, ive, binEncoder)
+    val featureToWrite = new FeatureToWrite(withFid, ds.defaultVisibilities, encoder, ive, binEncoder)
 
     // calculate all the mutations first, so that if something fails we won't have a partially written feature
     try {

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaOutputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaOutputFormat.scala
@@ -139,7 +139,7 @@ class GeoMesaRecordWriter(params: Map[String, String],
     val encoder = encoderCache.getOrElseUpdate(sftName, SimpleFeatureSerializers(sft, ds.getFeatureEncoding(sft)))
     val ive = indexEncoderCache.getOrElseUpdate(sftName, IndexValueEncoder(sft))
     val binEncoder = binEncoderCache.getOrElseUpdate(sftName, BinEncoder(sft))
-    val featureToWrite = new FeatureToWrite(withFid, ds.writeVisibilities, encoder, ive, binEncoder)
+    val featureToWrite = new FeatureToWrite(withFid, ds.defaultVisibilities, encoder, ive, binEncoder)
 
     // calculate all the mutations first, so that if something fails we won't have a partially written feature
     try {

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/ExplainCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/commands/ExplainCommand.scala
@@ -12,6 +12,7 @@ import com.beust.jcommander.{JCommander, Parameters}
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.data.Query
 import org.geotools.filter.text.ecql.ECQL
+import org.locationtech.geomesa.accumulo.index.ExplainPrintln
 import org.locationtech.geomesa.tools.commands.ExplainCommand.ExplainParameters
 
 class ExplainCommand(parent: JCommander) extends CommandWithCatalog(parent) with LazyLogging {
@@ -21,7 +22,7 @@ class ExplainCommand(parent: JCommander) extends CommandWithCatalog(parent) with
   override def execute() =
     try {
       val q = new Query(params.featureName, ECQL.toFilter(params.cqlFilter))
-      ds.explainQuery(q)
+      ds.getQueryPlan(q, explainer = new ExplainPrintln)
     } catch {
       case e: Exception =>
         logger.error(s"Error: Could not explain the query (${params.cqlFilter}): ${e.getMessage}", e)

--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/ShpIngestTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/ShpIngestTest.scala
@@ -17,7 +17,6 @@ import org.geotools.data.Transaction
 import org.geotools.data.shapefile.ShapefileDataStoreFactory
 import org.geotools.factory.Hints
 import org.geotools.geometry.jts.JTSFactoryFinder
-import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.tools.commands.IngestCommand.IngestParameters
 import org.locationtech.geomesa.utils.geotools.Conversions._
@@ -86,10 +85,6 @@ class ShpIngestTest extends Specification {
       bounds.getMinY mustEqual minY
       bounds.getMaxY mustEqual maxY
 
-      val timeBounds = ds.getTimeBounds("shpingest")
-      timeBounds.getStart mustEqual new DateTime(minDate)
-      timeBounds.getEnd mustEqual new DateTime(maxDate)
-
       val result = fs.getFeatures.features().toList
       result.length mustEqual 2
     }
@@ -99,10 +94,6 @@ class ShpIngestTest extends Specification {
       GeneralShapefileIngest.shpToDataStore(ingestParams.files(0), ds, ingestParams.featureName)
 
       val fs = ds.getFeatureSource("changed")
-
-      val timeBounds = ds.getTimeBounds("changed")
-      timeBounds.getStart mustEqual new DateTime(minDate)
-      timeBounds.getEnd mustEqual new DateTime(maxDate)
 
       val bounds = fs.getBounds
       bounds.getMinX mustEqual minX

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/FeatureUtils.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/FeatureUtils.scala
@@ -8,13 +8,13 @@
 
 package org.locationtech.geomesa.utils.geotools
 
-import org.geotools.data.{FeatureWriter, DataUtilities}
-import org.geotools.data.simple.SimpleFeatureWriter
+import java.lang.{Boolean => jBoolean}
+
+import org.geotools.data.{DataUtilities, FeatureWriter}
 import org.geotools.factory.Hints
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.geotools.filter.identity.FeatureIdImpl
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
-import java.lang.{Boolean => jBoolean}
 
 /** Utilities for re-typing and re-building [[SimpleFeatureType]]s and [[SimpleFeature]]s while
   * preserving user data which the standard Geo Tools utilities do not do.

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/FeatureUtils.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/FeatureUtils.scala
@@ -8,9 +8,13 @@
 
 package org.locationtech.geomesa.utils.geotools
 
-import org.geotools.data.DataUtilities
+import org.geotools.data.{FeatureWriter, DataUtilities}
+import org.geotools.data.simple.SimpleFeatureWriter
+import org.geotools.factory.Hints
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder
+import org.geotools.filter.identity.FeatureIdImpl
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import java.lang.{Boolean => jBoolean}
 
 /** Utilities for re-typing and re-building [[SimpleFeatureType]]s and [[SimpleFeature]]s while
   * preserving user data which the standard Geo Tools utilities do not do.
@@ -59,5 +63,18 @@ object FeatureUtils {
 
     builder.init(orig)
     builder
+  }
+
+  def copyToWriter(writer: FeatureWriter[SimpleFeatureType, SimpleFeature],
+                   sf: SimpleFeature,
+                   overrideFid: Boolean = false): SimpleFeature = {
+    val toWrite = writer.next()
+    toWrite.setAttributes(sf.getAttributes)
+    toWrite.getUserData.putAll(sf.getUserData)
+    if (overrideFid || jBoolean.TRUE == sf.getUserData.get(Hints.USE_PROVIDED_FID).asInstanceOf[jBoolean]) {
+      toWrite.getIdentifier.asInstanceOf[FeatureIdImpl].setID(sf.getID)
+      toWrite.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+    }
+    toWrite
   }
 }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/package.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/package.scala
@@ -11,6 +11,7 @@ package org.locationtech.geomesa.utils
 import org.geotools.data.FeatureReader
 import org.geotools.data.collection.DelegateFeatureReader
 import org.geotools.feature.collection.DelegateFeatureIterator
+import org.geotools.geometry.jts.ReferencedEnvelope
 import org.geotools.referencing.CRS
 import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.joda.time.format.DateTimeFormat
@@ -21,6 +22,8 @@ import scala.util.Try
 package object geotools {
   // use the epsg jar if it's available (e.g. in geoserver), otherwise use the less-rich constant
   val CRS_EPSG_4326 = try { CRS.decode("EPSG:4326") } catch { case t: Throwable => DefaultGeographicCRS.WGS84 }
+  // we make this a function, as envelopes are mutable
+  def wholeWorldEnvelope = new ReferencedEnvelope(-180, 180, -90, 90, CRS_EPSG_4326)
   // date format with geotools pattern
   val GeoToolsDateFormat = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZoneUTC()
 

--- a/geomesa-web/geomesa-web-data/src/main/scala/org/locationtech/geomesa/web/analytics/StatsEndpoint.scala
+++ b/geomesa-web/geomesa-web-data/src/main/scala/org/locationtech/geomesa/web/analytics/StatsEndpoint.scala
@@ -13,7 +13,7 @@ import org.joda.time.Interval
 import org.joda.time.format.ISODateTimeFormat
 import org.json4s.{DefaultFormats, Formats}
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
-import org.locationtech.geomesa.accumulo.stats.QueryStatReader
+import org.locationtech.geomesa.accumulo.stats.{QueryStat, QueryStatReader}
 import org.locationtech.geomesa.utils.cache.FilePersistence
 import org.locationtech.geomesa.web.core.GeoMesaDataStoreServlet
 import org.scalatra.BadRequest
@@ -62,10 +62,13 @@ class StatsEndpoint(val persistence: FilePersistence) extends GeoMesaDataStoreSe
         }
         BadRequest(reason = reason.toString())
       } else {
-        val reader = new QueryStatReader(ds.connector, ds.getQueriesTableName(_: String))
+        val getTable = (typeName: String) => {
+          ds.getStatTable(new QueryStat(typeName, 0L, "", "", "", 0L, 0L, 0))
+        }
+        val reader = new QueryStatReader(ds.connector, getTable)
         val interval = new Interval(dates(0), dates(1))
         // json response doesn't seem to handle iterators directly, have to convert to iterable
-        val iter = reader.query(sft, interval, ds.authorizationsProvider.getAuthorizations).toIterable
+        val iter = reader.query(sft, interval, ds.authProvider.getAuthorizations).toIterable
         // we do the user filtering here, instead of in the tservers - revisit if performance becomes an issue
         // 'user' appears to be reserved by scalatra
         params.get("who") match {


### PR DESCRIPTION
* Reorganized AccumuloDataStore methods
  * Moved bounds logic into separate trait
  * Separated GeoTools methods vs GeoMesa methods
  * Separated public vs private methods
* Removed visibility checks for writing data - OBE due to feature level visibility
* Removed calculation of spatial bounds when adding feature collections - not used

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>