### PR TITLE
Complex avro

### DIFF
--- a/geomesa-features/geomesa-feature-avro-complex/pom.xml
+++ b/geomesa-features/geomesa-feature-avro-complex/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>geomesa-features</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.2.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-avro-complex/pom.xml
+++ b/geomesa-features/geomesa-feature-avro-complex/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>geomesa-features</artifactId>
+        <groupId>org.locationtech.geomesa</groupId>
+        <version>1.2.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-feature-avro-complex</artifactId>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-feature-avro</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-main</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2_2.11</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/geomesa-features/geomesa-feature-avro-complex/pom.xml
+++ b/geomesa-features/geomesa-feature-avro-complex/pom.xml
@@ -31,6 +31,11 @@
             <artifactId>gt-main</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.geotools.xsd</groupId>
+            <artifactId>gt-xsd-gml3</artifactId>
+            <version>${gt.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
         </dependency>

--- a/geomesa-features/geomesa-feature-avro-complex/src/main/scala/org/locationtech/geomesa/features/avro/complex/AvroCodecs.scala
+++ b/geomesa-features/geomesa-feature-avro-complex/src/main/scala/org/locationtech/geomesa/features/avro/complex/AvroCodecs.scala
@@ -1,0 +1,697 @@
+package org.locationtech.geomesa.features.avro.complex
+
+import java.nio.ByteBuffer
+import java.sql.Timestamp
+import java.{net, sql, util}
+import java.util.function.Function
+import java.util.{Calendar, Date, GregorianCalendar, UUID, ArrayList => JArrayList, Collection => JCollection, Collections => JCollections, HashMap => JHashMap}
+
+import com.vividsolutions.jts.geom.Geometry
+import com.vividsolutions.jts.io.{WKBReader, WKBWriter}
+import org.apache.avro.Schema
+import org.apache.avro.io.{Decoder, Encoder}
+import org.geotools.feature.`type`.AttributeDescriptorImpl
+import org.geotools.feature.{AttributeImpl, ComplexAttributeImpl, FeatureImpl}
+import org.geotools.filter.identity.FeatureIdImpl
+import org.geotools.gml2.GMLSchema
+import org.locationtech.geomesa.features.avro.complex.AvroSchemas.{FieldNameEncoder, _}
+import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
+import org.opengis.feature.`type`.{PropertyDescriptor, _}
+import org.opengis.feature.{Attribute, ComplexAttribute, Property}
+import org.opengis.filter.identity.FeatureId
+
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+object AvroCodecs {
+
+  val primitiveTypes =
+    List(
+      classOf[String],
+      classOf[java.lang.Integer],
+      classOf[Int],
+      classOf[java.lang.Long],
+      classOf[Long],
+      classOf[java.lang.Double],
+      classOf[Double],
+      classOf[java.lang.Float],
+      classOf[Float],
+      classOf[java.lang.Boolean],
+      classOf[Boolean]
+    )
+
+  abstract case class AvroCodec[T](schema:Schema) {
+    val clazz: Class[T]
+    def enc(t: T, enc: Encoder): Unit
+    def dec(dec: Decoder): T
+  }
+
+  trait CodecRegistry {
+    protected val registry = mutable.Map.empty[Class[_],mutable.LinkedHashMap[Schema.Type,AvroCodec[_]]]
+    protected val cache = mutable.Map.empty[Class[_], Option[mutable.LinkedHashMap[Schema.Type,AvroCodec[_]]]]
+
+    def bind[T](encMethod: (Encoder,T)=>Unit, decMethod: (Decoder)=>T, schema: Schema)(implicit tag: ClassTag[T]) = {
+      val codec = new AvroCodec[T](schema) {
+        val clazz = tag.runtimeClass.asInstanceOf[Class[T]]
+        override def enc(t: T, out: Encoder): Unit = encMethod(out, t)
+        override def dec(in: Decoder): T = decMethod(in)
+      }
+      registry.getOrElseUpdate(tag.runtimeClass,mutable.LinkedHashMap.empty)(schema.getType) = codec
+      codec
+    }
+
+    val JBOOLEAN = classOf[java.lang.Boolean]
+    val JBYTE = classOf[java.lang.Byte]
+    val JCHAR = classOf[java.lang.Character]
+    val JSHORT = classOf[java.lang.Short]
+    val JINT = classOf[java.lang.Integer]
+    val JLONG = classOf[java.lang.Long]
+    val JFLOAT = classOf[java.lang.Float]
+    val JDOUBLE = classOf[java.lang.Double]
+
+    def normalizePrimitive(clazz:Class[_]) = clazz match {
+      case JBOOLEAN | java.lang.Boolean.TYPE => classOf[Boolean]
+      case JBYTE | java.lang.Byte.TYPE => classOf[Byte]
+      case JCHAR | java.lang.Character.TYPE => classOf[Char]
+      case JSHORT | java.lang.Short.TYPE => classOf[Short]
+      case JINT | java.lang.Integer.TYPE => classOf[Int]
+      case JLONG | java.lang.Long.TYPE => classOf[Long]
+      case JFLOAT | java.lang.Float.TYPE => classOf[Float]
+      case JDOUBLE | java.lang.Double.TYPE => classOf[Double]
+      case x => x
+    }
+
+    def findAll[T](clazz:Class[T]): Option[mutable.LinkedHashMap[Schema.Type, AvroCodec[_]]] =
+      cache.getOrElseUpdate(clazz, registry.get(normalizePrimitive(clazz))
+        .orElse(Option(clazz.getSuperclass).flatMap(findAll(_)))
+        .orElse {
+          for (ifc <- clazz.getInterfaces; map <- findAll(ifc))
+            return Some(map)
+          None
+        }
+      )
+
+    def find[T](clazz:Class[T], s:Schema.Type): Option[AvroCodec[_>:T]] =
+      findAll(clazz).flatMap(m=>m.get(s)).asInstanceOf[Option[AvroCodec[_>:T]]]
+
+    def find[T](clazz:Class[T]): Option[AvroCodec[_>:T]] =
+      findAll(clazz).flatMap(m=>m.headOption).map{case(t,c)=>c}.asInstanceOf[Option[AvroCodec[_>:T]]]
+  }
+
+  trait PrimitiveCodecs extends CodecRegistry {
+    implicit val STRING = bind(_.writeString(_:String), _.readString(), Schema.create(Schema.Type.STRING))
+    implicit val BYTES = bind(_.writeBytes(_:scala.Array[Byte]), d=>{
+      val buf = d.readBytes(null)
+      val pos = buf.position()
+      val len = buf.limit() - pos
+      if(len == 0)
+        scala.Array.emptyByteArray
+      else if(pos == 0 && buf.hasArray)
+        buf.array()
+      else {
+        val a = scala.Array.ofDim[Byte](len)
+        buf.get(a, 0, len)
+        a
+      }
+    }, Schema.create(Schema.Type.BYTES))
+    implicit val BYTEBUFFER = bind(_.writeBytes(_:ByteBuffer), _.readBytes(null), Schema.create(Schema.Type.BYTES))
+    implicit val BOOLEAN = bind(_.writeBoolean(_:Boolean), _.readBoolean(), Schema.create(Schema.Type.BOOLEAN))
+
+    val BYTE_AS_INT = bind[Byte](_.writeInt(_), _.readInt().toByte, Schema.create(Schema.Type.INT))
+    val SHORT_AS_INT = bind[Short](_.writeInt(_), _.readInt().toShort, Schema.create(Schema.Type.INT))
+    implicit val INT = bind[Int](_.writeInt(_), _.readInt(),  Schema.create(Schema.Type.INT))
+    val LONG_AS_INT = bind[Long]((e,l)=>e.writeInt(l.toInt), _.readInt(),  Schema.create(Schema.Type.INT))
+    val FLOAT_AS_INT = bind[Float]((e,l)=>e.writeInt(l.toInt), _.readInt(),  Schema.create(Schema.Type.INT))
+    val DOUBLE_AS_INT = bind[Double]((e,l)=>e.writeInt(l.toInt), _.readInt(),  Schema.create(Schema.Type.INT))
+
+    val BYTE_AS_LONG = bind[Short](_.writeLong(_), _.readLong().toByte,  Schema.create(Schema.Type.LONG))
+    val SHORT_AS_LONG = bind[Short](_.writeLong(_), _.readLong().toShort,  Schema.create(Schema.Type.LONG))
+    val INT_AS_LONG = bind[Int](_.writeLong(_), _.readLong().toInt,  Schema.create(Schema.Type.LONG))
+    implicit val LONG = bind[Long](_.writeLong(_), _.readLong(),  Schema.create(Schema.Type.LONG))
+    val FLOAT_AS_LONG = bind[Float]((e,l)=>e.writeLong(l.toLong), _.readLong(),  Schema.create(Schema.Type.LONG))
+    val DOUBLE_AS_LONG = bind[Double]((e,l)=>e.writeLong(l.toLong), _.readLong(),  Schema.create(Schema.Type.LONG))
+
+    val BYTE_AS_FLOAT = bind[Byte](_.writeFloat(_), _.readFloat().toByte,  Schema.create(Schema.Type.FLOAT))
+    val SHORT_AS_FLOAT = bind[Short](_.writeFloat(_), _.readFloat().toShort,  Schema.create(Schema.Type.FLOAT))
+    val INT_AS_FLOAT = bind[Int](_.writeFloat(_), _.readFloat().toInt,  Schema.create(Schema.Type.FLOAT))
+    val LONG_AS_FLOAT = bind[Long](_.writeFloat(_), _.readFloat().toLong,  Schema.create(Schema.Type.FLOAT))
+    implicit val FLOAT = bind[Float](_.writeFloat(_), _.readFloat(),  Schema.create(Schema.Type.FLOAT))
+    val DOUBLE_AS_FLOAT = bind[Double]((e,f)=>e.writeFloat(f.toFloat), _.readFloat(),  Schema.create(Schema.Type.FLOAT))
+
+    val BYTE_AS_DOUBLE = bind[Byte](_.writeDouble(_), _.readDouble().toByte,  Schema.create(Schema.Type.DOUBLE))
+    val SHORT_AS_DOUBLE = bind[Short](_.writeDouble(_), _.readDouble().toShort,  Schema.create(Schema.Type.DOUBLE))
+    val INT_AS_DOUBLE = bind[Int](_.writeDouble(_), _.readDouble().toInt,  Schema.create(Schema.Type.DOUBLE))
+    val LONG_AS_DOUBLE = bind[Long](_.writeDouble(_), _.readDouble().toLong,  Schema.create(Schema.Type.DOUBLE))
+    val FLOAT_AS_DOUBLE = bind[Float](_.writeDouble(_), _.readDouble().toFloat,  Schema.create(Schema.Type.DOUBLE))
+    implicit val DOUBLE = bind[Double](_.writeDouble(_), _.readDouble(),  Schema.create(Schema.Type.DOUBLE))
+  }
+
+  trait DerivedCodecs extends PrimitiveCodecs {
+    def derive[T,U](encMethod: T=>U, decMethod: U=>T)(implicit primitiveCodec: AvroCodec[U], tag: ClassTag[T]) = {
+      val codec = new AvroCodec[T](primitiveCodec.schema) {
+        override val clazz = tag.runtimeClass.asInstanceOf[Class[T]]
+        override def enc(t: T, out: Encoder) = primitiveCodec.enc(encMethod(t), out)
+        override def dec(in: Decoder) = decMethod(primitiveCodec.dec(in))
+      }
+      registry.getOrElseUpdate(tag.runtimeClass, mutable.LinkedHashMap.empty)(primitiveCodec.schema.getType)=codec
+      codec
+    }
+
+    implicit val DATE = derive[Date,Long](_.getTime, new Date(_))
+    implicit val CALENDAR = derive[Calendar,Long](_.getTimeInMillis, d=>{val gc=new GregorianCalendar(); gc.setTimeInMillis(d); gc})
+    implicit val SQL_DATE = derive[sql.Date,Long](_.getTime, new sql.Date(_))
+    implicit val SQL_TIMESTAMP = derive[Timestamp,Long](_.getTime, new Timestamp(_))
+    implicit val _UUID = derive(encodeUUID, decodeUUID)
+    implicit val URI = derive[net.URI,String](_.toString, net.URI.create)
+  }
+
+  class StatefulCodecs(wkbWriter: WKBWriter, wkbReader: WKBReader) extends DerivedCodecs {
+    val GEOMETRY = derive[Geometry,scala.Array[Byte]](wkbWriter.write, wkbReader.read)
+  }
+
+  def encodeUUID(uuid: UUID) =
+    ByteBuffer.allocate(16)
+      .putLong(uuid.getMostSignificantBits)
+      .putLong(uuid.getLeastSignificantBits)
+      .flip.asInstanceOf[ByteBuffer]
+
+  def decodeUUID(bb: ByteBuffer): UUID = new UUID(bb.getLong, bb.getLong)
+
+
+  /*
+   * These classes are specializations of Function to improve performance
+   */
+
+  private[this] abstract class EncodeComplexAttribute extends ((ComplexAttribute,JHashMap[Name,JArrayList[Property]], Encoder)=>Unit) {
+    def apply(ca:ComplexAttribute, props: JHashMap[Name,JArrayList[Property]], e:Encoder)
+  }
+
+  private[this] abstract class EncodeProperties extends ((JArrayList[Property],Encoder)=>Unit) {
+    def apply(props:JArrayList[Property], e:Encoder)
+  }
+
+  private[this] abstract class EncodeProperty extends ((Encoder,Property)=>Unit) {
+    def apply(e: Encoder, p: Property)
+  }
+
+  private[this] abstract class DecodeToAttribute extends (Decoder=>Attribute) {
+    def apply(d:Decoder): Attribute
+  }
+
+  private[this] abstract class DecodeToAttributes extends (Decoder=>JCollection[Attribute]) {
+    def apply(d:Decoder): JCollection[Attribute]
+  }
+
+  private[this] val arrayFactory = new Function[Name,JArrayList[Property]] { def apply(t: Name) = new JArrayList[Property]() }
+
+  trait FeatureCodecs { self: CodecRegistry =>
+    protected[this] val fne: FieldNameEncoder
+    private[this] val schemaFac = new SchemaFactory(fne, this)
+    private[this] val codecs = mutable.Map.empty[AttributeDescriptor,AvroCodec[Property]]
+    private[this] val constructing = mutable.Set.empty[Record]
+    private[this] val encoders = mutable.Map.empty[Record,EncodeProperty]
+    private[this] val decoders = mutable.Map.empty[Record, DecodeToAttribute]
+
+    def schemaFor(ct:ComplexType) = schemaFac(ct)
+
+    def find(ct:ComplexType): AvroCodec[Property] = {
+      find(new AttributeDescriptorImpl(ct, ct.getName, 1, 1, false, null))
+    }
+
+    def find(ad:AttributeDescriptor): AvroCodec[Property] = {
+      codecs.getOrElseUpdate(ad, {
+        val schema = schemaFac(ad.getType.asInstanceOf[ComplexType])
+        val schemaType = getType(schema, fne)
+        val enc = bindEnc(schemaType, ad)
+        val dec = bindDec(schemaType, ad)
+        bind[Property](enc,dec,schema)
+      })
+    }
+
+    private[this] def bindEnc(s:SchemaType, ad:PropertyDescriptor):EncodeProperty = s match {
+      case r@Record(fields) if ad.getType.isInstanceOf[ComplexType] =>
+        val ct = ad.getType.asInstanceOf[ComplexType]
+      encoders.get(r) match {
+        case Some(enc) => return enc
+        case _ =>
+      }
+
+      if(constructing(r)) {
+        return new EncodeProperty {
+          private[this] lazy val binding=encoders(r)
+          override def apply(e: Encoder, p: Property): Unit = binding(e,p)
+        }
+      }
+
+      constructing(r) = true
+
+      val descByName = AvroSchemas.allProps(ct).map(d => d.getName -> d).toMap
+
+      // Each field MUST be mapped
+      val bindings = r.fields.map { case (name, st) =>
+        if (AvroSchemas.AVRO_NAMESPACE == name.getNamespaceURI) {
+          name.getLocalPart match {
+            case "__version__" =>
+              new EncodeComplexAttribute {
+                def apply(ca: ComplexAttribute, p: JHashMap[Name, JArrayList[Property]], e: Encoder) = e.writeInt(1)
+              }
+
+            case "__fid__" =>
+              new EncodeComplexAttribute {
+                def apply(ca: ComplexAttribute, p: JHashMap[Name, JArrayList[Property]], e: Encoder) =
+                  e.writeString(Option(ca.getIdentifier) flatMap (i => Option(i.getID)) map (_.toString) getOrElse "")
+              }
+
+            case "simpleContent" => st match {
+              case n@Nullable(Primitive(t)) =>
+                val binding = bindEncPrimitive(AvroSchemas.nearestSimpleType(ct), t)
+                new EncodeComplexAttribute {
+                  def apply(ca: ComplexAttribute, p: JHashMap[Name, JArrayList[Property]], e: Encoder) =
+                    Option(ca.getProperty(GEOT_SIMPLE_CONTENT)) match {
+                      case Some(value) if value.getValue != null =>
+                        n.writeNonNull(e)
+                        binding(e, value)
+                      case _ =>
+                        n.writeNull(e)
+                    }
+                }
+
+              case _ =>
+                throw new IllegalStateException(s"The property $name must be a nullable primitive type")
+            }
+
+            case other => st match {
+              case n: Nullable =>
+                new EncodeComplexAttribute {
+                  def apply(ca: ComplexAttribute, p: JHashMap[Name, JArrayList[Property]], e: Encoder) = n.writeNull(e)
+                }
+              case _ => ???
+            }
+          }
+        } else {
+          descByName.get(name) match {
+            case Some(desc) =>
+              val binding = bindEncMany(st, desc.asInstanceOf[AttributeDescriptor])
+              new EncodeComplexAttribute {
+                def apply(ca: ComplexAttribute, p: JHashMap[Name, JArrayList[Property]], e: Encoder) =
+                  binding(p.computeIfAbsent(name, arrayFactory), e)
+              }
+            case None =>
+              st match {
+                case n: Nullable =>
+                  new EncodeComplexAttribute {
+                    def apply(ca: ComplexAttribute, p: JHashMap[Name, JArrayList[Property]], e: Encoder) = n.writeNull(e)
+                  }
+                case _ =>
+                  throw new IllegalStateException()
+              }
+          }
+        }
+      }.toArray
+
+
+      val ret = new EncodeProperty {
+        def apply(e: Encoder, p: Property) = {
+          val ca = p.asInstanceOf[ComplexAttribute]
+          val props = new JHashMap[Name, JArrayList[Property]]()
+          val pIt = ca.getProperties.iterator()
+          while (pIt.hasNext) {
+            val p = pIt.next()
+            props.computeIfAbsent(p.getName, arrayFactory).add(p)
+          }
+          val sz = bindings.length
+          var i = 0
+          while (i < sz) {
+            bindings(i)(ca, props, e)
+            i = i + 1
+          }
+        }
+      }
+      encoders(r) = ret
+      constructing(r) = false
+      ret
+    }
+
+    private[this] def bindEncMany(s:SchemaType, ad:AttributeDescriptor):EncodeProperties = s match {
+      case n@Nullable(st) =>
+        val binding = bindEncMany(st,ad)
+        new EncodeProperties { def apply(props: JArrayList[Property], e: Encoder) = {
+          // We want to be as gentle on the GC as possible, so don't allocate a list unless absolutely necessary
+          var out: JArrayList[Property] = props
+          var i = 0
+          val sz = props.size()
+          while(i<sz) {
+            if(props.get(i).getValue==null) {
+              out = new JArrayList[Property](sz)
+              out.addAll(props.subList(0,i))
+              i=i+1
+              while(i<sz) {
+                val prop=props.get(i)
+                if(prop.getValue!=null) {
+                  out.add(prop)
+                }
+                i=i+1
+              }
+            } else {
+              i=i+1
+            }
+          }
+          if (out.isEmpty) {
+            n.writeNull(e)
+          } else {
+            n.writeNonNull(e)
+            binding(out, e)
+          }
+        } }
+      case Array(Primitive(_)) if ad.isList =>
+        val binding = bindEncOne(s, ad)
+        new EncodeProperties {
+          override def apply(props: JArrayList[Property], e: Encoder) = binding(e,props.get(0))
+        }
+
+      case Array(Record(_)) if ad.isMap =>
+        val binding = bindEncOne(s, ad)
+        new EncodeProperties {
+          override def apply(props: JArrayList[Property], e: Encoder) = binding(e,props.get(0))
+        }
+
+      case Array(st) =>
+        val binding = bindEncOne(st,ad)
+        new EncodeProperties { override def apply(props: JArrayList[Property], e: Encoder) = {
+          e.writeArrayStart()
+          e.setItemCount(props.size)
+          var i=0
+          val sz=props.size()
+          while(i<sz) {
+            e.startItem()
+            binding(e, props.get(i))
+            i=i+1
+          }
+          e.writeArrayEnd()
+        }
+        }
+      case other =>
+        val binding = bindEncOne(other, ad)
+        new EncodeProperties { override def apply(props: JArrayList[Property], e: Encoder) = binding(e,props.get(0)) }
+      case _ => ???
+    }
+
+    private[this] def bindEncOne(s:SchemaType, ad:PropertyDescriptor):EncodeProperty = s match {
+      case n@Nullable(st) =>
+        val binding = bindEncOne(st,ad)
+        new EncodeProperty { def apply(e: Encoder, p: Property) ={
+          if(p.getValue==null)
+            n.writeNull(e)
+          else {
+            n.writeNonNull(e)
+            binding(e,p)
+          }
+        } }
+
+      case Array(Primitive(t)) if ad.isList =>
+        val clazz = ad.getListType().get
+        val Some(codec) = self.find(clazz, t)
+        new EncodeProperty { def apply(e: Encoder, p: Property) ={
+          e.writeArrayStart()
+          val list = p.getValue.asInstanceOf[java.util.List[AnyRef]]
+          e.setItemCount(list.size())
+          val it=list.iterator()
+          while(it.hasNext) {
+            val o=it.next()
+            e.startItem()
+            codec.asInstanceOf[AvroCodec[AnyRef]].enc(o,e)
+          }
+          e.writeArrayEnd()
+        } }
+
+      case Array(Record( (_,Primitive(keyType)) :: (_,Primitive(valType)) :: _ )) if ad.isMap =>
+        val Some((keyClass,valClass)) = ad.getMapTypes()
+        val Some(keyCodec) = self.find(keyClass,keyType)
+        val Some(valCodec) = self.find(valClass,valType)
+        new EncodeProperty { def apply(e: Encoder, p: Property) ={
+          e.writeArrayStart()
+          val map = p.getValue.asInstanceOf[java.util.Map[AnyRef,AnyRef]]
+          e.setItemCount(map.size())
+          val it = map.entrySet().iterator()
+          while(it.hasNext) {
+            val ent = it.next()
+            e.startItem()
+            keyCodec.asInstanceOf[AvroCodec[AnyRef]].enc(ent.getKey,e)
+            valCodec.asInstanceOf[AvroCodec[AnyRef]].enc(ent.getValue,e)
+          }
+          e.writeArrayEnd()
+        } }
+
+      case Array(st) =>
+        val binding = bindEncOne(st,ad)
+        new EncodeProperty { def apply(e: Encoder, p: Property) ={
+          e.writeArrayStart()
+          e.setItemCount(1)
+          e.startItem()
+          binding(e,p)
+          e.writeArrayEnd()
+        } }
+
+      case dr:DeferredRecord =>
+        bindEncOne(dr.rec, ad)
+
+      case r:Record if ad.getType.isInstanceOf[ComplexType] =>
+        bindEnc(r, ad)
+
+      case Primitive(t) =>
+        bindEncPrimitive(ad.getType, t)
+
+      case _ =>
+        ???
+    }
+
+    private[this] def bindEncPrimitive(pt:PropertyType, t:Schema.Type): EncodeProperty =
+      bindEncClass(pt.getBinding, t)
+
+    private[this] def bindEncClass(clazz:Class[_], t:Schema.Type): EncodeProperty =
+      self.find(clazz, t) match {
+        case Some(codec) =>
+          bindEncCodec(codec)
+        case None =>
+          ???
+      }
+
+    private[this] def bindEncCodec[T](codec:AvroCodec[T]): EncodeProperty =
+      new EncodeProperty { override def apply(e: Encoder, p: Property) = codec.enc(p.getValue.asInstanceOf[T],e) }
+
+
+    private[this] def bindDec(s:SchemaType, ad:PropertyDescriptor): DecodeToAttribute = s match {
+      case r@Record(fields) =>
+        val ct=ad.getType.asInstanceOf[ComplexType]
+        decoders.get(r) match { case Some(dec) => return dec case _ => }
+        if(constructing(r)) {
+          return new DecodeToAttribute {
+            private[this] lazy val binding=bindDec(r,ad)
+            def apply(d: Decoder) = binding(d)
+          }
+        }
+        constructing(r)=true
+        val descByName=AvroSchemas.allProps(ct).map(d=>d.getName->d).toMap
+        val isFeature = isDescendedFrom(ct, GMLSchema.ABSTRACTFEATURETYPE_TYPE)
+
+        abstract class Builder() {
+          @inline private[FeatureCodecs] final val props:JArrayList[Property] = new JArrayList[Property]()
+          final var id:FeatureId = null
+          def build(): ComplexAttribute
+        }
+
+        val builderFac: ()=>Builder = if(isFeature) ()=>new Builder() {
+          override def build(): ComplexAttribute = new FeatureImpl(props, ad.asInstanceOf[AttributeDescriptor], id)
+        } else ()=>new Builder() {
+          override def build(): ComplexAttribute = new ComplexAttributeImpl(props, ad.asInstanceOf[AttributeDescriptor], id)
+        }
+
+        abstract class Applier {
+          def apply(d:Decoder, props:JArrayList[Property], b:Builder): Unit
+        }
+
+        val bindings:scala.Array[Applier] = (for((name,st)<-r.fields) yield {
+          lazy val fieldSkipper = new Applier {
+            def apply(d:Decoder,props:JArrayList[Property], b:Builder)=st.skip(d)
+          }
+
+          if(AVRO_NAMESPACE == name.getNamespaceURI) name.getLocalPart match {
+            case "__version__" =>
+              new Applier {
+                def apply(d:Decoder,props:JArrayList[Property],b:Builder)=d.readInt()
+              }
+            case "__fid__" =>
+              new Applier {
+                def apply(d:Decoder,props:JArrayList[Property], b:Builder)={
+                  val s = d.readString()
+                  if(!s.isEmpty) b.id = new FeatureIdImpl(s)
+                }
+              }
+            case "simpleContent" => st match {
+              case n@Nullable(Primitive(t)) =>
+                val st=nearestSimpleType(ct)
+                self.find(st.getBinding, t) match {
+                  case Some(codec) =>
+                    new Applier {
+                      def apply(d:Decoder,props:JArrayList[Property], b:Builder)={
+                        val value = if(n.readNull(d)) null else codec.dec(d)
+                        props add new AttributeImpl(value, new AttributeDescriptorImpl(st.asInstanceOf[AttributeType], GEOT_SIMPLE_CONTENT, 0, 1, true, null), null)
+                      }
+                    }
+                }
+              case _ =>
+                fieldSkipper
+            }
+            case _ =>
+              fieldSkipper
+          } else descByName.get(name) match {
+            case Some(desc) =>
+              val binding = bindDecMany(st, desc.asInstanceOf[AttributeDescriptor])
+              new Applier {
+                def apply(d:Decoder,props:JArrayList[Property], b:Builder)=props.addAll(binding(d))
+              }
+            case _ =>
+              fieldSkipper
+          }
+        }).toArray
+
+        val ret = new DecodeToAttribute{
+          def apply(d: Decoder) = {
+            val b = builderFac()
+            val props = b.props
+            val sz = bindings.length
+            var i = 0
+            while (i < sz) {
+              bindings(i)(d, props, b)
+              i = i + 1
+            }
+            b.build()
+          }
+        }
+        decoders(r)=ret
+        constructing(r)=false
+        ret
+      case _ =>
+        ???
+    }
+
+    private[this] def bindDecMany(s: SchemaType, ad:AttributeDescriptor): DecodeToAttributes = s match {
+      case n@Nullable(st) =>
+        new DecodeToAttributes {
+          private[this] val binding=bindDecMany(st,ad)
+          override def apply(d: Decoder): JCollection[Attribute] =
+            if(n.readNull(d)) {
+              JCollections.emptyList[Attribute]
+            } else {
+              binding(d)
+            }
+        }
+      case Array(Primitive(_)) if ad.isList =>
+        new DecodeToAttributes {
+          private[this] val binding=bindDecOne(s,ad)
+          override def apply(d: Decoder): JCollection[Attribute] = JCollections.singletonList(binding(d))
+        }
+
+      case Array(Record(_)) if ad.isMap =>
+        new DecodeToAttributes {
+          private[this] val binding=bindDecOne(s,ad)
+          override def apply(d: Decoder): JCollection[Attribute] = JCollections.singletonList(binding(d))
+        }
+
+      case Array(st) =>
+        new DecodeToAttributes {
+          private[this] val binding = bindDecMany(st, ad)
+
+          override def apply(d: Decoder): JCollection[Attribute] = {
+            val buf = new JArrayList[Attribute]()
+            var sz = d.readArrayStart()
+            while (sz != 0) {
+              do {
+                buf.addAll(binding(d))
+                sz = sz - 1
+              } while (sz != 0)
+              sz = d.arrayNext()
+            }
+            buf
+          }
+        }
+
+      case _ =>
+        new DecodeToAttributes {
+          private[this] val binding=bindDecOne(s, ad)
+          override def apply(d: Decoder): JCollection[Attribute] = JCollections.singletonList(binding(d))
+        }
+    }
+
+    private[this] def bindDecOne(s: SchemaType, ad: AttributeDescriptor): DecodeToAttribute = s match {
+      case n@Nullable(st) =>
+        val binding = bindDecOne(st,ad)
+        new DecodeToAttribute {
+          def apply(d: Decoder) =
+            if (n.readNull(d))
+              new AttributeImpl(null, ad, null)
+            else
+              binding(d)
+        }
+
+      case dr:DeferredRecord =>
+        bindDecOne(dr.rec, ad)
+
+      case Array(Primitive(t)) if ad.isList =>
+        self.find(ad.getListType().get, t) match {
+          case Some(codec) =>
+            new DecodeToAttribute {
+              def apply(d: Decoder) = {
+                val buf = new util.ArrayList[Any]()
+                var sz = d.readArrayStart()
+                while (sz != 0) {
+                  do {
+                    buf.add(codec.dec(d))
+                    sz = sz - 1
+                  } while (sz != 0)
+                  sz = d.arrayNext()
+                }
+                new AttributeImpl(buf, ad, null)
+              }
+            }
+          case None => ???
+        }
+
+      case Array(Record( (_,Primitive(keyType)) :: (_,Primitive(valType)) :: _ )) if ad.isMap =>
+        val Some((keyClass, valClass)) = ad.getMapTypes()
+        val Some(keyCodec) = self.find(keyClass, keyType)
+        val Some(valCodec) = self.find(valClass, valType)
+        new DecodeToAttribute {
+          def apply(d: Decoder) = {
+            val map = new java.util.HashMap[Any, Any]()
+            var sz = d.readArrayStart()
+            while (sz != 0) {
+              do {
+                val k = keyCodec.dec(d)
+                val v = valCodec.dec(d)
+                map.put(k, v)
+                sz = sz - 1
+              } while (sz != 0)
+              sz = d.arrayNext()
+            }
+            new AttributeImpl(map, ad, null)
+          }
+        }
+      case r:Record =>
+        bindDec(s,ad)
+
+      case Primitive(t) =>
+        self.find(ad.getType.getBinding, t) match {
+          case Some(codec) =>
+            new DecodeToAttribute {
+              def apply(d: Decoder) = new AttributeImpl(codec.dec(d), ad, null)
+            }
+          case None => ???
+        }
+
+      case _ =>
+        ???
+    }
+
+  }
+}

--- a/geomesa-features/geomesa-feature-avro-complex/src/main/scala/org/locationtech/geomesa/features/avro/complex/AvroCodecs.scala
+++ b/geomesa-features/geomesa-feature-avro-complex/src/main/scala/org/locationtech/geomesa/features/avro/complex/AvroCodecs.scala
@@ -69,17 +69,24 @@ object AvroCodecs {
     val JFLOAT = classOf[java.lang.Float]
     val JDOUBLE = classOf[java.lang.Double]
 
-    def normalizePrimitive(clazz:Class[_]) = clazz match {
-      case JBOOLEAN | java.lang.Boolean.TYPE => classOf[Boolean]
-      case JBYTE | java.lang.Byte.TYPE => classOf[Byte]
-      case JCHAR | java.lang.Character.TYPE => classOf[Char]
-      case JSHORT | java.lang.Short.TYPE => classOf[Short]
-      case JINT | java.lang.Integer.TYPE => classOf[Int]
-      case JLONG | java.lang.Long.TYPE => classOf[Long]
-      case JFLOAT | java.lang.Float.TYPE => classOf[Float]
-      case JDOUBLE | java.lang.Double.TYPE => classOf[Double]
-      case x => x
-    }
+    val normalizePrimitive = Map[Class[_],Class[_]](
+      JBOOLEAN -> classOf[Boolean],
+      JBYTE -> classOf[Byte],
+      JCHAR -> classOf[Char],
+      JSHORT -> classOf[Short],
+      JINT -> classOf[Int],
+      JLONG -> classOf[Long],
+      JFLOAT -> classOf[Float],
+      JDOUBLE -> classOf[Double],
+      java.lang.Boolean.TYPE -> classOf[Boolean],
+      java.lang.Byte.TYPE -> classOf[Byte],
+      java.lang.Character.TYPE -> classOf[Char],
+      java.lang.Short.TYPE -> classOf[Short],
+      java.lang.Integer.TYPE -> classOf[Int],
+      java.lang.Long.TYPE -> classOf[Long],
+      java.lang.Float.TYPE -> classOf[Float],
+      java.lang.Double.TYPE -> classOf[Double]
+    ).withDefault(k=>k)
 
     def findAll[T](clazz:Class[T]): Option[mutable.LinkedHashMap[Schema.Type, AvroCodec[_]]] =
       cache.getOrElseUpdate(clazz, registry.get(normalizePrimitive(clazz))

--- a/geomesa-features/geomesa-feature-avro-complex/src/main/scala/org/locationtech/geomesa/features/avro/complex/AvroCodecs.scala
+++ b/geomesa-features/geomesa-feature-avro-complex/src/main/scala/org/locationtech/geomesa/features/avro/complex/AvroCodecs.scala
@@ -13,9 +13,9 @@ import org.apache.avro.io.{Decoder, Encoder}
 import org.geotools.feature.`type`.AttributeDescriptorImpl
 import org.geotools.feature.{AttributeImpl, ComplexAttributeImpl, FeatureImpl}
 import org.geotools.filter.identity.FeatureIdImpl
-import org.geotools.gml2.GMLSchema
+import org.geotools.gml3.GMLSchema
 import org.locationtech.geomesa.features.avro.complex.AvroSchemas.{FieldNameEncoder, _}
-import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
+import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors._
 import org.opengis.feature.`type`.{PropertyDescriptor, _}
 import org.opengis.feature.{Attribute, ComplexAttribute, Property}
 import org.opengis.filter.identity.FeatureId
@@ -396,7 +396,7 @@ object AvroCodecs {
       case _ => ???
     }
 
-    private[this] def bindEncOne(s:SchemaType, ad:PropertyDescriptor):EncodeProperty = s match {
+    private[this] def bindEncOne(s:SchemaType, ad:AttributeDescriptor):EncodeProperty = s match {
       case n@Nullable(st) =>
         val binding = bindEncOne(st,ad)
         new EncodeProperty { def apply(e: Encoder, p: Property) ={

--- a/geomesa-features/geomesa-feature-avro-complex/src/main/scala/org/locationtech/geomesa/features/avro/complex/AvroSchemas.scala
+++ b/geomesa-features/geomesa-feature-avro-complex/src/main/scala/org/locationtech/geomesa/features/avro/complex/AvroSchemas.scala
@@ -102,10 +102,6 @@ object AvroSchemas {
       f
     }
 
-    private[this] def computeFieldSchema(clazz:Class[_], nillable:Boolean, multi:Boolean) =
-      for(codec<-registry.find(clazz)) yield
-        computeType(codec.schema, nillable, multi)
-
     private[this] def computeType(s:Schema, ad:AttributeDescriptor):Schema =
       computeType(s, ad.getMinOccurs == 0 || ad.isNillable, ad.getMaxOccurs != 1)
 

--- a/geomesa-features/geomesa-feature-avro-complex/src/main/scala/org/locationtech/geomesa/features/avro/complex/AvroSchemas.scala
+++ b/geomesa-features/geomesa-feature-avro-complex/src/main/scala/org/locationtech/geomesa/features/avro/complex/AvroSchemas.scala
@@ -1,0 +1,253 @@
+package org.locationtech.geomesa.features.avro.complex
+
+import org.apache.avro.Schema.Field
+import org.apache.avro.Schema.Type._
+import org.apache.avro.io.{Decoder, Encoder}
+import org.apache.avro.{Schema, SchemaBuilder}
+import org.geotools.feature.NameImpl
+import org.geotools.gml3.GMLSchema
+import org.geotools.xs.XSSchema
+import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors._
+import org.opengis.feature.`type`._
+
+import scala.annotation.tailrec
+import scala.collection.JavaConversions._
+import scala.collection.immutable.{BitSet, Queue}
+import scala.collection.mutable
+
+object AvroSchemas {
+  val FEATURE_ID_AVRO_FIELD_NAME = "__fid__"
+  val AVRO_SIMPLE_FEATURE_VERSION = "__version__"
+  val AVRO_SIMPLE_FEATURE_USERDATA = "__userdata__"
+  val VERSION = 4
+  val AVRO_NAMESPACE = "org.geomesa"
+  val NAME_SIMPLE_CONTENT = new NameImpl(AVRO_NAMESPACE, "simpleContent")
+  val GEOT_SIMPLE_CONTENT = new NameImpl("simpleContent")
+  val USERDATAITEM_SCHEMA = SchemaBuilder.record("userDataItem")
+    .namespace(AVRO_NAMESPACE)
+    .fields()
+    .name("class").`type`.stringType().noDefault()
+    .name("key").`type`.stringType().noDefault()
+    .name("value").`type`.stringType().noDefault().endRecord()
+
+  trait FieldNameEncoder {
+    def encode(name:String): String
+    def decode(name:String): String
+
+    def decode(s:Schema): Name = {
+      s.getType match {
+        case RECORD|ENUM|FIXED => new NameImpl(decode(s.getNamespace), decode(s.getName))
+        case _ => new NameImpl(decode(s.getProp("namespace")), decode(s.getName))
+      }
+    }
+    def decode(f:Field, parent:Schema): Name = {
+      val ns = Option(f.getProp("namespace")).getOrElse(parent.getNamespace)
+      new NameImpl(decode(ns), decode(f.name))
+    }
+  }
+
+  object FieldNameEncoderV1 extends FieldNameEncoder{
+    private val radix = "0123456789ABCDEF"
+    private val allowedCharsInit:BitSet = ('A'.toInt.to('Z')++'a'.toInt.to('z')).map(identity)(scala.collection.breakOut)
+    private val allowedChars:BitSet = allowedCharsInit ++ '0'.toInt.to('9')
+
+    private def encodeCharInit(b:Byte) = if(allowedCharsInit(b)) b.toChar.toString else "_"+radix((b>>4)&0xf)+radix(b&0xf)
+    private def encodeChar(b:Byte) = if(allowedChars(b)) b.toChar.toString else "_"+radix((b>>4)&0xf)+radix(b&0xf)
+    private def fromHex(c:Char):Int = if(c>='0' && c<='9') c-'0' else if(c>='A' && c<='F') c-'A'+10 else if(c>='a' && c<='f') c-'a'+10 else throw new IllegalArgumentException()
+
+    override def encode(name: String): String = if(name == null) null else name.getBytes("UTF-8") match {
+      case scala.Array() => ""
+      case scala.Array(x,xs@_*) => (encodeCharInit(x) +: xs.map(encodeChar)).mkString
+    }
+
+    override def decode(name: String): String = {
+      @tailrec
+      def dec(i:Int, accum:Queue[String]):Queue[String] = if(i >= name.length) accum else name.charAt(i) match {
+        case '_'=> dec(i+3, accum:+((fromHex(name.charAt(i+1))<<4)+fromHex(name.charAt(i+2))).toChar.toString)
+        case c=>
+          val j = {val tmp=name.indexOf('_',i); if(tmp < 0) name.length else tmp}
+          dec(j,accum:+name.substring(i, j))
+      }
+      if(name == null) null else dec(0, Queue.empty).mkString
+    }
+  }
+
+  class SchemaFactory(nameEncoder: FieldNameEncoder,
+                      registry: AvroCodecs.CodecRegistry,
+                      namespace: String = AVRO_NAMESPACE) extends (ComplexType=>Schema) {
+    private[this] val typeCache = mutable.Map.empty[ComplexType,Schema]
+
+    def apply(ct: ComplexType): Schema = {
+      typeCache.get(ct) match { case Some(x) => return x case _ => }
+      val schema = Schema.createRecord(nameEncoder.encode(ct.getName.getLocalPart), null, nameEncoder.encode(ct.getName.getNamespaceURI), false)
+      typeCache(ct)=schema
+
+      val preludeFields = if(isDescendedFrom(ct, XSSchema.ANYSIMPLETYPE_TYPE)) {
+        val st = nearestSimpleType(ct)
+        for(codec<-registry.find(st.getBinding)) yield
+          computeField(ct, NAME_SIMPLE_CONTENT, computeType(codec.schema, nillable = true, multi = false))
+      } else {
+        None
+      }
+
+      schema.setFields((preludeFields ++ computeFields(ct)).toList)
+      schema
+    }
+
+    private[this] def computeField(parent:ComplexType, name:Name, s:Schema) = {
+      val f = new Field(nameEncoder.encode(name.getLocalPart), s, null, null)
+      if(name.getNamespaceURI != parent.getName.getNamespaceURI) {
+        f.addProp("namespace", nameEncoder.encode(name.getNamespaceURI))
+      }
+      f
+    }
+
+    private[this] def computeFieldSchema(clazz:Class[_], nillable:Boolean, multi:Boolean) =
+      for(codec<-registry.find(clazz)) yield
+        computeType(codec.schema, nillable, multi)
+
+    private[this] def computeType(s:Schema, ad:AttributeDescriptor):Schema =
+      computeType(s, ad.getMinOccurs == 0 || ad.isNillable, ad.getMaxOccurs != 1)
+
+    private[this] def computeType(s:Schema, nillable:Boolean, multi: Boolean):Schema = {
+      val maybeMulti = if(multi) Schema.createArray(s) else s
+      if(nillable) Schema.createUnion(List(Schema.create(Schema.Type.NULL), maybeMulti)) else maybeMulti
+    }
+
+    private[this] def computeFields[R](parent: ComplexType): Iterable[Field] = {
+      allProps(parent).map(_.asInstanceOf[AttributeDescriptor]).flatMap { ad=>
+        ad.getType match {
+          case ct: ComplexType =>
+            Some(computeField(parent, ad.getName, computeType(this(ct), ad)))
+          case _ if ad.isList =>
+            for(clazz<-ad.getListType(); codec<-registry.find(clazz)) yield
+              computeField(parent, ad.getName, computeType(Schema.createArray(codec.schema), ad))
+          case _ if ad.isMap =>
+            for((keyClass,valClass)<-ad.getMapTypes();
+                keyCodec<-registry.find(keyClass);
+                valCodec<-registry.find(valClass)) yield {
+              val keyField = new Field("k", keyCodec.schema, null, null)
+              val valField = new Field("v", valCodec.schema, null, null)
+              val schema = Schema.createRecord(List(keyField,valField))
+              computeField(parent, ad.getName, computeType(Schema.createArray(schema), ad))
+            }
+          case _ =>
+            val st = nearestSimpleType(ad.getType)
+            for(codec<-registry.find(st.getBinding)) yield computeField(parent, ad.getName, computeType(codec.schema, ad))
+        }
+      }
+    }
+  }
+
+  def subclassByRestriction(child: PropertyType) =
+    isDescendedFrom(child, GMLSchema.FEATUREPROPERTYTYPE_TYPE)
+
+  def allProps(ct:ComplexType):Iterable[PropertyDescriptor] = ct.getSuper match {
+    case st:ComplexType if subclassByRestriction(st) => allProps(st).drop(ct.getDescriptors.size())++ct.getDescriptors
+    case st:ComplexType => allProps(st)++ct.getDescriptors
+    case _ => ct.getDescriptors
+  }
+
+  def isDescendedFrom(child: PropertyType, ancestor: PropertyType): Boolean =
+    Iterator.iterate(child)(_.getSuper).takeWhile(_ != null).exists(_.eq(ancestor))
+
+  @scala.annotation.tailrec
+  def nearestSimpleType(at: PropertyType): PropertyType = at match {
+    case ct:ComplexType => nearestSimpleType(ct.getSuper)
+    case st => st
+  }
+
+  sealed trait SchemaType {
+    def skip(d:Decoder)
+  }
+
+  final case class Nullable(schema: SchemaType) extends SchemaType {
+    def this(schema: SchemaType, nullidx:Int) = { this(schema); this.nullidx = nullidx; }
+    private[this] var nullidx: Int = 0
+    def writeNull(e:Encoder) = { e.writeIndex(nullidx); e.writeNull(); }
+    def writeNonNull(e:Encoder) = e.writeIndex(1 - nullidx)
+    def readNull(d:Decoder) = if(d.readIndex() == nullidx) { d.readNull(); true; } else false
+    def skip(d:Decoder) = if(!readNull(d)) schema.skip(d)
+  }
+
+  case class Array(schema: SchemaType) extends SchemaType {
+    override def skip(d: Decoder): Unit = {
+      var sz=d.skipArray()
+      while(sz>0) {
+        do {
+          schema.skip(d)
+          sz = sz - 1
+        } while(sz > 0)
+        sz = d.skipArray()
+      }
+    }
+  }
+
+  case class Record(fields: List[(Name, SchemaType)]) extends SchemaType {
+    override def skip(d: Decoder): Unit = fields.foreach(_._2.skip(d))
+  }
+
+  case class DeferredRecord(r: ()=>Record) extends SchemaType {
+    lazy val rec = r()
+
+    override def skip(d: Decoder): Unit = rec.skip(d)
+  }
+
+  case class Fixed(sz: Int) extends SchemaType {
+    override def skip(d: Decoder): Unit = d.skipFixed(sz)
+  }
+
+  case class Primitive(t: Schema.Type) extends SchemaType {
+    override def skip(d: Decoder): Unit = t match {
+      case STRING => d.skipString()
+      case INT => d.readInt()
+      case LONG => d.readLong()
+      case FLOAT => d.readFloat()
+      case DOUBLE => d.readDouble()
+      case BOOLEAN => d.readBoolean()
+      case NULL => d.readNull()
+      case BYTES => d.skipBytes()
+    }
+  }
+
+  // Map keys in Avro are always strings; not general enough for our use case
+  //case class Map(k: SchemaType, v: SchemaType) extends SchemaType
+
+  def isPrimitive(t: Schema.Type) = t match {
+    case MAP|RECORD|ARRAY|UNION|ENUM => false
+    case _ => true
+  }
+
+  def isNullable(s:Schema) =
+    s.getType == UNION && s.getTypes.size() == 2 && s.getTypes.exists(_.getType == NULL)
+
+  def getType(s:Schema, fne:FieldNameEncoder):SchemaType = {
+    val constructed = mutable.Map.empty[Schema,Record]
+    val constructing = mutable.Set.empty[Schema]
+    def getType(s: Schema): SchemaType = s.getType match {
+      case UNION if isNullable(s) =>
+        val nullidx = s.getTypes.indexWhere(_.getType == NULL)
+        val schema = s.getTypes.get(1 - nullidx)
+        new Nullable(getType(schema), nullidx)
+      case ARRAY =>
+        Array(getType(s.getElementType))
+      case RECORD if constructing(s) =>
+        DeferredRecord(()=>constructed(s))
+      case RECORD if constructed.contains(s) =>
+        constructed(s)
+      case RECORD =>
+        constructing(s)=true
+        val ret=Record(s.getFields.map(f=>fne.decode(f,s)->getType(f.schema())).toList)
+        constructing(s)=false
+        constructed(s)=ret
+        ret
+      case FIXED =>
+        Fixed(s.getFixedSize)
+      case other if isPrimitive(other) =>
+        Primitive(other)
+      case _ =>
+        throw new IllegalStateException(s"Type not supported: $s");
+    }
+    getType(s)
+  }
+}

--- a/geomesa-features/geomesa-feature-avro-complex/src/test/scala/org/locationtech/geomesa/features/avro/complex/ComplexEncoderTest.scala
+++ b/geomesa-features/geomesa-feature-avro-complex/src/test/scala/org/locationtech/geomesa/features/avro/complex/ComplexEncoderTest.scala
@@ -1,0 +1,164 @@
+package org.locationtech.geomesa.features.avro.complex
+
+import java.io.ByteArrayOutputStream
+import java.net.URI
+import java.sql.Timestamp
+import java.util.UUID
+
+import com.vividsolutions.jts.geom.{Coordinate, GeometryFactory, PrecisionModel}
+import com.vividsolutions.jts.io.{WKBReader, WKBWriter}
+import org.apache.avro.generic.{GenericData, GenericDatumReader}
+import org.apache.avro.io.{DecoderFactory, EncoderFactory}
+import org.geotools.xs.XSSchema
+import org.locationtech.geomesa.features.avro.complex.AvroCodecs.{FeatureCodecs, StatefulCodecs}
+import org.locationtech.geomesa.features.avro.complex.AvroSchemas.FieldNameEncoderV1
+import org.locationtech.geomesa.utils.geotools.builder.{FeatureBuilder, FeatureTypeBuilder}
+import org.opengis.feature.`type`.FeatureType
+
+import scala.collection.JavaConverters._
+
+object ComplexEncoderTest {
+  def main(args:Array[String]) = {
+    val geomfac = new GeometryFactory(new PrecisionModel())
+
+    val hubType = FeatureTypeBuilder.namespace("urn:foo")
+      .`type`("HubType")
+      .string("material")
+      .end
+
+    val wheelType = FeatureTypeBuilder.namespace("urn:foo")
+      .`type`("WheelType")
+      .intProp("radius")
+      .feature("hub", hubType)
+      .end
+
+    lazy val carType:FeatureType = FeatureTypeBuilder.namespace("urn:foo")
+      .`type`("CarType")
+      .multi.feature("wheels", wheelType)
+      .optional.feature("spare", wheelType)
+      .optional.geometry("geometry")
+      .optional.point("point")
+      .optional.linestring("linestring")
+      .optional.polygon("polygon")
+      .optional.multiGeometry("multiGeometry")
+      .optional.multiPoint("multiPoint")
+      .optional.multiLinestring("multiLinestring")
+      .optional.multiPolygon("multiPolygon")
+      .optional.bool("isAcWorking")
+      .optional.string("manufacturer")
+      .optional.property(XSSchema.DATETIME_TYPE, "manufactureDate")
+      .optional.deferredFeature("yodawg", carType)
+      .optional.list[Integer]("bunchOfNumbers")
+      .optional.list[UUID]("bunchOfUUIDs")
+      .optional.map[String,UUID]("mapOfUUIDs")
+      .optional.multi.map[String,Timestamp]("lotsOfMaps")
+      .end
+
+    val car = FeatureBuilder(carType) { _
+      .set("name") { _
+        .set("simpleContent","foo")
+        .set("codeSpace",URI.create("urn:foo:awesome:codespace"))
+      }
+      .set("description", "Well it's a car.")
+      .set("wheels") { _
+        .set("Wheel") { _
+          .set("radius", 25)
+          .set("hub") { _
+            .set("Hub") { _
+              .set("material", "mahogany")
+            }
+          }
+        }
+      }
+      .set("wheels") { _
+        .set("Wheel") { _
+          .set("radius", 25)
+          .set("hub") { _
+            .set("Hub") { _
+              .set("material", "chrome")
+            }
+          }
+        }
+      }
+      .set("wheels") { _
+        .set("Wheel") { _
+          .set("radius", 25)
+          .set("hub") { _
+            .set("Hub") { _
+              .set("material", "AOL CDs")
+            }
+          }
+        }
+      }
+      .set("wheels") { _
+        .set("Wheel") { _
+          .set("radius", 25)
+          .set("hub") { _
+            .set("Hub") { _
+              .set("material", "comedy gold")
+            }
+          }
+        }
+      }
+      .set("spare") { _
+        .set("Wheel") { _
+          .set("radius", 12)
+          .set("hub") { _
+            .set("Hub") { _
+              .set("material", "sadness")
+            }
+          }
+        }
+      }
+      .set("isAcWorking", false)
+      .set("manufacturer", "Yotota")
+      .set("manufactureDate", new Timestamp(System.currentTimeMillis()))
+      .set("geometry", geomfac.createPoint(new Coordinate(0,0)))
+      .set("yodawg") { _
+          .set("Car") { _
+              .set("description", "There's a car in your car so you can drive while you drive")
+              .set("manufacturer", "Xzibit")
+          }
+      }
+      .set("bunchOfNumbers", List(1,3,4,7,11,18,29).asJava)
+      .set("bunchOfUUIDs", List.fill(4)(UUID.randomUUID()).asJava)
+      .set("mapOfUUIDs", Map("foo"->UUID.randomUUID(), "bar"->UUID.randomUUID()).asJava)
+      .set("lotsOfMaps", Map("now"->new Timestamp(System.currentTimeMillis())).asJava)
+      .set("lotsOfMaps", Map("then"->new Timestamp(0)).asJava)
+    }
+
+    val reg = new { val fne = FieldNameEncoderV1 } with StatefulCodecs(new WKBWriter(), new WKBReader()) with FeatureCodecs
+    val schema = reg.schemaFor(carType)
+    System.out.println(schema.toString(true))
+
+    val codec = reg.find(car.getDescriptor)
+    val baos = new ByteArrayOutputStream()
+
+    val encoder = EncoderFactory.get().directBinaryEncoder(baos,null)
+    //new AvroEncoder(validator).encodeComplexAttribute(schema, wheel)
+
+    codec.enc(car,encoder)
+
+    encoder.flush()
+    val bytes = baos.toByteArray
+    val genericData = GenericData.get().createDatumReader(schema)
+      .asInstanceOf[GenericDatumReader[Any]]
+      .read(null, DecoderFactory.get().validatingDecoder(schema,DecoderFactory.get().binaryDecoder(bytes, null)))
+
+    System.out.println(genericData)
+
+    baos.reset()
+    val avroenc = EncoderFactory.get().binaryEncoder(baos, null)
+    for(_<-0 until 500000) {
+      baos.reset()
+      codec.enc(car, EncoderFactory.get().binaryEncoder(baos, avroenc))
+    }
+
+    val avrodec = DecoderFactory.get().binaryDecoder(bytes,null)
+    for(_<-0 until 500000) {
+      codec.dec(DecoderFactory.get().binaryDecoder(bytes,avrodec))
+    }
+    val foo = codec.dec(DecoderFactory.get().binaryDecoder(bytes,avrodec))
+    System.out.println("Done")
+  }
+}

--- a/geomesa-features/pom.xml
+++ b/geomesa-features/pom.xml
@@ -17,6 +17,7 @@
         <module>geomesa-feature-nio</module>
         <module>geomesa-feature-common</module>
         <module>geomesa-feature-all</module>
+        <module>geomesa-feature-avro-complex</module>
     </modules>
 
 </project>

--- a/geomesa-utils/pom.xml
+++ b/geomesa-utils/pom.xml
@@ -80,6 +80,10 @@
             <artifactId>gt-data</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.geotools.xsd</groupId>
+            <artifactId>gt-xsd-gml3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/builder/AbstractFeatureTypeBuilder.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/builder/AbstractFeatureTypeBuilder.scala
@@ -1,0 +1,56 @@
+package org.locationtech.geomesa.utils.geotools.builder
+
+import org.geotools.feature
+import org.geotools.feature.NameImpl
+import org.geotools.feature.`type`.{ComplexTypeImpl, FeatureTypeImpl}
+import org.geotools.gml3.GMLSchema
+import org.opengis.feature.`type`.{ComplexType, Name, PropertyDescriptor, PropertyType, AttributeDescriptor}
+
+import scala.collection.Iterator.iterate
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+object AbstractFeatureTypeBuilder {
+  def isDescendedFrom(child: PropertyType, ancestor: PropertyType): Boolean = iterate(child)(_.getSuper).takeWhile(_ != null).contains(ancestor)
+  def subclassByRestriction(child: PropertyType) =
+    isDescendedFrom(child, GMLSchema.FEATUREPROPERTYTYPE_TYPE)
+}
+
+abstract class AbstractFeatureTypeBuilder[ReturnType] {
+
+
+  import AbstractFeatureTypeBuilder._
+  var targetNs: String = null
+  var _name: NameImpl = null
+  var superType: ComplexType = null
+  var descIndex = 0
+  final val descriptors: mutable.Buffer[PropertyDescriptor] = mutable.Buffer.empty
+
+  def namespace(ns: String): this.type = {
+    targetNs = ns
+    this
+  }
+
+  def `type`(name: String): DescriptorBuilder[_<:ReturnType] = `type`(name, GMLSchema.ABSTRACTFEATURETYPE_TYPE)
+
+  def `type`(name: String, superType: ComplexType): DescriptorBuilder[ReturnType] = {
+    _name = new NameImpl(targetNs, name)
+    this.superType = superType
+    new DescriptorBuilder[ReturnType](this)
+  }
+
+  protected[builder] def addDescriptor(desc: AttributeDescriptor): Unit =
+      descriptors += desc
+
+  def end: ReturnType
+
+  def makeType =
+    if (isDescendedFrom(superType, GMLSchema.ABSTRACTFEATURETYPE_TYPE))
+      saveType(new FeatureTypeImpl(_name, descriptors, null, false, null, superType, null))
+    else
+      saveType(new ComplexTypeImpl(_name, descriptors, false, false, null, superType, null))
+
+  def saveType[T<:ComplexType](t:T): T
+  def getType(name:Name): Option[ComplexType]
+  def getType(name:Name, computeFn: =>ComplexType): ComplexType
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/builder/DescriptorBuilder.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/builder/DescriptorBuilder.scala
@@ -1,0 +1,165 @@
+package org.locationtech.geomesa.utils.geotools.builder
+
+import java.util
+
+import org.geotools.feature.NameImpl
+import org.geotools.feature.`type`.{AttributeDescriptorImpl, AttributeTypeImpl, GeometryDescriptorImpl, GeometryTypeImpl}
+import org.geotools.gml3.GMLSchema
+import org.geotools.xs.XSSchema
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.{USER_DATA_LIST_TYPE, USER_DATA_MAP_KEY_TYPE, USER_DATA_MAP_VALUE_TYPE}
+import org.opengis.feature.Property
+import org.opengis.feature.`type`._
+import org.opengis.filter.Filter
+import org.opengis.util.InternationalString
+
+import scala.reflect.ClassTag
+
+class DescriptorBuilder[ReturnType](val target: AbstractFeatureTypeBuilder[ReturnType]) {
+
+  private var _optional: Boolean = false
+  private var _multi: Boolean = false
+  private var ns: String = _
+  private var name: String = _
+
+  reset()
+
+  private def reset() {
+    _optional = false
+    _multi = false
+    ns = target.targetNs
+  }
+
+  def optional = {
+    _optional = true
+    this
+  }
+
+  def multi = {
+    _multi = true
+    this
+  }
+
+  def namespace(ns: String): DescriptorBuilder[ReturnType] = {
+    this.ns = ns
+    this
+  }
+
+  def string(name: String) = property(XSSchema.STRING_TYPE, name)
+
+  def intProp(name: String) = property(XSSchema.INT_TYPE, name)
+
+  def bool(name: String) = property(XSSchema.BOOLEAN_TYPE, name)
+
+  def geometry(name: String) = property(GMLSchema.GEOMETRYPROPERTYTYPE_TYPE, name)
+  def point(name: String) = property(GMLSchema.POINTPROPERTYTYPE_TYPE, name)
+  def linestring(name: String) = property(GMLSchema.LINESTRINGPROPERTYTYPE_TYPE, name)
+  def polygon(name: String) = property(GMLSchema.POLYGONPROPERTYTYPE_TYPE, name)
+
+  def multiGeometry(name: String) = property(GMLSchema.MULTIGEOMETRYPROPERTYTYPE_TYPE, name)
+  def pointArray(name: String) = property(GMLSchema.POINTARRAYPROPERTYTYPE_TYPE, name)
+  def multiPoint(name: String) = property(GMLSchema.MULTIPOINTPROPERTYTYPE_TYPE, name)
+  def multiLinestring(name: String) = property(GMLSchema.MULTILINESTRINGPROPERTYTYPE_TYPE, name)
+  def multiPolygon(name: String) = property(GMLSchema.MULTIPOLYGONPROPERTYTYPE_TYPE, name)
+
+  def property(`type`: AttributeType, name: String) = {
+    this.name = name
+    finish(`type`)
+  }
+
+  def property(name: String) = {
+    this.name = name
+    new SubFeatureTypeBuilder[ReturnType](this).namespace(ns)
+  }
+
+  def feature(name: String, ft: FeatureType) = {
+    val descName = ft.getName.getLocalPart.stripSuffix("Type")
+    val ptn = new NameImpl(ft.getName.getNamespaceURI, descName+"PropertyType")
+    val pt = target.getType(ptn,
+      FeatureTypeBuilder.namespace(ptn.getNamespaceURI)
+        .`type`(ptn.getLocalPart, GMLSchema.FEATUREPROPERTYTYPE_TYPE)
+          .property(ft, descName)
+        .end
+    )
+    property(pt, name)
+  }
+
+  def deferredFeature(name: String, ft: =>FeatureType) = {
+
+    val propertyType = new ComplexType {
+
+      private[this] lazy val delegate = {
+        val descName = ft.getName.getLocalPart.stripSuffix("Type")
+        val ptn = new NameImpl(ft.getName.getNamespaceURI, descName+"PropertyType")
+        target.getType(ptn,
+          FeatureTypeBuilder.namespace(ptn.getNamespaceURI)
+            .`type`(ptn.getLocalPart, GMLSchema.FEATUREPROPERTYTYPE_TYPE)
+            .property(ft, descName)
+            .end
+        )
+      }
+
+      override def getSuper: AttributeType = delegate.getSuper
+      override def isIdentified: Boolean = delegate.isIdentified
+      override def getName: Name = delegate.getName
+      override def getDescription: InternationalString = delegate.getDescription
+      override def isAbstract: Boolean = delegate.isAbstract
+      override def getBinding: Class[util.Collection[Property]] = delegate.getBinding
+      override def getRestrictions: util.List[Filter] = delegate.getRestrictions
+      override def getUserData: util.Map[AnyRef, AnyRef] = delegate.getUserData
+      override def getDescriptor(name: Name): PropertyDescriptor = delegate.getDescriptor(name)
+      override def getDescriptor(name: String): PropertyDescriptor = delegate.getDescriptor(name)
+      override def isInline: Boolean = delegate.isInline
+      override def getDescriptors: util.Collection[PropertyDescriptor] = delegate.getDescriptors
+      override def toString = delegate.toString
+      override def hashCode:Int = delegate.hashCode
+      override def equals(x:Any) = delegate.equals(x)
+    }
+
+    property(propertyType, name)
+  }
+
+  def list[T](name:String)(implicit tag:ClassTag[T]) = {
+    val pt = new AttributeTypeImpl(new NameImpl(ns, s"ListOf${tag.runtimeClass.getSimpleName}Type"), classOf[java.util.List[_]], false, false, java.util.Collections.emptyList(), null, null)
+    pt.getUserData.put(USER_DATA_LIST_TYPE, tag.runtimeClass)
+    this.name = name
+    finish(pt, Map(USER_DATA_LIST_TYPE->tag.runtimeClass))
+  }
+
+  def map[K,V](name:String)(implicit kTag:ClassTag[K], vTag:ClassTag[V]) = {
+    val pt = new AttributeTypeImpl(new NameImpl(ns, s"MapOf${kTag.runtimeClass.getSimpleName}To${vTag.runtimeClass.getSimpleName}Type"), classOf[java.util.Map[K,V]], false, false, java.util.Collections.emptyList(), null, null)
+    pt.getUserData.put(USER_DATA_MAP_KEY_TYPE, kTag.runtimeClass)
+    pt.getUserData.put(USER_DATA_MAP_VALUE_TYPE, vTag.runtimeClass)
+    this.name = name
+    finish(pt, Map(USER_DATA_MAP_KEY_TYPE->kTag.runtimeClass, USER_DATA_MAP_VALUE_TYPE->vTag.runtimeClass))
+  }
+  //private def uncapitalize(s:String) = if(s.isEmpty || s(0).isLower) s else s(0).toLower + s.substring(1)
+
+  private[builder] def finish(`type`: AttributeType, userdata:Map[AnyRef,AnyRef]=Map.empty) = {
+    val desc = if (`type`.isInstanceOf[GeometryTypeImpl]) new GeometryDescriptorImpl(
+      `type`.asInstanceOf[GeometryType],
+      new NameImpl(ns, name),
+      if (_optional) 0 else 1,
+      if (_multi) -1 else 1,
+      false,
+      null
+    ) else new AttributeDescriptorImpl(
+      `type`,
+      new NameImpl(ns, name),
+      if (_optional) 0 else 1,
+      if (_multi) -1 else 1,
+      false,
+      null
+    )
+
+    for((k,v)<-userdata)
+      desc.getUserData.put(k,v)
+
+    target.addDescriptor(desc)
+    reset()
+    this
+  }
+
+  def end = {
+    target.end
+  }
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/builder/FeatureTypeBuilder.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/builder/FeatureTypeBuilder.scala
@@ -1,0 +1,119 @@
+package org.locationtech.geomesa.utils.geotools.builder
+
+import java.util.UUID
+
+import org.geotools.feature.`type`.AttributeDescriptorImpl
+import org.geotools.feature.{AttributeImpl, ComplexAttributeImpl, FeatureImpl, NameImpl}
+import org.geotools.filter.identity.FeatureIdImpl
+import org.geotools.gml3.GMLSchema
+import org.opengis.feature.`type`._
+import org.opengis.feature.{ComplexAttribute, Feature, Property}
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+object FeatureTypeBuilder {
+  def namespace(name: String) = new TopLevelFeatureTypeBuilder().namespace(name)
+
+  def descriptor(namespace: String, local: String): DescriptorBuilder[_<:AttributeDescriptor] = {
+    new TopLevelDescriptorBuilder().namespace(namespace).name(local)
+  }
+
+  def feature(`type`: ComplexType, name: String, id: String, values: Any*): Feature = {
+    val desc: AttributeDescriptor = new AttributeDescriptorImpl(`type`, new NameImpl(`type`.getName.getNamespaceURI, name), 1, 1, false, null)
+    val props = for((t,v)<-`type`.getDescriptors.zip(values)) yield new AttributeImpl(v, t.asInstanceOf[AttributeDescriptor], null)
+    new FeatureImpl(props, desc, new FeatureIdImpl(id))
+  }
+}
+
+object FeatureBuilder {
+  def apply(t: ComplexType)(fn: ComplexAttributeBuilder=>ComplexAttributeBuilder) = fn(new ComplexAttributeBuilder(t, makeDescriptor(t))).end
+  def apply(t: FeatureType)(fn: FeatureBuilder=>FeatureBuilder):Feature = fn(new FeatureBuilder(t, makeDescriptor(t))).end
+
+  def makeDescriptor(t:ComplexType): AttributeDescriptor = new AttributeDescriptorImpl(t, t.getName, 1, 1, false, null)
+
+  def isDescendedFrom(child: PropertyType, ancestor: PropertyType): Boolean =
+    Iterator.iterate(child)(_.getSuper).takeWhile(_ != null).contains(ancestor)
+
+  def subclassByRestriction(child: PropertyType) =
+    isDescendedFrom(child, GMLSchema.FEATUREPROPERTYTYPE_TYPE)
+
+  def allProps(ct:ComplexType):Iterable[PropertyDescriptor] = ct.getSuper match {
+    case st:ComplexType if subclassByRestriction(st) => allProps(st).drop(ct.getDescriptors.size())++ct.getDescriptors
+    case st:ComplexType => allProps(st)++ct.getDescriptors
+    case _ => ct.getDescriptors
+  }
+
+  @scala.annotation.tailrec
+  def nearestSimpleType(at: PropertyType): PropertyType = at match {
+    case ct:ComplexType => nearestSimpleType(ct.getSuper)
+    case st => st
+  }
+
+  class ComplexAttributeBuilder(t: ComplexType,d:AttributeDescriptor) { self =>
+    val byName = allProps(t).map(d=>d.getName.getLocalPart->d.asInstanceOf[AttributeDescriptor]).toMap
+    val props = mutable.HashMap.empty[AttributeDescriptor, mutable.Buffer[Property]]
+
+    def set(name:String, v: Any): self.type = {
+      val Some(desc)=byName.get(name).orElse(if("simpleContent"==name) {
+        Some(new AttributeDescriptorImpl(nearestSimpleType(t).asInstanceOf[AttributeType], new NameImpl("simpleContent"),0,1,true,null))
+      } else None)
+
+      if(desc.getType.isInstanceOf[ComplexType]) {
+        return set(name) { _.set("simpleContent", v) }
+      }
+
+      if(!desc.getType.getBinding.isInstance(v)) {
+        throw new IllegalArgumentException(s"$v not compatible with ${desc.getName}")
+      }
+
+      val prop=v match {
+        case p: Property => p
+        case _ => new AttributeImpl(v, desc, null)
+      }
+
+      internalSet(desc, prop)
+
+      this
+    }
+
+    /*def set(name:String): SubFeatureBuilder[self.type] = {
+      val desc=byName(name)
+      if(!desc.getType.isInstanceOf[ComplexType]) {
+        throw new IllegalArgumentException(s"Not a complex type: ${desc.getType.getName}")
+      }
+      new SubFeatureBuilder[FeatureBuilder.this.type](desc, this)
+    }*/
+
+    def set(name:String)(fn:ComplexAttributeBuilder=>ComplexAttributeBuilder):self.type = {
+      val desc=byName(name)
+      desc.getType match {
+        case ft: FeatureType =>
+          internalSet(desc, fn(new FeatureBuilder(ft,desc)).end)
+        case ct: ComplexType =>
+          internalSet(desc, fn(new ComplexAttributeBuilder(ct,desc)).end)
+        case _ =>
+          throw new IllegalArgumentException(s"Not a complex type: ${desc.getType.getName}")
+      }
+    }
+
+    protected[builder] def internalSet(desc:AttributeDescriptor, prop:Property): self.type = {
+      if(desc.getMaxOccurs != 1) {
+        props.getOrElseUpdate(desc, mutable.Buffer.empty).append(prop)
+      } else {
+        props(desc)=mutable.Buffer(prop)
+      }
+      this
+    }
+
+    def end: ComplexAttribute =
+        new ComplexAttributeImpl(props.values.flatten, d, new FeatureIdImpl (UUID.randomUUID ().toString) )
+  }
+
+  class FeatureBuilder(t: FeatureType, d:AttributeDescriptor) extends ComplexAttributeBuilder(t,d) {
+    override def end: Feature =
+        new FeatureImpl(props.values.flatten, d, new FeatureIdImpl (UUID.randomUUID ().toString) )
+  }
+}
+
+

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/builder/SubFeatureTypeBuilder.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/builder/SubFeatureTypeBuilder.scala
@@ -1,0 +1,15 @@
+package org.locationtech.geomesa.utils.geotools.builder
+import org.opengis.feature.`type`.{ComplexType,Name}
+
+class SubFeatureTypeBuilder[ReturnType](val target: DescriptorBuilder[ReturnType]) extends AbstractFeatureTypeBuilder[DescriptorBuilder[ReturnType]] {
+  override def namespace(ns: String) = super.namespace(ns)
+
+  def end = {
+    target.finish(makeType)
+    target
+  }
+
+  override def saveType[T <: ComplexType](t: T): T = target.target.saveType(t)
+  override def getType(name:Name) = target.target.getType(name)
+  override def getType(name:Name, computeFn: =>ComplexType) = target.target.getType(name, computeFn)
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/builder/TopLevelDescriptorBuilder.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/builder/TopLevelDescriptorBuilder.scala
@@ -1,0 +1,24 @@
+package org.locationtech.geomesa.utils.geotools.builder
+
+import org.geotools.feature.NameImpl
+import org.geotools.feature.`type`.AttributeDescriptorImpl
+import org.opengis.feature.`type`.{AttributeDescriptor, ComplexType, Name}
+
+import scala.collection.mutable
+
+class TopLevelDescriptorBuilder extends AbstractFeatureTypeBuilder[AttributeDescriptor] {
+  def name(n: String): DescriptorBuilder[_<:AttributeDescriptor] = {
+    _name = new NameImpl(targetNs, n)
+    `type`(n + "Type")
+  }
+
+  def end = new AttributeDescriptorImpl(makeType, _name, 1, 1, false, null)
+
+  val typeMap: scala.collection.mutable.Map[Name,ComplexType] = mutable.Map.empty
+
+  override def saveType[T <: ComplexType](t: T) = {typeMap(t.getName)=t;t}
+
+  override def getType(name:Name) = typeMap.get(name)
+
+  override def getType(name:Name, computeFn: =>ComplexType) = typeMap.getOrElseUpdate(name, computeFn)
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/builder/TopLevelFeatureTypeBuilder.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/builder/TopLevelFeatureTypeBuilder.scala
@@ -1,0 +1,20 @@
+package org.locationtech.geomesa.utils.geotools.builder
+
+import org.opengis.feature.`type`.{ComplexType, FeatureType, Name}
+
+import scala.collection.mutable
+
+class TopLevelFeatureTypeBuilder extends AbstractFeatureTypeBuilder[ComplexType] {
+
+  def end = makeType
+
+  val typeMap: mutable.Map[Name,ComplexType] = mutable.Map.empty
+
+  override def saveType[T <: ComplexType](t: T) = {typeMap(t.getName)=t;t}
+
+  override def getType(name:Name) = typeMap.get(name)
+
+  override def getType(name:Name, computeFn: =>ComplexType) = typeMap.getOrElseUpdate(name, computeFn)
+
+  override def `type`(name:String): DescriptorBuilder[FeatureType] = super.`type`(name).asInstanceOf[DescriptorBuilder[FeatureType]]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -736,6 +736,18 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.geotools.xsd</groupId>
+                <artifactId>gt-xsd-gml3</artifactId>
+                <version>${gt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>it.geosolutions.imageio-ext</groupId>
                 <artifactId>imageio-ext-gdalarcbinarygrid</artifactId>
                 <version>${imageio-ext.version}</version>


### PR DESCRIPTION
Rather than try to integrate this into all the existing code myself, I created a separate module that can encode complex features. ComplexEncoderTest isn't a unit test, just a main method. I've just completed all the main functionality so I haven't had a chance to make actual unit tests. Forgive the bad jokes in the example data.

To use it, create a new `FeatureCodecs`; this is required to be mixed into a `CodecRegistry` and requires a FieldNameEncoder to be initialized early:

```
    val reg = new { val fne = FieldNameEncoderV1 } with StatefulCodecs(new WKBWriter(), new WKBReader()) with FeatureCodecs
```

You can request an Avro `Schema` from it given a `ComplexType`:

```
    val schema = reg.schemaFor(carType)
```

To actually use this on an Avro `Encoder`, request a codec from the registry:

```
    val codec = reg.find(car.getDescriptor)
```

And then call `.enc`:

```
      codec.enc(car, EncoderFactory.get().binaryEncoder(baos, avroenc))
```

There is a corresponding `.dec` method, of course.

The `FeatureCodecs` mixin attempts to bind an Avro `Schema` to a `ComplexType` once before any encoding or decoding is done; this way, the schemas need only be interrogated when they change and the binding can be reused. There isn't any cache management of these bindings yet; memory is leaked when the schemas change, which could be an issue if they change a lot.

The `*Codecs` classes contain mappings between Avro primitives and Java classes. They're used to determine how to generate the `Schema` and how to do the actual encoding and decoding. Multiple Java classes can be bound to the same Avro type, and an Avro type can be bound to many Java classes. When generating a schema, the first Avro type bound to a particular Java type is chosen for the binding. This means that if you define a codec for `Short` that binds to `Schema.Type.INT` but then later define a mapping between `Short` and `Schema.Type.LONG`, the schema generator will prefer `Schema.Type.INT`.

The codecs include support for strings, booleans, numeric types, byte arrays, byte buffers, dates, UUIDs, URIs, and geometries.

`Map` and `List` valued properties are supported as well. I'm not sure if I got the in-memory format right; the Key/Value or List element classes are stored on the `AttributeDescriptor` and retrieved using `RichAttributeDescriptor`. The codecs expect `java.util.List` and `java.util.Map`. Let me know if that's not right. They're encoded directly into Avro and so show up in the schema. The same codecs are used to encode list element and key/value pairs. Maps are encoded as an array of records with `k` and `v` fields.

Properties inherited from GML AbstractFeatureType are also supported, as well as extensions of anySimpleType with attributes (e.g. gml:description, which has a codespace and an href if you want to store the description elsewhere).

I tried to profile and improve performance where I could. On my laptop, 500K 'encode' operations followed by 500K 'decode' operations takes 15s, which isn't great but still acceptable. There are a number of un-Scala like bits of code in order to speed things up.

How can we integrate this? What's the next step?

Lastly, I am open to changing _anything_. I've been working on this pretty hard this week and my eyes are starting to go a little blurry, so chances are there are mistakes or I've misunderstood something.
