### PR TITLE
GEOMESA-1297 Fix LaTeX build

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,11 +37,16 @@ To build HTML versions of the manuals:
 If you do not have Sphinx installed the manual will not be built.
 The outputted files are written to the ``target/html`` directory. 
 
-To build PDF versions:
+To build a PDF version:
 
-    $ mvn clean install -Puser-latex
-    $ cd target/latex/user
+    $ mvn clean install -Pdocs,latex
+    $ cd target/latex
     $ make
+
+There may be some errors during the LaTeX build; just press *Enter*
+when it prompts for input. It should build the whole document. If the
+table of contents doesn't render properly, delete ``GeoMesa.pdf``
+and run ``make`` again.
 
 ## About
 

--- a/docs/build.xml
+++ b/docs/build.xml
@@ -32,7 +32,7 @@
 	<target name="html" depends="init,all-html">
 	</target>
 
-	<target name="latex" depends="init,user-latex,developer-latex,tutorials-latex">
+	<target name="latex" depends="init,all-latex">
 	</target>
 
 	<target name="all-html" depends="init">
@@ -41,22 +41,11 @@
 			<param name="build" value="html" />
 		</antcall>
 	</target>
-
-	<target name="user-latex" depends="init">
-		<antcall target="sphinx-latex">
-			<param name="id" value="user" />
-		</antcall>
-	</target>
-
-	<target name="developer-latex" depends="init">
-		<antcall target="sphinx-latex">
-			<param name="id" value="developer" />
-		</antcall>
-	</target>
-
-	<target name="tutorials-latex" depends="init">
-		<antcall target="sphinx-latex">
-			<param name="id" value="tutorials" />
+	
+	<target name="all-latex" depends="init">
+		<antcall target="sphinx">
+			<param name="id" value="." />
+			<param name="build" value="latex" />
 		</antcall>
 	</target>
 
@@ -66,10 +55,4 @@
 		</exec>
 	</target>
 	
-	<target name="sphinx-latex" if="sphinx.available">
-		<exec executable="${sphinx.binary}" failonerror="true" dir="${basedir}/${id}">
-			<arg line="-D release=${project.version} -D version=${project.version} -b latex -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/latex&quot;" />
-		</exec>
-	</target>
-
 </project>

--- a/docs/common.py
+++ b/docs/common.py
@@ -289,7 +289,7 @@ latex_documents = [
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+latex_use_parts = True
 
 # If true, show page references after internal links.
 #latex_show_pagerefs = False

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -34,21 +34,9 @@
             </properties>
         </profile>
         <profile>
-            <id>user-latex</id>
+            <id>latex</id>
             <properties>
-                <target>user-latex</target>
-            </properties>
-        </profile>
-        <profile>
-            <id>developer-latex</id>
-            <properties>
-                <target>developer-latex</target>
-            </properties>
-        </profile>
-        <profile>
-            <id>tutorials-latex</id>
-            <properties>
-                <target>tutorials-latex</target>
+                <target>latex</target>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
(Mostly) fixes LaTeX build of docs, which was not changed when we
reorganized how the different manuals were built with HTML.

Signed-off-by: Matthew Zimmerman <matt.zimmerman@ccri.com>