### PR TITLE
GEOMESA-1102 Increase Cassandra and Kafka timeouts for builds

### DIFF
--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
@@ -11,7 +11,7 @@ package org.locationtech.geomesa.cassandra.data
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 
-import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.{Cluster, SocketOptions}
 import com.vividsolutions.jts.geom.Coordinate
 import org.cassandraunit.CQLDataLoader
 import org.cassandraunit.dataset.cql.ClassPathCQLDataSet
@@ -27,6 +27,7 @@ import org.locationtech.geomesa.utils.geotools.Conversions._
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
+
 import collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
@@ -237,7 +238,8 @@ object CassandraDataStoreTest {
       System.setProperty("cassandra.storagedir", storagedir.getPath)
 
       EmbeddedCassandraServerHelper.startEmbeddedCassandra("cassandra-config.yaml", 1200000L)
-      val cluster = new Cluster.Builder().addContactPoints(host).withPort(port).build()
+      // following line creates a cluster with read timeout of 40 minutes. If this is hit, something else is the issue.
+      val cluster = new Cluster.Builder().addContactPoints(host).withPort(port).withSocketOptions(new SocketOptions().setReadTimeoutMillis(2400000)).build().init()
       val session = cluster.connect()
       val cqlDataLoader = new CQLDataLoader(session)
       cqlDataLoader.load(new ClassPathCQLDataSet("init.cql", false, false))

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
@@ -238,9 +238,11 @@ object CassandraDataStoreTest {
       System.setProperty("cassandra.storagedir", storagedir.getPath)
 
       EmbeddedCassandraServerHelper.startEmbeddedCassandra("cassandra-config.yaml", 1200000L)
-      // following line creates a cluster with read timeout of 40 minutes. If this is hit, something else is the issue.
 
-      val cluster = new Cluster.Builder().addContactPoints(host).withPort(port).withSocketOptions(new SocketOptions().setReadTimeoutMillis(Option(System.getProperty("cassandraReadTimeout")).getOrElse(30000).asInstanceOf[Int])).build().init()
+      var readTimeout: Int = util.Try(System.getProperty("cassandraReadTimeout").toInt).getOrElse(12000)
+      if(readTimeout < 0) readTimeout = 12000
+      val cluster = new Cluster.Builder().addContactPoints(host).withPort(port)
+        .withSocketOptions(new SocketOptions().setReadTimeoutMillis(readTimeout)).build().init()
       val session = cluster.connect()
       val cqlDataLoader = new CQLDataLoader(session)
       cqlDataLoader.load(new ClassPathCQLDataSet("init.cql", false, false))

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
@@ -239,7 +239,8 @@ object CassandraDataStoreTest {
 
       EmbeddedCassandraServerHelper.startEmbeddedCassandra("cassandra-config.yaml", 1200000L)
       // following line creates a cluster with read timeout of 40 minutes. If this is hit, something else is the issue.
-      val cluster = new Cluster.Builder().addContactPoints(host).withPort(port).withSocketOptions(new SocketOptions().setReadTimeoutMillis(2400000)).build().init()
+
+      val cluster = new Cluster.Builder().addContactPoints(host).withPort(port).withSocketOptions(new SocketOptions().setReadTimeoutMillis(Option(System.getProperty("cassandraReadTimeout")).getOrElse(30000).asInstanceOf[Int])).build().init()
       val session = cluster.connect()
       val cqlDataLoader = new CQLDataLoader(session)
       cqlDataLoader.load(new ClassPathCQLDataSet("init.cql", false, false))

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <profile>
             <id>travis-ci</id>
             <properties>
-                <maven.test.jvmargs>-Duser.timezone=UTC -Xms512m -Xmx3g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dgeomesa.scan.ranges.batch=2000</maven.test.jvmargs>
+                <maven.test.jvmargs>-Duser.timezone=UTC -Xms512m -Xmx3g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dgeomesa.scan.ranges.batch=2000 -DcassandraReadTimeout=1800000</maven.test.jvmargs>
                 <test.fork.count>1</test.fork.count>
                 <test.fork.reuse>false</test.fork.reuse>
             </properties>


### PR DESCRIPTION
Changes ReadTimeoutMillis to 2400s. If errors during testing of Cassandra Data Store occurs, timeouts may not be the issue.

Signed-off-by: Charles Kelly <charles.kelly@ccri.com>