### PR TITLE
GEOMESA-1193,GEOMESA-1194 Persisting user data with simple feature type

### DIFF
--- a/docs/user/data_management.rst
+++ b/docs/user/data_management.rst
@@ -156,7 +156,7 @@ indices will all be created, as well as any attribute indices you have defined.
     indices may be added at any time through map/reduce jobs - see :ref:`attribute_indexing_job`.
 
 To enable only certain indices, you may set a hint in your simple feature type. The hint key is
-``table.indexes.enabled``, and it should contain a comma-delimited list containing a subset of:
+``geomesa.indexes.enabled``, and it should contain a comma-delimited list containing a subset of:
 
 - ``z2`` - corresponds to the Z2 index
 - ``z3`` - corresponds to the Z3 index
@@ -171,7 +171,7 @@ the hint to the end of the string, like so:
 .. code-block:: java
 
     // append the hints to the end of the string, separated by a semi-colon
-    String spec = "name:String,dtg:Date,*geom:Point:srid=4326;table.indexes.enabled='records,z3'";
+    String spec = "name:String,dtg:Date,*geom:Point:srid=4326;geomesa.indexes.enabled='records,z3'";
     SimpleFeatureType sft = SimpleFeatureTypes.createType("mySft", spec);
 
 If you have an existing simple feature type, or you are not using ``SimpleFeatureTypes.createType``,
@@ -181,7 +181,7 @@ you may set the hint directly in the feature type:
 
     // set the hint directly
     SimpleFeatureType sft = ...
-    sft.getUserData().put("table.indexes.enabled", "records,z3");
+    sft.getUserData().put("geomesa.indexes.enabled", "records,z3");
 
 If you are using TypeSafe configuration files to define your simple feature type, you may include
 a 'user-data' key:
