### PR TITLE
GEOMESA-1253 Initial support for attribute level visibility

### DIFF
--- a/docs/user/data_management.rst
+++ b/docs/user/data_management.rst
@@ -218,6 +218,82 @@ If you are using the GeoMesa ``SftBuilder``, you may call the ``withIndexes`` me
         .build("mySft")
 
 
+Accumulo Visibilities
+---------------------
+
+GeoMesa support Accumulo visibilities for securing data. Visibilities can be set at data store level,
+feature level or individual attribute level.
+
+
+Data Store Level Visibilities
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When creating your data store, a default visibility can be configured for all features:
+
+.. code-block:: java
+
+    Map<String, String> parameters = ...
+    parameters.put("visibilities", "admin&user");
+    DataStore ds = DataStoreFinder.getDataStore(parameters);
+
+If present, visibilities set at the feature or attribute level will take priority over the data store configuration.
+
+
+Feature Level Visibilities
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Visibilities can be set on individual features using the simple feature user data:
+
+.. code-block:: java
+
+    import org.locationtech.geomesa.security.SecurityUtils;
+
+    SecurityUtils.setFeatureVisibility(feature, "admin&user")
+
+or
+
+.. code-block:: java
+
+    feature.getUserData().put("geomesa.feature.visibility", "admin&user");
+
+
+Attribute-Level Visibilities
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For more advanced use cases, visibilities can be set at the attribute level.
+
+.. warning::
+
+    Attribute level visibilities is an experimental feature and currently does not support all query types.
+    Errors or data leaks may occur if the default date or geometry are not returned from a query
+    due to visibilities. Future versions of GeoMesa may not support the current attribute level visibilities.
+
+Attribute-level visibilities must be enabled when creating your simple feature type by setting
+the appropriate user data value:
+
+.. code-block:: java
+
+    sft.getUserData().put("geomesa.visibility.level", "attribute");
+    dataStore.createSchema(sft);
+
+When writing each feature, the per-attribute visibilities must be set in a comma-delimited string in the user data.
+Each attribute must have a corresponding value in the delimited string, otherwise an error will be thrown.
+
+For example, if your feature type has four attributes:
+
+.. code-block:: java
+
+    import org.locationtech.geomesa.security.SecurityUtils;
+
+    SecurityUtils.setFeatureVisibility(feature, "admin,user,admin,user")
+
+or
+
+.. code-block:: java
+
+    feature.getUserData().put("geomesa.feature.visibility", "admin,user,admin,user");
+
+
 Splitting the Record Index
 --------------------------
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/AttributeTable.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/AttributeTable.scala
@@ -10,7 +10,7 @@
 package org.locationtech.geomesa.accumulo.data.tables
 
 import java.nio.charset.Charset
-import java.util.{Collection => JCollection, Date, Locale}
+import java.util.{Date, Locale, Collection => JCollection}
 
 import com.google.common.collect.ImmutableSortedSet
 import com.google.common.primitives.Bytes
