### PR TITLE
Added dependency (htrace) to install-hadoop-accumulo.sh

### DIFF
--- a/geomesa-tools/bin/install-hadoop-accumulo.sh
+++ b/geomesa-tools/bin/install-hadoop-accumulo.sh
@@ -21,6 +21,9 @@ guava_version="11.0.2"
 com_log_version="1.1.3"
 commons_vfs2_version="2.0"
 
+# for the GeoServer plugin to work with Accumulo 1.7 we need htrace
+htrace_version="3.1.0-incubating"
+
 base_url="https://search.maven.org/remotecontent?filepath="
 
 if [[ (-z "$1") ]]; then
@@ -49,6 +52,7 @@ else
             "${base_url}commons-logging/commons-logging/${com_log_version}/commons-logging-${com_log_version}.jar"
             "${base_url}com/google/guava/guava/${guava_version}/guava-${guava_version}.jar"
             "${base_url}org/apache/commons/commons-vfs2/${commons_vfs2_version}/commons-vfs2-${commons_vfs2_version}.jar"
+            "${base_url}org/apache/htrace/htrace-core/${htrace_version}/htrace-core-${htrace_version}.jar"
             )
 
         for x in "${urls[@]}"; do


### PR DESCRIPTION
htrace is required in order for the GeoServer plugin to work with Accumulo v. 1.7