### PR TITLE
GEOMESA-1259 Add geomesa-process jar to accumulo gs plugin dist

### DIFF
--- a/geomesa-gs-plugin/geomesa-accumulo-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-accumulo-gs-plugin/pom.xml
@@ -47,6 +47,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-process</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
 
         <!-- provided dependencies -->
         <dependency>


### PR DESCRIPTION
Signed-off-by: Andrew Hulbert <andrew.hulbert@ccri.com>

this adds the process jar to the dist BUT will require users to install the wps plugin to make things work...thoughts? Else I can just include it without the process jar but we always use it. we can always update the docs to reflect that wps is required.