### PR TITLE
Update compute module dependencies and shaded jar exclusions

### DIFF
--- a/geomesa-compute/pom.xml
+++ b/geomesa-compute/pom.xml
@@ -43,6 +43,12 @@
             <artifactId>geomesa-jobs</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-wkt</artifactId>
+            <version>${gt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.metamodel</groupId>
             <artifactId>MetaModel-pojo</artifactId>
             <version>4.3.6</version>
@@ -150,6 +156,9 @@
                             <artifactSet>
                                 <excludes>
                                     <exclude>org.slf4j:*</exclude>
+                                    <exclude>org.geotools:gt-render:*</exclude>
+                                    <exclude>org.geotools:gt-coverage:*</exclude>
+                                    <exclude>it.geosolutions.jaiext.*</exclude>
                                 </excludes>
                             </artifactSet>
                             <filters>


### PR DESCRIPTION
This PR is intended to alleviate some issues using the `geomesa-compute` module in some Apache Spark environments.  In particular, those with hierarchical ClassLoaders (e.g. the Apache Toree Jupyter Spark Kernel).  The presence of some classes in a parent ClassLoader will preclude loading of interface implementations present in child ClassLoaders due to visibility issues.

To deal with this we can either:
- Include interface implementations in the the compute module.  This fixes the sent of implementations that may be used.
- Exclude classes that load interfaces from the compute module.  This requires explicit or deferred loading of the jar responsible for loading the interface implementation and all the desired implementations.

This PR _includes_ the GeoTools `gt-epsg-wkt` module so that a basic CRS lookup mechanism is available and _excludes_ the `gt-render` module due to the module size and number of JAI/Coverage operations that users may want to load.  Exclusion doesn't preclude the use of these classes, just requires that they be loaded lazily (e.g. with Toree's `%AddDeps`) or explicitly included on the classpath. 