### PR TITLE
GEOMESA-1213 Fix HBase GeoServer plugin deployment

### DIFF
--- a/geomesa-gs-plugin/geomesa-hbase-gs-plugin/README.md
+++ b/geomesa-gs-plugin/geomesa-hbase-gs-plugin/README.md
@@ -1,7 +1,7 @@
 # GeoMesa HBase GeoServer Plugin
 
-The HBase GeoServer plugin is a shaded jar that contains HBase 1.1.5. To change HBase versions,
-you would need to update the pom and re-build this module.
+The HBase GeoServer plugin is a shaded JAR that contains HBase 1.1.5. To change HBase versions,
+you would need to update `pom.xml` and rebuild this module.
 
 ### Build Instructions
 
@@ -13,8 +13,22 @@ $ mvn clean install -Phbase
 
 ### Installation Instructions
 
-After building, extract `target/geomesa-hbase-gs-plugin-<version>-install.tar.gz` into GeoServer's
-WEB-INF/lib directory.
+After building, extract `target/geomesa-hbase-gs-plugin-<version>-install.tar.gz` into GeoServer's ``WEB-INF/lib`` directory.
+
+This distribution does not include the Hadoop or Zookeeper JARs; the following JARs
+should be copied from the ``lib`` directory of your HBase or Hadoop installations into
+GeoServer's ``WEB-INF/lib`` directory:
+
+ * hadoop-annotations-2.5.1.jar
+ * hadoop-auth-2.5.1.jar
+ * hadoop-common-2.5.1.jar
+ * hadoop-mapreduce-client-core-2.5.1.jar
+ * hadoop-yarn-api-2.5.1.jar
+ * hadoop-yarn-common-2.5.1.jar
+ * zookeeper-3.4.6.jar
+ * commons-configuration-1.6.jar
+
+(Note the versions may vary depending on your installation.)
 
 ### Additional Resources
 

--- a/geomesa-gs-plugin/geomesa-hbase-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-hbase-gs-plugin/pom.xml
@@ -77,7 +77,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${hbase.guava.version}</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
 
         <!-- provided dependencies -->


### PR DESCRIPTION
Restores the shaded Guava version, and updates installation
instructions.

Signed-off-by: Matthew Zimmerman <matt.zimmerman@ccri.com>