### PR TITLE
GEOMESA-1205 Allow Avro schemas to use unmangled names

### DIFF
--- a/geomesa-features/geomesa-feature-avro/src/main/scala/org/locationtech/geomesa/features/avro/AvroDataFileWriter.scala
+++ b/geomesa-features/geomesa-feature-avro/src/main/scala/org/locationtech/geomesa/features/avro/AvroDataFileWriter.scala
@@ -13,6 +13,7 @@ import java.util.zip.Deflater
 
 import org.apache.avro.file.{CodecFactory, DataFileWriter}
 import org.geotools.data.simple.SimpleFeatureCollection
+import org.locationtech.geomesa.features.SerializationOption
 import org.locationtech.geomesa.features.SerializationOption.SerializationOptions
 import org.locationtech.geomesa.utils.geotools.Conversions
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -29,8 +30,8 @@ class AvroDataFileWriter(os: OutputStream,
                          sft: SimpleFeatureType,
                          compression: Int = Deflater.DEFAULT_COMPRESSION) extends Closeable with Flushable {
 
-  private val schema = AvroSimpleFeatureUtils.generateSchema(sft, withUserData = true)
-  private val writer = new AvroSimpleFeatureWriter(sft, SerializationOptions.withUserData)
+  private val schema = AvroSimpleFeatureUtils.generateSchema(sft, namespace = sft.getName.getNamespaceURI, withUserData = true, mangleNames = false)
+  private val writer = new AvroSimpleFeatureWriter(sft, SerializationOptions.withUserData + SerializationOption.WithUnmangledNames)
   private val dfw = new DataFileWriter[SimpleFeature](writer)
 
   if (compression != Deflater.NO_COMPRESSION) {

--- a/geomesa-features/geomesa-feature-avro/src/main/scala/org/locationtech/geomesa/features/avro/AvroSimpleFeatureWriter.scala
+++ b/geomesa-features/geomesa-feature-avro/src/main/scala/org/locationtech/geomesa/features/avro/AvroSimpleFeatureWriter.scala
@@ -24,7 +24,12 @@ class AvroSimpleFeatureWriter(sft: SimpleFeatureType, opts: Set[SerializationOpt
 
   import AvroSimpleFeatureUtils._
 
-  private var schema: Schema = generateSchema(sft, opts.withUserData)
+  private var schema: Schema =
+    generateSchema(sft,
+      withUserData = opts.withUserData,
+      namespace = sft.getName.getNamespaceURI,
+      mangleNames = !opts.withUnmangledNames)
+
   private val typeMap = createTypeMap(sft, new WKBWriter())
   private val names = DataUtilities.attributeNames(sft).map(encodeAttributeName)
   private var lastDataIdx = getLastDataIdx

--- a/geomesa-features/geomesa-feature-avro/src/test/scala/org/locationtech/geomesa/features/avro/AvroSimpleFeatureWriterTest.scala
+++ b/geomesa-features/geomesa-feature-avro/src/test/scala/org/locationtech/geomesa/features/avro/AvroSimpleFeatureWriterTest.scala
@@ -14,6 +14,7 @@ import java.util
 import org.apache.avro.io.{BinaryDecoder, DecoderFactory, Encoder, EncoderFactory}
 import org.geotools.factory.Hints
 import org.junit.runner.RunWith
+import org.locationtech.geomesa.features.SerializationOption
 import org.locationtech.geomesa.features.SerializationOption.SerializationOptions
 import org.locationtech.geomesa.features.avro.serde.Version2ASF
 import org.locationtech.geomesa.features.serialization.{AbstractWriter, HintKeySerialization}
@@ -130,6 +131,26 @@ class AvroSimpleFeatureWriterTest extends Specification with Mockito with Abstra
       there was one(encoder).writeString("null key")
 
       there was one(encoder).writeArrayEnd()
+    }
+
+    "use unmangled names when requested" >> {
+      import org.locationtech.geomesa.security._
+      val sf = createSimpleFeature
+
+      val vis = "test&usa"
+      sf.visibility = vis
+
+      val userData = sf.getUserData
+      userData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+      userData.put(java.lang.Integer.valueOf(5), null)
+      userData.put(null, "null key")
+
+      val afw = new AvroSimpleFeatureWriter(sf.getType, SerializationOptions.withUserData + SerializationOption.WithUnmangledNames)
+      val encoder = mock[Encoder]
+
+      afw.write(sf, encoder)
+
+      there was one(encoder).writeArrayStart()
     }
   }
 

--- a/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/SerializationOption.scala
+++ b/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/SerializationOption.scala
@@ -20,6 +20,12 @@ object SerializationOption extends Enumeration {
    */
   val WithUserData = Value
 
+  /**
+    * If this [[SerializationOption]] is specified, then names will not be mangled when computing
+    * the underlying serialization format.  Currently for Avro only.
+    */
+  val WithUnmangledNames = Value
+
   implicit class SerializationOptions(val options: Set[SerializationOption]) extends AnyVal {
 
     /**
@@ -30,6 +36,8 @@ object SerializationOption extends Enumeration {
 
     /** @return true iff ``this`` contains ``EncodingOption.WITH_USER_DATA`` */
     def withUserData: Boolean = options.contains(SerializationOption.WithUserData)
+
+    def withUnmangledNames: Boolean = options.contains(SerializationOption.WithUnmangledNames)
   }
 
   object SerializationOptions {

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/AccumuloRunner.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/AccumuloRunner.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.tools.accumulo
 
 import org.locationtech.geomesa.tools.accumulo.commands._
 import org.locationtech.geomesa.tools.common.Runner
-import org.locationtech.geomesa.tools.common.commands.{Command, VersionCommand}
+import org.locationtech.geomesa.tools.common.commands.{Command, SFT2AvroSchemaCommand, VersionCommand}
 
 object AccumuloRunner extends Runner {
   override val scriptName: String = "geomesa"
@@ -30,6 +30,7 @@ object AccumuloRunner extends Runner {
     new TableConfCommand(jc),
     new VersionCommand(jc),
     new QueryRasterStatsCommmand(jc),
-    new GetSftCommand(jc)
+    new GetSftCommand(jc),
+    new SFT2AvroSchemaCommand(jc)
   )
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/common/commands/SFT2AvroSchemaCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/common/commands/SFT2AvroSchemaCommand.scala
@@ -1,0 +1,39 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.tools.common.commands
+
+import com.beust.jcommander.{JCommander, Parameter, Parameters}
+import org.locationtech.geomesa.features.avro.AvroSimpleFeatureUtils
+import org.locationtech.geomesa.tools.common.commands.SFT2AvroSchemaCommand.SFT2AvroSchemaCommandParams
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypeLoader
+
+class SFT2AvroSchemaCommand(parent: JCommander) extends Command(parent) {
+
+  override val command = "sft2avro"
+  val params = new SFT2AvroSchemaCommandParams
+
+  override def execute() = {
+    val sft = SimpleFeatureTypeLoader.sftForName(params.sft)
+    if(sft.isDefined) {
+      val schema = AvroSimpleFeatureUtils.generateSchema(sft.get, withUserData = true, mangleNames = false)
+      println(schema.toString(true))
+    } else {
+      println(s"Could not find feature type ${params.sft}")
+    }
+  }
+
+}
+
+object SFT2AvroSchemaCommand {
+  @Parameters(commandDescription = "Convert SimpleFeatureTypes to Avro schemas")
+  class SFT2AvroSchemaCommandParams {
+    @Parameter(names = Array("-s", "--sft"), description = "SimpleFeatureTypeName", required = true)
+    var sft: String = null
+  }
+}


### PR DESCRIPTION
* Added serialization option that prevents attribute names from being mangled
* Added a command line tool to print out the Avro schema from a SimpleFeatureType

Signed-off-by: Anthony Fox <anthonyfox@ccri.com>