### PR TITLE
Java 8: Remove -XX:MaxPermSize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ jdk:
   - oraclejdk8
 
 script:
-  - export MAVEN_OPTS="-Xmx1g -XX:MaxPermSize=512m -Djava.net.preferIPv4Stack=true"
+  - export MAVEN_OPTS="-Xmx1g -Djava.net.preferIPv4Stack=true"
   - ./.travisbuild.sh

--- a/build/mvn
+++ b/build/mvn
@@ -22,7 +22,7 @@ _DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Preserve the calling directory
 _CALLING_DIR="$(pwd)"
 # Options used during compilation
-_COMPILE_JVM_OPTS="-Xmx8g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512m"
+_COMPILE_JVM_OPTS="-Xmx8g -XX:ReservedCodeCacheSize=512m"
 
 # Installs any application tarball given a URL, the expected tarball name,
 # and, optionally, a checkable binary path to determine if the binary has


### PR DESCRIPTION
As Java 8 is the minimum supported version, there is no reason to have -XX:MaxPermSize, as support for this parameter was dropped for Java 8.

This change mostly just reduces unnecessary build/runtime messages along the lines of
```
[WARNING] Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=512m; support was removed in 8.0
```
