### PR TITLE
GEOMESA-1357 The Native API's GeoMesaIndex should have a "removeSchem…

### DIFF
--- a/geomesa-native-api/src/main/java/org/locationtech/geomesa/api/GeoMesaIndex.java
+++ b/geomesa-native-api/src/main/java/org/locationtech/geomesa/api/GeoMesaIndex.java
@@ -77,6 +77,11 @@ public interface GeoMesaIndex<T> {
     void delete(String id);
 
     /**
+     * Removes the entire index from GeoMesa.
+     */
+    void removeSchema();
+
+    /**
      * Flushes any pending transactions
      */
     void flush();

--- a/geomesa-native-api/src/main/scala/org/locationtech/geomesa/api/AccumuloGeoMesaIndex.scala
+++ b/geomesa-native-api/src/main/scala/org/locationtech/geomesa/api/AccumuloGeoMesaIndex.scala
@@ -31,7 +31,7 @@ import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeature
 
 @InterfaceStability.Unstable
-class AccumuloGeoMesaIndex[T](ds: AccumuloDataStore,
+class AccumuloGeoMesaIndex[T](protected val ds: AccumuloDataStore,
                               name: String,
                               serde: ValueSerializer[T],
                               view: SimpleFeatureView[T]
@@ -111,6 +111,9 @@ class AccumuloGeoMesaIndex[T](ds: AccumuloDataStore,
   override def update(id: String, newValue: T, geometry: Geometry, dtg: Date): Unit = ???
 
   override def delete(id: String): Unit = fs.removeFeatures(ECQL.toFilter(s"IN('$id')"))
+
+  // should remove the index (SFT) as well as the associated Accumulo tables, if appropriate
+  override def removeSchema(): Unit = ds.removeSchema(sft.getTypeName)
 
   override def flush(): Unit = {
     // DO NOTHING - using AUTO_COMMIT


### PR DESCRIPTION
…a" method

Added the method signature to the GeoMesaIndex interface, an
implemention to the AccumuloGeoMesaIndex class, and a unit
test to confirm that this appears to work as intended.

Signed-off-by: Chris Eichelberger <cne1x@ccri.com>