### PR TITLE
GEOMESA-1264 Change csv export to have with-types flag

### DIFF
--- a/geomesa-tools/README.md
+++ b/geomesa-tools/README.md
@@ -766,7 +766,7 @@ To export features, use the `export` command.
            Accumulo user name
         --visibilities
            Accumulo scan visibilities
-        --without-types
+        --no-header
            Export as a delimited text format (csv|tsv) without a type header     
            Default: false
         -z, --zookeepers

--- a/geomesa-tools/README.md
+++ b/geomesa-tools/README.md
@@ -766,6 +766,9 @@ To export features, use the `export` command.
            Accumulo user name
         --visibilities
            Accumulo scan visibilities
+        --without-types
+           Export as a delimited text format (csv|tsv) without a type header     
+           Default: false
         -z, --zookeepers
            Zookeepers (host[:port], comma separated)
 

--- a/geomesa-tools/README.md
+++ b/geomesa-tools/README.md
@@ -758,6 +758,9 @@ To export features, use the `export` command.
         --mock
            Run everything with a mock accumulo instance instead of a real one
            Default: false
+        --no-header
+           Export as a delimited text format (csv|tsv) without a type header     
+           Default: false
         -o, --output
            name of the file to output to instead of std out
         -p, --password
@@ -765,10 +768,7 @@ To export features, use the `export` command.
       * -u, --user
            Accumulo user name
         --visibilities
-           Accumulo scan visibilities
-        --no-header
-           Export as a delimited text format (csv|tsv) without a type header     
-           Default: false
+           Accumulo scan visibilities      
         -z, --zookeepers
            Zookeepers (host[:port], comma separated)
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/FeatureExporter.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/FeatureExporter.scala
@@ -122,7 +122,7 @@ object ShapefileExport {
   }
 }
 
-class DelimitedExport(writer: Writer, format: Formats) extends FeatureExporter with LazyLogging {
+class DelimitedExport(writer: Writer, format: Formats, withTypes: Boolean = true) extends FeatureExporter with LazyLogging {
 
   import org.locationtech.geomesa.utils.geotools.GeoToolsDateFormat
 
@@ -141,8 +141,10 @@ class DelimitedExport(writer: Writer, format: Formats) extends FeatureExporter w
     val headers = indices.map(sft.getDescriptor).map(SimpleFeatureTypes.encodeDescriptor(sft, _))
 
     // write out a header line
-    printer.print("id")
-    printer.printRecord(headers: _*)
+    if (withTypes) {
+      printer.print("id")
+      printer.printRecord(headers: _*)
+    }
 
     var count = 0L
     features.features.foreach { sf =>

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/FeatureExporter.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/FeatureExporter.scala
@@ -122,7 +122,7 @@ object ShapefileExport {
   }
 }
 
-class DelimitedExport(writer: Writer, format: Formats, withTypes: Boolean = true) extends FeatureExporter with LazyLogging {
+class DelimitedExport(writer: Writer, format: Formats, withHeader: Boolean = true) extends FeatureExporter with LazyLogging {
 
   import org.locationtech.geomesa.utils.geotools.GeoToolsDateFormat
 
@@ -141,7 +141,7 @@ class DelimitedExport(writer: Writer, format: Formats, withTypes: Boolean = true
     val headers = indices.map(sft.getDescriptor).map(SimpleFeatureTypes.encodeDescriptor(sft, _))
 
     // write out a header line
-    if (withTypes) {
+    if (withHeader) {
       printer.print("id")
       printer.printRecord(headers: _*)
     }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/ExportCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/ExportCommand.scala
@@ -38,7 +38,7 @@ class ExportCommand(parent: JCommander) extends CommandWithCatalog(parent) with 
     val features = getFeatureCollection(fmt)
     lazy val avroCompression = Option(params.gzip).map(_.toInt).getOrElse(Deflater.DEFAULT_COMPRESSION)
     val exporter: FeatureExporter = fmt match {
-      case CSV | TSV      => new DelimitedExport(getWriter(), fmt)
+      case CSV | TSV      => new DelimitedExport(getWriter(), fmt, !params.withoutTypes)
       case SHP            => new ShapefileExport(checkShpFile())
       case GeoJson | JSON => new GeoJsonExport(getWriter())
       case GML            => new GmlExport(createOutputStream())
@@ -161,5 +161,8 @@ object ExportCommand {
 
     @Parameter(names = Array("-o", "--output"), description = "name of the file to output to instead of std out")
     var file: File = null
+
+    @Parameter(names = Array("--without-types"), description = "Export as a delimited text format (csv|tsv) without a type header", required = false)
+    var withoutTypes: Boolean = false
   }
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/ExportCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/ExportCommand.scala
@@ -38,7 +38,7 @@ class ExportCommand(parent: JCommander) extends CommandWithCatalog(parent) with 
     val features = getFeatureCollection(fmt)
     lazy val avroCompression = Option(params.gzip).map(_.toInt).getOrElse(Deflater.DEFAULT_COMPRESSION)
     val exporter: FeatureExporter = fmt match {
-      case CSV | TSV      => new DelimitedExport(getWriter(), fmt, !params.withoutTypes)
+      case CSV | TSV      => new DelimitedExport(getWriter(), fmt, !params.noHeader)
       case SHP            => new ShapefileExport(checkShpFile())
       case GeoJson | JSON => new GeoJsonExport(getWriter())
       case GML            => new GmlExport(createOutputStream())
@@ -162,7 +162,7 @@ object ExportCommand {
     @Parameter(names = Array("-o", "--output"), description = "name of the file to output to instead of std out")
     var file: File = null
 
-    @Parameter(names = Array("--without-types"), description = "Export as a delimited text format (csv|tsv) without a type header", required = false)
-    var withoutTypes: Boolean = false
+    @Parameter(names = Array("--no-header"), description = "Export as a delimited text format (csv|tsv) without a type header", required = false)
+    var noHeader: Boolean = false
   }
 }


### PR DESCRIPTION
* Adds a --without-types parameter to be used with delimited text formats (csv|tsv) to omit type headers on export.

Signed-off-by: Charles Kelly <charles.kelly@ccri.com>