### PR TITLE
GEOMESA-1108 Pull version for docs from pom.xml properly

### DIFF
--- a/docs/build.xml
+++ b/docs/build.xml
@@ -13,11 +13,6 @@
 			<isset property="build.directory" />
 		</condition>
 
-		<condition property="project.version" value="${project.version}" else="">
-			<isset property="project.version" />
-		</condition>
-
-		<echo message="Build version: ${project.version}" />
 		<echo message="Build directory: ${build.directory}" />
 	</target>
 
@@ -61,7 +56,7 @@
 
 	<target name="sphinx" if="sphinx.available">
 		<exec executable="${sphinx.binary}" failonerror="true" dir="${basedir}/${id}">
-			<arg line="-D release=${project.version} -D version=${project.version} -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;" />
+			<arg line="-b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;" />
 		</exec>
 	</target>
 	

--- a/docs/common.py
+++ b/docs/common.py
@@ -57,14 +57,13 @@ author = u''
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-# version: The short X.Y version.
-# release: The full version, including alpha/beta/rc tags.
-release = '1.2.4'
-version = '1.2.4'
+# Warning: current version numbers are handled in versions.py, which is preprocessed
+# by Maven. Do not hardcode current GeoMesa version numbers here!
+from target.versions import release,version,version_devel
 
+# Other versions and variables unlikely to change on every point release
 release_1_1 = '1.1.0-rc.7'
-version_devel = '1.2.5-SNAPSHOT'
-
+release_eclipse = '1.2.0'
 url_locationtech_release = "https://repo.locationtech.org/content/repositories/geomesa-releases/org/locationtech/geomesa"
 url_github_archive = "https://github.com/locationtech/geomesa/archive"
 
@@ -79,11 +78,11 @@ rst_epilog = """
 
 .. |release_kafka09_plugin| replace:: %(url_locationtech_release)s/geomesa-kafka-09-gs-plugin/%(release)s/geomesa-kafka-09-gs-plugin-%(release)s-install.tar.gz
 
-.. |eclipse_release| replace:: 1.2.0
+.. |eclipse_release| replace:: %(release_eclipse)s
 
-.. |eclipse_release_tarball| replace:: http://download.locationtech.org/geomesa/1.2.0/geomesa-dist-1.2.0-bin.tar.gz
+.. |eclipse_release_tarball| replace:: http://download.locationtech.org/geomesa/%(release_eclipse)s/geomesa-dist-%(release_eclipse)s-bin.tar.gz
 
-.. |eclipse_release_source_tarball| replace:: http://download.locationtech.org/geomesa/1.2.0/geomesa-source-1.2.0.tar.gz 
+.. |eclipse_release_source_tarball| replace:: http://download.locationtech.org/geomesa/%(release_eclipse)s/geomesa-source-%(release_eclipse)s.tar.gz
 
 .. |development| replace:: %(version_devel)s
 
@@ -109,6 +108,7 @@ rst_epilog = """
 
 """ % {"release": release,
        "release_1_1": release_1_1,
+       "release_eclipse": release_eclipse,
        "version_devel": version_devel,
        "url_locationtech_release": url_locationtech_release,
        "url_github_archive": url_github_archive}

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -66,13 +66,39 @@
                                     <tasks>
                                         <ant antfile="build.xml" dir="${basedir}" target="${target}">
                                             <property name="build.directory" value="${project.build.directory}" />
-                                            <property name="project.version" value="${project.version}" />
                                         </ant>
                                     </tasks>
                                 </configuration>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-resources</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>${basedir}</directory>
+                                            <includes>
+                                                <include>versions.py</include>
+                                                <include>__init__.py</include>
+                                            </includes>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/docs/versions.py
+++ b/docs/versions.py
@@ -1,0 +1,8 @@
+# NB: This file is preprocessed by Maven; the version that is used
+# by Sphinx is built in target/versions.py
+
+# version: The short X.Y version.
+# release: The full version, including alpha/beta/rc tags.
+release = '${project.version}'
+version = '${project.version}'
+version_devel = '${geomesa.devel.version}'

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- bump version right before performing releases for the README and the documentation -->
-        <geomesa.release.version>1.2.4</geomesa.release.version>
+        <geomesa.release.version>1.2.5</geomesa.release.version>
+        <geomesa.devel.version>1.2.6-SNAPSHOT</geomesa.devel.version>
 
         <scala.version>2.11.7</scala.version>
         <scala.xml.version>1.0.5</scala.xml.version>


### PR DESCRIPTION
Setting versions via Sphinx command line was not doing all of the
other substitions properly. This solution sets the versions via
the maven-resources-plugin prior to Sphinx invocation.

Signed-off-by: Matthew Zimmerman <matt.zimmerman@ccri.com>