### PR TITLE
Use tarLongFileMode of posix instead of gnu

### DIFF
--- a/geomesa-dist/pom.xml
+++ b/geomesa-dist/pom.xml
@@ -133,7 +133,7 @@
                         <configuration>
                             <attach>true</attach>
                             <finalName>geomesa-${project.version}</finalName>
-                            <tarLongFileMode>gnu</tarLongFileMode>
+                            <tarLongFileMode>posix</tarLongFileMode>
                             <descriptors>
                                 <descriptor>src/main/assemblies/binary-release.xml</descriptor>
                             </descriptors>

--- a/geomesa-tools/pom.xml
+++ b/geomesa-tools/pom.xml
@@ -213,7 +213,7 @@
                         <configuration>
                             <attach>true</attach>
                             <finalName>geomesa-tools-${project.version}</finalName>
-                            <tarLongFileMode>gnu</tarLongFileMode>
+                            <tarLongFileMode>posix</tarLongFileMode>
                             <descriptors>
                                 <descriptor>src/main/assemblies/binary-release.xml</descriptor>
                             </descriptors>

--- a/geomesa-web/geomesa-web-install/pom.xml
+++ b/geomesa-web/geomesa-web-install/pom.xml
@@ -207,7 +207,7 @@
                                 <configuration>
                                     <attach>false</attach>
                                     <finalName>spark-${project.version}</finalName>
-                                    <tarLongFileMode>gnu</tarLongFileMode>
+                                    <tarLongFileMode>posix</tarLongFileMode>
                                     <descriptors>
                                         <descriptor>src/main/assemblies/spark-assembly.xml</descriptor>
                                     </descriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -1937,6 +1937,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>2.6</version>
+                    <configuration>
+                      <tarLongFileMode>posix</tarLongFileMode>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
An error encountered during OS X builds involves the user ID and possibly group ID being too large for the default `gnu` `tarLongFileMode`. Using `posix` mode appears to resolve this issue.

Signed-off-by: Nathan Zimmerman npzimmerman@gmail.com