### PR TITLE
GEOMESA-1204 Use LocationTech/Eclipse Jar signing

### DIFF
--- a/docs/common.py
+++ b/docs/common.py
@@ -74,6 +74,12 @@ rst_epilog = """
 
 .. |release_source_tarball| replace:: https://github.com/locationtech/geomesa/archive/geomesa-%(release)s.tar.gz
 
+.. |eclipse_release| replace:: 1.2.0 
+
+.. |eclipse_release_tarball| replace:: http://download.locationtech.org/geomesa/1.2.0/geomesa-dist-1.2.0-bin.tar.gz
+
+.. |eclipse_release_source_tarball| replace:: http://download.locationtech.org/geomesa/1.2.0/geomesa-source-1.2.0.tar.gz 
+
 .. |development| replace:: %(version_devel)s
 
 .. |release_1_1| replace:: %(release_1_1)s

--- a/docs/user/installation_and_configuration.rst
+++ b/docs/user/installation_and_configuration.rst
@@ -44,7 +44,13 @@ Versions and Downloads
 
 * Source: https://github.com/locationtech/geomesa/archive/master.tar.gz
 
-**Latest Eclipse IP Reviewed release**: |eclipse_release|
+**Fully Eclipse IP reviewed release**: |eclipse_release|
+
+GeoMesa is part of the Locationtech working group at Eclipse. Eclipse fully reviews each major release for IP concerns.
+
+.. warning::
+
+    Eclipse releases may not contain all the bug fixes and improvements from the latest release.
 
 * Release distribution: |eclipse_release_tarball|
 * Source: |eclipse_release_source_tarball|

--- a/docs/user/installation_and_configuration.rst
+++ b/docs/user/installation_and_configuration.rst
@@ -44,6 +44,11 @@ Versions and Downloads
 
 * Source: https://github.com/locationtech/geomesa/archive/master.tar.gz
 
+**Latest Eclipse IP Reviewed release**: |eclipse_release|
+
+* Release distribution: |eclipse_release_tarball|
+* Source: |eclipse_release_source_tarball|
+
 **1.1.x release**: |release_1_1|
 
 * Release tarball: |release_1_1_tarball|

--- a/docs/user/installation_and_configuration.rst
+++ b/docs/user/installation_and_configuration.rst
@@ -44,9 +44,9 @@ Versions and Downloads
 
 * Source: https://github.com/locationtech/geomesa/archive/master.tar.gz
 
-**Fully Eclipse IP reviewed release**: |eclipse_release|
+**Latest release which has been fully reviewed by Eclipse Legal**: |eclipse_release|
 
-GeoMesa is part of the Locationtech working group at Eclipse. Eclipse fully reviews each major release for IP concerns.
+GeoMesa is part of the Locationtech working group at Eclipse. The Eclipse legal team fully reviews each major release for IP concerns.
 
 .. warning::
 

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,37 @@
                 </repository>
             </repositories>
         </profile>
+   <profile>
+     <id>eclipse-sign</id>
+     <build>
+       <plugins>
+         <plugin>
+           <groupId>org.eclipse.cbi.maven.plugins</groupId>
+           <artifactId>eclipse-jarsigner-plugin</artifactId>
+           <version>1.1.3</version>
+           <configuration>
+             <signerUrl>http://locationtech.org:31338/sign</signerUrl>
+             <excludeInnerJars>true</excludeInnerJars>
+           </configuration>
+           <executions>
+             <execution>
+               <id>sign</id>
+               <goals>
+                 <goal>sign</goal>
+               </goals>
+               <phase>verify</phase>
+             </execution>
+           </executions>
+         </plugin>
+       </plugins>
+     </build>
+     <pluginRepositories>
+       <pluginRepository>
+         <id>cbi-releases</id>
+         <url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
+       </pluginRepository>
+     </pluginRepositories>
+   </profile>
     </profiles>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -191,37 +191,37 @@
                 </repository>
             </repositories>
         </profile>
-   <profile>
-     <id>eclipse-sign</id>
-     <build>
-       <plugins>
-         <plugin>
-           <groupId>org.eclipse.cbi.maven.plugins</groupId>
-           <artifactId>eclipse-jarsigner-plugin</artifactId>
-           <version>1.1.3</version>
-           <configuration>
-             <signerUrl>http://locationtech.org:31338/sign</signerUrl>
-             <excludeInnerJars>true</excludeInnerJars>
-           </configuration>
-           <executions>
-             <execution>
-               <id>sign</id>
-               <goals>
-                 <goal>sign</goal>
-               </goals>
-               <phase>verify</phase>
-             </execution>
-           </executions>
-         </plugin>
-       </plugins>
-     </build>
-     <pluginRepositories>
-       <pluginRepository>
-         <id>cbi-releases</id>
-         <url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
-       </pluginRepository>
-     </pluginRepositories>
-   </profile>
+        <profile>
+            <id>eclipse-sign</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.cbi.maven.plugins</groupId>
+                        <artifactId>eclipse-jarsigner-plugin</artifactId>
+                        <version>1.1.3</version>
+                        <configuration>
+                            <signerUrl>http://locationtech.org:31338/sign</signerUrl>
+                            <excludeInnerJars>true</excludeInnerJars>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sign</id>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <phase>verify</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>cbi-releases</id>
+                    <url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
     </profiles>
 
     <distributionManagement>


### PR DESCRIPTION
* Integrates with the Eclipse signing service.
  This service is (and can) only used by the LocationTech build server.

* Adds documentation for the LocationTech downloads page.