### PR TITLE
Fixes for HBase/Bigtable data stores docs

### DIFF
--- a/docs/user/hbase_datastore.rst
+++ b/docs/user/hbase_datastore.rst
@@ -1,4 +1,4 @@
-HBase/BigTable Data Stores
+HBase/Bigtable Data Stores
 ==========================
 
 HBase
@@ -23,22 +23,23 @@ An instance of an HBase data store can be obtained through the normal GeoTools d
 
 The data store takes two parameters:
 
-* **bigtable.table.name** - the name of the HBase table that stores feature type data
-* **namespace** - the namespace URI for the data store (optional)
+* ``bigtable.table.name`` - the name of the HBase table that stores feature type data
+* ``namespace`` - the namespace URI for the data store (optional)
 
-More information on using GeoTools can be found in the GeoTools [user guide](http://docs.geotools.org/stable/userguide/).
+More information on using GeoTools can be found in the GeoTools `user guide
+<http://docs.geotools.org/stable/userguide/>`__.
 
 Using the HBase Data Store in GeoServer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 See :doc:`./geoserver`.
 
-BigTable
+Bigtable
 --------
 
-Experimental support for GeoMesa implemented on Google BigTable.
+Experimental support for GeoMesa implemented on `Google Cloud Bigtable <https://cloud.google.com/bigtable>`__.
 
-The code for BigTable support is found in two modules in the source distribution:
+The code for Bigtable support is found in two modules in the source distribution:
 
-* ``geomesa-hbase/geomesa-bigtable-datastore`` - contains a stub POM for building a Google BigTable-backed GeoTools data store
-* ``geomesa-gs-plugin/geomesa-bigtable-gs-plugin`` - contains a stub POM for building a bundle containing all of the JARs to use the Google BigTable data store in GeoServer
+* ``geomesa-hbase/geomesa-bigtable-datastore`` - contains a stub POM for building a Google Cloud Bigtable-backed GeoTools data store
+* ``geomesa-gs-plugin/geomesa-bigtable-gs-plugin`` - contains a stub POM for building a bundle containing all of the JARs to use the Google Cloud Bigtable data store in GeoServer

--- a/geomesa-hbase/README.md
+++ b/geomesa-hbase/README.md
@@ -1,6 +1,6 @@
-# GeoMesa HBase/BigTable
+# GeoMesa HBase/Bigtable
 
-HBase/BigTable support is broken out into these modules:
+HBase/Bigtable support is broken out into these modules:
 
 ## HBase
 
@@ -13,14 +13,14 @@ The HBase data store module contains the code for using an HBase-backed GeoTools
 The GeoServer plugin module builds a bundle containing all of the JARs necessary to use the
 HBase data store in GeoServer.
 
-## BigTable
+## Bigtable
 
-### [BigTable Data Store](geomesa-bigtable-datastore)
+### [Bigtable Data Store](geomesa-bigtable-datastore)
 
-This module contains a stub POM for building a Google BigTable-backed GeoTools
+This module contains a stub POM for building a [Google Cloud Bigtable](https://cloud.google.com/bigtable)-backed GeoTools
 data store.
 
-### [BigTable GeoServer Plugin](../geomesa-gs-plugin/geomesa-bigtable-gs-plugin)
+### [Bigtable GeoServer Plugin](../geomesa-gs-plugin/geomesa-bigtable-gs-plugin)
 
 The plugin module contains a stub POM for building a bundle containing
-all of the JARs to use the Google BigTable data store in GeoServer.
+all of the JARs to use the [Google Cloud Bigtable](https://cloud.google.com/bigtable) data store in GeoServer.


### PR DESCRIPTION
* Fixed link formatting from using Markdown-style to reStructuredText-style so
  that it renders properly, both on GitHub and on geomesa.org HTML pages
* Added code formatting for parameter names
* Fixed capitalization of Bigtable, added link to home page