### PR TITLE
GEOMESA-1028 GeoMesa ingest commands should warn when restricted fiel…

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -39,6 +39,7 @@ import org.locationtech.geomesa.security.{AuditProvider, AuthorizationsProvider}
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.{FeatureSpec, NonGeomAttributeSpec}
+import org.locationtech.geomesa.utils.index.GeoMesaSchemaValidator
 import org.opengis.feature.`type`.Name
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/TemporalIndexCheckTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/TemporalIndexCheckTest.scala
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo._
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.index.TemporalIndexCheck
 import org.opengis.feature.simple.SimpleFeatureType
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/DensityIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/DensityIteratorTest.scala
@@ -42,7 +42,7 @@ class DensityIteratorTest extends Specification with TestWithMultipleSfts {
   }
   val date = new DateTime("2012-01-01T19:00:00", DateTimeZone.UTC).toDate.getTime
 
-  def spec(binding: String) = s"id:java.lang.Integer,attr:java.lang.Double,dtg:Date,*geom:$binding:srid=4326"
+  def spec(binding: String) = s"an_id:java.lang.Integer,attr:java.lang.Double,dtg:Date,*geom:$binding:srid=4326"
 
   def getDensity(sftName: String, query: String): List[(Double, Double, Double)] = {
     val q = new Query(sftName, ECQL.toFilter(query))

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/KryoLazyDensityIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/KryoLazyDensityIteratorTest.scala
@@ -34,7 +34,7 @@ class KryoLazyDensityIteratorTest extends Specification with TestWithDataStore {
   sequential
 
   // to ensure the z3 index is used, the geom must be a point and the queries must include geom + time
-  override val spec = "id:java.lang.Integer,attr:java.lang.Double,dtg:Date,geom:Point:srid=4326"
+  override val spec = "an_id:java.lang.Integer,attr:java.lang.Double,dtg:Date,geom:Point:srid=4326"
 
   def getDensity(query: String): List[(Double, Double, Double)] = {
     val q = new Query(sftName, ECQL.toFilter(query))

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/MapAggregatingIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/MapAggregatingIteratorTest.scala
@@ -33,7 +33,7 @@ class MapAggregatingIteratorTest extends Specification with TestWithDataStore {
 
   sequential
 
-  override def spec = "id:Integer,map:Map[String,Integer],dtg:Date,geom:Geometry:srid=4326;geomesa.mixed.geometries=true"
+  override def spec = "an_id:Integer,map:Map[String,Integer],dtg:Date,geom:Geometry:srid=4326;geomesa.mixed.geometries=true"
 
   val testData : Map[String,String] = {
     val source = Source.fromInputStream(getClass.getResourceAsStream("/test-lines.tsv"))
@@ -191,7 +191,7 @@ class MapAggregatingIteratorTest extends Specification with TestWithDataStore {
 @RunWith(classOf[JUnitRunner])
 class MapAggregatingIteratorDoubleTest extends Specification with TestWithDataStore {
 
-  override val spec = "id:Integer,map:Map[Double,Integer],dtg:Date,geom:Geometry:srid=4326;geomesa.mixed.geometries=true"
+  override val spec = "an_id:Integer,map:Map[Double,Integer],dtg:Date,geom:Geometry:srid=4326;geomesa.mixed.geometries=true"
 
   val randomSeed = 62
   val random = new Random(randomSeed)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/TestData.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/TestData.scala
@@ -55,7 +55,7 @@ object TestData extends LazyLogging {
       .build()
 
   def getTypeSpec(suffix: String = "2") = {
-    s"POINT:String,LINESTRING:String,POLYGON:String,attr$suffix:String:index=true," +
+    s"A_POINT:String,A_LINESTRING:String,A_POLYGON:String,attr$suffix:String:index=true," +
         s"geom:Geometry:srid=4326,dtg:Date,dtg_end_time:Date;geomesa.mixed.geometries=true"
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/process/stats/KryoLazyStatsIteratorProcessTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/process/stats/KryoLazyStatsIteratorProcessTest.scala
@@ -28,7 +28,7 @@ class KryoLazyStatsIteratorProcessTest extends Specification with TestWithDataSt
 
   import org.locationtech.geomesa.utils.geotools.Conversions._
 
-  override val spec = "id:java.lang.Integer,attr:java.lang.Long,dtg:Date,*geom:Point:srid=4326"
+  override val spec = "an_id:java.lang.Integer,attr:java.lang.Long,dtg:Date,*geom:Point:srid=4326"
 
   addFeatures((0 until 150).toArray.map { i =>
     val attrs = Array(i.asInstanceOf[AnyRef], (i * 2).asInstanceOf[AnyRef],
@@ -61,7 +61,7 @@ class KryoLazyStatsIteratorProcessTest extends Specification with TestWithDataSt
     }
 
     "work with the Histogram stat" in {
-      val results = statsIteratorProcess.execute(fs.getFeatures(query), "Histogram(id)", encode = true)
+      val results = statsIteratorProcess.execute(fs.getFeatures(query), "Histogram(an_id)", encode = true)
       val sf = results.features().next
 
       val eh = decodeStat(sf.getAttribute(0).asInstanceOf[String], sft).asInstanceOf[Histogram[java.lang.Integer]]
@@ -72,7 +72,7 @@ class KryoLazyStatsIteratorProcessTest extends Specification with TestWithDataSt
     }
 
     "work with the RangeHistogram stat" in {
-      val results = statsIteratorProcess.execute(fs.getFeatures(query), "RangeHistogram(id,5,0,149)", encode = true)
+      val results = statsIteratorProcess.execute(fs.getFeatures(query), "RangeHistogram(an_id,5,0,149)", encode = true)
       val sf = results.features().next
 
       val rh = decodeStat(sf.getAttribute(0).asInstanceOf[String], sft).asInstanceOf[RangeHistogram[java.lang.Integer]]
@@ -82,7 +82,7 @@ class KryoLazyStatsIteratorProcessTest extends Specification with TestWithDataSt
 
     "work with multiple stats at once" in {
       val results = statsIteratorProcess.execute(fs.getFeatures(query),
-        "MinMax(attr);IteratorStackCount();Histogram(id);RangeHistogram(id,5,10,14)", encode = true)
+        "MinMax(attr);IteratorStackCount();Histogram(an_id);RangeHistogram(an_id,5,10,14)", encode = true)
       val sf = results.features().next
 
       val seqStat = decodeStat(sf.getAttribute(0).asInstanceOf[String], sft).asInstanceOf[SeqStat]
@@ -113,7 +113,7 @@ class KryoLazyStatsIteratorProcessTest extends Specification with TestWithDataSt
       fs.getFeatures(new Query(sftName, Filter.INCLUDE)).features().foreach(features.add)
 
       val results = statsIteratorProcess.execute(features,
-        "MinMax(attr);IteratorStackCount();Histogram(id);RangeHistogram(id,5,10,14)", encode = true)
+        "MinMax(attr);IteratorStackCount();Histogram(an_id);RangeHistogram(an_id,5,10,14)", encode = true)
       val sf = results.features().next
 
       val seqStat = decodeStat(sf.getAttribute(0).asInstanceOf[String], sft).asInstanceOf[SeqStat]

--- a/geomesa-compute/src/test/scala/org/locationtech/geomesa/compute/spark/GeoMesaSparkTest.scala
+++ b/geomesa-compute/src/test/scala/org/locationtech/geomesa/compute/spark/GeoMesaSparkTest.scala
@@ -78,7 +78,7 @@ class GeoMesaSparkTest extends Specification with LazyLogging {
       ds
     }
 
-    lazy val spec = "id:Integer,map:Map[String,Integer],dtg:Date,geom:Point:srid=4326"
+    lazy val spec = "an_id:Integer,map:Map[String,Integer],dtg:Date,geom:Point:srid=4326"
 
     def createFeatures(ds: DataStore, sft: SimpleFeatureType, encodedFeatures: Array[_ <: Array[_]]): Seq[SimpleFeature] = {
       val builder = ScalaSimpleFeatureFactory.featureBuilder(sft)
@@ -128,7 +128,7 @@ class GeoMesaSparkTest extends Specification with LazyLogging {
       val rdd = GeoMesaSpark.rdd(new Configuration(), sc, dsParams, new Query(typeName), useMock = true)
 
       rdd.count() should equalTo(feats.length)
-      feats.map(_.getAttribute("id")) should contain(rdd.take(1).head.getAttribute("id"))
+      feats.map(_.getAttribute("an_id")) should contain(rdd.take(1).head.getAttribute("an_id"))
     }
 
     "Write data" in {
@@ -148,7 +148,7 @@ class GeoMesaSparkTest extends Specification with LazyLogging {
 
       val coll = ds.getFeatureSource(typeName).getFeatures
       coll.size() should equalTo(encodedFeatures.length)
-      feats.map(_.getAttribute("id")) should contain(coll.features().next().getAttribute("id"))
+      feats.map(_.getAttribute("an_id")) should contain(coll.features().next().getAttribute("an_id"))
     }
   }
 
@@ -209,7 +209,7 @@ class GeoMesaSparkTest extends Specification with LazyLogging {
 
         val rdd = GeoMesaSpark.rdd(new Configuration(), sc, privParams, new Query(sftName), useMock = true)
         rdd.count() mustEqual 6
-        features.map(_.getAttribute("id")) should contain(rdd.take(1).head.getAttribute("id"))
+        features.map(_.getAttribute("an_id")) should contain(rdd.take(1).head.getAttribute("an_id"))
       }
 
       "user should get 3" >> {

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaDataStoreSchemaManager.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/KafkaDataStoreSchemaManager.scala
@@ -15,6 +15,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.I0Itec.zkclient.exception.ZkNodeExistsException
 import org.geotools.data.DataStore
 import org.geotools.feature.NameImpl
+import org.locationtech.geomesa.utils.index.GeoMesaSchemaValidator
 import org.locationtech.geomesa.kafka.common.ZkUtils
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.`type`.Name
@@ -45,6 +46,11 @@ trait KafkaDataStoreSchemaManager extends DataStore with LazyLogging {
     if (zkUtils.zkClient.exists(schemaPath)) {
       throw new IllegalArgumentException(s"Type $typeName already exists at $zkPath.")
     }
+
+    // inspect and update the simple feature type for various components
+    // do this before anything else so that any modifications will be in place
+    GeoMesaSchemaValidator.validate(featureType)
+
 
     val data = SimpleFeatureTypes.encodeType(featureType, includeUserData = true)
     createZkNode(schemaPath, data)

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/FeatureUtils.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/FeatureUtils.scala
@@ -9,6 +9,7 @@
 package org.locationtech.geomesa.utils.geotools
 
 import java.lang.{Boolean => jBoolean}
+import java.util.Locale
 
 import org.geotools.data.{DataUtilities, FeatureWriter}
 import org.geotools.factory.Hints
@@ -16,10 +17,54 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.geotools.filter.identity.FeatureIdImpl
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
+import scala.collection.JavaConverters._
+import scala.collection.immutable.HashSet
+
 /** Utilities for re-typing and re-building [[SimpleFeatureType]]s and [[SimpleFeature]]s while
   * preserving user data which the standard Geo Tools utilities do not do.
   */
 object FeatureUtils {
+
+  // sourced from the following:
+  //   https://github.com/geotools/geotools/blob/master/modules/library/cql/src/main/jjtree/ECQLGrammar.jjt
+  //   http://docs.geotools.org/latest/userguide/library/cql/internal.html
+  val ReservedWords = HashSet(
+    "AFTER",
+    "AND",
+    "BEFORE",
+    "BEYOND",
+    "CONTAINS",
+    "CROSSES",
+    "DISJOINT",
+    "DOES-NOT-EXIST",
+    "DURING",
+    "DWITHIN",
+    "EQUALS",
+    "EXCLUDE",
+    "EXISTS",
+    "FALSE",
+    "GEOMETRYCOLLECTION",
+    "ID",
+    "INCLUDE",
+    "INTERSECTS",
+    "IS",
+    "LIKE",
+    "LINESTRING",
+    "LOCATION",
+    "MULTILINESTRING",
+    "MULTIPOINT",
+    "MULTIPOLYGON",
+    "NOT",
+    "NULL",
+    "OR",
+    "OVERLAPS",
+    "POINT",
+    "POLYGON",
+    "RELATE",
+    "TOUCHES",
+    "TRUE",
+    "WITHIN"
+  )
 
   /** Retypes a [[SimpleFeatureType]], preserving the user data.
    *
@@ -77,4 +122,13 @@ object FeatureUtils {
     }
     toWrite
   }
+
+
+  /**
+    *
+    * @param sft
+    * @return
+    */
+  def sftReservedWords(sft: SimpleFeatureType): Seq[String] =
+    sft.getDescriptors.asScala.map(_.getName.getLocalPart.toUpperCase(Locale.US)).filter(ReservedWords.contains).toList
 }


### PR DESCRIPTION
…d names are used

This affects both the KafkaDataStore and the AccumuloDataStore.
A significant number of unit tests had to be amended to pass
with this change.

Signed-off-by: Chris Eichelberger <cne1x@ccri.com>