@@ -197,7 +197,7 @@ a 'user-data' key:
             { name = geom, type = Point, srid = 4326 }
           ]
           user-data = {
-            table.indexes.enabled = "records,z3,attr_idx"
+            geomesa.indexes.enabled = "records,z3,attr_idx"
           }
         }
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/package.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/package.scala
@@ -31,22 +31,27 @@ package object data {
   val FEATURE_ENCODING = "geomesa.feature.encoding"
 
   // Metadata keys
-  val ATTRIBUTES_KEY         = "attributes"
-  val SPATIAL_BOUNDS_KEY     = "bounds"
-  val TEMPORAL_BOUNDS_KEY    = "time.bounds"
-  val SCHEMA_KEY             = "schema"
-  val DTGFIELD_KEY           = "dtgfield"
-  val FEATURE_ENCODING_KEY   = "featureEncoding"
-  val ST_IDX_TABLE_KEY       = "tables.idx.st.name"
-  val ATTR_IDX_TABLE_KEY     = "tables.idx.attr.name"
-  val RECORD_TABLE_KEY       = "tables.record.name"
-  val Z2_TABLE_KEY           = "tables.z2.name"
-  val Z3_TABLE_KEY           = "tables.z3.name"
-  val QUERIES_TABLE_KEY      = "tables.queries.name"
-  val SHARED_TABLES_KEY      = "tables.sharing"
-  val TABLES_ENABLED_KEY     = SimpleFeatureTypes.ENABLED_INDEXES
-  val SCHEMA_ID_KEY          = "id"
-  val VERSION_KEY            = "version"
+  val ATTRIBUTES_KEY      = "attributes"
+  val SPATIAL_BOUNDS_KEY  = "bounds"
+  val TEMPORAL_BOUNDS_KEY = "time.bounds"
+  val ATTR_IDX_TABLE_KEY  = "tables.idx.attr.name"
+  val RECORD_TABLE_KEY    = "tables.record.name"
+  val Z2_TABLE_KEY        = "tables.z2.name"
+  val Z3_TABLE_KEY        = "tables.z3.name"
+  val QUERIES_TABLE_KEY   = "tables.queries.name"
+  val SCHEMA_ID_KEY       = "id"
+  val VERSION_KEY         = "version"
+
+  @deprecated
+  val SCHEMA_KEY           = "schema"
+  @deprecated
+  val DTGFIELD_KEY         = "dtgfield"
+  @deprecated
+  val FEATURE_ENCODING_KEY = "featureEncoding"
+  @deprecated
+  val ST_IDX_TABLE_KEY     = "tables.idx.st.name"
+  @deprecated
+  val SHARED_TABLES_KEY    = "tables.sharing"
 
   // Storage implementation constants
   val DATA_CQ              = new Text("SimpleFeatureAttribute")

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/STIdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/STIdxStrategy.scala
@@ -36,7 +36,7 @@ class STIdxStrategy(val filter: QueryFilter) extends Strategy with LazyLogging w
     val acc             = queryPlanner.ds
     val sft             = queryPlanner.sft
     val version         = sft.getSchemaVersion
-    val schema          = queryPlanner.ds.getIndexSchemaFmt(sft.getTypeName)
+    val schema          = queryPlanner.ds.getIndexSchemaFmt(sft)
     val featureEncoding = queryPlanner.ds.getFeatureEncoding(sft)
     val keyPlanner      = IndexSchema.buildKeyPlanner(schema)
     val cfPlanner       = IndexSchema.buildColumnFamilyPlanner(schema)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithMultipleSfts.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithMultipleSfts.scala
@@ -67,8 +67,9 @@ trait TestWithMultipleSfts extends Specification {
     sft.setTableSharing(tableSharing)
     schemaVersion.foreach(sft.setSchemaVersion)
     ds.createSchema(sft)
-    sfts += ds.getSchema(sftName) // reload the sft from the ds to ensure all user data is set properly
-    sfts.last
+    val reloaded = ds.getSchema(sftName) // reload the sft from the ds to ensure all user data is set properly
+    sfts += reloaded
+    reloaded
   }
 
   def addFeature(sft: SimpleFeatureType, feature: SimpleFeature): java.util.List[FeatureId] =

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreAlterSchemaTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreAlterSchemaTest.scala
@@ -1,0 +1,140 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.accumulo.data
+
+import org.apache.accumulo.core.client.mock.MockInstance
+import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.geotools.data._
+import org.geotools.factory.Hints
+import org.geotools.feature.DefaultFeatureCollection
+import org.geotools.filter.text.ecql.ECQL
+import org.joda.time.{DateTime, DateTimeZone}
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.accumulo.util.SelfClosingIterator
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.filter.Filter
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class AccumuloDataStoreAlterSchemaTest extends Specification {
+
+  // we use class name to prevent spillage between unit tests in the mock connector
+  val sftName = getClass.getSimpleName
+
+  val connector = new MockInstance("mycloud").getConnector("user", new PasswordToken("password"))
+
+  val ds = DataStoreFinder.getDataStore(
+    Map("connector" -> connector,
+        "caching"   -> false,
+        // note the table needs to be different to prevent testing errors
+        "tableName" -> sftName)
+    ).asInstanceOf[AccumuloDataStore]
+
+  val spec = "dtg:Date,*geom:Point:srid=4326"
+  ds.createSchema(SimpleFeatureTypes.createType(sftName, spec))
+  var sft = ds.getSchema(sftName)
+
+  ds.getFeatureSource(sftName).addFeatures {
+    val collection = new DefaultFeatureCollection()
+    collection.addAll {
+      (0 until 10).filter(_ % 2 == 0).map { i =>
+        val sf = new ScalaSimpleFeature(s"f$i", sft)
+        sf.setAttribute(0, s"2014-01-01T0$i:00:00.000Z")
+        sf.setAttribute(1, s"POINT(5$i 50)")
+        sf.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+        sf
+      }
+    }
+    collection
+  }
+
+  val updatedSpec = {
+    val old = ds.metadata.readRequired(sftName, ATTRIBUTES_KEY)
+    spec + ",attr1:String" + old.substring(old.indexOf(";"))
+  }
+  ds.metadata.insert(sftName, ATTRIBUTES_KEY, updatedSpec)
+  ds.metadata.expireCache(sftName)
+  sft = ds.getSchema(sftName)
+
+  ds.getFeatureSource(sftName).addFeatures {
+    val collection = new DefaultFeatureCollection()
+    collection.addAll {
+      (0 until 10).filter(_ % 2 == 1).map { i =>
+        val sf = new ScalaSimpleFeature(s"f$i", sft)
+        sf.setAttribute(0, s"2014-01-01T0$i:00:00.000Z")
+        sf.setAttribute(1, s"POINT(5$i 50)")
+        sf.setAttribute(2, s"$i")
+        sf.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+        sf
+      }
+    }
+    collection
+  }
+
+  "AccumuloDataStore" should {
+    "work with an altered schema" >> {
+      val query = new Query(sftName, Filter.INCLUDE)
+      val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toList
+      features.map(_.getID) must containTheSameElementsAs((0 until 10).map("f" + _))
+      forall(features)(_.getAttribute("dtg") must not(beNull))
+      forall(features)(_.getAttribute("geom") must not(beNull))
+      forall(features.filter(_.getID.substring(1).toInt % 2 == 0))(_.getAttribute("attr1") must beNull)
+      forall(features.filter(_.getID.substring(1).toInt % 2 == 1))(_.getAttribute("attr1") must not(beNull))
+    }
+    "handle transformations to updated types" >> {
+      "for old attributes with new and old features" >> {
+        val query = new Query(sftName, ECQL.toFilter("IN ('f1', 'f2')"), Array("geom", "dtg"))
+        val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toList
+        features.map(_.getID) must containTheSameElementsAs(Seq("f1", "f2"))
+        features.sortBy(_.getID).map(_.getAttribute("geom").toString) mustEqual Seq("POINT (51 50)", "POINT (52 50)")
+        features.sortBy(_.getID).map(_.getAttribute("dtg"))
+            .map(new DateTime(_).withZone(DateTimeZone.UTC).getHourOfDay) mustEqual Seq(1, 2)
+      }
+      "for old attributes with new features" >> {
+        val query = new Query(sftName, ECQL.toFilter("IN ('f1')"), Array("geom", "dtg"))
+        val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toList
+        features.map(_.getID) must containTheSameElementsAs(Seq("f1"))
+        features.head.getAttribute("geom").toString mustEqual "POINT (51 50)"
+        new DateTime(features.head.getAttribute("dtg")).withZone(DateTimeZone.UTC).getHourOfDay mustEqual 1
+      }
+      "for old attributes with old features" >> {
+        val query = new Query(sftName, ECQL.toFilter("IN ('f2')"), Array("geom", "dtg"))
+        val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toList
+        features.map(_.getID) must containTheSameElementsAs(Seq("f2"))
+        features.head.getAttribute("geom").toString mustEqual "POINT (52 50)"
+        new DateTime(features.head.getAttribute("dtg")).withZone(DateTimeZone.UTC).getHourOfDay mustEqual 2
+      }
+      "for new attributes with new and old features" >> {
+        val query = new Query(sftName, ECQL.toFilter("IN ('f1', 'f2')"), Array("geom", "attr1"))
+        val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toList
+        features.map(_.getID) must containTheSameElementsAs(Seq("f1", "f2"))
+        features.sortBy(_.getID).map(_.getAttribute("geom").toString) mustEqual Seq("POINT (51 50)", "POINT (52 50)")
+        features.sortBy(_.getID).map(_.getAttribute("attr1")) mustEqual Seq("1", null)
+      }
+      "for new attributes with new features" >> {
+        val query = new Query(sftName, ECQL.toFilter("IN ('f1')"), Array("geom", "attr1"))
+        val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toList
+        features.map(_.getID) must containTheSameElementsAs(Seq("f1"))
+        features.head.getAttribute("geom").toString mustEqual "POINT (51 50)"
+        features.head.getAttribute("attr1") mustEqual "1"
+      }
+      "for new attributes with old features" >> {
+        val query = new Query(sftName, ECQL.toFilter("IN ('f2')"), Array("geom", "attr1"))
+        val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toList
+        features.map(_.getID) must containTheSameElementsAs(Seq("f2"))
+        features.head.getAttribute("geom").toString mustEqual "POINT (52 50)"
+        features.head.getAttribute("attr1") must beNull
+      }
+    }
+  }
+}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/AttributeIndexStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/AttributeIndexStrategyTest.scala
@@ -39,7 +39,7 @@ class AttributeIndexStrategyTest extends Specification with TestWithDataStore {
   override val spec = "name:String:index=full,age:Integer:index=true,count:Long:index=true," +
       "weight:Double:index=true,height:Float:index=true,admin:Boolean:index=true," +
       "geom:Point:srid=4326,dtg:Date,indexedDtg:Date:index=true,fingers:List[String]:index=true," +
-      "toes:List[Double]:index=true,track:String;table.indexes.enabled='attr_idx,records'"
+      "toes:List[Double]:index=true,track:String;geomesa.indexes.enabled='attr_idx,records'"
 
   val geom = WKTUtils.read("POINT(45.0 49.0)")
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryPlannerTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryPlannerTest.scala
@@ -29,7 +29,7 @@ import scala.collection.JavaConversions._
 class QueryPlannerTest extends Specification with Mockito with TestWithDataStore {
 
   override val spec = "*geom:Point,dtg:Date,s:String"
-  val schema = ds.getIndexSchemaFmt(sftName)
+  val schema = ds.getIndexSchemaFmt(sft)
   val sf = new ScalaSimpleFeature("id", sft)
   sf.setAttributes(Array[AnyRef]("POINT(45 45)", "2014/10/10T00:00:00Z", "string"))
   val sf2 = new ScalaSimpleFeature("id2", sft)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategyTest.scala
@@ -49,7 +49,7 @@ class RecordIdxStrategyTest extends Specification with TestWithDataStore {
     IntersectionResult(computedIntersectionIds, trueIntersectionIds)
   }
 
-  override val spec = "name:String,track:String,dtg:Date,*geom:Point:srid=4326;table.indexes.enabled='records'"
+  override val spec = "name:String,track:String,dtg:Date,*geom:Point:srid=4326;geomesa.indexes.enabled='records'"
 
   val features = (0 until 20).map { i =>
     val name = s"name$i"

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategyTest.scala
@@ -37,7 +37,7 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
 
   sequential
 
-  val spec = "name:String,track:String,dtg:Date,*geom:Point:srid=4326;table.indexes.enabled='z3'"
+  val spec = "name:String,track:String,dtg:Date,*geom:Point:srid=4326;geomesa.indexes.enabled='z3'"
 
   val features =
     (0 until 10).map { i =>

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaConsumerFeatureSource.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaConsumerFeatureSource.scala
@@ -46,7 +46,9 @@ abstract class KafkaConsumerFeatureSource(entry: ContentEntry,
     val builder = new SimpleFeatureTypeBuilder()
     builder.init(schema)
     builder.setNamespaceURI(getDataStore.getNamespaceURI)
-    builder.buildFeatureType()
+    val sft = builder.buildFeatureType()
+    schema.getUserData.foreach { case (k, v) => sft.getUserData.put(k, v) }
+    sft
   }
 
   override def getCountInternal(query: Query): Int = getReaderInternal(query).getIterator.length

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaDataStoreSchemaManager.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaDataStoreSchemaManager.scala
@@ -46,7 +46,7 @@ trait KafkaDataStoreSchemaManager extends DataStore with LazyLogging {
       throw new IllegalArgumentException(s"Type $typeName already exists at $zkPath.")
     }
 
-    val data = SimpleFeatureTypes.encodeType(featureType)
+    val data = SimpleFeatureTypes.encodeType(featureType, includeUserData = true)
     createZkNode(schemaPath, data)
 
     // build the topic node

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/DescribeCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/DescribeCommand.scala
@@ -45,6 +45,13 @@ class DescribeCommand(parent: JCommander) extends CommandWithCatalog(parent) wit
 
         println(sb.toString())
       }
+
+      val userData = sft.getUserData
+      if (!userData.isEmpty) {
+        println("\nUser data:")
+        userData.foreach { case (key, value) => println(s"  $key: $value") }
+      }
+
     } catch {
       case npe: NullPointerException =>
         logger.error(s"Error: feature '${params.featureName}' not found. Check arguments...", npe)

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/kafka/commands/DescribeCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/kafka/commands/DescribeCommand.scala
@@ -43,6 +43,12 @@ class DescribeCommand(parent: JCommander) extends CommandWithKDS(parent) with La
         println(sb.toString())
       }
 
+      val userData = sft.getUserData
+      if (!userData.isEmpty) {
+        println("\nUser data:")
+        userData.foreach { case (key, value) => println(s"  $key: $value") }
+      }
+
       val topicName = zkClient.readData[String](ds.asInstanceOf[KafkaDataStore].getTopicPath(params.featureName))
       val topicMetadata = zkUtils.fetchTopicMetadataFromZk(topicName)
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -184,11 +184,13 @@ object RichSimpleFeatureType {
 
   import scala.collection.JavaConversions._
 
+  val GEOMESA_PREFIX      = "geomesa."
   val SCHEMA_VERSION_KEY  = "geomesa.version"
   val TABLE_SHARING_KEY   = "geomesa.table.sharing"
   val SHARING_PREFIX_KEY  = "geomesa.table.sharing.prefix"
   val DEFAULT_DATE_KEY    = "geomesa.index.dtg"
   val ST_INDEX_SCHEMA_KEY = "geomesa.index.st.schema"
+  val USER_DATA_PREFIX    = "geomesa.user-data.prefix"
 
   // in general we store everything as strings so that it's easy to pass to accumulo iterators
   implicit class RichSimpleFeatureType(val sft: SimpleFeatureType) extends AnyVal {
@@ -238,6 +240,10 @@ object RichSimpleFeatureType {
 
     def getEnabledTables: String = userData[String](SimpleFeatureTypes.ENABLED_INDEXES).getOrElse("")
     def setEnabledTables(tables: String): Unit = sft.getUserData.put(SimpleFeatureTypes.ENABLED_INDEXES, tables)
+
+    def setUserDataPrefixes(prefixes: Seq[String]): Unit = sft.getUserData.put(USER_DATA_PREFIX, prefixes.mkString(","))
+    def getUserDataPrefixes: Seq[String] =
+      Seq(GEOMESA_PREFIX) ++ userData[String](USER_DATA_PREFIX).map(_.split(",")).getOrElse(Array.empty)
 
     def userData[T](key: AnyRef): Option[T] = Option(sft.getUserData.get(key).asInstanceOf[T])
   }


### PR DESCRIPTION
* Simple feature type user data is persisted in the Accumulo and Kafka data stores
* By default, all user data that has a key starting with 'geomesa.' will be persisted
* To persist other data, indicate the (comma-separated) prefixes to include through the user data key 'geomesa.user-data.prefix'
  * Example: sft.getUserData.put("geomesa.user-data.prefix", "my-customi-prefix,my-second-prefix")
* User data values will be persisted and returned as strings
* Redundant catalog table data has been removed in favor of the user data

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>