### PR TITLE
GEOMESA-1215,GEOMESA-347 Better OR filter handling, limiting...

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/accumulo.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/accumulo.scala
@@ -53,6 +53,9 @@ package object accumulo {
       val QUERY_EXACT_COUNT    = PropAndDefault("geomesa.force.count", "false")
       val QUERY_COST_TYPE      = PropAndDefault("geomesa.query.cost.type", null)
       val QUERY_TIMEOUT_MILLIS = PropAndDefault("geomesa.query.timeout.millis", null) // default is no timeout
+      // rough upper limit on the number of accumulo ranges we will generate per query
+      val SCAN_RANGES_TARGET   = PropAndDefault("geomesa.scan.ranges.target", "2000")
+      // if we generate more ranges than this we will split them up into sequential scans
       val SCAN_BATCH_RANGES    = PropAndDefault("geomesa.scan.ranges.batch", "20000")
     }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/Z2Table.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/tables/Z2Table.scala
@@ -22,8 +22,7 @@ import org.locationtech.geomesa.accumulo.data.AccumuloFeatureWriter.FeatureToMut
 import org.locationtech.geomesa.accumulo.data._
 import org.locationtech.geomesa.curve.Z2SFC
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-import org.locationtech.sfcurve.zorder.Z2
-import org.locationtech.sfcurve.zorder.Z3.ZPrefix
+import org.locationtech.sfcurve.zorder.{Z2, ZPrefix}
 import org.opengis.feature.simple.SimpleFeatureType
 
 object Z2Table extends GeoMesaTable {
@@ -180,8 +179,8 @@ object Z2Table extends GeoMesaTable {
       val ZPrefix(zprefix, zbits) = Z2.longestCommonPrefix(min, max)
       if (zbits < GEOM_Z_NUM_BYTES * 8) {
         // divide the range into two smaller ones using tropf litmax/bigmin
-        val (litmax, bigmin) = Z2.zdivide(Z2((min + max) / 2), Z2(min), Z2(max))
-        in.enqueue((min, litmax.z), (bigmin.z, max))
+        val (litmax, bigmin) = Z2.zdivide((min + max) >>> 1, min, max) // >>> 1 is overflow safe mean
+        in.enqueue((min, litmax), (bigmin, max))
       } else {
         // we've found a prefix that contains our z range
         // truncate down to the bytes we use so we don't get dupes

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIdxStrategy.scala
@@ -29,20 +29,24 @@ import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleF
 import org.locationtech.geomesa.utils.index.VisibilityLevel
 import org.locationtech.geomesa.utils.stats.{Cardinality, IndexCoverage, Stat}
 import org.opengis.feature.simple.SimpleFeatureType
-import org.opengis.filter.{Filter, PropertyIsEqualTo}
+import org.opengis.filter._
+import org.opengis.filter.temporal.{After, Before, During, TEquals}
 
 import scala.util.Try
 
 class AttributeIdxStrategy(val filter: QueryFilter) extends Strategy with LazyLogging {
 
-  import org.locationtech.geomesa.accumulo.index.AttributeIdxStrategy._
+  import org.locationtech.geomesa.accumulo.index.AttributeIdxStrategy.{ScanPlanFn, attributeValueKvsToFeatures}
 
   /**
    * Perform scan against the Attribute Index Table and get an iterator returning records from the Record table
    */
-  override def getQueryPlan(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType) = {
-    val ds = queryPlanner.ds
+  override def getQueryPlan(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType): QueryPlan = {
     val sft = queryPlanner.sft
+
+    val primary = filter.primary.getOrElse {
+      throw new IllegalStateException("Attribute index does not support Filter.INCLUDE")
+    }
 
     // pull out any dates from the filter to help narrow down the attribute ranges
     val dates = for {
@@ -54,21 +58,24 @@ class AttributeIdxStrategy(val filter: QueryFilter) extends Strategy with LazyLo
       (intervals.map(_._1.getMillis).min, intervals.map(_._2.getMillis).max)
     }
 
-    // for an attribute query, the primary filters are considered an OR
-    // (an AND would never match unless the attribute is a list...)
-    val propsAndRanges = {
-      val primary = filter.singlePrimary.getOrElse {
-        throw new IllegalStateException("Attribute index does not support Filter.INCLUDE")
-      }
-      getBounds(sft, primary, dates)
+    // TODO currently exclusive ANDs will return nothing - but if it's a list type it could actually match
+    val bounds = AttributeIdxStrategy.getBounds(sft, primary, dates)
+
+    if (bounds.isEmpty) {
+      EmptyPlan(filter)
+    } else {
+      nonEmptyQueryPlan(queryPlanner, hints, bounds)
     }
-    val attribute = propsAndRanges.headOption.map(_.attribute).getOrElse {
-      throw new IllegalStateException(s"No ranges found for query filter $filter. " +
-          "This should have been checked during query planning")
-    }
-    val ranges = propsAndRanges.map(_.range)
+  }
+
+  private def nonEmptyQueryPlan(queryPlanner: QueryPlanner, hints: Hints, bounds: Seq[PropertyBounds]): QueryPlan = {
+    val ds = queryPlanner.ds
+    val sft = queryPlanner.sft
+
+    val attribute = bounds.head.attribute
+    val ranges = bounds.map(_.range)
     // ensure we only have 1 prop we're working on
-    assert(propsAndRanges.forall(_.attribute == attribute))
+    require(bounds.forall(_.attribute == attribute), "Found multiple attributes in attribute filter")
 
     val descriptor = sft.getDescriptor(attribute)
     val transform = hints.getTransformSchema
@@ -223,7 +230,7 @@ object AttributeIdxStrategy extends StrategyProvider {
                                         filter: QueryFilter,
                                         transform: Option[SimpleFeatureType],
                                         stats: GeoMesaStats): Option[Long] = {
-    filter.singlePrimary match {
+    filter.primary match {
       case None => Some(Long.MaxValue)
       case Some(f) =>
         stats.getCount(sft, f, exact = false).map { count =>
@@ -258,14 +265,14 @@ object AttributeIdxStrategy extends StrategyProvider {
                                         filter: QueryFilter,
                                         transform: Option[SimpleFeatureType]): Long = {
     // note: names should be only a single attribute
-    val attrsAndCounts = filter.primary
-      .flatMap(getAttributeProperty)
-      .map(_.name)
-      .groupBy((f: String) => f)
-      .map { case (name, itr) => (name, itr.size) }
-
-    val cost = attrsAndCounts.map { case (attr, count) =>
-      val descriptor = sft.getDescriptor(attr)
+    val cost = for {
+      f          <- filter.primary
+      attribute  <- FilterHelper.propertyNames(f, sft).headOption
+      descriptor <- Option(sft.getDescriptor(attribute))
+      binding    =  descriptor.getType.getBinding
+      bounds     <- FilterHelper.extractAttributeBounds(f, attribute, binding)
+      if bounds.bounds.nonEmpty
+    } yield {
       // join queries are much more expensive than non-join queries
       // TODO figure out the actual cost of each additional range...I'll make it 2
       val additionalRangeCost = 1
@@ -273,10 +280,10 @@ object AttributeIdxStrategy extends StrategyProvider {
       val multiplier =
         if (descriptor.getIndexCoverage == IndexCoverage.FULL ||
               IteratorTrigger.canUseAttrIdxValues(sft, filter.secondary, transform) ||
-              IteratorTrigger.canUseAttrKeysPlusValues(attr, sft, filter.secondary, transform)) {
+              IteratorTrigger.canUseAttrKeysPlusValues(attribute, sft, filter.secondary, transform)) {
           1
         } else {
-          joinCost + (additionalRangeCost*(count-1))
+          joinCost + (additionalRangeCost * (bounds.bounds.length - 1))
         }
 
       // scale attribute cost by expected cardinality
@@ -285,8 +292,29 @@ object AttributeIdxStrategy extends StrategyProvider {
         case Cardinality.UNKNOWN => 101 * multiplier
         case Cardinality.LOW     => Long.MaxValue
       }
-    }.sum
-    if (cost == 0) Long.MaxValue else cost // cost == 0 if somehow the filters don't match anything
+    }
+    cost.getOrElse(Long.MaxValue)
+  }
+
+  /**
+    * Checks for attribute filters that we can satisfy using the attribute index strategy
+    *
+    * @param filter filter to evaluate
+    * @return true if we can process it as an attribute query
+    */
+  def attributeCheck(filter: Filter): Boolean = {
+    filter match {
+      case _: And | _: Or => true // note: implies further processing of children
+      case _: PropertyIsEqualTo => true
+      case _: PropertyIsBetween => true
+      case _: PropertyIsGreaterThan | _: PropertyIsLessThan => true
+      case _: PropertyIsGreaterThanOrEqualTo | _: PropertyIsLessThanOrEqualTo => true
+      case _: During |  _: Before | _: After | _: TEquals => true
+      case _: PropertyIsNull => true // we need this to be able to handle 'not null'
+      case f: PropertyIsLike => likeEligible(f)
+      case f: Not =>  f.getFilter.isInstanceOf[PropertyIsNull]
+      case _ => false
+    }
   }
 
   /**
@@ -381,40 +409,21 @@ object AttributeIdxStrategy extends StrategyProvider {
   }
 
   def tryMergeAttrStrategy(toMerge: QueryFilter, mergeTo: QueryFilter): QueryFilter = {
-    // TODO: check disjoint range queries on an attribute
-    // e.g. 'height < 5 OR height > 6'
-    tryMergeDisjointAttrEquals(toMerge, mergeTo)
-  }
-
-  def tryMergeDisjointAttrEquals(toMerge: QueryFilter, mergeTo: QueryFilter): QueryFilter = {
-    // determine if toMerge.primary and mergeTo.primary are all Equals filters on the same attribute
     // TODO this will be incorrect for multi-valued properties where we have an AND in the primary filter
-    if (isPropertyIsEqualToFilter(toMerge) && isPropertyIsEqualToFilter(mergeTo) && isSameProperty(toMerge, mergeTo)) {
-      // if we have disjoint attribute queries with the same secondary filter, merge into a multi-range query
-      (toMerge.secondary, mergeTo.secondary) match {
-        case (Some(f1), Some(f2)) if f1.equals(f2) =>
-          mergeTo.copy(primary = mergeTo.primary ++ toMerge.primary, or = true)
+    val leftAttributes = toMerge.primary.map(FilterHelper.propertyNames(_, null))
+    val rightAttributes = mergeTo.primary.map(FilterHelper.propertyNames(_, null))
 
-        case (None, None) =>
-          mergeTo.copy(primary = mergeTo.primary ++ toMerge.primary, or = true)
+    val canMergePrimary = (leftAttributes, rightAttributes) match {
+      case (Some(left), Some(right)) => left.length == 1 && right.length == 1 && left.head == right.head
+      case _ => true
+    }
 
-        case _ =>
-          null
-      }
+    if (canMergePrimary && toMerge.secondary == mergeTo.secondary) {
+      QueryFilter(mergeTo.strategy, orOption(toMerge.primary.toSeq ++ mergeTo.primary), mergeTo.secondary)
     } else {
       null
     }
   }
-
-  def isPropertyIsEqualToFilter(qf: QueryFilter) = qf.primary.forall(_.isInstanceOf[PropertyIsEqualTo])
-
-  def isSameProperty(l: QueryFilter, r: QueryFilter) = {
-    val lp = distinctProperties(l)
-    val rp = distinctProperties(r)
-    lp.length == 1 && rp.length == 1 && lp.head == rp.head
-  }
-
-  def distinctProperties(qf: QueryFilter) = qf.primary.flatMap { f => DataUtilities.attributeNames(f) }.distinct
 }
 
 case class PropertyBounds(attribute: String, bounds: (Option[Any], Option[Any]), range: AccRange)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIdxStrategy.scala
@@ -58,7 +58,7 @@ class AttributeIdxStrategy(val filter: QueryFilter) extends Strategy with LazyLo
       (intervals.map(_._1.getMillis).min, intervals.map(_._2.getMillis).max)
     }
 
-    // TODO currently exclusive ANDs will return nothing - but if it's a list type it could actually match
+    // TODO GEOMESA-1336 fix exclusive AND handling for list types
     val bounds = AttributeIdxStrategy.getBounds(sft, primary, dates)
 
     if (bounds.isEmpty) {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIdxStrategy.scala
@@ -408,6 +408,18 @@ object AttributeIdxStrategy extends StrategyProvider {
     }
   }
 
+  /**
+    * Tries to merge the two filters that are OR'd together into a single filter that can be queried in one pass.
+    * Will return the merged filter, or null if they can't be merged.
+    *
+    * We can merge filters if they have the same secondary filter AND:
+    *   1. One of them does not have a primary filter
+    *   2. They both have a primary filter on the same attribute
+    *
+    * @param toMerge first filter
+    * @param mergeTo second filter
+    * @return merged filter that satisfies both inputs, or null if that isn't possible
+    */
   def tryMergeAttrStrategy(toMerge: QueryFilter, mergeTo: QueryFilter): QueryFilter = {
     // TODO this will be incorrect for multi-valued properties where we have an AND in the primary filter
     val leftAttributes = toMerge.primary.map(FilterHelper.propertyNames(_, null))

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIdxStrategyV5.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIdxStrategyV5.scala
@@ -50,7 +50,11 @@ class AttributeIdxStrategyV5(val filter: QueryFilter) extends Strategy with Lazy
    * Perform scan against the Attribute Index Table and get an iterator returning records from the Record table
    */
   override def getQueryPlan(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType) = {
-    val propsAndRanges = filter.primary.map(getPropertyAndRange(_, queryPlanner.sft))
+    import scala.collection.JavaConversions._
+    val propsAndRanges = filter.primary.collect {
+      case or: Or => or.getChildren.map(getPropertyAndRange(_, queryPlanner.sft))
+      case f => Seq(getPropertyAndRange(f, queryPlanner.sft))
+    }.getOrElse(Seq.empty)
     val attributeName = propsAndRanges.head._1
     val ranges = propsAndRanges.map(_._2)
     // ensure we only have 1 prop we're working on

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/QueryPlanners.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/QueryPlanners.scala
@@ -42,6 +42,17 @@ sealed trait QueryPlan {
   def join: Option[(JoinFunction, QueryPlan)] = None
 }
 
+// plan that will not actually scan anything
+case class EmptyPlan(filter: QueryFilter) extends QueryPlan {
+  override val table: String = ""
+  override val iterators: Seq[IteratorSetting] = Seq.empty
+  override val kvsToFeatures: FeatureFunction = (_) => null
+  override val ranges: Seq[AccRange] = Seq.empty
+  override val columnFamilies: Seq[Text] = Seq.empty
+  override val hasDuplicates: Boolean = false
+  override val numThreads: Int = 0
+}
+
 // single scan plan
 case class ScanPlan(filter: QueryFilter,
                     table: String,
@@ -50,8 +61,8 @@ case class ScanPlan(filter: QueryFilter,
                     columnFamilies: Seq[Text],
                     kvsToFeatures: FeatureFunction,
                     hasDuplicates: Boolean) extends QueryPlan {
-  val numThreads = 1
-  val ranges = Seq(range)
+  override val numThreads = 1
+  override val ranges = Seq(range)
 }
 
 // batch scan plan
@@ -74,7 +85,7 @@ case class JoinPlan(filter: QueryFilter,
                     hasDuplicates: Boolean,
                     joinFunction: JoinFunction,
                     joinQuery: BatchScanPlan) extends QueryPlan {
-  def kvsToFeatures: FeatureFunction = joinQuery.kvsToFeatures
+  override def kvsToFeatures: FeatureFunction = joinQuery.kvsToFeatures
   override val join = Some((joinFunction, joinQuery))
 }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategy.scala
@@ -21,7 +21,7 @@ import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.locationtech.geomesa.utils.index.VisibilityLevel
 import org.opengis.feature.simple.SimpleFeatureType
-import org.opengis.filter.{Filter, Id}
+import org.opengis.filter.{And, Filter, Id, Or}
 
 import scala.collection.JavaConversions._
 
@@ -33,22 +33,21 @@ object RecordIdxStrategy extends StrategyProvider {
                                         filter: QueryFilter,
                                         transform: Option[SimpleFeatureType],
                                         stats: GeoMesaStats): Option[Long] = {
-    if (QueryFilterSplitter.isFullTableScan(filter)) Some(Long.MaxValue) else Some(1L)
+    if (filter.primary.isDefined) Some(1L) else Some(Long.MaxValue)
   }
 
   // top-priority index - always 1
   override protected def indexBasedCost(sft: SimpleFeatureType,
                                         filter: QueryFilter,
                                         transform: Option[SimpleFeatureType]): Long =
-    if (QueryFilterSplitter.isFullTableScan(filter)) Int.MaxValue else 1
+  if (filter.primary.isDefined) 1 else Long.MaxValue
 
-  def intersectIdFilters(filters: Seq[Filter]): Set[String] = {
-    if (filters.length < 2) {
-      filters.map(_.asInstanceOf[Id]).flatMap(_.getIDs.map(_.toString)).toSet
-    } else {
-      // get the Set of IDs in *each* filter and convert to a Scala immutable Set
-      // take the intersection of all sets, since the filters and joined with 'and'
-      filters.map(_.asInstanceOf[Id].getIDs.map(_.toString).toSet).reduceLeft(_ intersect _)
+  def intersectIdFilters(filter: Filter): Set[String] = {
+    filter match {
+      case f: And => f.getChildren.map(intersectIdFilters).reduceLeftOption(_ intersect _).getOrElse(Set.empty)
+      case f: Or  => f.getChildren.flatMap(intersectIdFilters).toSet
+      case f: Id  => f.getIDs.map(_.toString).toSet
+      case _ => throw new IllegalArgumentException(s"Expected ID filter, got ${filterToString(filter)}")
     }
   }
 }
@@ -61,62 +60,62 @@ class RecordIdxStrategy(val filter: QueryFilter) extends Strategy with LazyLoggi
     val featureEncoding = queryPlanner.ds.getFeatureEncoding(sft)
     val prefix = sft.getTableSharingPrefix
 
-    val ranges = if (filter.primary.forall(_ == Filter.INCLUDE)) {
-      // allow for full table scans - we use the record index for queries that can't be satisfied elsewhere
-      filter.secondary.foreach { f =>
-        logger.warn(s"Running full table scan for schema ${sft.getTypeName} with filter ${filterToString(f)}")
-      }
-      val start = new Text(prefix)
-      Seq(new aRange(start, true, aRange.followingPrefix(start), false))
-    } else {
-      // Multiple sets of IDs in a ID Filter are ORs. ANDs of these call for the intersection to be taken.
-      // intersect together all groups of ID Filters, producing Some[Id] if the intersection returns something
-      val identifiers = RecordIdxStrategy.intersectIdFilters(filter.primary)
-      output(s"Extracted ID filter: ${identifiers.mkString(", ")}")
-      if (identifiers.nonEmpty) {
+    val ranges = filter.primary match {
+      case None =>
+        // allow for full table scans
+        filter.secondary.foreach { f =>
+          logger.warn(s"Running full table scan for schema ${sft.getTypeName} with filter ${filterToString(f)}")
+        }
+        val start = new Text(prefix)
+        Seq(new aRange(start, true, aRange.followingPrefix(start), false))
+
+      case Some(primary) =>
+        // Multiple sets of IDs in a ID Filter are ORs. ANDs of these call for the intersection to be taken.
+        // intersect together all groups of ID Filters, producing a set of IDs
+        val identifiers = RecordIdxStrategy.intersectIdFilters(primary)
+        output(s"Extracted ID filter: ${identifiers.mkString(", ")}")
         identifiers.toSeq.map(id => aRange.exact(RecordTable.getRowKey(prefix, id)))
-      } else {
-        // TODO GEOMESA-347 instead pass empty query plan
-        Seq.empty
-      }
     }
 
-    val table = ds.getTableName(sft.getTypeName, RecordTable)
-    val threads = ds.getSuggestedThreads(sft.getTypeName, RecordTable)
+    if (ranges.isEmpty) { EmptyPlan(filter) } else {
+      val table = ds.getTableName(sft.getTypeName, RecordTable)
+      val threads = ds.getSuggestedThreads(sft.getTypeName, RecordTable)
+      val dupes = false // record table never has duplicate entries
 
-    if (sft.getSchemaVersion > 5) {
-      // optimized path when we know we're using kryo serialization
-      val perAttributeIter = sft.getVisibilityLevel match {
-        case VisibilityLevel.Feature   => Seq.empty
-        case VisibilityLevel.Attribute => Seq(KryoVisibilityRowEncoder.configure(sft))
-      }
-      val (iters, kvsToFeatures) = if (hints.isBinQuery) {
-        // use the server side aggregation
-        val iter = BinAggregatingIterator.configureDynamic(sft, RecordTable, filter.secondary, hints, deduplicate = false)
-        (Seq(iter), BinAggregatingIterator.kvsToFeatures())
-      } else if (hints.isDensityQuery) {
-        val iter = KryoLazyDensityIterator.configure(sft, RecordTable, filter.secondary, hints)
-        (Seq(iter), KryoLazyDensityIterator.kvsToFeatures())
-      } else if (hints.isStatsIteratorQuery) {
-        val iter = KryoLazyStatsIterator.configure(sft, RecordTable, filter.secondary, hints, deduplicate = false)
-        (Seq(iter), KryoLazyStatsIterator.kvsToFeatures(sft))
+      if (sft.getSchemaVersion > 5) {
+        // optimized path when we know we're using kryo serialization
+        val perAttributeIter = sft.getVisibilityLevel match {
+          case VisibilityLevel.Feature   => Seq.empty
+          case VisibilityLevel.Attribute => Seq(KryoVisibilityRowEncoder.configure(sft))
+        }
+        val (iters, kvsToFeatures) = if (hints.isBinQuery) {
+          // use the server side aggregation
+          val iter = BinAggregatingIterator.configureDynamic(sft, RecordTable, filter.secondary, hints, dupes)
+          (Seq(iter), BinAggregatingIterator.kvsToFeatures())
+        } else if (hints.isDensityQuery) {
+          val iter = KryoLazyDensityIterator.configure(sft, RecordTable, filter.secondary, hints)
+          (Seq(iter), KryoLazyDensityIterator.kvsToFeatures())
+        } else if (hints.isStatsIteratorQuery) {
+          val iter = KryoLazyStatsIterator.configure(sft, RecordTable, filter.secondary, hints, dupes)
+          (Seq(iter), KryoLazyStatsIterator.kvsToFeatures(sft))
+        } else {
+          val iter = KryoLazyFilterTransformIterator.configure(sft, filter.secondary, hints)
+          (iter.toSeq, queryPlanner.kvsToFeatures(sft, hints.getReturnSft, RecordTable))
+        }
+        BatchScanPlan(filter, table, ranges, iters ++ perAttributeIter, Seq.empty, kvsToFeatures, threads, dupes)
       } else {
-        val iter = KryoLazyFilterTransformIterator.configure(sft, filter.secondary, hints)
-        (iter.toSeq, queryPlanner.kvsToFeatures(sft, hints.getReturnSft, RecordTable))
+        val iters = if (filter.secondary.isDefined || hints.getTransformSchema.isDefined) {
+          Seq(configureRecordTableIterator(sft, featureEncoding, filter.secondary, hints))
+        } else {
+          Seq.empty
+        }
+        val kvsToFeatures = if (hints.isBinQuery) {
+          BinAggregatingIterator.nonAggregatedKvsToFeatures(sft, RecordTable, hints, featureEncoding)
+        } else {
+          queryPlanner.kvsToFeatures(sft, hints.getReturnSft, RecordTable)
+        }
+        BatchScanPlan(filter, table, ranges, iters, Seq.empty, kvsToFeatures, threads, dupes)
       }
-      BatchScanPlan(filter, table, ranges, iters ++ perAttributeIter, Seq.empty, kvsToFeatures, threads, hasDuplicates = false)
-    } else {
-      val iters = if (filter.secondary.isDefined || hints.getTransformSchema.isDefined) {
-        Seq(configureRecordTableIterator(sft, featureEncoding, filter.secondary, hints))
-      } else {
-        Seq.empty
-      }
-      val kvsToFeatures = if (hints.isBinQuery) {
-        BinAggregatingIterator.nonAggregatedKvsToFeatures(sft, RecordTable, hints, featureEncoding)
-      } else {
-        queryPlanner.kvsToFeatures(sft, hints.getReturnSft, RecordTable)
-      }
-      BatchScanPlan(filter, table, ranges, iters, Seq.empty, kvsToFeatures, threads, hasDuplicates = false)
     }
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Strategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Strategy.scala
@@ -79,6 +79,8 @@ object Strategy extends LazyLogging {
    */
   private def getScanner(queryPlan: QueryPlan, acc: AccumuloConnectorCreator): KVIter =
     queryPlan match {
+      case qp: EmptyPlan =>
+        CloseableIterator.empty
       case qp: ScanPlan =>
         val scanner = acc.getScanner(qp.table)
         configureScanner(scanner, qp)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategy.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategy.scala
@@ -10,9 +10,10 @@ package org.locationtech.geomesa.accumulo.index
 
 import com.google.common.primitives.{Bytes, Longs, Shorts}
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.accumulo.core.data.Range
+import org.apache.accumulo.core.data.{Range => aRange}
 import org.apache.hadoop.io.Text
 import org.geotools.factory.Hints
+import org.locationtech.geomesa.accumulo.GeomesaSystemProperties.QueryProperties
 import org.locationtech.geomesa.accumulo.data.stats.GeoMesaStats
 import org.locationtech.geomesa.accumulo.data.tables.{GeoMesaTable, Z3Table}
 import org.locationtech.geomesa.accumulo.iterators._
@@ -21,78 +22,60 @@ import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.locationtech.geomesa.utils.geotools._
 import org.locationtech.geomesa.utils.index.VisibilityLevel
-import org.locationtech.sfcurve.zorder.Z3
 import org.opengis.feature.simple.SimpleFeatureType
-import org.opengis.filter.Filter
-import org.opengis.filter.spatial._
 
 class Z3IdxStrategy(val filter: QueryFilter) extends Strategy with LazyLogging with IndexFilterHelpers  {
 
   /**
    * Plans the query - strategy implementations need to define this
    */
-  override def getQueryPlan(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType) = {
+  override def getQueryPlan(queryPlanner: QueryPlanner, hints: Hints, output: ExplainerOutputType): QueryPlan = {
 
     import QueryHints.{LOOSE_BBOX, RichHints}
     import Z3IdxStrategy._
+    import Z3Table.GEOM_Z_NUM_BYTES
     import org.locationtech.geomesa.filter.FilterHelper._
 
     val ds  = queryPlanner.ds
     val sft = queryPlanner.sft
 
-    val dtgField = sft.getDtgField
+    // note: z3 requires a date field
+    val dtgField = sft.getDtgField.getOrElse {
+      throw new RuntimeException("Trying to execute a z3 query but the schema does not have a date")
+    }
 
-    val (geomFilters, temporalFilters) = {
-      val (g, t) = filter.primary.partition(isSpatialFilter)
-      if (g.isEmpty) {
-        // allow for date only queries - if no geom, use whole world
-        (Seq(ff.bbox(sft.getGeomField, -180, -90, 180, 90, "EPSG:4326")), t)
-      } else {
-        (g, t)
+    if (filter.primary.isEmpty) {
+      filter.secondary.foreach { f =>
+        logger.warn(s"Running full table scan for schema ${sft.getTypeName} with filter ${filterToString(f)}")
       }
     }
 
-    output(s"Geometry filters: ${filtersToString(geomFilters)}")
-    output(s"Temporal filters: ${filtersToString(temporalFilters)}")
-
     // standardize the two key query arguments:  polygon and date-range
-    // TODO GEOMESA-1215 this can handle OR'd geoms, but the query splitter won't currently send them
-    val geometryToCover =
-      filter.singlePrimary.flatMap(extractSingleGeometry(_, sft.getGeomField, sft.isPoints)).getOrElse(WholeWorldPolygon)
+
+    val geometries = filter.primary.map(extractGeometries(_, sft.getGeomField, sft.isPoints))
+        .filter(_.nonEmpty).getOrElse(Seq(WholeWorldPolygon))
 
     // since we don't apply a temporal filter, we pass handleExclusiveBounds to
     // make sure we exclude the non-inclusive endpoints of a during filter.
     // note that this isn't completely accurate, as we only index down to the second
-    val interval = {
-      // TODO GEOMESA-1215 this can handle OR'd intervals, but the query splitter won't currently send them
-      val intervals = for { dtg <- dtgField; filter <- andOption(temporalFilters) } yield {
-        extractIntervals(filter, dtg)
-      }
-      // note: because our filters were and'ed, there will be at most one interval
-      intervals.flatMap(_.headOption).getOrElse {
-        throw new RuntimeException(s"Couldn't extract interval from filters '${filtersToString(temporalFilters)}'")
-      }
-    }
+    val intervals = filter.primary.map(extractIntervals(_, dtgField, handleExclusiveBounds = true)).getOrElse(Seq.empty)
 
-    output(s"GeomsToCover: $geometryToCover")
-    output(s"Interval:  $interval")
+    output(s"Geometries: $geometries")
+    output(s"Intervals: $intervals")
 
     val looseBBox = if (hints.containsKey(LOOSE_BBOX)) Boolean.unbox(hints.get(LOOSE_BBOX)) else ds.config.looseBBox
+    val hasSplits = Z3Table.hasSplits(sft)
 
-    val ecql: Option[Filter] = if (!looseBBox || sft.nonPoints) {
-      // if the user has requested strict bounding boxes, we apply the full filter
-      // if this is a non-point geometry, the index is coarse-grained, so we apply the full filter
-      filter.filter
+    // if the user has requested strict bounding boxes, we apply the full filter
+    // if this is a non-point geometry type, the index is coarse-grained, so we apply the full filter
+    // if the spatial predicate is rectangular (e.g. a bbox), the index is fine enough that we
+    // don't need to apply the filter on top of it. this may cause some minor errors at extremely
+    // fine resolutions, but the performance is worth it
+    // if we have a complicated geometry predicate, we need to pass it through to be evaluated
+    val ecql = if (looseBBox && sft.isPoints && geometries.forall(GeometryUtils.isRectangular)) {
+      filter.secondary
     } else {
-      // for normal bboxes, the index is fine enough that we don't need to apply the filter on top of it
-      // this may cause some minor errors at extremely fine resolution, but the performance is worth it
-      // if we have a complicated geometry predicate, we need to pass it through to be evaluated
-      val complexGeomFilter = filterListAsAnd(geomFilters.filter(isComplicatedSpatialFilter))
-      (complexGeomFilter, filter.secondary) match {
-        case (Some(gf), Some(fs)) => filterListAsAnd(Seq(gf, fs))
-        case (None, fs)           => fs
-        case (gf, None)           => gf
-      }
+      filter.filter
     }
 
     val (iterators, kvsToFeatures, colFamily, hasDupes) = if (hints.isBinQuery) {
@@ -123,55 +106,52 @@ class Z3IdxStrategy(val filter: QueryFilter) extends Strategy with LazyLogging w
     val z3table = ds.getTableName(sft.getTypeName, Z3Table)
     val numThreads = ds.getSuggestedThreads(sft.getTypeName, Z3Table)
 
-    // setup Z3 iterator
-    val env = geometryToCover.getEnvelopeInternal
-    val (lx, ly, ux, uy) = (env.getMinX, env.getMinY, env.getMaxX, env.getMaxY)
+    // compute our accumulo ranges based on the coarse bounds for our query
+    val (ranges, zIterator) = if (filter.primary.isEmpty) { (Seq(new aRange()), None) } else {
+      val xy = geometries.map(GeometryUtils.bounds)
 
-    val (epochWeekStart, lt) = Z3Table.getWeekAndSeconds(interval._1)
-    val (epochWeekEnd, ut) = Z3Table.getWeekAndSeconds(interval._2)
-    val weeks = scala.Range.inclusive(epochWeekStart, epochWeekEnd).map(_.toShort)
+      // calculate map of weeks to time intervals in that week
+      val timesByWeek = scala.collection.mutable.Map.empty[Short, Seq[(Long, Long)]].withDefaultValue(Seq.empty)
+      // note: intervals shouldn't have any overlaps
+      intervals.foreach { interval =>
+        val (lWeek, lt) = Z3Table.getWeekAndSeconds(interval._1)
+        val (uWeek, ut) = Z3Table.getWeekAndSeconds(interval._2)
+        if (lWeek == uWeek) {
+          timesByWeek(lWeek) ++= Seq((lt, ut))
+        } else {
+          timesByWeek(lWeek) ++= Seq((lt, MaxTime))
+          timesByWeek(uWeek) ++= Seq((MinTime, ut))
+          Range.inclusive(lWeek + 1, uWeek - 1).foreach(w => timesByWeek(w.toShort) = WholeWeek)
+        }
+      }
 
-    // time range for a chunk is 0 to 1 week (in seconds)
-    val (tStart, tEnd) = (Z3SFC.time.min.toInt, Z3SFC.time.max.toInt)
+      val rangeTarget = QueryProperties.SCAN_RANGES_TARGET.option.map(_.toInt)
+      def toZRanges(t: Seq[(Long, Long)]): Seq[(Array[Byte], Array[Byte])] = if (sft.isPoints) {
+        Z3SFC.ranges(xy, t, 64, rangeTarget).map(r => (Longs.toByteArray(r.lower), Longs.toByteArray(r.upper)))
+      } else {
+        Z3SFC.ranges(xy, t, 8 * GEOM_Z_NUM_BYTES, rangeTarget).map { r =>
+          (Longs.toByteArray(r.lower).take(GEOM_Z_NUM_BYTES), Longs.toByteArray(r.upper).take(GEOM_Z_NUM_BYTES))
+        }
+      }
 
-    val getRanges: (Seq[Array[Byte]], (Double, Double), (Double, Double), (Long, Long)) => Seq[Range] =
-      if (sft.isPoints) getPointRanges else getGeomRanges
+      lazy val wholeWeekRanges = toZRanges(WholeWeek)
 
-    val hasSplits = Z3Table.hasSplits(sft)
+      val ranges = timesByWeek.flatMap { case (w, times) =>
+        val zs = if (times.eq(WholeWeek)) wholeWeekRanges else toZRanges(times)
+        val wBytes = Shorts.toByteArray(w)
+        val prefixes = if (hasSplits) Z3Table.SPLIT_ARRAYS.map(Bytes.concat(_, wBytes)) else Seq(wBytes)
+        prefixes.flatMap { prefix =>
+          zs.map { case (lo, hi) =>
+            val start = Bytes.concat(prefix, lo)
+            val end = Bytes.concat(prefix, hi)
+            new aRange(new Text(start), true, aRange.followingPrefix(new Text(end)), false)
+          }
+        }
+      }
 
-    val prefixes = if (hasSplits) {
-      val wBytes = weeks.map(Shorts.toByteArray)
-      Z3Table.SPLIT_ARRAYS.flatMap(s => wBytes.map(b => Array(s(0), b(0), b(1))))
-    } else {
-      weeks.map(Shorts.toByteArray)
+      val zIter = Z3Iterator.configure(xy, timesByWeek.toMap, sft.isPoints, hasSplits, Z3_ITER_PRIORITY)
+      (ranges.toSeq, Some(zIter))
     }
-
-    // the z3 index breaks time into 1 week chunks, so create a range for each week in our range
-    val ranges = if (weeks.length == 1) {
-      getRanges(prefixes, (lx, ux), (ly, uy), (lt, ut))
-    } else {
-      val head +: middle :+ last = prefixes.toList
-      val headRanges = getRanges(Seq(head), (lx, ux), (ly, uy), (lt, tEnd))
-      val lastRanges = getRanges(Seq(last), (lx, ux), (ly, uy), (tStart, ut))
-      val middleRanges = if (middle.isEmpty) Seq.empty else getRanges(middle, (lx, ux), (ly, uy), (tStart, tEnd))
-      headRanges ++ middleRanges ++ lastRanges
-    }
-
-    // index space values for comparing in the iterator
-    def decode(x: Double, y: Double, t: Int): (Int, Int, Int) = if (sft.isPoints) {
-      Z3SFC.index(x, y, t).decode
-    } else {
-      Z3(Z3SFC.index(x, y, t).z & Z3Table.GEOM_Z_MASK).decode
-    }
-
-    val (xmin, ymin, tmin) = decode(lx, ly, lt)
-    val (xmax, ymax, tmax) = decode(ux, uy, ut)
-    val (tLo, tHi) = (Z3SFC.time.normalize(tStart), Z3SFC.time.normalize(tEnd))
-
-    val wmin = weeks.head
-    val wmax = weeks.last
-
-    val zIter = Z3Iterator.configure(sft.isPoints, xmin, xmax, ymin, ymax, tmin, tmax, wmin, wmax, tLo, tHi, hasSplits, Z3_ITER_PRIORITY)
 
     val perAttributeIter = sft.getVisibilityLevel match {
       case VisibilityLevel.Feature   => Seq.empty
@@ -179,32 +159,8 @@ class Z3IdxStrategy(val filter: QueryFilter) extends Strategy with LazyLogging w
     }
     val cf = if (perAttributeIter.isEmpty) colFamily else GeoMesaTable.AttributeColumnFamily
 
-    val iters = perAttributeIter ++ Seq(zIter) ++ iterators
+    val iters = perAttributeIter ++ zIterator.toSeq ++ iterators
     BatchScanPlan(filter, z3table, ranges, iters, Seq(cf), kvsToFeatures, numThreads, hasDupes)
-  }
-
-  def getPointRanges(prefixes: Seq[Array[Byte]], x: (Double, Double), y: (Double, Double), t: (Long, Long)): Seq[Range] = {
-    Z3SFC.ranges(x, y, t).flatMap { case indexRange =>
-      val startBytes = Longs.toByteArray(indexRange.lower)
-      val endBytes = Longs.toByteArray(indexRange.upper)
-      prefixes.map { prefix =>
-        val start = new Text(Bytes.concat(prefix, startBytes))
-        val end = Range.followingPrefix(new Text(Bytes.concat(prefix, endBytes)))
-        new Range(start, true, end, false)
-      }
-    }
-  }
-
-  def getGeomRanges(prefixes: Seq[Array[Byte]], x: (Double, Double), y: (Double, Double), t: (Long, Long)): Seq[Range] = {
-    Z3SFC.ranges(x, y, t, 8 * Z3Table.GEOM_Z_NUM_BYTES).flatMap { indexRange =>
-      val startBytes = Longs.toByteArray(indexRange.lower).take(Z3Table.GEOM_Z_NUM_BYTES)
-      val endBytes = Longs.toByteArray(indexRange.upper).take(Z3Table.GEOM_Z_NUM_BYTES)
-      prefixes.map { prefix =>
-        val start = new Text(Bytes.concat(prefix, startBytes))
-        val end = Range.followingPrefix(new Text(Bytes.concat(prefix, endBytes)))
-        new Range(start, true, end, false)
-      }
-    }
   }
 }
 
@@ -213,6 +169,10 @@ object Z3IdxStrategy extends StrategyProvider {
   val Z3_ITER_PRIORITY = 23
   val FILTERING_ITER_PRIORITY = 25
 
+  val MinTime = Z3SFC.time.min.toLong
+  val MaxTime = Z3SFC.time.max.toLong
+  val WholeWeek = Seq((MinTime, MaxTime))
+
   override protected def statsBasedCost(sft: SimpleFeatureType,
                                         filter: QueryFilter,
                                         transform: Option[SimpleFeatureType],
@@ -220,7 +180,7 @@ object Z3IdxStrategy extends StrategyProvider {
     // https://geomesa.atlassian.net/browse/GEOMESA-1166
     // TODO check date range and use z2 instead if too big
     // TODO also if very small bbox, z2 has ~10 more bits of lat/lon info
-    filter.singlePrimary match {
+    filter.primary match {
       case Some(f) => stats.getCount(sft, f, exact = false)
       case None    => Some(Long.MaxValue)
     }
@@ -236,18 +196,4 @@ object Z3IdxStrategy extends StrategyProvider {
                                         transform: Option[SimpleFeatureType]): Long = {
     if (filter.primary.exists(isSpatialFilter)) 200L else 401L
   }
-
-  def isComplicatedSpatialFilter(f: Filter): Boolean = {
-    f match {
-      case _: BBOX => false
-      case _: DWithin => true
-      case _: Contains => true
-      case _: Crosses => true
-      case _: Intersects => true
-      case _: Overlaps => true
-      case _: Within => true
-      case _ => false        // Beyond, Disjoint, DWithin, Equals, Touches
-    }
-  }
-
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3Iterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3Iterator.scala
@@ -10,83 +10,36 @@ package org.locationtech.geomesa.accumulo.iterators
 
 import com.google.common.primitives.{Longs, Shorts}
 import org.apache.accumulo.core.client.IteratorSetting
-import org.apache.accumulo.core.data.{ByteSequence, Key, Range => AccRange, Value}
+import org.apache.accumulo.core.data.{ByteSequence, Key, Value, Range => AccRange}
 import org.apache.accumulo.core.iterators.{IteratorEnvironment, SortedKeyValueIterator}
 import org.apache.hadoop.io.Text
 import org.locationtech.geomesa.accumulo.data.tables.Z3Table
+import org.locationtech.geomesa.accumulo.index.Z3IdxStrategy
+import org.locationtech.geomesa.curve.Z3SFC
 import org.locationtech.sfcurve.zorder.Z3
 
 class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
 
-  import org.locationtech.geomesa.accumulo.iterators.Z3Iterator.{pointsKey, splitsKey, zKey}
+  import org.locationtech.geomesa.accumulo.iterators.Z3Iterator._
 
   var source: SortedKeyValueIterator[Key, Value] = null
-  var zNums: Array[Int] = null
 
-  var xmin: Int = -1
-  var xmax: Int = -1
-  var ymin: Int = -1
-  var ymax: Int = -1
-  var tmin: Int = -1
-  var tmax: Int = -1
-  var wmin: Short = -1
-  var wmax: Short = -1
+  var keyXY: Array[String] = null
+  var keyT: Array[String] = null
 
-  var tLo: Int = -1
-  var tHi: Int = -1
+  var xyvals: Array[(Int, Int, Int, Int)] = null
+  var tvals: Array[Array[(Int, Int)]] = null
+
+  var minWeek: Short = Short.MinValue
+  var maxWeek: Short = Short.MinValue
 
   var isPoints: Boolean = false
   var hasSplits: Boolean = false
-  var rowToLong: Array[Byte] => Long = null
+  var rowToWeekZ: Array[Byte] => (Short, Long) = null
 
   var topKey: Key = null
   var topValue: Value = null
   val row = new Text()
-
-  override def next(): Unit = {
-    source.next()
-    findTop()
-  }
-
-  def findTop(): Unit = {
-    topKey = null
-    topValue = null
-    while (source.hasTop && !inBounds(source.getTopKey, rowToLong)) { source.next() }
-    if (source.hasTop) {
-      topKey = source.getTopKey
-      topValue = source.getTopValue
-    }
-  }
-
-  private def inBounds(k: Key, getZ: (Array[Byte] => Long)): Boolean = {
-    k.getRow(row)
-    val bytes = row.getBytes
-    val week = if (hasSplits) Shorts.fromBytes(bytes(1), bytes(2)) else Shorts.fromBytes(bytes(0), bytes(1))
-    val keyZ = getZ(bytes)
-    val (x, y, t) = Z3(keyZ).decode
-    x >= xmin && x <= xmax && y >= ymin && y <= ymax && {
-      if (week == wmin) {
-        t >= tmin && t <= tHi
-      } else if (week == wmax) {
-        t >= tLo && t <= tmax
-      } else {
-        true
-      }
-    }
-  }
-
-  private def rowToLong(count: Int): (Array[Byte]) => Long = count match {
-    case 3 if hasSplits => (bb) => Longs.fromBytes(bb(3), bb(4), bb(5), 0, 0, 0, 0, 0)
-    case 3              => (bb) => Longs.fromBytes(bb(2), bb(3), bb(4), 0, 0, 0, 0, 0)
-    case 4 if hasSplits => (bb) => Longs.fromBytes(bb(3), bb(4), bb(5), bb(6), 0, 0, 0, 0)
-    case 4              => (bb) => Longs.fromBytes(bb(2), bb(3), bb(4), bb(5), 0, 0, 0, 0)
-    case 8 if hasSplits => (bb) => Longs.fromBytes(bb(3), bb(4), bb(5), bb(6), bb(7), bb(8), bb(9), bb(10))
-    case 8              => (bb) => Longs.fromBytes(bb(2), bb(3), bb(4), bb(5), bb(6), bb(7), bb(8), bb(9))
-  }
-
-  override def getTopValue: Value = topValue
-  override def getTopKey: Key = topKey
-  override def hasTop: Boolean = topKey != null
 
   override def init(source: SortedKeyValueIterator[Key, Value],
                     options: java.util.Map[String, String],
@@ -95,22 +48,109 @@ class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
 
     this.source = source.deepCopy(env)
 
-    isPoints = options.get(pointsKey).toBoolean
-    hasSplits = options.get(splitsKey).toBoolean
+    isPoints = options.get(PointsKey).toBoolean
 
-    zNums = options.get(zKey).split(":").map(_.toInt)
-    xmin = zNums(0)
-    xmax = zNums(1)
-    ymin = zNums(2)
-    ymax = zNums(3)
-    tmin = zNums(4)
-    tmax = zNums(5)
-    wmin = zNums(6).toShort
-    wmax = zNums(7).toShort
-    tLo = if (wmin == wmax) tmin else zNums(8)
-    tHi = if (wmin == wmax) tmax else zNums(9)
+    keyXY = options.get(ZKeyXY).split(RangeSeparator)
+    keyT = options.get(ZKeyT).split(WeekSeparator).filterNot(_.isEmpty)
 
-    rowToLong = if (isPoints) rowToLong(8) else rowToLong(Z3Table.GEOM_Z_NUM_BYTES)
+    xyvals = keyXY.map(_.toInt).grouped(4).map { case Array(x1, y1, x2, y2) => (x1, y1, x2, y2) }.toArray
+
+    minWeek = Short.MinValue
+    maxWeek = Short.MinValue
+
+    val weeksAndTimes = keyT.map { times =>
+      val parts = times.split(RangeSeparator)
+      val week = parts(0).toShort
+      // set min/max weeks - note: side effect in map
+      if (minWeek == Short.MinValue) {
+        minWeek = week
+        maxWeek = week
+      } else if (week < minWeek) {
+        minWeek = week
+      } else if (week > maxWeek) {
+        maxWeek = week
+      }
+      (week, parts.drop(1).grouped(2).map { case Array(t1, t2) => (t1.toInt, t2.toInt) }.toArray)
+    }
+
+    tvals = if (minWeek == Short.MinValue) Array.empty else Array.ofDim(maxWeek - minWeek + 1)
+    weeksAndTimes.foreach { case (w, times) => tvals(w - minWeek) = times }
+
+    hasSplits = options.get(SplitsKey).toBoolean
+    val count = if (isPoints) 8 else Z3Table.GEOM_Z_NUM_BYTES
+    rowToWeekZ = rowToWeekZ(count, hasSplits)
+  }
+
+  override def next(): Unit = {
+    source.next()
+    findTop()
+  }
+
+  private def findTop(): Unit = {
+    topKey = null
+    topValue = null
+    while (source.hasTop) {
+      if (inBounds(source.getTopKey)) {
+        topKey = source.getTopKey
+        topValue = source.getTopValue
+        return
+      } else {
+        source.next()
+      }
+    }
+  }
+
+  private def inBounds(k: Key): Boolean = {
+    k.getRow(row)
+    val (week, keyZ) = rowToWeekZ(row.getBytes)
+    timeInBounds(week, keyZ) && pointInBounds(keyZ)
+  }
+
+  private def pointInBounds(z: Long): Boolean = {
+    val x = Z3(z).d0
+    val y = Z3(z).d1
+    var i = 0
+    while (i < xyvals.length) {
+      val (xmin, ymin, xmax, ymax) = xyvals(i)
+      if (x >= xmin && x <= xmax && y >= ymin && y <= ymax) {
+        return true
+      }
+      i += 1
+    }
+    false
+  }
+
+  private def timeInBounds(week: Short, z: Long): Boolean = {
+    // we know we're only going to scan appropriate weeks, so leave out whole weeks
+    if (week > maxWeek || week < minWeek) { true } else {
+      val times = tvals(week - minWeek)
+      if (times == null) { true } else {
+        val t = Z3(z).d2
+        var i = 0
+        while (i < times.length) {
+          val (tmin, tmax) = times(i)
+          if (t >= tmin && t <= tmax) {
+            return true
+          }
+          i += 1
+        }
+        false
+      }
+    }
+  }
+
+  private def rowToWeekZ(count: Int, splits: Boolean): (Array[Byte]) => (Short, Long) = {
+    val zBytes = Longs.fromBytes _
+    val wBytes = Shorts.fromBytes _
+    (count, splits) match {
+      case (3, true)  => (b) => (wBytes(b(1), b(2)), zBytes(b(3), b(4), b(5), 0, 0, 0, 0, 0))
+      case (3, false) => (b) => (wBytes(b(0), b(1)), zBytes(b(2), b(3), b(4), 0, 0, 0, 0, 0))
+      case (4, true)  => (b) => (wBytes(b(1), b(2)), zBytes(b(3), b(4), b(5), b(6), 0, 0, 0, 0))
+      case (4, false) => (b) => (wBytes(b(0), b(1)), zBytes(b(2), b(3), b(4), b(5), 0, 0, 0, 0))
+      case (8, true)  => (b) => (wBytes(b(1), b(2)), zBytes(b(3), b(4), b(5), b(6), b(7), b(8), b(9), b(10)))
+      case (8, false) => (b) => (wBytes(b(0), b(1)), zBytes(b(2), b(3), b(4), b(5), b(6), b(7), b(8), b(9)))
+      case _ => throw new IllegalArgumentException(s"Unhandled number of bytes for z value: $count")
+    }
   }
 
   override def seek(range: AccRange, columnFamilies: java.util.Collection[ByteSequence], inclusive: Boolean): Unit = {
@@ -118,10 +158,19 @@ class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
     findTop()
   }
 
+  override def getTopValue: Value = topValue
+  override def getTopKey: Key = topKey
+  override def hasTop: Boolean = topKey != null
+
   override def deepCopy(env: IteratorEnvironment): SortedKeyValueIterator[Key, Value] = {
     import scala.collection.JavaConversions._
+    val opts = Map(
+      ZKeyXY    -> keyXY.mkString(RangeSeparator),
+      ZKeyT     -> keyT.mkString(WeekSeparator),
+      PointsKey -> isPoints.toString,
+      SplitsKey -> hasSplits.toString
+    )
     val iter = new Z3Iterator
-    val opts = Map(pointsKey -> isPoints.toString, splitsKey -> hasSplits.toString, zKey -> zNums.mkString(":"))
     iter.init(source, opts, env)
     iter
   }
@@ -129,27 +178,64 @@ class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
 
 object Z3Iterator {
 
-  val zKey = "z"
-  val pointsKey = "p"
-  val splitsKey = "s"
+  val ZKeyXY = "zxy"
+  val ZKeyT  = "zt"
 
-  def configure(isPoints: Boolean,
-                xmin: Int,
-                xmax: Int,
-                ymin: Int,
-                ymax: Int,
-                tmin: Int,
-                tmax: Int,
-                wmin: Short,
-                wmax: Short,
-                tLo: Int,
-                tHi: Int,
-                splits: Boolean,
+  val PointsKey = "points"
+  val SplitsKey = "splits"
+
+  val RangeSeparator = ":"
+  val WeekSeparator = ";"
+
+  def configure(bounds: Seq[(Double, Double, Double, Double)],
+                timesByWeek: Map[Short, Seq[(Long, Long)]],
+                isPoints: Boolean,
+                hasSplits: Boolean,
                 priority: Int) = {
+
+    import Z3IdxStrategy.MinTime
+
     val is = new IteratorSetting(priority, "z3", classOf[Z3Iterator])
-    is.addOption(pointsKey, isPoints.toString)
-    is.addOption(zKey, s"$xmin:$xmax:$ymin:$ymax:$tmin:$tmax:$wmin:$wmax:$tLo:$tHi")
-    is.addOption(splitsKey, splits.toString)
+
+    // index space values for comparing in the iterator
+    val (xyOpts, tOpts) = if (isPoints) {
+      val xyOpts = bounds.map { case (xmin, ymin, xmax, ymax) =>
+        s"${Z3SFC.lon.normalize(xmin)}$RangeSeparator${Z3SFC.lat.normalize(ymin)}$RangeSeparator" +
+            s"${Z3SFC.lon.normalize(xmax)}$RangeSeparator${Z3SFC.lat.normalize(ymax)}"
+      }
+      // we know we're only going to scan appropriate weeks, so leave out whole weeks
+      val tOpts = timesByWeek.filter(_._2 != Z3IdxStrategy.WholeWeek).toSeq.sortBy(_._1).map { case (w, times) =>
+        val time = times.map { case (t1, t2) =>
+          s"${Z3SFC.time.normalize(t1)}$RangeSeparator${Z3SFC.time.normalize(t2)}"
+        }
+        s"$w$RangeSeparator${time.mkString(RangeSeparator)}"
+      }
+      (xyOpts, tOpts)
+    } else {
+      val normalized = bounds.map { case (xmin, ymin, xmax, ymax) =>
+        val (lx, ly, _) = decodeNonPoints(xmin, ymin, MinTime) // note: time is not used
+        val (ux, uy, _) = decodeNonPoints(xmax, ymax, MinTime) // note: time is not used
+        s"$lx$RangeSeparator$ly$RangeSeparator$ux$RangeSeparator$uy"
+      }
+
+      // we know we're only going to scan appropriate weeks, so leave out whole weeks
+      val tOpts = timesByWeek.filter(_._2 == Z3IdxStrategy.WholeWeek).toSeq.sortBy(_._1).map { case (w, times) =>
+        val time = times.map { case (t1, t2) =>
+          s"${decodeNonPoints(0, 0, t1)._3}$RangeSeparator${decodeNonPoints(0, 0, t2)._3}"
+        }
+        s"$w$RangeSeparator${time.mkString(RangeSeparator)}"
+      }
+      (normalized, tOpts)
+    }
+
+    is.addOption(ZKeyXY, xyOpts.mkString(RangeSeparator))
+    is.addOption(ZKeyT, tOpts.mkString(WeekSeparator))
+    is.addOption(PointsKey, isPoints.toString)
+    is.addOption(SplitsKey, hasSplits.toString)
+
     is
   }
+
+  private def decodeNonPoints(x: Double, y: Double, t: Long): (Int, Int, Int) =
+    Z3(Z3SFC.index(x, y, t).z & Z3Table.GEOM_Z_MASK).decode
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreStatsTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreStatsTest.scala
@@ -288,7 +288,7 @@ class AccumuloDataStoreStatsTest extends Specification with TestWithDataStore {
         // this doesn't seem to happen with regular accumulo
         // so only test one of each query type here
         val filters = Seq("bbox(geom,0,0,10,5)", "name < '7'",
-          "bbox(geom,0,0,10,5) AND dtg during 2016-01-03T00:00:00.000Z/2016-01-03T04:00:00.000Z")
+          "bbox(geom,0,0,10,5) AND dtg during 2016-01-02T23:00:00.000Z/2016-01-03T01:00:00.000Z")
         forall(filters.map(ECQL.toFilter)) { filter =>
           val reader = ds.getFeatureReader(new Query(sft.getTypeName, filter), Transaction.AUTO_COMMIT)
           val exact = SelfClosingIterator(reader).length

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureReaderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureReaderTest.scala
@@ -25,6 +25,8 @@ import scala.collection.mutable.ArrayBuffer
 @RunWith(classOf[JUnitRunner])
 class AccumuloFeatureReaderTest extends Specification with TestWithDataStore {
 
+  sequential
+
   override def spec = s"name:String,dtg:Date,*geom:Point"
 
   val features = (0 until 100).map { i =>

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryFilterSplitterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryFilterSplitterTest.scala
@@ -14,11 +14,12 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.data.tables.AvailableTables
 import org.locationtech.geomesa.accumulo.index.Strategy.StrategyType
 import org.locationtech.geomesa.filter
+import org.locationtech.geomesa.filter.visitor.QueryPlanFilterVisitor
+import org.locationtech.geomesa.filter.{decomposeAnd, decomposeOr}
 import org.locationtech.geomesa.utils.geotools.SftBuilder.Opts
 import org.locationtech.geomesa.utils.geotools.{SftBuilder, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.stats.Cardinality
 import org.opengis.filter._
-import org.opengis.filter.expression.PropertyName
 import org.opengis.filter.temporal.During
 import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
@@ -32,6 +33,8 @@ class QueryFilterSplitterTest extends Specification {
   val sft = new SftBuilder()
     .stringType("attr1")
     .stringType("attr2", index = true)
+    .stringType("attr3")
+    .stringType("attr4")
     .stringType("high", Opts(index = true, cardinality = Cardinality.HIGH))
     .stringType("low", Opts(index = true, cardinality = Cardinality.LOW))
     .date("dtg", default = true)
@@ -45,7 +48,7 @@ class QueryFilterSplitterTest extends Specification {
   val geom2               = "BBOX(geom,60,60,70,70)"
   val geomOverlap         = "BBOX(geom,35,35,55,55)"
   val dtg                 = "dtg DURING 2014-01-01T00:00:00Z/2014-01-01T23:59:59Z"
-  val dtg2                = "dtg DURING 2014-01-02T00:00:00Z/2014-01-02T23:59:59"
+  val dtg2                = "dtg DURING 2014-01-02T00:00:00Z/2014-01-02T23:59:59Z"
   val dtgOverlap          = "dtg DURING 2014-01-01T00:00:00Z/2014-01-02T23:59:59Z"
   val nonIndexedAttr      = "attr1 = 'test'"
   val nonIndexedAttr2     = "attr1 = 'test2'"
@@ -56,6 +59,8 @@ class QueryFilterSplitterTest extends Specification {
 
   val wholeWorld          = "BBOX(geom,-180,-90,180,90)"
 
+  val includeStrategy     = StrategyType.Z3
+
   def and(clauses: Filter*) = ff.and(clauses)
   def or(clauses: Filter*)  = ff.or(clauses)
   def and(clauses: String*)(implicit d: DummyImplicit) = ff.and(clauses.map(ECQL.toFilter))
@@ -63,207 +68,210 @@ class QueryFilterSplitterTest extends Specification {
   def not(clauses: String*) = filter.andFilters(clauses.map(ECQL.toFilter).map(ff.not))(ff)
   def f(filter: String)     = ECQL.toFilter(filter)
 
+  def compareAnd(primary: Option[Filter], clauses: Filter*): MatchResult[Option[Seq[Filter]]] =
+    primary.map(decomposeAnd) must beSome(containTheSameElementsAs(clauses))
+  def compareAnd(primary: Option[Filter], clauses: String*)
+                (implicit d: DummyImplicit): MatchResult[Option[Seq[Filter]]] =
+    compareAnd(primary, clauses.map(ECQL.toFilter): _*)
+
+  def compareOr(primary: Option[Filter], clauses: Filter*): MatchResult[Option[Seq[Filter]]] =
+    primary.map(decomposeOr) must beSome(containTheSameElementsAs(clauses))
+  def compareOr(primary: Option[Filter], clauses: String*)
+                (implicit d: DummyImplicit): MatchResult[Option[Seq[Filter]]] =
+    compareOr(primary, clauses.map(ECQL.toFilter): _*)
+
   "QueryFilterSplitter" should {
 
     "return for filter include" >> {
       val filter = Filter.INCLUDE
-      val options = splitter.getQueryOptions(Filter.INCLUDE, ExplainNull)
+      val options = splitter.getQueryOptions(Filter.INCLUDE)
       options must haveLength(1)
       options.head.filters must haveLength(1)
-      options.head.filters.head.strategy mustEqual StrategyType.Z2
-      options.head.filters.head.primary mustEqual Seq(filter)
+      options.head.filters.head.strategy mustEqual StrategyType.Z3
+      options.head.filters.head.primary must beNone
       options.head.filters.head.secondary must beNone
     }
 
     "return none for filter exclude" >> {
-      val options = splitter.getQueryOptions(Filter.EXCLUDE, ExplainNull)
+      val options = splitter.getQueryOptions(Filter.EXCLUDE)
       options must beEmpty
     }
-
-    "return none for exclusive anded geoms" >> {
-      val options = splitter.getQueryOptions(and(geom, geom2, dtg), ExplainNull)
-      options must beEmpty
-    }.pendingUntilFixed("not implemented")
-
-    "return none for exclusive anded dates" >> {
-      val options = splitter.getQueryOptions(and(geom, dtg, dtg2), ExplainNull)
-      options must beEmpty
-    }.pendingUntilFixed("not implemented")
 
     "work for spatio-temporal queries" >> {
       "with a simple and" >> {
         val filter = and(geom, dtg)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(2)
         forall(options)(_.filters must haveLength(1))
         options.map(_.filters.head.strategy) must contain(StrategyType.Z2, StrategyType.Z3)
         val z2 = options.find(_.filters.head.strategy == StrategyType.Z2).get
-        z2.filters.head.primary mustEqual Seq(f(geom))
+        z2.filters.head.primary must beSome(f(geom))
         z2.filters.head.secondary must beSome(f(dtg))
         val z3 = options.find(_.filters.head.strategy == StrategyType.Z3).get
-        z3.filters.head.primary mustEqual Seq(f(geom), f(dtg))
+        z3.filters.head.primary.map(decomposeAnd) must beSome(containTheSameElementsAs(Seq(f(geom), f(dtg))))
         z3.filters.head.secondary must beNone
       }
 
       "with multiple geometries" >> {
         val filter = and(geom, geom2, dtg)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(2)
         forall(options)(_.filters must haveLength(1))
         options.map(_.filters.head.strategy) must contain(StrategyType.Z2, StrategyType.Z3)
         val z2 = options.find(_.filters.head.strategy == StrategyType.Z2).get
-        z2.filters.head.primary mustEqual Seq(f(geom), f(geom2))
+        compareAnd(z2.filters.head.primary, geom, geom2)
         z2.filters.head.secondary must beSome(f(dtg))
         val z3 = options.find(_.filters.head.strategy == StrategyType.Z3).get
-        z3.filters.head.primary mustEqual Seq(f(geom), f(geom2), f(dtg))
+        compareAnd(z3.filters.head.primary, geom, geom2, dtg)
         z3.filters.head.secondary must beNone
       }
 
       "with multiple dates" >> {
         val filter = and(geom, dtg, dtgOverlap)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(2)
         forall(options)(_.filters must haveLength(1))
         options.map(_.filters.head.strategy) must contain(StrategyType.Z2, StrategyType.Z3)
         val z2 = options.find(_.filters.head.strategy == StrategyType.Z2).get
-        z2.filters.head.primary mustEqual Seq(f(geom))
+        z2.filters.head.primary must beSome(f(geom))
         z2.filters.head.secondary must beSome(and(dtg, dtgOverlap))
         val z3 = options.find(_.filters.head.strategy == StrategyType.Z3).get
-        z3.filters.head.primary mustEqual Seq(f(geom), f(dtg), f(dtgOverlap))
+        compareAnd(z3.filters.head.primary, geom, dtg, dtgOverlap)
         z3.filters.head.secondary must beNone
       }
 
       "with multiple geometries and dates" >> {
         val filter = and(geom, geomOverlap, dtg, dtgOverlap)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(2)
         forall(options)(_.filters must haveLength(1))
         options.map(_.filters.head.strategy) must contain(StrategyType.Z2, StrategyType.Z3)
         val z2 = options.find(_.filters.head.strategy == StrategyType.Z2).get
-        z2.filters.head.primary must containTheSameElementsAs(Seq(f(geom), f(geomOverlap)))
+        z2.filters.head.primary must beSome(and(geom, geomOverlap))
         z2.filters.head.secondary must beSome(and(dtg, dtgOverlap))
         val z3 = options.find(_.filters.head.strategy == StrategyType.Z3).get
-        z3.filters.head.primary must containTheSameElementsAs(Seq(f(geom), f(geomOverlap), f(dtg), f(dtgOverlap)))
+        compareAnd(z3.filters.head.primary, geom, geomOverlap, dtg, dtgOverlap)
         z3.filters.head.secondary must beNone
       }
 
       "with single attribute ors" >> {
         val filter = and(or(geom, geom2), f(dtg))
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(2)
-        forall(options)(_.filters must haveLength(2))
-        options.map(_.filters.map(_.strategy).toSet) must containTheSameElementsAs(Seq(Set(StrategyType.Z2), Set(StrategyType.Z3)))
+        forall(options)(_.filters must haveLength(1))
+        options.map(_.filters.head.strategy) must containTheSameElementsAs(Seq(StrategyType.Z2, StrategyType.Z3))
         val z2 = options.find(_.filters.head.strategy == StrategyType.Z2).get
-        z2.filters.map(_.primary) must containTheSameElementsAs(Seq(Seq(f(geom)), Seq(f(geom2))))
+        compareOr(z2.filters.head.primary, geom, geom2)
         forall(z2.filters.map(_.secondary))(_ must beSome)
         z2.filters.map(_.secondary.get) must contain(beAnInstanceOf[During], beAnInstanceOf[And])
-        z2.filters.map(_.secondary.get).collect { case a: And => a.getChildren }.flatten must contain(beAnInstanceOf[During], beAnInstanceOf[Not])
+        z2.filters.map(_.secondary.get).collect { case a: And => a.getChildren }.flatten must
+            contain(beAnInstanceOf[During], beAnInstanceOf[Not])
         val z3 = options.find(_.filters.head.strategy == StrategyType.Z3).get
-        z3.filters.map(_.primary) must containTheSameElementsAs(Seq(Seq(f(geom), f(dtg)), Seq(f(geom2), f(dtg))))
-        z3.filters.map(_.secondary).filter(_.isDefined) must haveLength(1)
-        z3.filters.map(_.secondary).filter(_.isDefined).head.get must beAnInstanceOf[Not]
+        compareAnd(z3.filters.head.primary, or(geom, geom2), f(dtg))
+        z3.filters.head.secondary must beNone
       }
 
       "with multiple attribute ors" >> {
         val filter = or(and(geom, dtg), and(geom2, dtg2))
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(2)
-        forall(options)(_.filters must haveLength(2))
-        options.map(_.filters.map(_.strategy).toSet) must containTheSameElementsAs(Seq(Set(StrategyType.Z2), Set(StrategyType.Z3)))
+        forall(options)(_.filters must haveLength(1))
+        options.map(_.filters.head.strategy) must containTheSameElementsAs(Seq(StrategyType.Z2, StrategyType.Z3))
         val z2 = options.find(_.filters.head.strategy == StrategyType.Z2).get
-        z2.filters.map(_.primary) must containTheSameElementsAs(Seq(Seq(f(geom)), Seq(f(geom2))))
-        forall(z2.filters.map(_.secondary))(_ must beSome)
-        z2.filters.map(_.secondary.get) must contain(beAnInstanceOf[During], beAnInstanceOf[And])
-        z2.filters.map(_.secondary.get).collect { case a: And => a.getChildren }.flatten must contain(beAnInstanceOf[During], beAnInstanceOf[Not])
+        compareOr(z2.filters.head.primary, geom, geom2)
+        z2.filters.head.secondary must beSome // secondary filter is too complex to compare here...
         val z3 = options.find(_.filters.head.strategy == StrategyType.Z3).get
-        z3.filters.map(_.primary) must containTheSameElementsAs(Seq(Seq(f(geom), f(dtg)), Seq(f(geom2), f(dtg2))))
-        z3.filters.map(_.secondary).filter(_.isDefined) must haveLength(1)
-        z3.filters.map(_.secondary).filter(_.isDefined).head.get must beAnInstanceOf[Not]
+        z3.filters.head.primary must beSome
+        z3.filters.head.primary.get must beAnInstanceOf[And]
+        z3.filters.head.primary.get.asInstanceOf[And].getChildren must haveLength(2)
+        z3.filters.head.primary.get.asInstanceOf[And].getChildren.map(Option.apply) must
+            contain(compareOr(_: Option[Filter], geom, geom2), compareOr(_: Option[Filter], dtg, dtg2))
+        z3.filters.head.secondary must beSome // secondary filter is too complex to compare here...
       }
 
       "with spatiotemporal and non-indexed attributes clauses" >> {
         val filter = and(geom, dtg, nonIndexedAttr)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(2)
         forall(options)(_.filters must haveLength(1))
         options.map(_.filters.head.strategy) must contain(StrategyType.Z2, StrategyType.Z3)
         val z2 = options.find(_.filters.head.strategy == StrategyType.Z2).get
-        z2.filters.head.primary mustEqual Seq(f(geom))
+        z2.filters.head.primary must beSome(f(geom))
         z2.filters.head.secondary must beSome(and(dtg, nonIndexedAttr))
         val z3 = options.find(_.filters.head.strategy == StrategyType.Z3).get
-        z3.filters.head.primary mustEqual Seq(f(geom), f(dtg))
+        compareAnd(z3.filters.head.primary, geom, dtg)
         z3.filters.head.secondary must beSome(f(nonIndexedAttr))
       }
 
       "with spatiotemporal and indexed attributes clauses" >> {
         val filter = and(geom, dtg, indexedAttr)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(3)
         forall(options)(_.filters must haveLength(1))
         options.map(_.filters.head.strategy) must contain(StrategyType.Z2, StrategyType.Z3, StrategyType.ATTRIBUTE)
         val z2 = options.find(_.filters.head.strategy == StrategyType.Z2).get
-        z2.filters.head.primary mustEqual Seq(f(geom))
+        z2.filters.head.primary must beSome(f(geom))
         z2.filters.head.secondary must beSome(and(dtg, indexedAttr))
         val z3 = options.find(_.filters.head.strategy == StrategyType.Z3).get
-        z3.filters.head.primary mustEqual Seq(f(geom), f(dtg))
+        compareAnd(z3.filters.head.primary, geom, dtg)
         z3.filters.head.secondary must beSome(f(indexedAttr))
         val attr = options.find(_.filters.head.strategy == StrategyType.ATTRIBUTE).get
-        attr.filters.head.primary mustEqual Seq(f(indexedAttr))
+        attr.filters.head.primary must beSome(f(indexedAttr))
         attr.filters.head.secondary must beSome(and(geom, dtg))
       }
 
       "with spatiotemporal, indexed and non-indexed attributes clauses" >> {
         val filter = and(geom, dtg, indexedAttr, nonIndexedAttr)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(3)
         forall(options)(_.filters must haveLength(1))
         options.map(_.filters.head.strategy) must contain(StrategyType.Z2, StrategyType.Z3, StrategyType.ATTRIBUTE)
         val z2 = options.find(_.filters.head.strategy == StrategyType.Z2).get
-        z2.filters.head.primary mustEqual Seq(f(geom))
+        z2.filters.head.primary must beSome(f(geom))
         z2.filters.head.secondary must beSome(and(dtg, indexedAttr, nonIndexedAttr))
         val z3 = options.find(_.filters.head.strategy == StrategyType.Z3).get
-        z3.filters.head.primary mustEqual Seq(f(geom), f(dtg))
+        compareAnd(z3.filters.head.primary, geom, dtg)
         z3.filters.head.secondary must beSome(and(indexedAttr, nonIndexedAttr))
         val attr = options.find(_.filters.head.strategy == StrategyType.ATTRIBUTE).get
-        attr.filters.head.primary mustEqual Seq(f(indexedAttr))
+        attr.filters.head.primary must beSome(f(indexedAttr))
         attr.filters.head.secondary must beSome(and(geom, dtg, nonIndexedAttr))
       }
 
       "with spatiotemporal clauses and non-indexed attributes or" >> {
         val filter = and(f(geom), f(dtg), or(nonIndexedAttr, nonIndexedAttr2))
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(2)
         forall(options)(_.filters must haveLength(1))
         options.map(_.filters.head.strategy) must contain(StrategyType.Z2, StrategyType.Z3)
         val z2 = options.find(_.filters.head.strategy == StrategyType.Z2).get
-        z2.filters.head.primary mustEqual Seq(f(geom))
+        z2.filters.head.primary must beSome(f(geom))
         z2.filters.head.secondary must beSome(and(f(dtg), or(nonIndexedAttr, nonIndexedAttr2)))
         val z3 = options.find(_.filters.head.strategy == StrategyType.Z3).get
-        z3.filters.head.primary mustEqual Seq(f(geom), f(dtg))
+        compareAnd(z3.filters.head.primary, geom, dtg)
         z3.filters.head.secondary must beSome(or(nonIndexedAttr, nonIndexedAttr2))
       }
 
       "while ignoring world-covering geoms" >> {
-        val filter = f(wholeWorld)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val filter = QueryPlanFilterVisitor(null, f(wholeWorld))
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(1)
-        options.head.filters.head.strategy mustEqual StrategyType.Z2
-        options.head.filters.head.primary mustEqual Seq(Filter.INCLUDE)
+        options.head.filters.head.strategy mustEqual includeStrategy
+        options.head.filters.head.primary must beNone
         options.head.filters.head.secondary must beNone
       }
 
       "while ignoring world-covering geoms when other filters are present" >> {
-        val filter = and(wholeWorld, geom, dtg)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val filter = QueryPlanFilterVisitor(null, and(wholeWorld, geom, dtg))
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(2)
         forall(options)(_.filters must haveLength(1))
         options.map(_.filters.head.strategy) must contain(StrategyType.Z2, StrategyType.Z3)
         val z2 = options.find(_.filters.head.strategy == StrategyType.Z2).get
-        z2.filters.head.primary mustEqual Seq(f(geom))
+        z2.filters.head.primary must beSome(f(geom))
         z2.filters.head.secondary must beSome(f(dtg))
         val z3 = options.find(_.filters.head.strategy == StrategyType.Z3).get
-        z3.filters.head.primary mustEqual Seq(f(geom), f(dtg))
+        compareAnd(z3.filters.head.primary, geom, dtg)
         z3.filters.head.secondary must beNone
       }
     }
@@ -271,61 +279,61 @@ class QueryFilterSplitterTest extends Specification {
     "work for single clause filters" >> {
       "spatial" >> {
         val filter = f(geom)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(1)
         options.head.filters.head.strategy mustEqual StrategyType.Z2
-        options.head.filters.head.primary mustEqual Seq(filter)
+        options.head.filters.head.primary must beSome(filter)
         options.head.filters.head.secondary must beNone
       }
 
       "temporal" >> {
         val filter = f(dtg)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(1)
         options.head.filters.head.strategy mustEqual StrategyType.Z3
-        options.head.filters.head.primary mustEqual Seq(dtg).map(f)
+        options.head.filters.head.primary must beSome(filter)
         options.head.filters.head.secondary must beNone
       }
 
       "non-indexed attributes" >> {
         val filter = f(nonIndexedAttr)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(1)
-        options.head.filters.head.strategy mustEqual StrategyType.Z2
-        options.head.filters.head.primary mustEqual Seq(Filter.INCLUDE)
+        options.head.filters.head.strategy mustEqual includeStrategy
+        options.head.filters.head.primary must beNone
         options.head.filters.head.secondary must beSome(filter)
       }
 
       "indexed attributes" >> {
         val filter = f(indexedAttr)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(1)
         options.head.filters.head.strategy mustEqual StrategyType.ATTRIBUTE
-        options.head.filters.head.primary mustEqual Seq(filter)
+        options.head.filters.head.primary must beSome(filter)
         options.head.filters.head.secondary must beNone
       }
 
       "low-cardinality attributes" >> {
         val filter = f(lowCardinaltiyAttr)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(1)
         options.head.filters.head.strategy mustEqual StrategyType.ATTRIBUTE
-        options.head.filters.head.primary mustEqual Seq(filter)
+        options.head.filters.head.primary must beSome(filter)
         options.head.filters.head.secondary must beNone
       }
 
       "high-cardinality attributes" >> {
         val filter = f(highCardinaltiyAttr)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(1)
         options.head.filters.head.strategy mustEqual StrategyType.ATTRIBUTE
-        options.head.filters.head.primary mustEqual Seq(filter)
+        options.head.filters.head.primary must beSome(filter)
         options.head.filters.head.secondary must beNone
       }
     }
@@ -333,51 +341,51 @@ class QueryFilterSplitterTest extends Specification {
     "work for simple ands" >> {
       "spatial" >> {
         val filter = and(geom, geom2)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(1)
         options.head.filters.head.strategy mustEqual StrategyType.Z2
-        options.head.filters.head.primary mustEqual Seq(geom, geom2).map(f)
+        compareAnd(options.head.filters.head.primary, geom, geom2)
         options.head.filters.head.secondary must beNone
       }
 
       "temporal" >> {
         val filter = and(dtg, dtgOverlap)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(1)
         options.head.filters.head.strategy mustEqual StrategyType.Z3
-        options.head.filters.head.primary mustEqual Seq(dtg, dtgOverlap).map(f)
+        compareAnd(options.head.filters.head.primary, dtg, dtgOverlap)
         options.head.filters.head.secondary must beNone
       }
 
       "non-indexed attributes" >> {
         val filter = and(nonIndexedAttr, nonIndexedAttr2)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(1)
-        options.head.filters.head.strategy mustEqual StrategyType.Z2
-        options.head.filters.head.primary mustEqual Seq(Filter.INCLUDE)
+        options.head.filters.head.strategy mustEqual includeStrategy
+        options.head.filters.head.primary must beNone
         options.head.filters.head.secondary must beSome(filter)
       }
 
       "indexed attributes" >> {
         val filter = and(indexedAttr, indexedAttr2)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
-        options must haveLength(2)
+        val options = splitter.getQueryOptions(filter)
+        options must haveLength(1)
         options.head.filters must haveLength(1)
         options.head.filters.head.strategy mustEqual StrategyType.ATTRIBUTE
-        options.head.filters.head.primary.head mustEqual f(indexedAttr)
-        options.head.filters.head.secondary.head mustEqual f(indexedAttr2)
+        options.head.filters.head.primary must beSome(filter)
+        options.head.filters.head.secondary must beNone
       }
 
       "low-cardinality attributes" >> {
         val filter = and(lowCardinaltiyAttr, nonIndexedAttr)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(1)
         options.head.filters.head.strategy mustEqual StrategyType.ATTRIBUTE
-        options.head.filters.head.primary mustEqual Seq(f(lowCardinaltiyAttr))
+        options.head.filters.head.primary must beSome(f(lowCardinaltiyAttr))
         options.head.filters.head.secondary must beSome(f(nonIndexedAttr))
       }
     }
@@ -385,112 +393,79 @@ class QueryFilterSplitterTest extends Specification {
     "split filters on OR" >> {
       "with spatiotemporal clauses" >> {
         val filter = or(geom, dtg)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(2)
         val z3 = options.head.filters.find(_.strategy == StrategyType.Z3)
         z3 must beSome
-        z3.get.primary mustEqual Seq(dtg).map(f)
+        z3.get.primary must beSome(f(dtg))
         z3.get.secondary must beSome(not(geom))
         val st = options.head.filters.find(_.strategy == StrategyType.Z2)
         st must beSome
-        st.get.primary mustEqual Seq(f(geom))
+        st.get.primary must beSome(f(geom))
         st.get.secondary must beNone
       }
 
       "with multiple spatial clauses" >> {
         val filter = or(geom, geom2)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
-        options.head.filters must haveLength(2)
-        forall(options.head.filters)(_.strategy mustEqual StrategyType.Z2)
-        options.head.filters.head.primary mustEqual Seq(f(geom))
+        options.head.filters must haveLength(1)
+        options.head.filters.head.strategy mustEqual StrategyType.Z2
+        compareOr(options.head.filters.head.primary, geom, geom2)
         options.head.filters.head.secondary must beNone
-        options.head.filters.tail.head.primary mustEqual Seq(f(geom2))
-        options.head.filters.tail.head.secondary must beSome(not(geom))
       }
 
       "with spatiotemporal and indexed attribute clauses" >> {
         val filter = or(geom, indexedAttr)
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(2)
         options.head.filters.map(_.strategy) must containTheSameElementsAs(Seq(StrategyType.Z2, StrategyType.ATTRIBUTE))
-        options.head.filters.find(_.strategy == StrategyType.Z2).get.primary mustEqual Seq(f(geom))
+        options.head.filters.find(_.strategy == StrategyType.Z2).get.primary must beSome(f(geom))
         options.head.filters.find(_.strategy == StrategyType.Z2).get.secondary must beNone
-        options.head.filters.find(_.strategy == StrategyType.ATTRIBUTE).get.primary mustEqual Seq(f(indexedAttr))
+        options.head.filters.find(_.strategy == StrategyType.ATTRIBUTE).get.primary must beSome(f(indexedAttr))
         options.head.filters.find(_.strategy == StrategyType.ATTRIBUTE).get.secondary must beSome(not(geom))
       }
 
       "and collapse overlapping query filters" >> {
         "with spatiotemporal and non-indexed attribute clauses" >> {
           val filter = or(geom, nonIndexedAttr)
-          val options = splitter.getQueryOptions(filter, ExplainNull)
+          val options = splitter.getQueryOptions(filter)
           options must haveLength(1)
           options.head.filters must haveLength(1)
-          options.head.filters.head.strategy mustEqual StrategyType.Z2
-          options.head.filters.head.primary mustEqual Seq(Filter.INCLUDE)
+          options.head.filters.head.strategy mustEqual includeStrategy
+          options.head.filters.head.primary must beNone
           options.head.filters.head.secondary must beSome(filter)
         }
-
-        "with overlapping geometries" >> {
-          val filter = or(geom, geomOverlap)
-          val options = splitter.getQueryOptions(filter, ExplainNull)
-          options must haveLength(1)
-          options.head.filters must haveLength(1)
-          options.head.filters.head.strategy mustEqual StrategyType.Z2
-          options.head.filters.head.primary mustEqual Seq(f(geomOverlap))
-          options.head.filters.head.secondary must beNone
-        }.pendingUntilFixed("not implemented")
-
-        "with overlapping dates" >> {
-          val filter = or(dtg, dtgOverlap)
-          val options = splitter.getQueryOptions(filter, ExplainNull)
-          options must haveLength(1)
-          options.head.filters must haveLength(1)
-          options.head.filters.head.strategy mustEqual StrategyType.Z3
-          options.head.filters.head.primary mustEqual Seq(wholeWorld, dtgOverlap).map(f)
-          options.head.filters.head.secondary must beNone
-        }.pendingUntilFixed("not implemented")
-
-        "with overlapping geometries and dates" >> {
-          val filter = or(and(geom, dtg), and(geomOverlap, dtgOverlap))
-          val options = splitter.getQueryOptions(filter, ExplainNull)
-          options must haveLength(1)
-          options.head.filters must haveLength(1)
-          options.head.filters.head.strategy mustEqual StrategyType.Z3
-          options.head.filters.head.primary mustEqual Seq(geomOverlap, dtgOverlap).map(f)
-          options.head.filters.head.secondary must beNone
-        }.pendingUntilFixed("not implemented")
       }
     }
 
     "split nested filters" >> {
       "with ANDs" >> {
         val filter = and(f(geom), and(dtg, nonIndexedAttr))
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(2)
         forall(options)(_.filters must haveLength(1))
         options.map(_.filters.head.strategy) must contain(StrategyType.Z2, StrategyType.Z3)
         val z2 = options.find(_.filters.head.strategy == StrategyType.Z2).get
-        z2.filters.head.primary mustEqual Seq(f(geom))
+        z2.filters.head.primary must beSome(f(geom))
         z2.filters.head.secondary must beSome(and(dtg, nonIndexedAttr))
         val z3 = options.find(_.filters.head.strategy == StrategyType.Z3).get
-        z3.filters.head.primary mustEqual Seq(f(geom), f(dtg))
+        compareAnd(z3.filters.head.primary, geom, dtg)
         z3.filters.head.secondary must beSome(f(nonIndexedAttr))
       }
 
       "with ORs" >> {
         val filter = or(f(geom), or(dtg, indexedAttr))
-        val options = splitter.getQueryOptions(filter, ExplainNull)
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(1)
         options.head.filters must haveLength(3)
         options.head.filters.map(_.strategy) must
             containTheSameElementsAs(Seq(StrategyType.Z3, StrategyType.Z2, StrategyType.ATTRIBUTE))
-        options.head.filters.map(_.primary) must
-            containTheSameElementsAs(Seq(Seq(f(geom)), Seq(f(dtg)), Seq(f(indexedAttr))))
-        options.head.filters.map(_.secondary) must
-            containTheSameElementsAs(Seq(None, Some(not(geom)), Some(not(geom, dtg))))
+        options.head.filters.map(_.primary) must contain(beSome(f(geom)), beSome(f(dtg)), beSome(f(indexedAttr)))
+        options.head.filters.map(_.secondary) must contain(beSome(not(geom)), beSome(not(geom, dtg)))
+        options.head.filters.map(_.secondary) must contain(beNone)
       }
     }
 
@@ -498,19 +473,20 @@ class QueryFilterSplitterTest extends Specification {
       val sft = SimpleFeatureTypes.createType("dtgIndex", "dtg:Date:index=full,*geom:Point:srid=4326")
       val splitter = new QueryFilterSplitter(sft)
       val filter = f("dtg TEQUALS 2014-01-01T12:30:00.000Z")
-      val options = splitter.getQueryOptions(filter, ExplainNull)
+      val options = splitter.getQueryOptions(filter)
       options must haveLength(1)
       options.head.filters must haveLength(1)
       options.head.filters.head.strategy mustEqual StrategyType.ATTRIBUTE
-      options.head.filters.head.primary mustEqual Seq(filter)
+      options.head.filters.head.primary must beSome(filter)
       options.head.filters.head.secondary must beNone
     }
 
     "provide only one option on OR queries of high cardinality indexed attributes" >> {
       def testHighCard(attrPart: String): MatchResult[Any] = {
-        val filterString = s"($attrPart) AND BBOX(geom, 40.0,40.0,50.0,50.0) " +
-            "AND dtg DURING 2014-01-01T00:00:00+00:00/2014-01-01T23:59:59+00:00"
-        val options = splitter.getQueryOptions(f(filterString), ExplainNull)
+        val bbox = "BBOX(geom, 40.0,40.0,50.0,50.0)"
+        val dtg  = "dtg DURING 2014-01-01T00:00:00+00:00/2014-01-01T23:59:59+00:00"
+        val filter = f(s"($attrPart) AND $bbox AND $dtg")
+        val options = splitter.getQueryOptions(filter)
         options must haveLength(3)
 
         forall(options)(_.filters must haveLength(1))
@@ -518,34 +494,41 @@ class QueryFilterSplitterTest extends Specification {
             containTheSameElementsAs(Seq(StrategyType.ATTRIBUTE, StrategyType.Z2, StrategyType.Z3))
 
         val attrQueryFilter = options.find(_.filters.head.strategy == StrategyType.ATTRIBUTE).get.filters.head
-        attrQueryFilter.primary.length mustEqual 5
-        attrQueryFilter.primary.forall(_ must beAnInstanceOf[PropertyIsEqualTo])
-        val attrProps = attrQueryFilter.primary.map(_.asInstanceOf[PropertyIsEqualTo])
-        forall(attrProps)(_.getExpression1.asInstanceOf[PropertyName].getPropertyName mustEqual "high")
-        attrQueryFilter.secondary must beSome
-        attrQueryFilter.secondary.get must beAnInstanceOf[And]
-        attrQueryFilter.secondary.get.asInstanceOf[And].getChildren.length mustEqual 2
+        compareOr(attrQueryFilter.primary, decomposeOr(f(attrPart)): _*)
+        compareAnd(attrQueryFilter.secondary, bbox, dtg)
 
         val z2QueryFilters = options.find(_.filters.head.strategy == StrategyType.Z2).get.filters.head
-        z2QueryFilters.primary.length mustEqual 1
-        z2QueryFilters.secondary.get must beAnInstanceOf[And]
-        val z2Filters = z2QueryFilters.secondary.get.asInstanceOf[And].getChildren.toSeq
-        z2Filters must contain(beAnInstanceOf[Or], beAnInstanceOf[During])
-        val ors = z2Filters.collect { case o: Or => o.getChildren }.head
-        forall(ors)(_ must beAnInstanceOf[PropertyIsEqualTo])
-        val z2Props = ors.map(_.asInstanceOf[PropertyIsEqualTo])
-        forall(z2Props)(_.getExpression1.asInstanceOf[PropertyName].getPropertyName mustEqual "high")
+        z2QueryFilters.primary must beSome(f(bbox))
+        z2QueryFilters.secondary must beSome(beAnInstanceOf[And])
+        val z2secondary = z2QueryFilters.secondary.get.asInstanceOf[And].getChildren.toSeq
+        z2secondary must haveLength(2)
+        z2secondary must contain(beAnInstanceOf[Or], beAnInstanceOf[During])
+        compareOr(z2secondary.find(_.isInstanceOf[Or]), decomposeOr(f(attrPart)): _*)
+        z2secondary.find(_.isInstanceOf[During]).get mustEqual f(dtg)
 
         val z3QueryFilters = options.find(_.filters.head.strategy == StrategyType.Z3).get.filters.head
-        z3QueryFilters.primary.length mustEqual 2
-        z3QueryFilters.secondary.get must beAnInstanceOf[Or]
-        val z3Props = z3QueryFilters.secondary.get.asInstanceOf[Or].getChildren.map(_.asInstanceOf[PropertyIsEqualTo])
-        forall(z3Props)(_.getExpression1.asInstanceOf[PropertyName].getPropertyName mustEqual "high")
+        compareAnd(z3QueryFilters.primary, bbox, dtg)
+        compareOr(z3QueryFilters.secondary, decomposeOr(f(attrPart)): _*)
       }
 
       val orQuery = (0 until 5).map( i => s"high = 'h$i'").mkString(" OR ")
       val inQuery = s"high in (${(0 until 5).map( i => s"'h$i'").mkString(",")})"
       Seq(orQuery, inQuery).forall(testHighCard)
+    }
+
+    "extract the simple parts from complex filters" >> {
+      val bbox1 = "bbox(geom, -120, 45, -121, 46)"
+      val bbox2 = "bbox(geom, -120, 48, -121, 49)"
+      val bboxOr = s"($bbox1 OR $bbox2)"
+      val attribute1 = "(attr1 IN ('foo', 'bar') AND attr3 IS NOT NULL AND attr4 IN ('qaz', 'wsx'))"
+      val attribute2 = "(attr1 IN ('baz', 'jim') AND attr3 IS NOT NULL AND attr4 IN ('qaz', 'wsx'))"
+      val filter = f(s"$bboxOr AND ($attribute1 OR $attribute2)")
+      val options = splitter.getQueryOptions(filter)
+      options must haveLength(1)
+      options.head.filters must haveLength(1)
+      options.head.filters.head.strategy mustEqual StrategyType.Z2
+      compareOr(options.head.filters.head.primary, bbox1, bbox2)
+      options.head.filters.head.secondary must beSome // note: filter is too complex to compare explicitly...
     }
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategyTest.scala
@@ -40,10 +40,10 @@ class RecordIdxStrategyTest extends Specification with TestWithDataStore {
                              correctIntersection: String): IntersectionResult = {
     // extract the IDs from the a priori correct answer
     val trueIntersectionIds = ECQL.toFilter(correctIntersection)
-      .asInstanceOf[Id].getIDs.asScala.toSet.map { a:AnyRef =>a.toString }
+      .asInstanceOf[Id].getIDs.asScala.toSet[AnyRef].map(_.toString)
     // process the string sequences for the test
-    val filterSeq=stringSeqToTest.map ( ECQL.toFilter )
-    val combinedIDFilter = RecordIdxStrategy.intersectIdFilters(filterSeq)
+    val filterSeq = stringSeqToTest.map(ECQL.toFilter)
+    val combinedIDFilter = RecordIdxStrategy.intersectIdFilters(ff.and(filterSeq.asJava))
     val computedIntersectionIds = if (combinedIDFilter.isEmpty) None else Some(combinedIDFilter)
 
     IntersectionResult(computedIntersectionIds, trueIntersectionIds)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/Z3IteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/Z3IteratorTest.scala
@@ -26,6 +26,8 @@ import scala.collection.JavaConversions._
 @RunWith(classOf[JUnitRunner])
 class Z3IteratorTest extends Specification {
 
+  import Z3Iterator._
+
   sequential
 
   "Z3Iterator" should {
@@ -58,8 +60,9 @@ class Z3IteratorTest extends Specification {
       val (xmax, ymax, tmax) = Z3SFC.index(ux, uy, ut).decode
 
       val iter = new Z3Iterator
-      iter.init(srcIter, Map(Z3Iterator.pointsKey -> "true", Z3Iterator.splitsKey -> "false",
-        Z3Iterator.zKey -> s"$xmin:$xmax:$ymin:$ymax:$tmin:$tmax:0:0:0:${Z3SFC.time.max.toLong}"), null)
+
+      iter.init(srcIter, Map(PointsKey -> "true", SplitsKey -> "false",
+        ZKeyXY -> s"$xmin:$ymin:$xmax:$ymax", ZKeyT -> s"0:$tmin:$tmax"), null)
 
       "keep in bounds values" >> {
         val test1 = Z3SFC.index(-76.0, 38.5, 500)
@@ -85,8 +88,8 @@ class Z3IteratorTest extends Specification {
       val (xmax, ymax, tmax) = Z3(Z3SFC.index(ux, uy, ut).z & Z3Table.GEOM_Z_MASK).decode
 
       val iter = new Z3Iterator
-      iter.init(srcIter, Map(Z3Iterator.pointsKey -> "false", Z3Iterator.splitsKey -> "false",
-        Z3Iterator.zKey -> s"$xmin:$xmax:$ymin:$ymax:$tmin:$tmax:0:0:0:${Z3SFC.time.max.toLong}"), null)
+      iter.init(srcIter, Map(PointsKey -> "false", SplitsKey -> "false",
+        ZKeyXY -> s"$xmin:$ymin:$xmax:$ymax", ZKeyT -> s"0:$tmin:$tmax"), null)
 
       "keep in bounds values" >> {
         val test1 = Z3SFC.index(-76.0, 38.5, 500)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/process/knn/GenerateKNNQueryTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/process/knn/GenerateKNNQueryTest.scala
@@ -8,6 +8,7 @@
 
 package org.locationtech.geomesa.accumulo.process.knn
 
+import com.vividsolutions.jts.geom.GeometryCollection
 import org.geotools.data.{DataStoreFinder, Query}
 import org.geotools.factory.CommonFactoryFinder
 import org.geotools.referencing.CRS
@@ -107,8 +108,12 @@ class GenerateKNNQueryTest extends Specification {
 
       val geomsToCover = {
         import scala.collection.JavaConversions._
-        val geom = sft.getGeometryDescriptor.getLocalName
-        FilterHelper.extractSingleGeometry(ff.and(tweakedGeomFilters), geom, intersect = true).orNull
+        val geoms = FilterHelper.extractGeometries(ff.and(tweakedGeomFilters), sft.getGeometryDescriptor.getLocalName, intersect = true)
+        if (geoms.length < 2) {
+          geoms.headOption.orNull
+        } else {
+          new GeometryCollection(geoms.toArray, geoms.head.getFactory)
+        }
       }
 
       val geometryToCover = new org.locationtech.geomesa.accumulo.index.IndexFilterHelpers{}.netGeom(geomsToCover)

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraFeatureStore.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraFeatureStore.scala
@@ -125,12 +125,11 @@ class CassandraFeatureStore(entry: ContentEntry) extends ContentFeatureStore(ent
     iter
   }
 
-  def planQueryForContiguousRowRange(s: Int, e: Int, rowRanges: Seq[Int]): Seq[RowAndColumnQueryPlan] = {
+  def planQueryForContiguousRowRange(s: Long, e: Long, rowRanges: Seq[Int]): Seq[RowAndColumnQueryPlan] = {
     rowRanges.flatMap { r =>
       val CassandraPrimaryKey.Key(_, _, _, _, z) = CassandraPrimaryKey.unapply(r)
       val (minx, miny, maxx, maxy) = CassandraPrimaryKey.SFC2D.bound(z)
-      val z3ranges =
-        org.locationtech.geomesa.cassandra.data.CassandraPrimaryKey.SFC3D.ranges((minx, maxx), (miny, maxy), (s, e))
+      val z3ranges = CassandraPrimaryKey.SFC3D.ranges((minx, maxx), (miny, maxy), (s, e))
 
       z3ranges.map { ir =>
         val (l, u, contains) = ir.tuple
@@ -155,7 +154,7 @@ class CassandraFeatureStore(entry: ContentEntry) extends ContentFeatureStore(ent
           else CassandraPrimaryKey.ONE_WEEK_IN_SECONDS
         (starts, ends)
       }
-    val zranges = org.locationtech.geomesa.cassandra.data.CassandraPrimaryKey.SFC2D.toRanges(lx, ly, ux, uy)
+    val zranges = CassandraPrimaryKey.SFC2D.toRanges(lx, ly, ux, uy)
     val shiftedRanges = zranges.flatMap { ir =>
       val (l, u, _) = ir.tuple
       (l to u).map { i => (dtshift + i).toInt }

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/visitor/FilterExtractingVisitor.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/visitor/FilterExtractingVisitor.scala
@@ -1,0 +1,152 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.filter.visitor
+
+import org.locationtech.geomesa.filter.FilterHelper
+import org.opengis.feature.simple.SimpleFeatureType
+import org.opengis.filter.spatial.{DWithin, _}
+import org.opengis.filter.temporal.{Before, Ends, Meets, TOverlaps, _}
+import org.opengis.filter.{ExcludeFilter, Or, _}
+
+import scala.collection.JavaConversions._
+
+/**
+  * Extracts filters for a given attribute
+  */
+object FilterExtractingVisitor {
+  def apply(filter: Filter,
+            attribute: String,
+            sft: SimpleFeatureType,
+            predicate: (Filter) => Boolean = (_) => true): (Option[Filter], Option[Filter]) = {
+    val visitor = new FilterExtractingVisitor(attribute, sft, predicate)
+    val (yes, no) = filter.accept(visitor, null).asInstanceOf[(Filter, Filter)]
+    (Option(yes), Option(no))
+  }
+}
+
+class FilterExtractingVisitor(attribute: String, sft: SimpleFeatureType, predicate: (Filter) => Boolean)
+    extends FilterVisitor {
+
+  import org.locationtech.geomesa.filter.{andOption, ff, orOption}
+
+  /**
+    * Should we keep the filter or discard it
+    *
+    * @param f filter
+    * @return true if it contains the attribute we want
+    */
+  private def keep(f: Filter): Boolean = FilterHelper.propertyNames(f, sft).contains(attribute) && predicate(f)
+
+  override def visit(f: Or, data: AnyRef): AnyRef = {
+    val children = f.getChildren.map(_.accept(this, data).asInstanceOf[(Filter, Filter)])
+    val yes = children.map(_._1).filter(_ != null)
+    val no  = children.map(_._2).filter(_ != null)
+    // only return ORs where both sides satisfy the predicate
+    // we handle the returned predicates as implicit ANDs, if we split an OR we break that
+    if (no.isEmpty) {
+      (orOption(yes).orNull, null)
+    } else {
+      (null, orOption(yes ++ no).orNull)
+    }
+  }
+
+  override def visit(f: And, data: AnyRef): AnyRef = {
+    val children = f.getChildren.map(_.accept(this, data).asInstanceOf[(Filter, Filter)])
+    val yes = children.map(_._1).filter(_ != null)
+    val no  = children.map(_._2).filter(_ != null)
+    (andOption(yes).orNull, andOption(no).orNull)
+  }
+
+  override def visit(f: Not, data: AnyRef): AnyRef = {
+    if (predicate(f)) {
+      val (yes, no) = f.getFilter.accept(this, data).asInstanceOf[(Filter, Filter)]
+      (if (yes == null) null else ff.not(yes), if (no == null) null else ff.not(no))
+    } else {
+      (null, f)
+    }
+  }
+
+  override def visit(f: IncludeFilter, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: ExcludeFilter, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Id, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Meets, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: Ends, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: EndedBy, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: During, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: BegunBy, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: Begins, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: Before, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: AnyInteracts, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: After, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: Within, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: Touches, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: MetBy, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: OverlappedBy, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: TContains, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: TEquals, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: TOverlaps, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: PropertyIsLessThanOrEqualTo, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: PropertyIsLessThan, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: PropertyIsGreaterThanOrEqualTo, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: PropertyIsGreaterThan, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: PropertyIsNotEqualTo, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: PropertyIsEqualTo, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: PropertyIsBetween, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: PropertyIsLike, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: PropertyIsNull, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: PropertyIsNil, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: BBOX, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: Beyond, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: Contains, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: Crosses, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: Disjoint, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: DWithin, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: Equals, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: Intersects, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visit(f: Overlaps, data: AnyRef): AnyRef = if (keep(f)) (f, null) else (null, f)
+
+  override def visitNullFilter(data: AnyRef): AnyRef = (null, null)
+}

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/visitor/IdDetectingFilterVisitor.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/visitor/IdDetectingFilterVisitor.scala
@@ -1,0 +1,19 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.filter.visitor
+
+import org.geotools.filter.visitor.DefaultFilterVisitor
+import org.opengis.filter.{Id, Or}
+
+/**
+  * Returns true if filter contains an ID filter
+  */
+class IdDetectingFilterVisitor extends DefaultFilterVisitor {
+  override def visit(f: Id, data: AnyRef): AnyRef = java.lang.Boolean.TRUE
+}

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/visitor/IdExtractingVisitor.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/visitor/IdExtractingVisitor.scala
@@ -1,0 +1,127 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.filter.visitor
+
+import org.opengis.filter.spatial.{DWithin, _}
+import org.opengis.filter.temporal.{Before, Ends, Meets, TOverlaps, _}
+import org.opengis.filter.{ExcludeFilter, Or, _}
+
+import scala.collection.JavaConversions._
+
+/**
+  * Extracts ID filters
+  */
+object IdExtractingVisitor {
+  def apply(filter: Filter): (Option[Filter], Option[Filter]) = {
+    val (yes, no) = filter.accept(new IdExtractingVisitor, null).asInstanceOf[(Filter, Filter)]
+    (Option(yes), Option(no))
+  }
+}
+
+class IdExtractingVisitor extends FilterVisitor {
+
+  import org.locationtech.geomesa.filter.{andOption, ff, orOption}
+
+  override def visit(f: Or, data: AnyRef): AnyRef = {
+    val children = f.getChildren.map(_.accept(this, data).asInstanceOf[(Filter, Filter)])
+    val yes = children.map(_._1).filter(_ != null)
+    val no  = children.map(_._2).filter(_ != null)
+    (orOption(yes).orNull, orOption(no).orNull)
+  }
+
+  override def visit(f: And, data: AnyRef): AnyRef = {
+    val children = f.getChildren.map(_.accept(this, data).asInstanceOf[(Filter, Filter)])
+    val yes = children.map(_._1).filter(_ != null)
+    val no  = children.map(_._2).filter(_ != null)
+    (andOption(yes).orNull, andOption(no).orNull)
+  }
+
+  override def visit(f: Not, data: AnyRef): AnyRef = {
+    val (yes, no) = f.getFilter.accept(this, data).asInstanceOf[(Filter, Filter)]
+    (if (yes == null) null else ff.not(yes), if (no == null) null else ff.not(no))
+  }
+
+  override def visit(f: Id, data: AnyRef): AnyRef = (f, null)
+
+  override def visit(f: IncludeFilter, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: ExcludeFilter, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Meets, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Ends, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: EndedBy, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: During, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: BegunBy, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Begins, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Before, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: AnyInteracts, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: After, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Within, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Touches, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: MetBy, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: OverlappedBy, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: TContains, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: TEquals, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: TOverlaps, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: PropertyIsLessThanOrEqualTo, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: PropertyIsLessThan, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: PropertyIsGreaterThanOrEqualTo, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: PropertyIsGreaterThan, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: PropertyIsNotEqualTo, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: PropertyIsEqualTo, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: PropertyIsBetween, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: PropertyIsLike, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: PropertyIsNull, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: PropertyIsNil, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: BBOX, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Beyond, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Contains, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Crosses, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Disjoint, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: DWithin, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Equals, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Intersects, data: AnyRef): AnyRef = (null, f)
+
+  override def visit(f: Overlaps, data: AnyRef): AnyRef = (null, f)
+
+  override def visitNullFilter(data: AnyRef): AnyRef = (null, null)
+}

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/visitor/QueryPlanFilterVisitor.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/visitor/QueryPlanFilterVisitor.scala
@@ -99,3 +99,9 @@ class QueryPlanFilterVisitor(sft: SimpleFeatureType) extends DuplicatingFilterVi
 
   private def includeEquivalent(f: Filter): Boolean = f == Filter.INCLUDE || isFilterWholeWorld(f)
 }
+
+object QueryPlanFilterVisitor {
+  def apply(filter: Filter): Filter = filter.accept(new QueryPlanFilterVisitor(null), null).asInstanceOf[Filter]
+  def apply(sft: SimpleFeatureType, filter: Filter): Filter =
+    filter.accept(new QueryPlanFilterVisitor(sft), null).asInstanceOf[Filter]
+}

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/stats/FrequencyTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/stats/FrequencyTest.scala
@@ -61,7 +61,7 @@ class FrequencyTest extends Specification with StatTestHelper {
     "enumerate ranges" >> {
       val min = Z2SFC.invert(Z2(2, 2))
       val max = Z2SFC.invert(Z2(3, 6))
-      val ranges = Z2SFC.ranges((min._1, max._1), (min._2, max._2))
+      val ranges = Z2SFC.ranges(Seq((min._1, min._2, max._1, max._2)))
       val indices = Frequency.enumerate(ranges, 64).toSeq
       indices must containTheSameElementsAs(Seq(12, 13, 14, 15, 36, 37, 38, 39, 44, 45))
     }

--- a/geomesa-z3/pom.xml
+++ b/geomesa-z3/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.locationtech.sfcurve</groupId>
             <artifactId>sfcurve-zorder_2.11</artifactId>
-            <version>0.1.3</version>
+            <version>0.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/SpaceFillingCurve.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/SpaceFillingCurve.scala
@@ -11,18 +11,74 @@ package org.locationtech.geomesa.curve
 import org.locationtech.sfcurve.IndexRange
 
 trait SpaceFillingCurve[T] {
+
+  import SpaceFillingCurve.FullPrecision
+
   def lat: NormalizedDimension
   def lon: NormalizedDimension
   def index(x: Double, y: Double): T
   def invert(i: T): (Double, Double)
-  def ranges(x: (Double, Double), y: (Double, Double), precision: Int = 64): Seq[IndexRange]
+
+  def ranges(x: (Double, Double), y: (Double, Double)): Seq[IndexRange] =
+    ranges(Seq((x._1, y._1, x._2, y._2)), FullPrecision, None)
+
+  def ranges(x: (Double, Double), y: (Double, Double), precision: Int): Seq[IndexRange] =
+    ranges(Seq((x._1, y._1, x._2, y._2)), precision, None)
+
+  def ranges(x: (Double, Double), y: (Double, Double), precision: Int, maxRanges: Option[Int]): Seq[IndexRange] =
+    ranges(Seq((x._1, y._1, x._2, y._2)), precision, maxRanges)
+
+  /**
+    * Gets ranges
+    *
+    * @param xy sequence of bounding boxes, in the form of (xmin, ymin, xmax, ymax)
+    * @param precision precision of the zvalues to consider, up to 64 bits
+    * @param maxRanges rough upper bound on the number of ranges to return
+    * @return
+    */
+  def ranges(xy: Seq[(Double, Double, Double, Double)],
+             precision: Int = FullPrecision,
+             maxRanges: Option[Int] = None): Seq[IndexRange]
 }
 
 trait SpaceTimeFillingCurve[T] {
+
+  import SpaceFillingCurve.FullPrecision
+
   def lat: NormalizedDimension
   def lon: NormalizedDimension
   def time: NormalizedDimension
   def index(x: Double, y: Double, t: Long): T
   def invert(i: T): (Double, Double, Long)
-  def ranges(x: (Double, Double), y: (Double, Double), t: (Long, Long), precision: Int = 64): Seq[IndexRange]
+
+  def ranges(x: (Double, Double), y: (Double, Double), t: (Long, Long)): Seq[IndexRange] =
+    ranges(Seq((x._1, y._1, x._2, y._2)), Seq(t), FullPrecision, None)
+
+  def ranges(x: (Double, Double), y: (Double, Double), t: (Long, Long), precision: Int): Seq[IndexRange] =
+    ranges(Seq((x._1, y._1, x._2, y._2)), Seq(t), precision, None)
+
+  def ranges(x: (Double, Double),
+             y: (Double, Double),
+             t: (Long, Long),
+             precision: Int,
+             maxRanges: Option[Int]): Seq[IndexRange] =
+    ranges(Seq((x._1, y._1, x._2, y._2)), Seq(t), precision, maxRanges)
+
+  /**
+    * Gets ranges
+    *
+    * @param xy sequence of bounding boxes, in the form of (xmin, ymin, xmax, ymax)
+    * @param t sequence of time bounds, in the form of (tmin, tmax)
+    * @param precision precision of the zvalues to consider, up to 64 bits
+    * @param maxRanges rough upper bound on the number of ranges to return
+    * @return
+    */
+  def ranges(xy: Seq[(Double, Double, Double, Double)],
+             t: Seq[(Long, Long)],
+             precision: Int = FullPrecision,
+             maxRanges: Option[Int] = None): Seq[IndexRange]
+}
+
+object SpaceFillingCurve {
+  val FullPrecision: Int = 64
 }

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z2SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z2SFC.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.curve
 
 import org.locationtech.sfcurve.IndexRange
-import org.locationtech.sfcurve.zorder.Z2
+import org.locationtech.sfcurve.zorder.{Z2, ZRange}
 
 object Z2SFC extends SpaceFillingCurve[Z2] {
 
@@ -21,11 +21,15 @@ object Z2SFC extends SpaceFillingCurve[Z2] {
 
   override def index(x: Double, y: Double): Z2 = Z2(lon.normalize(x), lat.normalize(y))
 
-  override def ranges(x: (Double, Double), y: (Double, Double), precision: Int): Seq[IndexRange] =
-    Z2.zranges(index(x._1, y._1), index(x._2, y._2), precision)
-
   override def invert(z: Z2): (Double, Double) = {
     val (x, y) = z.decode
     (lon.denormalize(x), lat.denormalize(y))
+  }
+
+  override def ranges(xy: Seq[(Double, Double, Double, Double)],
+                      precision: Int,
+                      maxRanges: Option[Int]): Seq[IndexRange] = {
+    val zbounds = xy.map { case (xmin, ymin, xmax, ymax) => ZRange(index(xmin, ymin).z, index(xmax, ymax).z) }
+    Z2.zranges(zbounds.toArray, precision, maxRanges)
   }
 }

--- a/geomesa-z3/src/test/scala/org/locationtech/geomesa/curve/Z2Test.scala
+++ b/geomesa-z3/src/test/scala/org/locationtech/geomesa/curve/Z2Test.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.curve
 
 import org.junit.runner.RunWith
 import org.locationtech.sfcurve.CoveredRange
-import org.locationtech.sfcurve.zorder.Z2
+import org.locationtech.sfcurve.zorder.{Z2, ZRange}
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -78,33 +78,25 @@ class Z2Test extends Specification {
     }
 
     "support bigmin" >> {
-      val zmin = Z2(2, 2)
-      val zmax = Z2(3, 6)
-      val f = Z2(5, 1)
+      val zmin = Z2(2, 2).z
+      val zmax = Z2(3, 6).z
+      val f = Z2(5, 1).z
       val (_, bigmin) = Z2.zdivide(f, zmin, zmax)
-      bigmin match {
-        case Z2(xhi, yhi) =>
-          xhi mustEqual 2
-          yhi mustEqual 4
-      }
+      Z2(bigmin).decode mustEqual((2, 4))
     }
 
     "support litmax" >> {
-      val zmin = Z2(2, 2)
-      val zmax = Z2(3, 6)
-      val f = Z2(1, 7)
+      val zmin = Z2(2, 2).z
+      val zmax = Z2(3, 6).z
+      val f = Z2(1, 7).z
       val (litmax, _) = Z2.zdivide(f, zmin, zmax)
-      litmax match {
-        case Z2(xlow, ylow) =>
-          xlow mustEqual 3
-          ylow mustEqual 5
-      }
+      Z2(litmax).decode mustEqual((3, 5))
     }
 
     "calculate ranges" >> {
-      val min = Z2(2, 2)
-      val max = Z2(3, 6)
-      val ranges = Z2.zranges(min, max)
+      val min = Z2(2, 2).z
+      val max = Z2(3, 6).z
+      val ranges = Z2.zranges(ZRange(min, max))
       ranges must haveLength(3)
       ranges must containTheSameElementsAs(
         Seq(
@@ -137,7 +129,7 @@ class Z2Test extends Specification {
         (math.round(z._1 * 1000.0) / 1000.0, math.round(z._2 * 1000.0) / 1000.0)
 
       forall(ranges) { r =>
-        val ret = Z2.zranges(r._1, r._2)
+        val ret = Z2.zranges(ZRange(r._1, r._2))
         ret.length must beGreaterThan(0)
       }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dist.dev>dev</dist.dev>
 
         <!-- testing properties -->
-        <maven.test.jvmargs>-Duser.timezone=UTC -Xms1g -Xmx8g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true</maven.test.jvmargs>
+        <maven.test.jvmargs>-Duser.timezone=UTC -Xms1g -Xmx8g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dgeomesa.scan.ranges.target=500</maven.test.jvmargs>
         <test.fork.count>1</test.fork.count>
         <test.fork.reuse>true</test.fork.reuse>
     </properties>
@@ -134,14 +134,14 @@
         <profile>
             <id>debug-tests</id>
             <properties>
-                <maven.test.jvmargs>-Duser.timezone=UTC -Xms1g -Xmx8g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y</maven.test.jvmargs>
+                <maven.test.jvmargs>-Duser.timezone=UTC -Xms1g -Xmx8g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dgeomesa.scan.ranges.target=500 -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y</maven.test.jvmargs>
             </properties>
         </profile>
 
         <profile>
             <id>travis-ci</id>
             <properties>
-                <maven.test.jvmargs>-Duser.timezone=UTC -Xms512m -Xmx3g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dgeomesa.scan.ranges.batch=2000</maven.test.jvmargs>
+                <maven.test.jvmargs>-Duser.timezone=UTC -Xms512m -Xmx3g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dgeomesa.scan.ranges.target=500 -Dgeomesa.scan.ranges.batch=2000</maven.test.jvmargs>
                 <test.fork.count>1</test.fork.count>
                 <test.fork.reuse>false</test.fork.reuse>
             </properties>


### PR DESCRIPTION
... ranges created by z-index, allowing for full table scans on Z3 index

Note: stacks on top of #951, please consider only last commit(s)
Note: depends on https://github.com/locationtech/sfcurve/pull/15 and needs an SfCurve release

* Most OR filters can be handled in a single query plan
* Z3 index can run any query, allowing for more flexibility with enabled indices
* System property "geomesa.scan.ranges.target" sets a rough upper limit on number of ranges per query, defaults to 2000

Also fixes GEOMESA-1167 - need to update commit comment before merge
    
Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>