@@ -26,6 +26,7 @@ import org.locationtech.geomesa.accumulo.data._
 import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.index.VisibilityLevel
 import org.locationtech.geomesa.utils.stats.IndexCoverage
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType
@@ -48,36 +49,86 @@ object AttributeTable extends GeoMesaTable with LazyLogging {
 
   private type TryEncoder = Try[(TypeEncoder[Any, String], TypeEncoder[_, String])]
 
-  override def supports(sft: SimpleFeatureType) =
-    sft.getSchemaVersion > 5 && sft.getAttributeDescriptors.exists(_.isIndexed)
+  override def supports(sft: SimpleFeatureType) = {
+    val ok = sft.getSchemaVersion > 5 && sft.getAttributeDescriptors.exists(_.isIndexed)
+    if (ok && sft.getVisibilityLevel == VisibilityLevel.Attribute &&
+        !sft.getAttributeDescriptors.filter(_.isIndexed).forall(_.getIndexCoverage() == IndexCoverage.FULL)) {
+      // TODO GEOMESA-1254 support index values
+      throw new IllegalArgumentException("Attribute level visibility is currently only supported for fully" +
+          " covering attribute indices. Use e.g. 'foo:String:index=full'.")
+    }
+    ok
+  }
 
   override val suffix: String = "attr"
 
-  override def writer(sft: SimpleFeatureType): FeatureToMutations = mutator(sft, delete = false)
-
-  override def remover(sft: SimpleFeatureType): FeatureToMutations = mutator(sft, delete = true)
-
-  private def mutator(sft: SimpleFeatureType, delete: Boolean): FeatureToMutations = {
-    val indexedAttributes = SimpleFeatureTypes.getSecondaryIndexedAttributes(sft)
-    val indexesOfIndexedAttributes = indexedAttributes.map(a => sft.indexOf(a.getName))
-    val attributesToIdx = indexedAttributes.zip(indexesOfIndexedAttributes)
-    val prefixBytes = sft.getTableSharingPrefix.getBytes(UTF8)
-
-    sft.getDtgIndex match {
-      case None =>
-        (toWrite: FeatureToWrite) => {
-          val idBytes = toWrite.feature.getID.getBytes(UTF8)
-          getMutations(toWrite, attributesToIdx, prefixBytes, idBytes, delete)
+  override def writer(sft: SimpleFeatureType): FeatureToMutations = {
+    val getRows = getRowKeys(sft)
+    sft.getVisibilityLevel match {
+      case VisibilityLevel.Feature =>
+        (fw) => {
+          getRows(fw).map { case (descriptor, row) =>
+            val mutation = new Mutation(row)
+            val value = descriptor.getIndexCoverage() match {
+              case IndexCoverage.FULL => fw.dataValue
+              case IndexCoverage.JOIN => fw.indexValue
+            }
+            mutation.put(EMPTY_TEXT, EMPTY_TEXT, fw.columnVisibility, value)
+            mutation
+          }
         }
-      case Some(dtgIndex) =>
-        (toWrite: FeatureToWrite) => {
-          val dtg = toWrite.feature.getAttribute(dtgIndex).asInstanceOf[Date]
-          val time = if (dtg == null) System.currentTimeMillis() else dtg.getTime
-          val timeBytes = timeToBytes(time)
-          val idBytes = toWrite.feature.getID.getBytes(UTF8)
-          getMutations(toWrite, attributesToIdx, prefixBytes, Bytes.concat(timeBytes, idBytes), delete)
+      case VisibilityLevel.Attribute =>
+        (fw) => {
+          getRows(fw).map { case (descriptor, row) =>
+            val mutation = new Mutation(row)
+            // TODO GEOMESA-1254 support index values
+            fw.perAttributeValues.foreach(v => mutation.put(v.cf, v.cq, v.vis, v.value))
+            mutation
+          }
         }
     }
+  }
+
+  override def remover(sft: SimpleFeatureType): FeatureToMutations = {
+    val getRows = getRowKeys(sft)
+    sft.getVisibilityLevel match {
+      case VisibilityLevel.Feature =>
+        (fw) => {
+          getRows(fw).map { case (descriptor, row) =>
+            val mutation = new Mutation(row)
+            mutation.putDelete(EMPTY_TEXT, EMPTY_TEXT, fw.columnVisibility)
+            mutation
+          }
+        }
+      case VisibilityLevel.Attribute =>
+        (fw) => {
+          getRows(fw).map { case (descriptor, row) =>
+            val mutation = new Mutation(row)
+            // TODO GEOMESA-1254 support index values
+            fw.perAttributeValues.foreach(v => mutation.putDelete(v.cf, v.cq, v.vis))
+            mutation
+          }
+        }
+    }
+  }
+
+  private def getRowKeys(sft: SimpleFeatureType): (FeatureToWrite) => Seq[(AttributeDescriptor, Array[Byte])] = {
+    val indexedAttributes = SimpleFeatureTypes.getSecondaryIndexedAttributes(sft).map { d =>
+      val i = sft.indexOf(d.getName)
+      (d, i, indexToBytes(i))
+    }
+    val prefix = sft.getTableSharingPrefix.getBytes(UTF8)
+    val getSuffix: (FeatureToWrite) => Array[Byte] = sft.getDtgIndex match {
+      case None => (fw: FeatureToWrite) => fw.feature.getID.getBytes(UTF8)
+      case Some(dtgIndex) =>
+        (fw: FeatureToWrite) => {
+          val dtg = fw.feature.getAttribute(dtgIndex).asInstanceOf[Date]
+          val timeBytes = timeToBytes(if (dtg == null) 0L else dtg.getTime)
+          val idBytes = fw.feature.getID.getBytes(UTF8)
+          Bytes.concat(timeBytes, idBytes)
+        }
+    }
+    getRowKeys(indexedAttributes, prefix, getSuffix)
   }
 
   /**
@@ -90,27 +141,14 @@ object AttributeTable extends GeoMesaTable with LazyLogging {
    * - 12 bytes storing the dtg of the feature (OPTIONAL - only if the sft has a dtg field)
    * - n bytes storing the feature ID
    */
-  private def getMutations(toWrite: FeatureToWrite,
-                           indexedAttributes: Seq[(AttributeDescriptor, Int)],
-                           prefix: Array[Byte],
-                           suffix: Array[Byte],
-                           delete: Boolean): Seq[Mutation] = {
-    indexedAttributes.flatMap { case (descriptor, idx) =>
-      val indexBytes = indexToBytes(idx)
-      val attributes = encodeForIndex(toWrite.feature.getAttribute(idx), descriptor)
-      val mutations = attributes.map { attribute =>
-        new Mutation(Bytes.concat(prefix, indexBytes, attribute.getBytes(UTF8), NULLBYTE, suffix))
-      }
-      if (delete) {
-        mutations.foreach(_.putDelete(EMPTY_TEXT, EMPTY_TEXT, toWrite.columnVisibility))
-      } else {
-        val value = descriptor.getIndexCoverage() match {
-          case IndexCoverage.FULL => toWrite.dataValue
-          case IndexCoverage.JOIN => toWrite.indexValue
-        }
-        mutations.foreach(_.put(EMPTY_TEXT, EMPTY_TEXT, toWrite.columnVisibility, value))
-      }
-      mutations
+  private def getRowKeys(indexedAttributes: Seq[(AttributeDescriptor, Int, Array[Byte])],
+                         prefix: Array[Byte],
+                         suffix: (FeatureToWrite) => Array[Byte])
+                        (fw: FeatureToWrite): Seq[(AttributeDescriptor, Array[Byte])] = {
+    val suffixBytes = suffix(fw)
+    indexedAttributes.flatMap { case (descriptor, idx, idxBytes) =>
+      val attributes = encodeForIndex(fw.feature.getAttribute(idx), descriptor)
+      attributes.map(a => (descriptor, Bytes.concat(prefix, idxBytes, a.getBytes(UTF8), NULLBYTE, suffixBytes)))
     }
   }
 
@@ -243,7 +281,7 @@ object AttributeTable extends GeoMesaTable with LazyLogging {
   /**
    * Returns a function to get the feature ID from the row key
    */
-  def getIdFromRow(sft: SimpleFeatureType): (Array[Byte]) => String = {
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte]) => String = {
     val from = if (sft.isTableSharing) 3 else 2  // exclude feature byte and index bytes
     // drop the encoded value and the date field (12 bytes) if it's present - the rest of the row is the ID
     if (sft.getDtgField.isDefined) {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/AttributeTableV5.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/AttributeTableV5.scala
@@ -53,6 +53,8 @@ object AttributeTableV5 extends GeoMesaTable with LazyLogging {
     (toWrite: FeatureToWrite) => getAttributeIndexMutations(toWrite, attributesToIdx, rowIdPrefix, delete = true)
   }
 
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte]) => String = ???
+
   private val NULLBYTE = "\u0000"
 
   /**

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/GeoMesaTable.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/GeoMesaTable.scala
@@ -52,6 +52,14 @@ trait GeoMesaTable {
   def remover(sft: SimpleFeatureType): FeatureToMutations
 
   /**
+    * Retrieve an ID from a row. All tables are assumed to encode the feature ID into the row key
+    *
+    * @param sft simple feature type
+    * @return a function to retrieve an ID from a row
+    */
+  def getIdFromRow(sft: SimpleFeatureType): (Array[Byte]) => String
+
+  /**
    * Deletes all features from the table
    */
   def deleteFeaturesForType(sft: SimpleFeatureType, bd: BatchDeleter): Unit = {
@@ -67,6 +75,12 @@ object GeoMesaTable {
 
   // noinspection ScalaDeprecation
   val AllTables = Seq(RecordTable, SpatioTemporalTable, AttributeTableV5, AttributeTable, Z2Table, Z3Table)
+
+  val FullColumnFamily      = new Text("F")
+  val BinColumnFamily       = new Text("B")
+  val AttributeColumnFamily = new Text("A")
+
+  val EmptyColumnQualifier  = new Text()
 
   def getTables(sft: SimpleFeatureType): Seq[GeoMesaTable] = {
     val enabled = sft.getEnabledTables.collect {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/RecordTable.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/RecordTable.scala
@@ -8,6 +8,8 @@
 
 package org.locationtech.geomesa.accumulo.data.tables
 
+import java.nio.charset.StandardCharsets
+
 import com.google.common.collect.ImmutableSortedSet
 import org.apache.accumulo.core.client.admin.TableOperations
 import org.apache.accumulo.core.conf.Property
@@ -18,6 +20,7 @@ import org.locationtech.geomesa.accumulo.data.AccumuloFeatureWriter._
 import org.locationtech.geomesa.accumulo.data._
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.index.VisibilityLevel
 import org.opengis.feature.simple.SimpleFeatureType
 
 // TODO: Implement as traits and cache results to gain flexibility and speed-up.
@@ -32,25 +35,46 @@ object RecordTable extends GeoMesaTable {
 
   override def writer(sft: SimpleFeatureType): FeatureToMutations = {
     val rowIdPrefix = sft.getTableSharingPrefix
+    val putValues: (FeatureToWrite, Mutation) => Unit = sft.getVisibilityLevel match {
+      case VisibilityLevel.Feature =>
+        (toWrite, mutation) => mutation.put(SFT_CF, EMPTY_COLQ, toWrite.columnVisibility, toWrite.dataValue)
+      case VisibilityLevel.Attribute =>
+        (toWrite, mutation) => toWrite.perAttributeValues.foreach(key => mutation.put(key.cf, key.cq, key.vis, key.value))
+    }
     (toWrite: FeatureToWrite) => {
-      val m = new Mutation(getRowKey(rowIdPrefix, toWrite.feature.getID))
-      m.put(SFT_CF, EMPTY_COLQ, toWrite.columnVisibility, toWrite.dataValue)
-      Seq(m)
+      val mutation = new Mutation(getRowKey(rowIdPrefix, toWrite.feature.getID))
+      putValues(toWrite, mutation)
+      Seq(mutation)
     }
   }
 
   override def remover(sft: SimpleFeatureType): FeatureToMutations = {
     val rowIdPrefix = sft.getTableSharingPrefix
+    val putValues: (FeatureToWrite, Mutation) => Unit = sft.getVisibilityLevel match {
+      case VisibilityLevel.Feature =>
+        (toWrite, mutation) => mutation.putDelete(SFT_CF, EMPTY_COLQ, toWrite.columnVisibility)
+      case VisibilityLevel.Attribute =>
+        (toWrite, mutation) => toWrite.perAttributeValues.foreach(key => mutation.putDelete(key.cf, key.cq, key.vis))
+    }
     (toWrite: FeatureToWrite) => {
-      val m = new Mutation(getRowKey(rowIdPrefix, toWrite.feature.getID))
-      m.putDelete(SFT_CF, EMPTY_COLQ, toWrite.columnVisibility)
-      Seq(m)
+      val mutation = new Mutation(getRowKey(rowIdPrefix, toWrite.feature.getID))
+      putValues(toWrite, mutation)
+      Seq(mutation)
+    }
+  }
+
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte]) => String = {
+    val offset = sft.getTableSharingPrefix.length
+    if (offset == 0) {
+      (row) => new String(row, StandardCharsets.UTF_8)
+    } else {
+      (row) => new String(row.drop(offset), StandardCharsets.UTF_8)
     }
   }
 
   def getRowKey(rowIdPrefix: String, id: String): String = rowIdPrefix + id
 
-  override def configureTable(featureType: SimpleFeatureType, recordTable: String, tableOps: TableOperations): Unit = {
+  override def configureTable(featureType: SimpleFeatureType, table: String, tableOps: TableOperations): Unit = {
     import scala.collection.JavaConversions._
 
     val prefix = featureType.getTableSharingPrefix
@@ -61,14 +85,15 @@ object RecordTable extends GeoMesaTable {
     val splitterOptions = featureType.getUserData.getOrElse(SimpleFeatureTypes.TABLE_SPLITTER_OPTIONS, Map.empty[String, String]).asInstanceOf[Map[String, String]]
     val splits = splitter.getSplits(splitterOptions)
     val sortedSplits = splits.map(_.toString).map(prefixFn).map(new Text(_)).toSet
-    val splitsToAdd = sortedSplits -- tableOps.listSplits(recordTable).toSet
+    val splitsToAdd = sortedSplits -- tableOps.listSplits(table).toSet
     if (splitsToAdd.nonEmpty) {
-      tableOps.addSplits(recordTable, ImmutableSortedSet.copyOf(splitsToAdd.toIterable))
+      // noinspection RedundantCollectionConversion
+      tableOps.addSplits(table, ImmutableSortedSet.copyOf(splitsToAdd.toIterable))
     }
 
     // enable the row functor as the feature ID is stored in the Row ID
-    tableOps.setProperty(recordTable, Property.TABLE_BLOOM_KEY_FUNCTOR.getKey, classOf[RowFunctor].getCanonicalName)
-    tableOps.setProperty(recordTable, Property.TABLE_BLOOM_ENABLED.getKey, "true")
-    tableOps.setProperty(recordTable, Property.TABLE_BLOCKCACHE_ENABLED.getKey, "true")
+    tableOps.setProperty(table, Property.TABLE_BLOOM_KEY_FUNCTOR.getKey, classOf[RowFunctor].getCanonicalName)
+    tableOps.setProperty(table, Property.TABLE_BLOOM_ENABLED.getKey, "true")
+    tableOps.setProperty(table, Property.TABLE_BLOCKCACHE_ENABLED.getKey, "true")
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/SpatioTemporalTable.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/SpatioTemporalTable.scala
@@ -46,6 +46,8 @@ object SpatioTemporalTable extends GeoMesaTable with LazyLogging {
     (toWrite: FeatureToWrite) => stEncoder.encode(toWrite, delete = true)
   }
 
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte]) => String = ???
+
   // index rows have an index flag as part of the schema
   def isIndexEntry(key: Key): Boolean = key.getRow.find(INDEX_CHECK) != -1
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategy.scala
@@ -16,9 +16,10 @@ import org.locationtech.geomesa.accumulo.data.stats.GeoMesaStats
 import org.locationtech.geomesa.accumulo.data.tables.RecordTable
 import org.locationtech.geomesa.accumulo.index.QueryHints.RichHints
 import org.locationtech.geomesa.accumulo.index.Strategy._
-import org.locationtech.geomesa.accumulo.iterators.{BinAggregatingIterator, KryoLazyFilterTransformIterator, KryoLazyStatsIterator}
+import org.locationtech.geomesa.accumulo.iterators.{BinAggregatingIterator, KryoLazyFilterTransformIterator, KryoLazyStatsIterator, KryoVisibilityRowEncoder}
 import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+import org.locationtech.geomesa.utils.index.VisibilityLevel
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.{Filter, Id}
 
@@ -85,20 +86,22 @@ class RecordIdxStrategy(val filter: QueryFilter) extends Strategy with LazyLoggi
 
     if (sft.getSchemaVersion > 5) {
       // optimized path when we know we're using kryo serialization
-      if (hints.isBinQuery) {
-        // use the server side aggregation
-        val iters = Seq(BinAggregatingIterator.configureDynamic(sft, filter.secondary, hints, deduplicate = false))
-        val kvsToFeatures = BinAggregatingIterator.kvsToFeatures()
-        BatchScanPlan(filter, table, ranges, iters, Seq.empty, kvsToFeatures, threads, hasDuplicates = false)
-      } else if (hints.isStatsIteratorQuery) {
-        val iters = Seq(KryoLazyStatsIterator.configure(sft, filter.secondary, hints, deduplicate = false))
-        val kvsToFeatures = KryoLazyStatsIterator.kvsToFeatures(sft)
-        BatchScanPlan(filter, table, ranges, iters, Seq.empty, kvsToFeatures, threads, hasDuplicates = false)
-      } else {
-        val iters = KryoLazyFilterTransformIterator.configure(sft, filter.secondary, hints).toSeq
-        val kvsToFeatures = queryPlanner.defaultKVsToFeatures(hints)
-        BatchScanPlan(filter, table, ranges, iters, Seq.empty, kvsToFeatures, threads, hasDuplicates = false)
+      val perAttributeIter = sft.getVisibilityLevel match {
+        case VisibilityLevel.Feature   => Seq.empty
+        case VisibilityLevel.Attribute => Seq(KryoVisibilityRowEncoder.configure(sft, RecordTable))
       }
+      val (iters, kvsToFeatures) = if (hints.isBinQuery) {
+        // use the server side aggregation
+        val iter = BinAggregatingIterator.configureDynamic(sft, filter.secondary, hints, deduplicate = false)
+        (Seq(iter), BinAggregatingIterator.kvsToFeatures())
+      } else if (hints.isStatsIteratorQuery) {
+        val iter = KryoLazyStatsIterator.configure(sft, filter.secondary, hints, deduplicate = false)
+        (Seq(iter), KryoLazyStatsIterator.kvsToFeatures(sft))
+      } else {
+        val iter = KryoLazyFilterTransformIterator.configure(sft, filter.secondary, hints)
+        (iter.toSeq, queryPlanner.defaultKVsToFeatures(hints))
+      }
+      BatchScanPlan(filter, table, ranges, iters ++ perAttributeIter, Seq.empty, kvsToFeatures, threads, hasDuplicates = false)
     } else {
       val iters = if (filter.secondary.isDefined || hints.getTransformSchema.isDefined) {
         Seq(configureRecordTableIterator(sft, featureEncoding, filter.secondary, hints))

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoVisibilityRowEncoder.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoVisibilityRowEncoder.scala
@@ -1,0 +1,145 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.accumulo.iterators
+
+import com.esotericsoftware.kryo.io.Output
+import org.apache.accumulo.core.client.IteratorSetting
+import org.apache.accumulo.core.data.{Key, Value}
+import org.apache.accumulo.core.iterators.user.RowEncodingIterator
+import org.apache.accumulo.core.iterators.{IteratorEnvironment, SortedKeyValueIterator}
+import org.locationtech.geomesa.accumulo.data.tables.GeoMesaTable
+import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
+import org.locationtech.geomesa.features.serialization.CacheKeyGenerator
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.feature.simple.SimpleFeatureType
+
+/**
+  * Assumes cq are byte-encoded attribute number
+  */
+class KryoVisibilityRowEncoder extends RowEncodingIterator {
+
+  private var sft: SimpleFeatureType = null
+  private var output: Output = new Output(1024, -1)
+  private var nullBytes: Array[Array[Byte]] = null
+  private var idFromRow: (Array[Byte]) => String = null
+  private var offsets: Array[Int] = null
+
+  override def init(source: SortedKeyValueIterator[Key, Value],
+                    options: java.util.Map[String, String],
+                    env: IteratorEnvironment): Unit = {
+
+    IteratorClassLoader.initClassLoader(getClass)
+
+    super.init(source, options, env)
+
+    sft = SimpleFeatureTypes.createType("", options.get(KryoVisibilityRowEncoder.SftOpt))
+    val table = {
+      val name = options.get(KryoVisibilityRowEncoder.TableOpt)
+      GeoMesaTable.AllTables.find(_.getClass.getSimpleName == name).getOrElse {
+        throw new IllegalArgumentException(s"Table $name not found")
+      }
+    }
+    idFromRow = table.getIdFromRow(sft)
+    val cacheKey = CacheKeyGenerator.cacheKeyForSFT(sft)
+    if (offsets == null || offsets.length != sft.getAttributeCount) {
+      offsets = Array.ofDim[Int](sft.getAttributeCount)
+    }
+    nullBytes = KryoFeatureSerializer.getWriters(cacheKey, sft).map { writer =>
+      output.clear()
+      writer(output, null)
+      output.toBytes
+    }
+  }
+
+  override def rowEncoder(keys: java.util.List[Key], values: java.util.List[Value]): Value = {
+    val allValues = Array.ofDim[Array[Byte]](sft.getAttributeCount)
+
+    var i = 0
+    while (i < keys.size) {
+      val indices = keys.get(i).getColumnQualifier.getBytes.map(_.toInt)
+      val input = KryoFeatureSerializer.getInput(values.get(i).get)
+      indices.foreach { i =>
+        val value = Array.ofDim[Byte](input.readInt(true))
+        input.readBytes(value)
+        allValues(i) = value
+      }
+      i += 1
+    }
+
+    i = 0
+    while (i < allValues.length) {
+      if (allValues(i) == null) {
+        allValues(i) = nullBytes(i)
+      }
+      i += 1
+    }
+
+    val id = idFromRow(keys.get(0).getRow.copyBytes)
+    // TODO if we don't have a geometry, skip the record?
+    KryoVisibilityRowEncoder.encode(id, allValues, output, offsets)
+  }
+
+  override def rowDecoder(rowKey: Key, rowValue: Value): java.util.SortedMap[Key, Value] =
+    throw new NotImplementedError("")
+
+  override def deepCopy(env: IteratorEnvironment): SortedKeyValueIterator[Key, Value] = {
+    val iterator = new KryoVisibilityRowEncoder
+    if (sourceIter != null) {
+      iterator.sourceIter = sourceIter.deepCopy(env)
+    }
+    iterator.sft = sft
+    iterator.idFromRow = idFromRow
+    iterator.offsets = Array.ofDim[Int](sft.getAttributeCount)
+    iterator.nullBytes = nullBytes
+    iterator
+  }
+}
+
+object KryoVisibilityRowEncoder {
+
+  val SftOpt   = "sft"
+  val TableOpt = "table"
+
+  val DefaultPriority = 21 // needs to be first thing that runs after the versioning iterator at 20
+
+  def configure(sft: SimpleFeatureType, table: GeoMesaTable, priority: Int = DefaultPriority): IteratorSetting = {
+    val is = new IteratorSetting(priority, "feature-merge-iter", classOf[KryoVisibilityRowEncoder])
+    is.addOption(SftOpt, SimpleFeatureTypes.encodeType(sft, includeUserData = true)) // need user data for id calc
+    is.addOption(TableOpt, table.getClass.getSimpleName)
+    is
+  }
+
+  private def encode(id: String, values: Array[Array[Byte]], output: Output, offsets: Array[Int]): Value = {
+    output.clear()
+    output.writeInt(KryoFeatureSerializer.VERSION, true)
+    output.setPosition(5) // leave 4 bytes to write the offsets
+    output.writeString(id)
+    // write attributes and keep track off offset into byte array
+    var i = 0
+    while (i < values.length) {
+      offsets(i) = output.position()
+      output.write(values(i))
+      i += 1
+    }
+    // write the offsets - variable width
+    i = 0
+    val offsetStart = output.position()
+    while (i < values.length) {
+      output.writeInt(offsets(i), true)
+      i += 1
+    }
+    // got back and write the start position for the offsets
+    val total = output.position()
+    output.setPosition(1)
+    output.writeInt(offsetStart)
+    output.setPosition(total) // set back to the end so that we get all the bytes
+
+    new Value(output.toBytes)
+  }
+}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreAttributeVisibilityTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreAttributeVisibilityTest.scala
@@ -1,0 +1,137 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.accumulo.data
+
+import org.apache.accumulo.core.client.mock.MockInstance
+import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.security.Authorizations
+import org.geotools.data._
+import org.geotools.factory.Hints
+import org.geotools.feature.DefaultFeatureCollection
+import org.geotools.filter.text.ecql.ECQL
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
+import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType.StrategyType
+import org.locationtech.geomesa.accumulo.util.SelfClosingIterator
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.security.SecurityUtils
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.feature.simple.SimpleFeature
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class AccumuloDataStoreAttributeVisibilityTest extends Specification {
+
+  import scala.collection.JavaConversions._
+
+  sequential
+
+  val sftName = getClass.getSimpleName
+  val spec = "name:String:index=full,age:Int,dtg:Date,*geom:Point:srid=4326;geomesa.visibility.level='attribute'"
+
+  val connector = {
+    val mockInstance = new MockInstance("mycloud")
+    val mockConnector = mockInstance.getConnector("user", new PasswordToken("password"))
+    mockConnector.securityOperations().changeUserAuthorizations("user", new Authorizations("admin", "user"))
+    mockConnector
+  }
+
+  val (ds, sft) = {
+    val sft = SimpleFeatureTypes.createType(sftName, spec)
+    val ds = DataStoreFinder.getDataStore(Map(
+      "connector" -> connector,
+      // note the table needs to be different to prevent testing errors
+      "tableName" -> sftName)).asInstanceOf[AccumuloDataStore]
+    ds.createSchema(sft)
+    (ds, ds.getSchema(sftName)) // reload the sft from the ds to ensure all user data is set properly
+  }
+
+  val user = {
+    val sf = new ScalaSimpleFeature("user", sft)
+    sf.setAttribute(0, "name-user")
+    sf.setAttribute(1, "10")
+    sf.setAttribute(2, "2014-01-01T01:00:00.000Z")
+    sf.setAttribute(3, "POINT (-120 45)")
+    SecurityUtils.setFeatureVisibility(sf, "user,user,user,user")
+    sf.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+    sf
+  }
+  val admin = {
+    val sf = new ScalaSimpleFeature("admin", sft)
+    sf.setAttribute(0, "name-admin")
+    sf.setAttribute(1, "11")
+    sf.setAttribute(2, "2014-01-02T01:00:00.000Z")
+    sf.setAttribute(3, "POINT (-120 46)")
+    SecurityUtils.setFeatureVisibility(sf, "admin,admin,admin,admin")
+    sf.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+    sf
+  }
+  val mixed = {
+    val sf = new ScalaSimpleFeature("mixed", sft)
+    sf.setAttribute(0, "name-mixed")
+    sf.setAttribute(1, "12")
+    sf.setAttribute(2, "2014-01-03T01:00:00.000Z")
+    sf.setAttribute(3, "POINT (-120 47)")
+    SecurityUtils.setFeatureVisibility(sf, "admin,user,admin,user")
+    sf.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+    sf
+  }
+
+  val featureCollection = new DefaultFeatureCollection(sftName, sft)
+  featureCollection.add(user)
+  featureCollection.add(admin)
+  featureCollection.add(mixed)
+
+  // write the feature to the store
+  val fs = ds.getFeatureSource(sftName)
+  fs.addFeatures(featureCollection)
+
+  def queryByAuths(auths: String, filter: String, expectedStrategy: StrategyType): Seq[SimpleFeature] = {
+    val ds = DataStoreFinder.getDataStore(Map(
+      "connector"    -> connector,
+      "tableName"    -> sftName,
+      "auths"        -> auths)).asInstanceOf[AccumuloDataStore]
+    val query = new Query(sftName, ECQL.toFilter(filter))
+    val plans = ds.getQueryPlan(query)
+    plans must haveLength(1)
+    plans.head.filter.strategy mustEqual expectedStrategy
+    SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toSeq
+  }
+
+  val filters = Seq(
+    ("IN ('user', 'admin', 'mixed')", StrategyType.RECORD),
+    ("bbox(geom, -121, 44, -119, 48)", StrategyType.Z2),
+    ("bbox(geom, -121, 44, -119, 48) AND dtg DURING 2014-01-01T00:00:00.000Z/2014-01-04T00:00:00.000Z", StrategyType.Z3),
+    ("name = 'name-user' OR name = 'name-admin' OR name = 'name-mixed'", StrategyType.ATTRIBUTE)
+  )
+
+  "AccumuloDataStore" should {
+    "correctly return all features with appropriate auths" in {
+      forall(filters) { case (filter, strategy) =>
+        val features = queryByAuths("admin,user", filter, strategy)
+        features must haveLength(3)
+        features must containTheSameElementsAs(Seq(user, admin, mixed))
+      }
+    }
+    "correctly return some features with appropriate auths" in {
+      forall(filters) { case (filter, strategy) =>
+        val features = queryByAuths("user", filter, strategy)
+        features must haveLength(2)
+        features must contain(user)
+        val m = features.find(_.getID == "mixed")
+        m must beSome
+        m.get.getAttribute(0) must beNull
+        m.get.getAttribute(1) mustEqual 12
+        m.get.getAttribute(2) must beNull
+        m.get.getAttribute(3) mustEqual mixed.getAttribute(3)
+      }
+    }
+  }
+}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreAttributeVisibilityTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreAttributeVisibilityTest.scala
@@ -100,8 +100,7 @@ class AccumuloDataStoreAttributeVisibilityTest extends Specification {
       "auths"        -> auths)).asInstanceOf[AccumuloDataStore]
     val query = new Query(sftName, ECQL.toFilter(filter))
     val plans = ds.getQueryPlan(query)
-    plans must haveLength(1)
-    plans.head.filter.strategy mustEqual expectedStrategy
+    forall(plans)(_.filter.strategy mustEqual expectedStrategy)
     SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toSeq
   }
 

--- a/geomesa-features/geomesa-feature-avro/src/main/scala/org/locationtech/geomesa/features/avro/AvroFeatureSerializer.scala
+++ b/geomesa-features/geomesa-feature-avro/src/main/scala/org/locationtech/geomesa/features/avro/AvroFeatureSerializer.scala
@@ -37,6 +37,8 @@ class AvroFeatureSerializer(sft: SimpleFeatureType, val options: Set[Serializati
     reuse.flush()
     baos.toByteArray
   }
+
+  override def serialize(i: Int, value: AnyRef): Array[Byte] = throw new NotImplementedError()
 }
 
 /**

--- a/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/SimpleFeatureSerializer.scala
+++ b/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/SimpleFeatureSerializer.scala
@@ -26,6 +26,7 @@ trait HasEncodingOptions {
  */
 trait SimpleFeatureSerializer extends HasEncodingOptions {
   def serialize(feature: SimpleFeature): Array[Byte]
+  def serialize(i: Int, value: AnyRef): Array[Byte]
 }
 
 /**

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/KryoFeatureSerializer.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/KryoFeatureSerializer.scala
@@ -46,6 +46,12 @@ class KryoFeatureSerializer(sft: SimpleFeatureType, val options: Set[Serializati
   override def serialize(sf: SimpleFeature): Array[Byte] = doWrite(sf)
   override def deserialize(bytes: Array[Byte]): SimpleFeature = doRead(bytes)
 
+  override def serialize(i: Int, value: AnyRef): Array[Byte] = {
+    val output = getOutput()
+    writers(i)(output, value)
+    output.toBytes
+  }
+
   private val doWrite: (SimpleFeature) => Array[Byte] = if (options.withUserData) writeWithUserData else write
   private val doRead: (Array[Byte]) => SimpleFeature = if (options.withUserData) readWithUserData else read
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -19,6 +19,8 @@ import org.geotools.geometry.DirectPosition2D
 import org.geotools.temporal.`object`.{DefaultInstant, DefaultPeriod, DefaultPosition}
 import org.joda.time.DateTime
 import org.locationtech.geomesa.CURRENT_SCHEMA_VERSION
+import org.locationtech.geomesa.utils.index.VisibilityLevel
+import org.locationtech.geomesa.utils.index.VisibilityLevel.{apply => _, _}
 import org.locationtech.geomesa.utils.stats.Cardinality._
 import org.locationtech.geomesa.utils.stats.IndexCoverage._
 import org.locationtech.geomesa.utils.stats.{Cardinality, IndexCoverage}
@@ -200,6 +202,7 @@ object RichSimpleFeatureType {
   val ST_INDEX_SCHEMA_KEY = "geomesa.index.st.schema"
   val USER_DATA_PREFIX    = "geomesa.user-data.prefix"
   val KEYWORDS_KEY        = "geomesa.keywords"
+  val VIS_LEVEL_KEY       = "geomesa.visibility.level"
 
   val KEYWORDS_DELIMITER = "\u0000"
 
@@ -242,6 +245,12 @@ object RichSimpleFeatureType {
       val gd = sft.getGeometryDescriptor
       gd != null && gd.getType.getBinding == classOf[LineString]
     }
+
+    def getVisibilityLevel: VisibilityLevel = userData[String](VIS_LEVEL_KEY) match {
+      case None        => VisibilityLevel.Feature
+      case Some(level) => VisibilityLevel.withName(level.toLowerCase)
+    }
+    def setVisibilityLevel(vis: VisibilityLevel): Unit = sft.getUserData.put(VIS_LEVEL_KEY, vis.toString)
 
     //  If no user data is specified when creating a new SFT, we should default to 'true'.
     def isTableSharing: Boolean = userData[String](TABLE_SHARING_KEY).forall(_.toBoolean)

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/VisibilityLevel.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/VisibilityLevel.scala
@@ -1,0 +1,15 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.utils.index
+
+object VisibilityLevel extends Enumeration {
+  type VisibilityLevel = Value
+  val Feature   = Value("feature")
+  val Attribute = Value("attribute")
+}


### PR DESCRIPTION
* Enable in the sft with the user data: geomesa.visibility.level='attribute'
* Put comma-delimited visibilities in the simple feature user data corresponding to each attribute
* WARNING: Experimental, does not support all query types and compatibility is not gauranteed going forward

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>