### PR TITLE
GEOMESA-1392 Fix Geoserver Docs links in Geomesa Docs

### DIFF
--- a/docs/tutorials/geomesa-examples-gdelt.rst
+++ b/docs/tutorials/geomesa-examples-gdelt.rst
@@ -263,7 +263,7 @@ The above map is using the `Stamen
 Toner <http://maps.stamen.com/toner>`__ layer as a base layer. For more
 information about adding multiple layers into one group see the
 `GeoServer
-documentation <http://docs.geoserver.org/stable/en/user/webadmin/data/layergroups.html>`__.
+documentation <http://docs.geoserver.org/stable/en/user/data/webadmin/layergroups.html>`__.
 
 Filter
 ~~~~~~
@@ -282,12 +282,12 @@ OpenLayers preview.
    :alt: Enter CQL Filter into Toolbar
 
 Let's use a custom icon to display THREATEN events, by adding an `SLD
-style <http://docs.geoserver.org/latest/en/user/styling/index.html>`__
+style <http://docs.geoserver.org/stable/en/user/styling/index.html>`__
 to the layer. Add the SLD file
 :download:`threat.sld <_static/geomesa-examples-gdelt/threat.sld>`
 to GeoServer (See the GeoServer documentation for `more information
 about adding SLD
-files <http://docs.geoserver.org/latest/en/user/styling/sld-working.html>`__.
+files <http://docs.geoserver.org/stable/en/user/styling/sld-working.html>`__.
 For the ExternalGraphic in the SLD to work, move the image file to the
 specified location in your GeoServer installation.
 

--- a/docs/tutorials/geomesa-quickstart-accumulo.rst
+++ b/docs/tutorials/geomesa-quickstart-accumulo.rst
@@ -232,7 +232,7 @@ add the following to the end:
 That tells GeoServer to display the records for the entire month of
 January 2014. You can find more information about the TIME parameter
 from `GeoServer's
-documentation <http://docs.geoserver.org/latest/en/user/services/wms/time.html>`__.
+documentation <http://docs.geoserver.org/stable/en/user/services/wms/time.html>`__.
 
 Once you press <Enter>, the display will update, and you should see a
 collection of red dots similar to the following image.
@@ -259,7 +259,7 @@ Here are just a few simple ways you can play with the visualization:
    your filter criterion. This is a CQL filter, which can be constructed
    in various ways to query our data. You can find more information
    about CQL from `GeoServer's CQL
-   tutorial <http://docs.geoserver.org/latest/en/user/tutorials/cql/cql_tutorial.html>`__.
+   tutorial <http://docs.geoserver.org/stable/en/user/tutorials/cql/cql_tutorial.html>`__.
 
 Generating Heatmaps
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/geomesa-quickstart-hbase.rst
+++ b/docs/tutorials/geomesa-quickstart-hbase.rst
@@ -257,4 +257,4 @@ display will now show only those points matching your filter criterion.
 
 This is a CQL filter, which can be constructed in various ways to query
 our data. You can find more information about CQL from `GeoServer's CQL
-tutorial <http://docs.geoserver.org/latest/en/user/tutorials/cql/cql_tutorial.html>`__.
+tutorial <http://docs.geoserver.org/stable/en/user/tutorials/cql/cql_tutorial.html>`__.

--- a/docs/tutorials/geomesa-tubeselect.rst
+++ b/docs/tutorials/geomesa-tubeselect.rst
@@ -55,7 +55,7 @@ Using the GeoServer Plugin
 
 Once everything is installed you should see "geomesa:TubeSelect" appear
 in the `WPS Request
-Builder <http://docs.geoserver.org/stable/en/user/extensions/wps/requestbuilder.html>`__,
+Builder <http://docs.geoserver.org/stable/en/user/services/wps/requestbuilder.html>`__,
 which is found under the *Demos* link in the menu bar on the left side
 of the GeoServer web administration interface.
 
@@ -294,7 +294,7 @@ Chaining Processes
 WPS supports chaining other WPS processes. This is useful when selecting
 data from an existing layer or storing data back into GeoServer to
 create a new layer. The GeoServer User Guide has a section on `Process
-Chaining <http://docs.geoserver.org/stable/en/user/extensions/wps/processes.html#process-chaining>`__.
+Chaining <http://docs.geoserver.org/stable/en/user/services/wps/processes/chaining.html>`__.
 
 Tube Selections
 ---------------

--- a/docs/user/accumulo_datastore.rst
+++ b/docs/user/accumulo_datastore.rst
@@ -94,7 +94,7 @@ Given a data store and a query, you can ask GeoMesa to explain its plan for how 
 
 Instead of ``ExplainPrintln``, you can also use ``ExplainString`` or ``ExplainLogging`` to redirect the explainer output elsewhere.
 
-For enabling ``ExplainLogging`` in GeoServer, see :ref:`geoserver_explain_query`. It may also be helpful to refer to GeoServer's `Advanced log configuration <http://docs.geoserver.org/2.8.x/en/user/advanced/logging.html>`_ documentation for the specifics of how and where to manage the GeoServer logs.
+For enabling ``ExplainLogging`` in GeoServer, see :ref:`geoserver_explain_query`. It may also be helpful to refer to GeoServer's `Advanced log configuration <http://docs.geoserver.org/stable/en/user/configuration/logging.html>`_ documentation for the specifics of how and where to manage the GeoServer logs.
 
 Knowing the plan -- including information such as the indexing strategy -- can be useful when you need to debug slow queries.  It can suggest when indexes should be added as well as when query-hints may expedite execution times.
 

--- a/docs/user/geoserver.rst
+++ b/docs/user/geoserver.rst
@@ -156,7 +156,7 @@ show only those points matching your filter criterion.
 
 This is a CQL filter, which can be constructed in various ways to query data. You can
 find more information about CQL from `GeoServer's CQL
-tutorial <http://docs.geoserver.org/latest/en/user/tutorials/cql/cql_tutorial.html>`__.
+tutorial <http://docs.geoserver.org/stable/en/user/tutorials/cql/cql_tutorial.html>`__.
 
 Analysis with WPS
 -----------------

--- a/docs/user/installation_and_configuration.rst
+++ b/docs/user/installation_and_configuration.rst
@@ -201,6 +201,10 @@ The instructions below assume that the ``geomesa-tools-$VERSION`` directory is k
 ``geomesa-$VERSION/dist/tools`` directory, but the tools distribution may be moved elsewhere
 as desired.
 
+.. note::
+
+    You can configure environment variables and classpath settings in geomesa-env.sh.
+
 In the ``geomesa-tools-$VERSION`` directory, run ``bin/geomesa configure`` to set up the tools.
 
 .. code-block:: bash
@@ -312,12 +316,12 @@ As described in section :ref:`geomesa_and_geoserver`, GeoMesa implements a
 `GeoTools <http://geotools.org/>`_-compatible data store. This makes it possible
 to use GeoMesa as a data store in `GeoServer <http://geoserver.org>`_. The documentation
 below describes how to configure GeoServer to connect to GeoMesa Accumulo and Kafka data stores.
-GeoServer's web site includes `installation instructions for GeoServer <http://docs.geoserver.org/latest/en/user/installation/index.html>`_.
+GeoServer's web site includes `installation instructions for GeoServer <http://docs.geoserver.org/stable/en/user/installation/index.html>`_.
 
 After GeoServer is running, you will also need to install the WPS plugin to
 your GeoServer instance. The GeoServer WPS Plugin must match the version of
 GeoServer instance. This is needed for both the Accumulo and Kafka variants of
-the plugin. The GeoServer website includes `instructions for downloading and installing <http://docs.geoserver.org/stable/en/user/extensions/wps/install.html>`_ the WPS plugin.
+the plugin. The GeoServer website includes `instructions for downloading and installing <http://docs.geoserver.org/stable/en/user/services/wps/install.html>`_ the WPS plugin.
 
 .. note::
 

--- a/docs/user/process.rst
+++ b/docs/user/process.rst
@@ -38,7 +38,7 @@ available in the binary distribution in the gs-plugins directory.
 
 Documentation about the GeoServer WPS Extension (including download
 instructions) is available here:
-http://docs.geoserver.org/2.8.1/user/extensions/wps/install.html.
+http://docs.geoserver.org/stable/en/user/services/wps/install.html.
 
 To verify the install, start GeoServer, and you should see a line like
 ``INFO [geoserver.wps] - Found 11 bindable processes in GeoMesa Process Factory``.


### PR DESCRIPTION
Geoserver.org changed the structuring of some of their documentation, breaking the relative (/stable/) links in the geomesa docs. I've corrected these and standardized all the links to point to 'stable' docs rather than a mix of 'stable' and 'latest'.

Signed-off-by: Austin Heyne <aheyne@ccri.com>