### PR TITLE
GEOMESA-1346 Generate Ordered Bresenham Coordate List

### DIFF
--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GridSnap.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GridSnap.scala
@@ -108,7 +108,7 @@ class GridSnap(env: Envelope, xSize: Int, ySize: Int) {
 
   /** Generate an ordered List of Coordinates between two given Snap Coordinates which includes both start and end points*/
   def generateLineCoordList(coordOne: Coordinate, coordTwo: Coordinate): List[Coordinate] = {
-    coordOne +: genBresenhamCoordList(i(coordOne.x), j(coordOne.y), i(coordTwo.x), j(coordTwo.y)) :+ coordTwo
+    (coordOne +: genBresenhamCoordList(i(coordOne.x), j(coordOne.y), i(coordTwo.x), j(coordTwo.y)) :+ coordTwo).distinct
   }
 
   /** return a SimpleFeatureSource grid the same size and extent as the bbox */

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GridSnap.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GridSnap.scala
@@ -9,7 +9,6 @@
 
 package org.locationtech.geomesa.utils.geotools
 
-import com.sun.xml.internal.bind.v2.runtime.Coordinator
 import com.vividsolutions.jts.geom.{Coordinate, Envelope}
 import org.geotools.data.simple.SimpleFeatureSource
 import org.geotools.geometry.jts.ReferencedEnvelope
@@ -83,7 +82,7 @@ class GridSnap(env: Envelope, xSize: Int, ySize: Int) {
   /** Generate a Sequence of Coordinates between two given Snap Coordinates using Bresenham's Line Algorithm */
   def genBresenhamCoordList(x0: Int, y0: Int, x1: Int, y1: Int): List[Coordinate] = {
     val ( deltaX, deltaY ) = (abs(x1 - x0), abs(y1 - y0))
-    if ((deltaX == 0) && (deltaY == 0)) Set[Coordinate](new Coordinate(x(x0), y(y0)))
+    if ((deltaX == 0) && (deltaY == 0)) List[Coordinate]()
     else {
       val ( stepX, stepY ) = (if (x0 < x1) 1 else -1, if (y0 < y1) 1 else -1)
       val (fX, fY) =  ( stepX * x1, stepY * y1 )

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GridSnap.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GridSnap.scala
@@ -9,6 +9,7 @@
 
 package org.locationtech.geomesa.utils.geotools
 
+import com.sun.xml.internal.bind.v2.runtime.Coordinator
 import com.vividsolutions.jts.geom.{Coordinate, Envelope}
 import org.geotools.data.simple.SimpleFeatureSource
 import org.geotools.geometry.jts.ReferencedEnvelope
@@ -80,7 +81,7 @@ class GridSnap(env: Envelope, xSize: Int, ySize: Int) {
   def snap(x: Double, y: Double): (Double, Double) = (this.x(i(x)), this.y(j(y)))
 
   /** Generate a Sequence of Coordinates between two given Snap Coordinates using Bresenham's Line Algorithm */
-  def genBresenhamCoordSet(x0: Int, y0: Int, x1: Int, y1: Int): Set[Coordinate] = {
+  def genBresenhamCoordList(x0: Int, y0: Int, x1: Int, y1: Int): List[Coordinate] = {
     val ( deltaX, deltaY ) = (abs(x1 - x0), abs(y1 - y0))
     if ((deltaX == 0) && (deltaY == 0)) Set[Coordinate](new Coordinate(x(x0), y(y0)))
     else {
@@ -97,13 +98,18 @@ class GridSnap(env: Envelope, xSize: Int, ySize: Int) {
         }
         def hasNext = stepX * xT <= fX && stepY * yT <= fY
       }
-      iter.toList.dropRight(1).toSet
+      iter.toList.dropRight(1).distinct
     }
   }
 
   /** Generate a Set of Coordinates between two given Snap Coordinates which includes both start and end points*/
   def generateLineCoordSet(coordOne: Coordinate, coordTwo: Coordinate): Set[Coordinate] = {
-    genBresenhamCoordSet(i(coordOne.x), j(coordOne.y), i(coordTwo.x), j(coordTwo.y)) + coordOne + coordTwo
+    genBresenhamCoordList(i(coordOne.x), j(coordOne.y), i(coordTwo.x), j(coordTwo.y)).toSet + coordOne + coordTwo
+  }
+
+  /** Generate an ordered List of Coordinates between two given Snap Coordinates which includes both start and end points*/
+  def generateLineCoordList(coordOne: Coordinate, coordTwo: Coordinate): List[Coordinate] = {
+    coordOne +: genBresenhamCoordList(i(coordOne.x), j(coordOne.y), i(coordTwo.x), j(coordTwo.y)) :+ coordTwo
   }
 
   /** return a SimpleFeatureSource grid the same size and extent as the bbox */

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GridSnapTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GridSnapTest.scala
@@ -103,7 +103,7 @@ class GridSnapTest extends Specification with LazyLogging {
       resultHorizontal must haveLength(9)
 
       val resultSamePoint = gridSnap.genBresenhamCoordList(0, 0, 0, 0)
-      resultSamePoint must haveLength(1)
+      resultSamePoint must haveLength(0)
 
       val resultInverse = gridSnap.genBresenhamCoordList(9, 9, 0, 0)
       resultInverse must haveLength(9)

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GridSnapTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GridSnapTest.scala
@@ -93,19 +93,19 @@ class GridSnapTest extends Specification with LazyLogging {
       val bbox = new Envelope(0.0, 10.0, 0.0, 10.0)
       val gridSnap = new GridSnap(bbox, 10, 10)
 
-      val resultDiagonal = gridSnap.genBresenhamCoordSet(0, 0, 9, 9).toList
+      val resultDiagonal = gridSnap.genBresenhamCoordSet(0, 0, 9, 9)
       resultDiagonal must haveLength(9)
 
-      val resultVertical = gridSnap.genBresenhamCoordSet(0, 0, 0, 9).toList
+      val resultVertical = gridSnap.genBresenhamCoordSet(0, 0, 0, 9)
       resultVertical must haveLength(9)
 
-      val resultHorizontal = gridSnap.genBresenhamCoordSet(0, 0, 9, 0).toList
+      val resultHorizontal = gridSnap.genBresenhamCoordSet(0, 0, 9, 0)
       resultHorizontal must haveLength(9)
 
-      val resultSamePoint = gridSnap.genBresenhamCoordSet(0, 0, 0, 0).toList
+      val resultSamePoint = gridSnap.genBresenhamCoordSet(0, 0, 0, 0)
       resultSamePoint must haveLength(1)
 
-      val resultInverse = gridSnap.genBresenhamCoordSet(9, 9, 0, 0).toList
+      val resultInverse = gridSnap.genBresenhamCoordSet(9, 9, 0, 0)
       resultInverse must haveLength(9)
     }
 

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GridSnapTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GridSnapTest.scala
@@ -93,19 +93,19 @@ class GridSnapTest extends Specification with LazyLogging {
       val bbox = new Envelope(0.0, 10.0, 0.0, 10.0)
       val gridSnap = new GridSnap(bbox, 10, 10)
 
-      val resultDiagonal = gridSnap.genBresenhamCoordSet(0, 0, 9, 9)
+      val resultDiagonal = gridSnap.genBresenhamCoordList(0, 0, 9, 9)
       resultDiagonal must haveLength(9)
 
-      val resultVertical = gridSnap.genBresenhamCoordSet(0, 0, 0, 9)
+      val resultVertical = gridSnap.genBresenhamCoordList(0, 0, 0, 9)
       resultVertical must haveLength(9)
 
-      val resultHorizontal = gridSnap.genBresenhamCoordSet(0, 0, 9, 0)
+      val resultHorizontal = gridSnap.genBresenhamCoordList(0, 0, 9, 0)
       resultHorizontal must haveLength(9)
 
-      val resultSamePoint = gridSnap.genBresenhamCoordSet(0, 0, 0, 0)
+      val resultSamePoint = gridSnap.genBresenhamCoordList(0, 0, 0, 0)
       resultSamePoint must haveLength(1)
 
-      val resultInverse = gridSnap.genBresenhamCoordSet(9, 9, 0, 0)
+      val resultInverse = gridSnap.genBresenhamCoordList(9, 9, 0, 0)
       resultInverse must haveLength(9)
     }
 


### PR DESCRIPTION
genBresenhamCoordList now returns a list. GenerateLineCoordSet and generateLineCoordList
call genBresenhamCoordList and return their respective types.

Signed-off-by: Austin Heyne <aheyne@ccri.com>