### PR TITLE
For Comment: Load Converters and Config via annotations

### DIFF
--- a/geomesa-convert/geomesa-convert-common/pom.xml
+++ b/geomesa-convert/geomesa-convert-common/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>jai_core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.specs2</groupId>
             <artifactId>specs2_2.11</artifactId>
             <scope>test</scope>

--- a/geomesa-convert/geomesa-convert-common/src/main/java/org/locationtech/geomesa/convert/annotations/ConverterConfig.java
+++ b/geomesa-convert/geomesa-convert-common/src/main/java/org/locationtech/geomesa/convert/annotations/ConverterConfig.java
@@ -1,0 +1,3 @@
+package org.locationtech.geomesa.convert.annotations;
+
+public @interface ConverterConfig {}

--- a/geomesa-convert/geomesa-convert-common/src/main/java/org/locationtech/geomesa/convert/annotations/ConverterFactory.java
+++ b/geomesa-convert/geomesa-convert-common/src/main/java/org/locationtech/geomesa/convert/annotations/ConverterFactory.java
@@ -1,0 +1,3 @@
+package org.locationtech.geomesa.convert.annotations;
+
+public @interface ConverterFactory {}

--- a/geomesa-convert/geomesa-convert-common/src/main/java/org/locationtech/geomesa/convert/annotations/TransformFactory.java
+++ b/geomesa-convert/geomesa-convert-common/src/main/java/org/locationtech/geomesa/convert/annotations/TransformFactory.java
@@ -1,0 +1,3 @@
+package org.locationtech.geomesa.convert.annotations;
+
+public @interface TransformFactory {}

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverters.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverters.scala
@@ -12,10 +12,13 @@ import javax.imageio.spi.ServiceRegistry
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
+import org.locationtech.geomesa.convert.annotations.ConverterFactory
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypeLoader
 import org.opengis.feature.simple.SimpleFeatureType
+import org.reflections.Reflections
 
 import scala.collection.JavaConversions._
+import scala.collection.mutable
 
 /**
   * Simplified API to build SimpleFeatureType converters
@@ -23,10 +26,26 @@ import scala.collection.JavaConversions._
 object SimpleFeatureConverters extends LazyLogging {
 
   private[convert] val providers = {
-    val pList = ServiceRegistry.lookupProviders(classOf[SimpleFeatureConverterFactory[_]]).toList
-    logger.debug(s"Found ${pList.size} SPI providers for ${classOf[SimpleFeatureConverterFactory[_]].getName}" +
-      s": ${pList.map(_.getClass.getName).mkString(", ")}")
-    pList
+    val spiList = ServiceRegistry.lookupProviders(classOf[SimpleFeatureConverterFactory[_]]).toList
+    logger.info(s"Found ${spiList.size} SPI providers for ${classOf[SimpleFeatureConverterFactory[_]].getName}" +
+      s": ${spiList.map(_.getClass.getName).mkString(", ")}")
+
+    val refProv = new mutable.ListBuffer[SimpleFeatureConverterFactory[_]]()
+    new Reflections("org.locationtech.geomesa.convert")
+      .getTypesAnnotatedWith(classOf[ConverterFactory]).foreach { case cls =>
+         if (classOf[SimpleFeatureConverterFactory[_]].isAssignableFrom(cls)) {
+            refProv += cls.newInstance().asInstanceOf[SimpleFeatureConverterFactory[_]]
+          } else {
+            logger.warn(s"Class annotated with ${classOf[ConverterFactory].getName} must " +
+              s"implement ${classOf[SimpleFeatureConverterFactory[_]]} in order to load converters")
+          }
+        }
+
+    logger.info(s"Registered ${refProv.size} annotated providers for ${classOf[ConverterFactory].getSimpleName}" +
+      s": ${refProv.map(_.getClass.getName).mkString(", ")}")
+
+    import scala.collection.JavaConverters._
+    (spiList ++ refProv).asJava
   }
 
   def build[I](typeName: String, converterName: String): SimpleFeatureConverter[I] = {

--- a/geomesa-convert/geomesa-convert-xml/src/main/resources/META-INF/services/org.locationtech.geomesa.convert.SimpleFeatureConverterFactory
+++ b/geomesa-convert/geomesa-convert-xml/src/main/resources/META-INF/services/org.locationtech.geomesa.convert.SimpleFeatureConverterFactory
@@ -1,1 +1,0 @@
-org.locationtech.geomesa.convert.xml.XMLConverterFactory

--- a/geomesa-convert/geomesa-convert-xml/src/main/resources/META-INF/services/org.locationtech.geomesa.convert.TransformerFunctionFactory
+++ b/geomesa-convert/geomesa-convert-xml/src/main/resources/META-INF/services/org.locationtech.geomesa.convert.TransformerFunctionFactory
@@ -1,1 +1,0 @@
-org.locationtech.geomesa.convert.xml.XmlFunctionFactory

--- a/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XMLConverter.scala
+++ b/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XMLConverter.scala
@@ -22,6 +22,7 @@ import org.apache.commons.io.IOUtils
 import org.locationtech.geomesa.convert.LineMode.LineMode
 import org.locationtech.geomesa.convert.Transformers.{EvaluationContext, Expr}
 import org.locationtech.geomesa.convert._
+import org.locationtech.geomesa.convert.annotations.ConverterFactory
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.w3c.dom.NodeList
 import org.xml.sax.InputSource
@@ -71,6 +72,7 @@ class XMLConverter(val targetSFT: SimpleFeatureType,
     }
 }
 
+@ConverterFactory
 class XMLConverterFactory extends SimpleFeatureConverterFactory[String] {
 
   private val xpath = XPathFactory.newInstance().newXPath()

--- a/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlFunctionFactory.scala
+++ b/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlFunctionFactory.scala
@@ -11,14 +11,15 @@ package org.locationtech.geomesa.convert.xml
 import java.io.StringWriter
 import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
-import javax.xml.transform.{OutputKeys, TransformerFactory, Transformer}
+import javax.xml.transform.{OutputKeys, Transformer, TransformerFactory}
 
-import org.apache.avro.generic.GenericRecord
 import org.locationtech.geomesa.convert.Transformers.EvaluationContext
+import org.locationtech.geomesa.convert.annotations.TransformFactory
 import org.locationtech.geomesa.convert.{TransformerFn, TransformerFunctionFactory}
 import org.locationtech.geomesa.utils.cache.SoftThreadLocal
 import org.w3c.dom.Element
 
+@TransformFactory
 class XmlFunctionFactory extends TransformerFunctionFactory {
 
   override def functions = Seq(xml2string)

--- a/pom.xml
+++ b/pom.xml
@@ -1876,6 +1876,11 @@
                 <artifactId>jcommander</artifactId>
                 <version>1.48</version>
             </dependency>
+            <dependency>
+                <groupId>org.reflections</groupId>
+                <artifactId>reflections</artifactId>
+                <version>0.9.10</version>
+            </dependency>
 
             <!-- test dependencies -->
             <dependency>


### PR DESCRIPTION
Example of how we can load things via annotations and not have to worry about META-INF/resources SPI files...Users can just annotate things. We could also do a SimpleFeatureType loading this way as well.

Lemme know what you think.

Signed-off-by: Andrew Hulbert <andrew.hulbert@ccri.com>
