### PR TITLE
[GEOMESA-1201] Adds 'converter-name=' to print out of converters. All…

### DIFF
--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/EnvironmentCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/EnvironmentCommand.scala
@@ -61,7 +61,7 @@ class EnvironmentCommand(parent: JCommander) extends Command(parent) with LazyLo
     } else {
       val options = ConfigRenderOptions.defaults().setJson(false).setOriginComments(false)
       def render(c: Config) = c.root().render(options).replaceAll("\n", "\n\t")
-      filtered.map { case (name, conf)=> s"\t$name\n\t${render(conf)}\n"}.foreach(println)
+      filtered.map { case (name, conf)=> s"\tconverter-name=$name\n\t${render(conf)}\n"}.foreach(println)
     }
   }
 }


### PR DESCRIPTION
…ows 'geomesa env | grep converter-name' to return all converter names in GeoMesa environment.

Signed-off-by: cfkelly <charles.kelly@ccri.com>