### PR TITLE
GEOMESA-1175 Doc fixes for 1.2.2 release.

### DIFF
--- a/docs/_static/css/theme_custom.css
+++ b/docs/_static/css/theme_custom.css
@@ -1,3 +1,234 @@
 @import url("theme.css");
 
 /* Add overrides of theme.css rules below */
+body {
+   color: #bbb;
+}
+
+.wy-alert.wy-alert-neutral a,.rst-content .wy-alert-neutral.note a,.rst-content .wy-alert-neutral.attention a,.rst-content .wy-alert-neutral.caution a,.rst-content .wy-alert-neutral.danger a,.rst-content .wy-alert-neutral.error a,.rst-content .wy-alert-neutral.hint a,.rst-content .wy-alert-neutral.important a,.rst-content .wy-alert-neutral.tip a,.rst-content .wy-alert-neutral.warning a,.rst-content .wy-alert-neutral.seealso a,.rst-content .wy-alert-neutral.admonition-todo a {
+   color: #E6A150
+}
+
+.wy-tray-container li.wy-tray-item-info {
+   background: #E6A150
+}
+
+.wy-tray-container li.wy-tray-item-danger {
+   background: #E6A160
+}
+
+.btn-info {
+   background-color: #E6A150 !important
+}
+
+.btn-danger {
+   background-color: #E6A160 !important
+}
+
+.btn-link {
+   color: #E6A150;
+}
+
+.wy-dropdown-menu {
+   background: #333;
+}
+
+.wy-dropdown-menu>dd>a:hover {
+   background: #E6A150;
+}
+
+.wy-dropdown-menu>dd>a:hover {
+   background: #E6A150;
+}
+
+.wy-dropdown.wy-dropdown-bubble .wy-dropdown-menu {
+   background: #333;
+}
+
+.wy-dropdown.wy-dropdown-bubble .wy-dropdown-menu a:hover {
+   background: #E6A150;
+}
+
+.wy-control-group.wy-control-group-required>label:after {
+   color: #E6A160
+}
+
+input:focus:invalid,textarea:focus:invalid,select:focus:invalid {
+   color: #E6A160;
+   border: 1px solid #E6A160
+}
+
+input:focus:invalid:focus,textarea:focus:invalid:focus,select:focus:invalid:focus {
+   border-color: #E6A160
+}
+
+input[type="file"]:focus:invalid:focus,input[type="radio"]:focus:invalid:focus,input[type="checkbox"]:focus:invalid:focus {
+   outline-color: #E6A160
+}
+
+.wy-control-group.wy-control-group-error .wy-form-message,.wy-control-group.wy-control-group-error>label {
+   color: #E6A160
+}
+
+.wy-control-group.wy-control-group-error input[type="text"],.wy-control-group.wy-control-group-error input[type="password"],.wy-control-group.wy-control-group-error input[type="email"],.wy-control-group.wy-control-group-error input[type="url"],.wy-control-group.wy-control-group-error input[type="date"],.wy-control-group.wy-control-group-error input[type="month"],.wy-control-group.wy-control-group-error input[type="time"],.wy-control-group.wy-control-group-error input[type="datetime"],.wy-control-group.wy-control-group-error input[type="datetime-local"],.wy-control-group.wy-control-group-error input[type="week"],.wy-control-group.wy-control-group-error input[type="number"],.wy-control-group.wy-control-group-error input[type="search"],.wy-control-group.wy-control-group-error input[type="tel"],.wy-control-group.wy-control-group-error input[type="color"] {
+   border: solid 1px #E6A160
+}
+
+.wy-control-group.wy-control-group-error textarea {
+   border: solid 1px #E6A160
+}
+
+.wy-inline-validate.wy-inline-validate-danger .wy-input-context {
+   color: #E6A160
+}
+
+.wy-inline-validate.wy-inline-validate-info .wy-input-context {
+   color: #E6A150
+}
+
+.wy-text-info {
+   color: #E6A150 !important
+}
+
+.wy-text-danger {
+   color: #E6A160 !important
+}
+
+code,.rst-content tt,.rst-content code {
+   color: #E6A160;
+}
+
+.wy-menu-vertical li.on a,.wy-menu-vertical li.current>a {
+   background: #333;
+}
+
+.wy-menu-vertical li.on a:hover,.wy-menu-vertical li.current>a:hover {
+   background: #333
+}
+
+.wy-menu-vertical a:active {
+   background-color: #E6A150;
+}
+
+.wy-side-nav-search {
+   background-color: #E6A150;
+   color: #333;
+}
+
+.wy-side-nav-search img {
+   background-color: #E6A150;
+}
+
+.wy-side-nav-search>a,.wy-side-nav-search .wy-dropdown>a {
+   color: #333;
+}
+
+.wy-side-nav-search>div.version {
+   color: #666;
+}
+
+.wy-nav .wy-menu-vertical header {
+   color: #E6A150
+}
+
+.wy-nav .wy-menu-vertical a:hover {
+   background-color: #E6A150;
+}
+
+.wy-body-for-nav {
+   background: left repeat-y #333;
+}
+
+.wy-nav-top {
+   background: #E6A150;
+}
+
+.wy-nav-top img {
+   background-color: #E6A150;
+}
+
+.wy-nav-content {
+   background: #333;
+}
+
+.wy-nav-content-wrap {
+   background: #333;
+}
+
+@media screen and (max-width: 768px) {
+    .wy-body-for-nav {
+        background: #333
+    }
+    .wy-nav-content {
+        background: #333
+    }
+}
+
+.rst-versions {
+   color: #333;
+}
+
+.rst-versions a {
+   color: #E6A150;
+}
+
+.rst-versions .rst-current-version .fa,.rst-versions .rst-current-version .wy-menu-vertical li span.toctree-expand,.wy-menu-vertical li .rst-versions .rst-current-version span.toctree-expand,.rst-versions .rst-current-version .rst-content .admonition-title,.rst-content .rst-versions .rst-current-version .admonition-title,.rst-versions .rst-current-version .rst-content h1 .headerlink,.rst-content h1 .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content h2 .headerlink,.rst-content h2 .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content h3 .headerlink,.rst-content h3 .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content h4 .headerlink,.rst-content h4 .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content h5 .headerlink,.rst-content h5 .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content h6 .headerlink,.rst-content h6 .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content dl dt .headerlink,.rst-content dl dt .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content p.caption .headerlink,.rst-content p.caption .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content tt.download span:first-child,.rst-content tt.download .rst-versions .rst-current-version span:first-child,.rst-versions .rst-current-version .rst-content code.download span:first-child,.rst-content code.download .rst-versions .rst-current-version span:first-child,.rst-versions .rst-current-version .icon {
+   color: #333
+}
+
+.rst-versions .rst-current-version.rst-out-of-date {
+   background-color: #E6A160;
+}
+
+.rst-versions .rst-other-versions dd a {
+   color: #333
+}
+
+.rst-content tt.literal,.rst-content tt.literal,.rst-content code.literal {
+   color: #E6A160
+}
+.rst-content a tt,.rst-content a tt,.rst-content a code {
+   color: #E6A150
+}
+
+.rst-content dl:not(.docutils) dt {
+   color: #E6A150;
+}
+
+a {
+   color: #e6a150;
+}
+
+a:visited {
+   color: #e6a150;
+}
+
+a:hover {
+   color: #e6a150;
+}
+
+a.icon-home {
+   color: #333;
+}
+
+a.icon-home:hover {
+   color: #333; /* i.e. for the house icon and "GeoMesa" in the top, don't change color when visited */
+}
+
+a.icon-home:visited {
+   color: #333; /* i.e. for the house icon and "GeoMesa" in the top, don't change color when visited */
+}
+
+.pre {
+   background: #444;
+}
+
+code.docutils {
+   background: #444;
+}
+
+code.literal {
+   background: #444;
+}
+
+.wy-menu-vertical li.current > a { color: #777; } 

--- a/docs/common.py
+++ b/docs/common.py
@@ -59,11 +59,11 @@ author = u''
 #
 # version: The short X.Y version.
 # release: The full version, including alpha/beta/rc tags.
-release = '1.2.1'
-version = '1.2.1'
+release = '1.2.2'
+version = '1.2.2'
 
 release_1_1 = '1.1.0-rc.7'
-version_devel = '1.2.2-SNAPSHOT'
+version_devel = '1.2.3-SNAPSHOT'
 
 # RST appended to every file. Used for global substitions.
 # (the "%(release)s" substitutions are done by the Python format() method

--- a/docs/user/installation_and_configuration.rst
+++ b/docs/user/installation_and_configuration.rst
@@ -476,8 +476,8 @@ is printed out when you start GeoServer::
     - GEOSERVER_DATA_DIR: /opt/devel/install/geoserver-data-dir
     ----------------------------------
 
-Note about Apache Commons Collections
--------------------------------------
+Apache Commons Collections
+--------------------------
 
 Version 3.2.1 and earlier of the Apache Commons Collections library have a CVSS 10.0 vulnerability.  Read more `here
 https://commons.apache.org/proper/commons-collections/security-reports.html`__.

--- a/docs/user/installation_and_configuration.rst
+++ b/docs/user/installation_and_configuration.rst
@@ -124,13 +124,26 @@ In the ``geomesa-tools-$VERSION`` directory, run ``bin/geomesa configure`` to se
 
 Update and re-source your ``~/.bashrc`` file to include the ``$GEOMESA_HOME`` and ``$PATH`` updates.
 
-
 .. warning::
 
     Please note that the ``$GEOMESA_HOME`` variable points to the location of the ``geomesa-tools-$VERSION``
     directory, not the main geomesa binary distribution directory!
 
-Due to licensing restrictions, dependencies for shape file support and raster 
+.. note::
+
+    ``geomesa`` will read the ``$ACCUMULO_HOME`` and ``$HADOOP_HOME`` environment variables to load the
+    appropriate JAR files for Hadoop, Accumulo, Zookeeper, and Thrift. If possible, we recommend
+    installing the tools on the Accumulo master server, as you may also need various configuration
+    files from Hadoop/Accumulo in order to run certain commands. Use the ``geomesa classpath``
+    command in order to see what JARs are being used.
+
+    If you are running the tools on a system without
+    Accumulo installed and configured, the ``install-hadoop-accumulo.sh`` script
+    in the ``bin`` directory may be used to download the needed Hadoop/Accumulo JARs into
+    the ``lib`` directory. You should edit this script to match the versions used by your
+    installation.
+
+Due to licensing restrictions, dependencies for shape file support and raster
 ingest must be separately installed. Do this with the following commands: 
 
 .. code-block:: bash

--- a/docs/user/installation_and_configuration.rst
+++ b/docs/user/installation_and_configuration.rst
@@ -237,8 +237,12 @@ namespace in the Accumulo shell:
     $ accumulo shell -u root
     > createnamespace myNamespace
     > grant NameSpace.CREATE_TABLE -ns myNamespace -u myUser
-    > config -s general.vfs.context.classpath.myNamespace=hdfs://NAME_NODE_FDQN:8020/accumulo/classpath/myNamespace/[^.]
+    > config -s general.vfs.context.classpath.myNamespace=hdfs://NAME_NODE_FDQN:54310/accumulo/classpath/myNamespace/[^.].*.jar
     > config -ns myNamespace -s table.classpath.context=myNamespace
+
+.. note::
+
+    Depending on Hadoop version, you may need to use ``hdfs://NAME_NODE_FDQN:8020``.
 
 Then copy the distributed runtime jar into HDFS under the path you specified.
 The path above is just an example; you can included nested folders with project

--- a/docs/user/installation_and_configuration.rst
+++ b/docs/user/installation_and_configuration.rst
@@ -137,7 +137,6 @@ ingest must be separately installed. Do this with the following commands:
 
     $ bin/install-jai
     $ bin/install-jline
-    $ bin/install-vecmath
 
 Test the command that invokes the GeoMesa Tools:
 

--- a/docs/user/installation_and_configuration.rst
+++ b/docs/user/installation_and_configuration.rst
@@ -475,3 +475,12 @@ is printed out when you start GeoServer::
     ----------------------------------
     - GEOSERVER_DATA_DIR: /opt/devel/install/geoserver-data-dir
     ----------------------------------
+
+Note about Apache Commons Collections
+-------------------------------------
+
+Version 3.2.1 and earlier of the Apache Commons Collections library have a CVSS 10.0 vulnerability.  Read more `here
+https://commons.apache.org/proper/commons-collections/security-reports.html`__.
+
+Note that Accumulo 1.6.5 is the first version of Accumulo which addresses this security concern.
+Fixes for the GeoServer project will be available in versions 2.8.3+ and 2.9.0+.

--- a/geomesa-tools/README.md
+++ b/geomesa-tools/README.md
@@ -9,22 +9,26 @@ To begin using the command line tools, first build the full GeoMesa project from
 
     mvn clean install
     
-You can also make the build process significantly faster by adding `-DskipTests`. This will create a file "geomesa-{version}-bin.tar.gz"
-in the geomesa-assemble/target directory. Untar this file with
+You can also make the build process significantly faster by adding `-DskipTests`. This will create a file called ``geomesa-tools-{version}-bin.tar.gz``
+in the ``geomesa-tools/target`` directory. Untar this file with
 
-    tar xvfz geomesa-assemble/target/geomesa-${version}-bin.tar.gz
+    tar xvfz geomesa-tools/target/geomesa-tools-${version}-bin.tar.gz
     
 Next, `cd` into the newly created directory with
     
-    cd geomesa-${version}
+    cd geomesa-tools-${version}
 
 GeoMesa Tools relies on a GEOMESA_HOME environment variable. Running
     
     . bin/geomesa configure
 
-with the `. ` prefix will set this for you, add $GEOMESA_HOME/bin to your PATH, and source your new environment variables in your current shell session.
+with the `. ` prefix will set this for you, add $GEOMESA_HOME/bin to your PATH, and source your new environment variables in your current shell session. Now you should be able to use GeoMesa from any directory on your computer.
 
-Now, you should be able to use GeoMesa from any directory on your computer. To test, `cd` to a different directory and run:
+Note: the tools will read the ACCUMULO_HOME and HADOOP_HOME environment variables to load the appropriate JAR files for Hadoop, Accumulo, Zookeeper, and Thrift. If possible, we recommend installing the tools on the Accumulo master server, as you may also need various configuration files from Hadoop/Accumulo in order to run certain commands. Use the ``geomesa classpath`` command in order to see what JARs are being used.
+
+If you are running the tools on a system without Accumulo installed and configured, the ``install-hadoop-accumulo.sh`` script in the ``bin`` directory may be used to download the needed Hadoop/Accumulo JARs into the ``lib`` directory. You should edit this script to match the versions used by your installation. 
+
+To test, `cd` to a different directory and run:
 
     geomesa
 

--- a/geomesa-tools/README.md
+++ b/geomesa-tools/README.md
@@ -20,11 +20,11 @@ Next, `cd` into the newly created directory with
 
 GeoMesa Tools relies on a GEOMESA_HOME environment variable. Running
     
-    . bin/geomesa configure
+    source bin/geomesa configure
 
-with the `. ` prefix will set this for you, add $GEOMESA_HOME/bin to your PATH, and source your new environment variables in your current shell session. Now you should be able to use GeoMesa from any directory on your computer.
+with the `source` shell function will set this for you, add $GEOMESA_HOME/bin to your PATH, and set your new environment variables in your current shell session. Now you should be able to use GeoMesa from any directory on your computer.
 
-Note: the tools will read the ACCUMULO_HOME and HADOOP_HOME environment variables to load the appropriate JAR files for Hadoop, Accumulo, Zookeeper, and Thrift. If possible, we recommend installing the tools on the Accumulo master server, as you may also need various configuration files from Hadoop/Accumulo in order to run certain commands. Use the ``geomesa classpath`` command in order to see what JARs are being used.
+Note: The tools will read the ACCUMULO_HOME and HADOOP_HOME environment variables to load the appropriate JAR files for Hadoop, Accumulo, Zookeeper, and Thrift. If possible, we recommend installing the tools on the Accumulo master server, as you may also need various configuration files from Hadoop/Accumulo in order to run certain commands. Use the ``geomesa classpath`` command in order to see what JARs are being used.
 
 If you are running the tools on a system without Accumulo installed and configured, the ``install-hadoop-accumulo.sh`` script in the ``bin`` directory may be used to download the needed Hadoop/Accumulo JARs into the ``lib`` directory. You should edit this script to match the versions used by your installation. 
 
@@ -132,14 +132,14 @@ Due to licensing restrictions, a number of necessary dependencies required for r
     </dependency>
 
 
-To install, you can either locate the jar files or run the following included script which will attempt to wget and install the jars.
+To install, you can either locate the JAR files or run the following included script which will attempt to wget and install the JARs.
 
 `$GEOMESA_HOME/bin/install-jai`
  
 ###Logging configuration
 GeoMesa tools comes bundled by default with an slf4j implementation that is installed to the $GEOMESA_HOME/lib directory
  named `slf4j-log4j12-1.7.5.jar` If you already have an slf4j implementation installed on your Java Classpath you may
- see errors at runtime and will have to exclude one of the jars. This can be done by simply renaming the bundled
+ see errors at runtime and will have to exclude one of the JARs. This can be done by simply renaming the bundled
  `slf4j-log4j12-1.7.5.jar` file to `slf4j-log4j12-1.7.5.jar.exclude`
  
 Note that if no slf4j implementation is installed you will see this error:
@@ -525,7 +525,7 @@ can be either local or in HDFS. You cannot mix target files (e.g. local and HDFS
 Converters and SFTs are specified in HOCON format (https://github.com/typesafehub/config/blob/master/HOCON.md) and 
 loaded using TypeSafe config. They can be referenced by name using the ``-s`` and ``-C`` args.
 
-To define new converters for the users can package a ``reference.conf`` file inside a jar and drop it in the 
+To define new converters for the users can package a ``reference.conf`` file inside a JAR and drop it in the 
 ``$GEOMESA_HOME/lib`` directory or add config definitions to the ``$GEOMESA_TOOLS/conf/application.conf`` file which 
 includes some examples. SFT and Converter specifications should use the path prefixes 
 ``geomesa.converters.<convertername>`` and ``geomesa.sfts.<typename>``

--- a/geomesa-tools/README.md
+++ b/geomesa-tools/README.md
@@ -100,7 +100,7 @@ This library can be downloaded from your local nexus repo or `http://download.ja
 To install, copy the jai_core.jar and jai_codec.jar into `$GEOMESA_HOME/lib/`
 
 Optionally there is a script bundled as `$GEOMESA_HOME/bin/install-jai` that will attempt to wget and install 
-the jai libraries
+the jai libraries.
 
 
 ### Enabling Raster Ingest
@@ -126,19 +126,12 @@ Due to licensing restrictions, a number of necessary dependencies required for r
         <artifactId>jai_imageio</artifactId>
         <version>1.1</version>
     </dependency>
-    <dependency>
-        <groupId>java3d</groupId>
-        <artifactId>vecmath</artifactId>
-        <version>1.3.2</version>
-    </dependency>
 
 
-To install, you can either locate the jar files or run the two following included scripts which will attempt to wget and install the jars.
+To install, you can either locate the jar files or run the following included script which will attempt to wget and install the jars.
 
 `$GEOMESA_HOME/bin/install-jai`
  
-`$GEOMESA_HOME/bin/install-vecmath`
-
 ###Logging configuration
 GeoMesa tools comes bundled by default with an slf4j implementation that is installed to the $GEOMESA_HOME/lib directory
  named `slf4j-log4j12-1.7.5.jar` If you already have an slf4j implementation installed on your Java Classpath you may
@@ -484,7 +477,7 @@ Gets an existing simple feature type as an encoded string.
     geomesa getsft -u username -p password -c test_catalog -f test_feature -i instance
 
 ### ingest
-Ingests various file formats into GeoMesa using the GeoMesa Converter Framework. CConverters are specified in HOCON 
+Ingests various file formats into GeoMesa using the GeoMesa Converter Framework. Converters are specified in HOCON 
 format (https://github.com/typesafehub/config/blob/master/HOCON.md). GeoMesa defines several common converter factories 
 for formats such as delimited text (TSV, CSV), fixed width files, JSON, XML, and Avro. New converter factories (e.g. 
 for custom binary formats) can be registered on the classpath using Java SPI. Shapefile ingest is also supported. Files 


### PR DESCRIPTION
* Update settings in common.py.
* Remove references to vecmath.
* Update Kafka tutorial with feature listener and load tester.

Signed-off-by: Matthew Zimmerman <matt.zimmerman@ccri.com>