### PR TITLE
GEOMESA-1401 Creating per-index schema version to allow arbitrary mixing of indices

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloConnectorCreator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloConnectorCreator.scala
@@ -10,6 +10,7 @@ package org.locationtech.geomesa.accumulo.data
 
 import org.apache.accumulo.core.client.{BatchScanner, Connector, Scanner}
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.AccumuloFeatureIndex
+import org.locationtech.geomesa.accumulo.index.AccumuloWritableIndex
 
 trait AccumuloConnectorCreator {
 
@@ -23,7 +24,7 @@ trait AccumuloConnectorCreator {
   /**
    * Gets the accumulo table name for the given table
    */
-  def getTableName(featureName: String, index: AccumuloFeatureIndex): String
+  def getTableName(featureName: String, index: AccumuloWritableIndex): String
 
   /**
    * Gets the suggested number of threads for querying the given table

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -22,6 +22,7 @@ import org.geotools.factory.Hints
 import org.geotools.feature.{FeatureTypes, NameImpl}
 import org.joda.time.DateTimeUtils
 import org.locationtech.geomesa.CURRENT_SCHEMA_VERSION
+import org.locationtech.geomesa.accumulo.GeomesaSystemProperties
 import org.locationtech.geomesa.accumulo.data.GeoMesaMetadata._
 import org.locationtech.geomesa.accumulo.data.stats._
 import org.locationtech.geomesa.accumulo.data.stats.usage.{GeoMesaUsageStats, GeoMesaUsageStatsImpl, HasGeoMesaUsageStats}
@@ -29,14 +30,11 @@ import org.locationtech.geomesa.accumulo.data.tables._
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.AccumuloFeatureIndex
 import org.locationtech.geomesa.accumulo.index._
 import org.locationtech.geomesa.accumulo.index.attribute.AttributeIndex
-import org.locationtech.geomesa.accumulo.index.z2.XZ2Index
-import org.locationtech.geomesa.accumulo.index.z3.XZ3Index
-import org.locationtech.geomesa.accumulo.GeomesaSystemProperties
+import org.locationtech.geomesa.utils.index.IndexMode
+import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
 // noinspection ScalaDeprecation
 import org.locationtech.geomesa.accumulo.index.geohash.GeoHashIndex
 import org.locationtech.geomesa.accumulo.index.id.RecordIndex
-import org.locationtech.geomesa.accumulo.index.z2.Z2Index
-import org.locationtech.geomesa.accumulo.index.z3.Z3Index
 import org.locationtech.geomesa.accumulo.iterators.ProjectVersionIterator
 import org.locationtech.geomesa.accumulo.util.{DistributedLocking, GeoMesaBatchWriterConfig, Releasable}
 import org.locationtech.geomesa.features.SerializationOption.SerializationOptions
@@ -130,7 +128,7 @@ class AccumuloDataStore(val connector: Connector,
    */
   override def createSchema(sft: SimpleFeatureType): Unit = {
     if (getSchema(sft.getTypeName) == null) {
-      val lock = acquireDistributedLock()
+      val lock = acquireCatalogLock()
       try {
         // check a second time now that we have the lock
         if (getSchema(sft.getTypeName) == null) {
@@ -153,7 +151,7 @@ class AccumuloDataStore(val connector: Connector,
               .foreach(k => reloadedSft.getUserData.put(k, sft.getUserData.get(k)))
 
           // create the tables in accumulo
-          AccumuloFeatureIndex.indices(reloadedSft).foreach(_.configure(reloadedSft, this))
+          AccumuloFeatureIndex.indices(reloadedSft, IndexMode.Any).foreach(_.configure(reloadedSft, this))
         }
       } finally {
         lock.release()
@@ -180,7 +178,7 @@ class AccumuloDataStore(val connector: Connector,
     val attributes = metadata.read(typeName, ATTRIBUTES_KEY).orElse {
       // check for old-style metadata and re-write it if necessary
       if (oldMetadata.read(typeName, ATTRIBUTES_KEY, cache = false).isDefined) {
-        val lock = acquireDistributedLock()
+        val lock = acquireFeatureLock(typeName)
         try {
           if (oldMetadata.read(typeName, ATTRIBUTES_KEY, cache = false).isDefined) {
             metadata.asInstanceOf[MultiRowAccumuloMetadata[String]].migrate(typeName)
@@ -200,35 +198,52 @@ class AccumuloDataStore(val connector: Connector,
 
       checkProjectVersion()
 
-      // back compatible check if user data wasn't encoded with the sft
-      if (!sft.getUserData.containsKey(SCHEMA_VERSION_KEY)) {
-        metadata.read(typeName, "dtgfield").foreach(sft.setDtgField)
-        sft.setSchemaVersion(metadata.readRequired(typeName, VERSION_KEY).toInt)
+      // back compatible check for index versions
+      if (!sft.getUserData.contains(SimpleFeatureTypes.INDEX_VERSIONS)) {
+        // back compatible check if user data wasn't encoded with the sft
+        if (!sft.getUserData.containsKey(SCHEMA_VERSION_KEY)) {
+          metadata.read(typeName, "dtgfield").foreach(sft.setDtgField)
+          sft.getUserData.put(SCHEMA_VERSION_KEY, metadata.readRequired(typeName, VERSION_KEY))
 
-        // If no data is written, we default to 'false' in order to support old tables.
-        if (metadata.read(typeName, "tables.sharing").exists(_.toBoolean)) {
-          sft.setTableSharing(true)
-          // use schema id if available or fall back to old type name for backwards compatibility
-          val prefix = metadata.read(typeName, SCHEMA_ID_KEY).getOrElse(s"${sft.getTypeName}~")
-          sft.setTableSharingPrefix(prefix)
-        } else {
-          sft.setTableSharing(false)
-          sft.setTableSharingPrefix("")
+          // If no data is written, we default to 'false' in order to support old tables.
+          if (metadata.read(typeName, "tables.sharing").exists(_.toBoolean)) {
+            sft.setTableSharing(true)
+            // use schema id if available or fall back to old type name for backwards compatibility
+            val prefix = metadata.read(typeName, SCHEMA_ID_KEY).getOrElse(s"${sft.getTypeName}~")
+            sft.setTableSharingPrefix(prefix)
+          } else {
+            sft.setTableSharing(false)
+            sft.setTableSharingPrefix("")
+          }
+          SimpleFeatureTypes.ENABLED_INDEXES.foreach { i =>
+            metadata.read(typeName, i).foreach(e => sft.getUserData.put(SimpleFeatureTypes.ENABLED_INDEXES.head, e))
+          }
+          // old st_idx schema, kept around for back-compatibility
+          metadata.read(typeName, "schema").foreach(sft.setStIndexSchema)
         }
-        // noinspection ScalaDeprecation
-        metadata.read(typeName, SimpleFeatureTypes.ENABLED_INDEXES_OLD)
-            .foreach(sft.getUserData.put(SimpleFeatureTypes.ENABLED_INDEXES, _))
-        // old st_idx schema, kept around for back-compatibility
-        metadata.read(typeName, "schema").foreach(sft.setStIndexSchema)
+
+        // set the enabled indices
+        sft.setIndices(AccumuloDataStore.getEnabledIndices(sft))
       }
+
+      val missingIndices = sft.getIndices.filterNot { case (n, v, _) =>
+        AccumuloFeatureIndex.AllIndices.exists(i => i.name == n && i.version == v)
+      }
+      lazy val error = new IllegalStateException(s"The schema ${sft.getTypeName} was written with a newer " +
+          "version of GeoMesa than this client can handle. Please ensure that you are using the " +
+          "same GeoMesa jar versions across your entire workflow. For more information, see " +
+          "http://www.geomesa.org/documentation/user/installation_and_configuration.html#upgrading")
 
       if (sft.getSchemaVersion > CURRENT_SCHEMA_VERSION) {
         logger.error(s"Trying to access schema ${sft.getTypeName} with version ${sft.getSchemaVersion} " +
             s"but client can only handle up to version $CURRENT_SCHEMA_VERSION.")
-        throw new IllegalStateException(s"The schema ${sft.getTypeName} was written with a newer " +
-            "version of GeoMesa than this client can handle. Please ensure that you are using the " +
-            "same GeoMesa jar versions across your entire workflow. For more information, see " +
-            "http://www.geomesa.org/documentation/user/installation_and_configuration.html#upgrading")
+        throw error
+      } else if (missingIndices.nonEmpty) {
+        val versions = missingIndices.map { case (n, v, _) => s"$n:$v" }.mkString(",")
+        val available = AccumuloFeatureIndex.AllIndices.map(i => s"${i.name}:${i.version}").mkString(",")
+        logger.error(s"Trying to access schema ${sft.getTypeName} with invalid index versions '$versions' - " +
+            s"available indices are '$available'")
+        throw error
       }
 
       // back compatibility check for stat configuration
@@ -236,7 +251,7 @@ class AccumuloDataStore(val connector: Connector,
         // configure the stats combining iterator - we only use this key for older data stores
         val configuredKey = "stats-configured"
         if (!metadata.read(typeName, configuredKey).contains("true")) {
-          val lock = acquireDistributedLock()
+          val lock = acquireCatalogLock()
           try {
             if (!metadata.read(typeName, configuredKey, cache = false).contains("true")) {
               GeoMesaMetadataStats.configureStatCombiner(connector, statsTable, sft)
@@ -258,59 +273,94 @@ class AccumuloDataStore(val connector: Connector,
   }
 
   /**
-   * @see org.geotools.data.DataStore#updateSchema(java.lang.String, org.opengis.feature.simple.SimpleFeatureType)
-   * @param typeName simple feature type name
-   * @param sft new simple feature type
-   */
+    * Allows the following modifications to the schema:
+    *   modifying keywords through user-data
+    *   enabling/disabling indices through RichSimpleFeatureType.setIndexVersion (SimpleFeatureTypes.INDEX_VERSIONS)
+    *   appending of new attributes
+    *
+    * Other modifications are not supported.
+    *
+    * @see org.geotools.data.DataStore#updateSchema(java.lang.String, org.opengis.feature.simple.SimpleFeatureType)
+    * @param typeName simple feature type name
+    * @param sft new simple feature type
+    */
   override def updateSchema(typeName: String, sft: SimpleFeatureType): Unit =
     updateSchema(new NameImpl(typeName), sft)
 
   /**
-   * @see org.geotools.data.DataAccess#updateSchema(org.opengis.feature.type.Name, org.opengis.feature.type.FeatureType)
-   * @param typeName simple feature type name
-   * @param sft new simple feature type
-   */
+    * Allows the following modifications to the schema:
+    *   modifying keywords through user-data
+    *   enabling/disabling indices through RichSimpleFeatureType.setIndexVersion (SimpleFeatureTypes.INDEX_VERSIONS)
+    *   appending of new attributes
+    *
+    * Other modifications are not supported.
+    *
+    * @see org.geotools.data.DataAccess#updateSchema(org.opengis.feature.type.Name, org.opengis.feature.type.FeatureType)
+    * @param typeName simple feature type name
+    * @param sft new simple feature type
+    */
   override def updateSchema(typeName: Name, sft: SimpleFeatureType): Unit = {
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType._
+    import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 
-    // Currently this method only allows for updating of keywords in user data. All other attempted changes will fail
-
-    val schemaTypeName = sft.getTypeName
-
-    // Prevent modifying wrong type if type names don't match
-    if (!schemaTypeName.equals(typeName.toString)) {
-      throw new UnsupportedOperationException(s"Updating the type name of a schema is not allowed: $schemaTypeName $typeName")
+    // validate type name has not changed
+    if (typeName.toString != sft.getTypeName) {
+      val msg = s"Updating the name of a schema is not allowed: '$typeName' changed to '${sft.getTypeName}'"
+      throw new UnsupportedOperationException(msg)
     }
 
-    // Get previous schema and user data
-    val previousSft = getSchema(typeName)
+    val lock = acquireFeatureLock(sft.getTypeName)
+    try {
+      // Get previous schema and user data
+      val previousSft = getSchema(typeName)
 
-    if (previousSft == null) {
-      throw new IllegalArgumentException(s"No schema found for given type name $typeName")
-    }
-
-    val existingUserData = metadata.read(schemaTypeName, ATTRIBUTES_KEY)
-
-    // Check that unmodifiable user data has not changed
-    val unmodifiableUserdataKeys = Set(SCHEMA_VERSION_KEY, TABLE_SHARING_KEY, SHARING_PREFIX_KEY,
-                                   DEFAULT_DATE_KEY, ST_INDEX_SCHEMA_KEY, SimpleFeatureTypes.ENABLED_INDEXES)
-
-    unmodifiableUserdataKeys.foreach { key =>
-      if (sft.getUserData.contains(key) && sft.userData[String](key) != previousSft.userData[String](key)) {
-        throw new UnsupportedOperationException(s"Updating $key is not allowed")
+      if (previousSft == null) {
+        throw new IllegalArgumentException(s"Schema '$typeName' does not exist")
       }
-    }
 
-    // Check that the rest of the schema has not changed (columns, types, etc)
-    val previousColumns = previousSft.getAttributeDescriptors
-    val currentColumns = sft.getAttributeDescriptors
-    if (previousColumns != currentColumns) {
-      throw new UnsupportedOperationException("Updating schema columns is not allowed")
-    }
+      // validate that default geometry has not changed
+      if (sft.getGeomField != previousSft.getGeomField) {
+        throw new UnsupportedOperationException("Changing the default geometry is not supported")
+      }
 
-    // If all is well, update the metadata
-    val attributesValue   = SimpleFeatureTypes.encodeType(sft, includeUserData = true)
-    metadata.insert(schemaTypeName, ATTRIBUTES_KEY, attributesValue)
+      // Check that unmodifiable user data has not changed
+      val unmodifiableUserdataKeys =
+        Set(SCHEMA_VERSION_KEY, TABLE_SHARING_KEY, SHARING_PREFIX_KEY, DEFAULT_DATE_KEY, ST_INDEX_SCHEMA_KEY)
+
+      unmodifiableUserdataKeys.foreach { key =>
+        if (sft.userData[Any](key) != previousSft.userData[Any](key)) {
+          throw new UnsupportedOperationException(s"Updating '$key' is not supported")
+        }
+      }
+
+      // Check that the rest of the schema has not changed (columns, types, etc)
+      val previousColumns = previousSft.getAttributeDescriptors
+      val currentColumns = sft.getAttributeDescriptors
+      if (previousColumns.toSeq != currentColumns.take(previousColumns.length)) {
+        throw new UnsupportedOperationException("Updating schema columns is not allowed")
+      }
+
+      // update the configured indices if needed
+      val previousIndices = previousSft.getIndices.map { case (name, version, _) => (name, version)}
+      val newIndices = sft.getIndices.collect {
+        case (name, version, _) if !previousIndices.contains((name, version)) => (name, version)
+      }
+      newIndices.flatMap(AccumuloFeatureIndex.IndexLookup.get).filter(_.supports(sft)).foreach(_.configure(sft, this))
+
+      // check for newly indexed attributes and re-configure the splits
+      val previousAttrIndices = previousSft.getAttributeDescriptors.collect {
+        case d if d.isIndexed => d.getLocalName
+      }
+      if (sft.getAttributeDescriptors.exists(d => d.isIndexed && !previousAttrIndices.contains(d.getLocalName))) {
+        AttributeIndex.configure(sft, this)
+      }
+
+      // If all is well, update the metadata
+      val attributesValue = SimpleFeatureTypes.encodeType(sft, includeUserData = true)
+      metadata.insert(sft.getTypeName, ATTRIBUTES_KEY, attributesValue)
+    } finally {
+      lock.release()
+    }
   }
 
   /**
@@ -322,7 +372,7 @@ class AccumuloDataStore(val connector: Connector,
    * @param typeName simple feature type name
    */
   override def removeSchema(typeName: String) = {
-    val lock = acquireDistributedLock()
+    val typeLock = acquireFeatureLock(typeName)
     try {
       Option(getSchema(typeName)).foreach { sft =>
         if (sft.isTableSharing && getTypeNames.filter(_ != typeName).map(getSchema).exists(_.isTableSharing)) {
@@ -332,9 +382,14 @@ class AccumuloDataStore(val connector: Connector,
         }
         stats.clearStats(sft)
       }
+    } finally {
+      typeLock.release()
+    }
+    val catalogLock = acquireCatalogLock()
+    try {
       metadata.delete(typeName)
     } finally {
-      lock.release()
+      catalogLock.release()
     }
   }
 
@@ -484,19 +539,17 @@ class AccumuloDataStore(val connector: Connector,
    * @param index table
    * @return accumulo table name
    */
-  override def getTableName(featureName: String, index: AccumuloFeatureIndex): String = {
-    val key = index match {
-      case Z3Index        => Z3_TABLE_KEY
-      case Z2Index        => Z2_TABLE_KEY
-      case XZ3Index       => XZ3_TABLE_KEY
-      case XZ2Index       => XZ2_TABLE_KEY
-      case RecordIndex    => RECORD_TABLE_KEY
-      case AttributeIndex => ATTR_IDX_TABLE_KEY
-      // noinspection ScalaDeprecation
-      case GeoHashIndex   => ST_IDX_TABLE_KEY
-      case _ => throw new NotImplementedError("Unknown table")
+  // noinspection ScalaDeprecation
+  override def getTableName(featureName: String, index: AccumuloWritableIndex): String = {
+    lazy val oldKey = index match {
+      case RecordIndex  => "tables.record.name"
+      case GeoHashIndex => "tables.idx.st.name"
+      case i if i.name == AttributeIndex.name => "tables.idx.attr.name"
+      case i => s"tables.${i.name}.name"
     }
-    metadata.readRequired(featureName, key)
+    metadata.read(featureName, index.tableNameKey).orElse(metadata.read(featureName, oldKey)).getOrElse {
+      throw new RuntimeException(s"Could not read table name from metadata for index ${index.name}:${index.version}")
+    }
   }
 
   /**
@@ -524,7 +577,7 @@ class AccumuloDataStore(val connector: Connector,
    */
   def delete() = {
     val indexTables = getTypeNames.map(getSchema)
-        .flatMap(sft => AccumuloFeatureIndex.indices(sft).map(getTableName(sft.getTypeName, _)))
+        .flatMap(sft => AccumuloFeatureIndex.indices(sft, IndexMode.Any).map(getTableName(sft.getTypeName, _)))
         .distinct
     val metadataTables = Seq(statsTable, catalogTable)
     // Delete index tables first then catalog table in case of error
@@ -557,33 +610,6 @@ class AccumuloDataStore(val connector: Connector,
     } else {
       new KryoFeatureSerializer(sft, SerializationOptions.withoutId)
     }
-  }
-
-  /**
-   * Used to update the attributes that are marked as indexed - partial implementation of updateSchema.
-   *
-   * @param typeName feature type name
-   * @param attributes attribute string, as is passed to SimpleFeatureTypes.createType
-   */
-  def updateIndexedAttributes(typeName: String, attributes: String): Unit = {
-    val FeatureSpec(existing, _) = SimpleFeatureTypes.parse(metadata.read(typeName, ATTRIBUTES_KEY).getOrElse(""))
-    val FeatureSpec(updated, _)  = SimpleFeatureTypes.parse(attributes)
-    // check that the only changes are to non-geometry index flags
-    val ok = existing.length == updated.length &&
-        existing.zip(updated).forall { case (e, u) => e == u ||
-            (e.isInstanceOf[NonGeomAttributeSpec] &&
-                u.isInstanceOf[NonGeomAttributeSpec] &&
-                e.clazz == u.clazz &&
-                e.name == u.name) }
-    if (!ok) {
-      throw new IllegalArgumentException("Attribute spec is not consistent with existing spec")
-    }
-
-    metadata.insert(typeName, ATTRIBUTES_KEY, attributes)
-
-    // reconfigure the splits on the attribute table
-    val sft = getSchema(typeName)
-    AttributeIndex.configure(sft, this)
   }
 
   /**
@@ -636,33 +662,19 @@ class AccumuloDataStore(val connector: Connector,
       sft.setTableSharing(true) // explicitly set it in case this was just the default
       sft.setTableSharingPrefix(schemaIdString)
     }
-    // handle renaming of enabled indices key so that it gets persisted
-    // noinspection ScalaDeprecation
-    Option(sft.getUserData.get(SimpleFeatureTypes.ENABLED_INDEXES_OLD)).foreach { old =>
-      sft.getUserData.put(SimpleFeatureTypes.ENABLED_INDEXES, old)
-    }
+
+    // set the enabled indices
+    sft.setIndices(AccumuloDataStore.getEnabledIndices(sft))
+    SimpleFeatureTypes.ENABLED_INDEXES.foreach(sft.getUserData.remove)
 
     // compute the metadata values - IMPORTANT: encode type has to be called after all user data is set
     val attributesValue   = SimpleFeatureTypes.encodeType(sft, includeUserData = true)
-    val z2TableValue      = GeoMesaTable.formatTableName(catalogTable, Z2Index.name, sft)
-    // z3 always needs a separate table since we don't include the feature name in the row key
-    val z3TableValue      = GeoMesaTable.formatSoloTableName(catalogTable, Z3Index.name, sft.getTypeName)
-    val xz2TableValue     = GeoMesaTable.formatTableName(catalogTable, XZ2Index.name, sft)
-    val xz3TableValue     = GeoMesaTable.formatTableName(catalogTable, XZ3Index.name, sft)
-    val attrIdxTableValue = GeoMesaTable.formatTableName(catalogTable, AttributeIndex.name, sft)
-    val recordTableValue  = GeoMesaTable.formatTableName(catalogTable, RecordIndex.name, sft)
     val statDateValue     = GeoToolsDateFormat.print(DateTimeUtils.currentTimeMillis())
     val dataStoreVersion  = sft.getSchemaVersion.toString
 
     // store each metadata in the associated key
     val metadataMap = Map(
       ATTRIBUTES_KEY        -> attributesValue,
-      Z2_TABLE_KEY          -> z2TableValue,
-      Z3_TABLE_KEY          -> z3TableValue,
-      XZ2_TABLE_KEY         -> xz2TableValue,
-      XZ3_TABLE_KEY         -> xz3TableValue,
-      ATTR_IDX_TABLE_KEY    -> attrIdxTableValue,
-      RECORD_TABLE_KEY      -> recordTableValue,
       STATS_GENERATION_KEY  -> statDateValue,
       VERSION_KEY           -> dataStoreVersion,
       SCHEMA_ID_KEY         -> schemaIdString
@@ -675,11 +687,11 @@ class AccumuloDataStore(val connector: Connector,
   }
 
   private def deleteSharedTables(sft: SimpleFeatureType) =
-    AccumuloFeatureIndex.indices(sft).par.foreach(_.removeAll(sft, this))
+    AccumuloFeatureIndex.indices(sft, IndexMode.Any).par.foreach(_.removeAll(sft, this))
 
   // NB: We are *not* currently deleting the query table and/or query information.
   private def deleteStandAloneTables(sft: SimpleFeatureType) = {
-    val tables = AccumuloFeatureIndex.indices(sft).map(getTableName(sft.getTypeName, _)).distinct
+    val tables = AccumuloFeatureIndex.indices(sft, IndexMode.Any).map(getTableName(sft.getTypeName, _)).distinct
     tables.filter(tableOps.exists).foreach(tableOps.delete)
   }
 
@@ -711,10 +723,44 @@ class AccumuloDataStore(val connector: Connector,
    * Acquires a distributed lock for all accumulo data stores sharing this catalog table.
    * Make sure that you 'release' the lock in a finally block.
    */
-  private def acquireDistributedLock(): Releasable = {
+  private def acquireCatalogLock(): Releasable = {
     val path = s"/org.locationtech.geomesa/accumulo/ds/$catalogTable"
     acquireDistributedLock(path, 120000).getOrElse {
       throw new RuntimeException(s"Could not acquire distributed lock at '$path'")
+    }
+  }
+
+  /**
+    * Acquires a distributed lock for a single feature type across all accumulo data stores sharing
+    * this catalog table. Make sure that you 'release' the lock in a finally block.
+    */
+  private def acquireFeatureLock(typeName: String): Releasable = {
+    val path = s"/org.locationtech.geomesa/accumulo/ds/$catalogTable-$typeName"
+    acquireDistributedLock(path, 120000).getOrElse {
+      throw new RuntimeException(s"Could not acquire distributed lock at '$path'")
+    }
+  }
+}
+
+object AccumuloDataStore {
+
+  /**
+    * Reads the indices configured using SimpleFeatureTypes.ENABLED_INDICES, or the
+    * default indices for the schema version
+    *
+    * @param sft simple feature type
+    * @return sequence of index (name, version)
+    */
+  private def getEnabledIndices(sft: SimpleFeatureType): Seq[(String, Int, IndexMode)] = {
+    val marked: Seq[String] = SimpleFeatureTypes.ENABLED_INDEXES.map(sft.getUserData.get).find(_ != null) match {
+      case None => AccumuloFeatureIndex.AllIndices.map(_.name).distinct
+      case Some(enabled) =>
+        val e = enabled.toString.split(",").map(_.trim).filter(_.length > 0)
+        // check for old attribute index name
+        if (e.contains("attr_idx")) {  e :+ AttributeIndex.name } else { e }
+    }
+    AccumuloFeatureIndex.getDefaultIndices(sft).collect {
+      case i if marked.contains(i.name) => (i.name, i.version, IndexMode.ReadWrite)
     }
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/GeoMesaMetadata.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/GeoMesaMetadata.scala
@@ -104,15 +104,6 @@ object GeoMesaMetadata {
   val VERSION_KEY         = "version"
   val SCHEMA_ID_KEY       = "id"
 
-  val ATTR_IDX_TABLE_KEY  = "tables.idx.attr.name"
-  val RECORD_TABLE_KEY    = "tables.record.name"
-  val Z2_TABLE_KEY        = "tables.z2.name"
-  val Z3_TABLE_KEY        = "tables.z3.name"
-  val XZ2_TABLE_KEY       = "tables.xz2.name"
-  val XZ3_TABLE_KEY       = "tables.xz3.name"
-  @deprecated
-  val ST_IDX_TABLE_KEY    = "tables.idx.st.name"
-
   val STATS_GENERATION_KEY   = "stats-date"
   val STATS_INTERVAL_KEY     = "stats-interval"
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloFeatureIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloFeatureIndex.scala
@@ -15,9 +15,11 @@ import org.apache.hadoop.io.Text
 import org.geotools.filter.identity.FeatureIdImpl
 import org.locationtech.geomesa.accumulo.data._
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.AccumuloFeatureIndex
-import org.locationtech.geomesa.accumulo.index.attribute.AttributeIndex
-import org.locationtech.geomesa.accumulo.index.z2.XZ2Index
-import org.locationtech.geomesa.accumulo.index.z3.XZ3Index
+// noinspection ScalaDeprecation
+import org.locationtech.geomesa.accumulo.index.attribute.{AttributeIndex, AttributeIndexV1}
+import org.locationtech.geomesa.accumulo.index.z2.{XZ2Index, Z2IndexV1, Z2IndexV2}
+import org.locationtech.geomesa.accumulo.index.z3.{XZ3Index, Z3IndexV1, Z3IndexV2, Z3IndexV3}
+import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
 // noinspection ScalaDeprecation
 import org.locationtech.geomesa.accumulo.index.geohash.GeoHashIndex
 import org.locationtech.geomesa.accumulo.index.id.RecordIndex
@@ -30,26 +32,63 @@ import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.security.SecurityUtils
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
+// noinspection ScalaDeprecation
 object AccumuloFeatureIndex {
 
   type AccumuloFeatureIndex = GeoMesaFeatureIndex[AccumuloDataStore, WritableFeature, Seq[Mutation], QueryPlan]
   type AccumuloFilterPlan = FilterPlan[AccumuloDataStore, WritableFeature, Seq[Mutation], QueryPlan]
   type AccumuloFilterStrategy = FilterStrategy[AccumuloDataStore, WritableFeature, Seq[Mutation], QueryPlan]
 
-  // noinspection ScalaDeprecation
+  private val SpatialIndices        = Seq(Z2Index, XZ2Index, Z2IndexV2, Z2IndexV1, GeoHashIndex)
+  private val SpatioTemporalIndices = Seq(Z3Index, XZ3Index, Z3IndexV3, Z3IndexV2, Z3IndexV1)
+  private val AttributeIndices      = Seq(AttributeIndex, AttributeIndexV1)
+
   // note: keep in priority order for running full table scans
   val AllIndices: Seq[AccumuloWritableIndex] =
-    Seq(Z3Index, XZ3Index, Z2Index, XZ2Index, RecordIndex, AttributeIndex, GeoHashIndex)
+    (SpatioTemporalIndices ++ SpatialIndices :+ RecordIndex) ++ AttributeIndices
 
-  def indices(sft: SimpleFeatureType): Seq[AccumuloWritableIndex] = AllIndices.filter(_.supports(sft))
+  val IndexLookup = AllIndices.map(i => (i.name, i.version) -> i).toMap
+
+  def indices(sft: SimpleFeatureType, mode: IndexMode): Seq[AccumuloWritableIndex] = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    sft.getIndices.flatMap { case (n, v, m) => if (m.supports(mode)) IndexLookup.get((n, v)) else None }
+  }
 
   object Schemes {
     val Z3TableScheme: List[String] = List(AttributeIndex, RecordIndex, Z3Index, XZ3Index).map(_.name)
     val Z2TableScheme: List[String] = List(AttributeIndex, RecordIndex, Z2Index, XZ2Index).map(_.name)
   }
+
+  /**
+    * Maps a simple feature type to a set of default indices based on
+    * attributes and when it was created (schema version)
+    *
+    * @param sft simple feature type
+    * @return
+    */
+  def getDefaultIndices(sft: SimpleFeatureType): Seq[AccumuloWritableIndex] = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    val indices = sft.getSchemaVersion match {
+      case 10 => Seq(Z3Index, XZ3Index, Z2Index, XZ2Index, RecordIndex, AttributeIndex)
+      case 9  => Seq(Z3IndexV3, Z2IndexV2, RecordIndex, AttributeIndex)
+      case 8  => Seq(Z3IndexV2, Z2IndexV1, RecordIndex, AttributeIndex)
+      case 7  => Seq(Z3IndexV2, GeoHashIndex, RecordIndex, AttributeIndex)
+      case 6  => Seq(Z3IndexV1, GeoHashIndex, RecordIndex, AttributeIndex)
+      case 5  => Seq(Z3IndexV1, GeoHashIndex, RecordIndex, AttributeIndexV1)
+      case 4  => Seq(GeoHashIndex, RecordIndex, AttributeIndexV1)
+      case 3  => Seq(GeoHashIndex, RecordIndex, AttributeIndexV1)
+      case 2  => Seq(GeoHashIndex, RecordIndex, AttributeIndexV1)
+      case _  => Seq.empty
+    }
+    indices.filter(_.supports(sft))
+  }
 }
 
 trait AccumuloWritableIndex extends AccumuloFeatureIndex {
+
+  def tableNameKey: String = s"table.$name.v$version"
+
+  def tableSuffix: String = if (version == 1) name else s"${name}_v$version"
 
   override def removeAll(sft: SimpleFeatureType, ops: AccumuloDataStore): Unit = {
     import org.apache.accumulo.core.data.{Range => aRange}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloStrategyDecider.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloStrategyDecider.scala
@@ -12,9 +12,11 @@ import org.apache.accumulo.core.data.Mutation
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, WritableFeature}
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.AccumuloFeatureIndex
 import org.locationtech.geomesa.index.api.StrategyDecider
+import org.locationtech.geomesa.utils.index.IndexMode
 import org.opengis.feature.simple.SimpleFeatureType
 
 object AccumuloStrategyDecider extends StrategyDecider[AccumuloDataStore, WritableFeature, Seq[Mutation], QueryPlan] {
 
-  override def indices(sft: SimpleFeatureType): Seq[AccumuloFeatureIndex] = AccumuloFeatureIndex.indices(sft)
+  override def indices(sft: SimpleFeatureType): Seq[AccumuloFeatureIndex] =
+    AccumuloFeatureIndex.indices(sft, IndexMode.Read)
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/QueryPlanner.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/QueryPlanner.scala
@@ -37,6 +37,7 @@ import org.locationtech.geomesa.index.utils.{ExplainLogging, Explainer}
 import org.locationtech.geomesa.security.SecurityUtils
 import org.locationtech.geomesa.utils.cache.SoftThreadLocal
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.index.IndexMode
 import org.locationtech.geomesa.utils.stats.{MethodProfiling, Timing}
 import org.opengis.feature.`type`.{AttributeDescriptor, GeometryDescriptor}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -301,11 +302,11 @@ object QueryPlanner extends LazyLogging {
           Some(RecordIndex)
         } else {
           val check = name.toLowerCase(Locale.US)
-          AccumuloFeatureIndex.indices(sft).find(_.name.toLowerCase(Locale.US) == check)
+          AccumuloFeatureIndex.indices(sft, IndexMode.Read).find(_.name.toLowerCase(Locale.US) == check)
         }
         if (value.isEmpty) {
           logger.error(s"Ignoring invalid strategy name from view params: $name. Valid values " +
-              s"are ${AccumuloFeatureIndex.indices(sft).map(_.name).mkString(", ")}")
+              s"are ${AccumuloFeatureIndex.indices(sft, IndexMode.Read).map(_.name).mkString(", ")}")
         }
         value
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/attribute/AttributeIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/attribute/AttributeIndex.scala
@@ -8,91 +8,50 @@
 
 package org.locationtech.geomesa.accumulo.index.attribute
 
-import org.apache.accumulo.core.data.Mutation
-import org.apache.hadoop.io.Text
-import org.geotools.factory.Hints
-import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, WritableFeature}
+import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.{AccumuloFeatureIndex, AccumuloFilterStrategy}
-import org.locationtech.geomesa.accumulo.index._
-import org.locationtech.geomesa.index.utils.Explainer
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
-object AttributeIndex extends AccumuloFeatureIndex with AccumuloWritableIndex {
-
-  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+// current version - added feature ID and dates to row key
+object AttributeIndex extends AccumuloFeatureIndex with AttributeWritableIndex with AttributeQueryableIndex {
 
   override val name: String = "attr"
 
-  // check for old suffix
-  private val enabledSuffixes = Seq(name, "attr_idx")
+  override val version: Int = 2
 
   override def supports(sft: SimpleFeatureType): Boolean = {
     import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
-    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
     import scala.collection.JavaConversions._
-    sft.getAttributeDescriptors.exists(_.isIndexed) && enabledSuffixes.exists(sft.isTableEnabled)
+    sft.getAttributeDescriptors.exists(_.isIndexed)
   }
+}
 
-  override def writer(sft: SimpleFeatureType, ops: AccumuloDataStore): (WritableFeature) => Seq[Mutation] =
-    if (sft.getSchemaVersion > 5) {
-      AttributeIndexV6.writer(sft, ops)
-    } else {
-      AttributeIndexV5.writer(sft, ops)
-    }
+// noinspection ScalaDeprecation
+// initial implementation
+@deprecated
+object AttributeIndexV1 extends AccumuloFeatureIndex with AttributeWritableIndexV5 with AttributeQueryableIndexV5 {
 
-  override def remover(sft: SimpleFeatureType, ops: AccumuloDataStore): (WritableFeature) => Seq[Mutation] =
-    if (sft.getSchemaVersion > 5) {
-      AttributeIndexV6.remover(sft, ops)
-    } else {
-      AttributeIndexV5.remover(sft, ops)
-    }
+  override val name: String = "attr"
 
-  override def getIdFromRow(sft: SimpleFeatureType): (Text) => String =
-    if (sft.getSchemaVersion > 5) {
-      AttributeIndexV6.getIdFromRow(sft)
-    } else {
-      AttributeIndexV5.getIdFromRow(sft)
-    }
+  override val version: Int = 1
 
-  override def configure(sft: SimpleFeatureType, ops: AccumuloDataStore): Unit =
-    if (sft.getSchemaVersion > 5) {
-      AttributeIndexV6.configure(sft, ops)
-    } else {
-      AttributeIndexV5.configure(sft, ops)
-    }
+  override def supports(sft: SimpleFeatureType): Boolean = {
+    import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
+
+    import scala.collection.JavaConversions._
+    sft.getAttributeDescriptors.exists(_.isIndexed)
+  }
 
   override def getFilterStrategy(sft: SimpleFeatureType, filter: Filter): Seq[AccumuloFilterStrategy] =
     // note: strategy is the same between versioned indices
-    AttributeIndexV6.getFilterStrategy(sft, filter)
+    AttributeIndex.getFilterStrategy(sft, filter)
 
   override def getCost(sft: SimpleFeatureType,
                        ops: Option[AccumuloDataStore],
                        filter: AccumuloFilterStrategy,
                        transform: Option[SimpleFeatureType]): Long =
-  // note: cost is the same between versioned indices
-    AttributeIndexV6.getCost(sft, ops, filter, transform)
-
-  override def getQueryPlan(sft: SimpleFeatureType,
-                            ops: AccumuloDataStore,
-                            filter: AccumuloFilterStrategy,
-                            hints: Hints,
-                            explain: Explainer): QueryPlan =
-    if (sft.getSchemaVersion > 5) {
-      AttributeIndexV6.getQueryPlan(sft, ops, filter, hints, explain)
-    } else {
-      AttributeIndexV5.getQueryPlan(sft, ops, filter, hints, explain)
-    }
-
-  object AttributeIndexV6 extends AccumuloFeatureIndex with AttributeWritableIndex with AttributeQueryableIndex {
-    override def name: String = AttributeIndex.name
-    override def supports(sft: SimpleFeatureType): Boolean = AttributeIndex.supports(sft)
-  }
-
-  // noinspection ScalaDeprecation
-  object AttributeIndexV5 extends AccumuloFeatureIndex with AttributeWritableIndexV5 with AttributeQueryableIndexV5 {
-    override def name: String = AttributeIndex.name
-    override def supports(sft: SimpleFeatureType): Boolean = AttributeIndex.supports(sft)
-  }
+    // note: cost is the same between versioned indices
+    AttributeIndex.getCost(sft, ops, filter, transform)
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/attribute/AttributeQueryableIndexV5.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/attribute/AttributeQueryableIndexV5.scala
@@ -24,7 +24,6 @@ import org.locationtech.geomesa.accumulo.index.QueryHints.RichHints
 import org.locationtech.geomesa.accumulo.index.QueryPlan.JoinFunction
 import org.locationtech.geomesa.accumulo.index.QueryPlanner._
 import org.locationtech.geomesa.accumulo.index._
-import org.locationtech.geomesa.accumulo.index.attribute.AttributeIndex.AttributeIndexV5
 import org.locationtech.geomesa.accumulo.index.geohash.Strategy._
 import org.locationtech.geomesa.accumulo.index.id.RecordIndex
 import org.locationtech.geomesa.accumulo.iterators._
@@ -259,9 +258,9 @@ trait AttributeQueryableIndexV5 extends AccumuloFeatureIndex with LazyLogging {
     val rowIdPrefix = sft.getTableSharingPrefix
     // grab the first encoded row - right now there will only ever be a single item in the seq
     // eventually we may support searching a whole collection at once
-    val rowWithValue = AttributeIndexV5.getAttributeIndexRows(rowIdPrefix, descriptor, typedValue).headOption
+    val rowWithValue = AttributeIndexV1.getAttributeIndexRows(rowIdPrefix, descriptor, typedValue).headOption
     // if value is null there won't be any rows returned, instead just use the row prefix
-    rowWithValue.getOrElse(AttributeIndexV5.getAttributeIndexRowPrefix(rowIdPrefix, descriptor))
+    rowWithValue.getOrElse(AttributeIndexV1.getAttributeIndexRowPrefix(rowIdPrefix, descriptor))
   }
 
   /**
@@ -401,12 +400,12 @@ trait AttributeQueryableIndexV5 extends AccumuloFeatureIndex with LazyLogging {
 
   private def lowerBound(sft: SimpleFeatureType, prop: String): Text = {
     val rowIdPrefix = sft.getTableSharingPrefix
-    new Text(AttributeIndexV5.getAttributeIndexRowPrefix(rowIdPrefix, sft.getDescriptor(prop)))
+    new Text(AttributeIndexV1.getAttributeIndexRowPrefix(rowIdPrefix, sft.getDescriptor(prop)))
   }
 
   private def upperBound(sft: SimpleFeatureType, prop: String): Text = {
     val rowIdPrefix = sft.getTableSharingPrefix
-    val end = new Text(AttributeIndexV5.getAttributeIndexRowPrefix(rowIdPrefix, sft.getDescriptor(prop)))
+    val end = new Text(AttributeIndexV1.getAttributeIndexRowPrefix(rowIdPrefix, sft.getDescriptor(prop)))
     AccRange.followingPrefix(end)
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/attribute/AttributeWritableIndexV5.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/attribute/AttributeWritableIndexV5.scala
@@ -17,6 +17,7 @@ import org.apache.hadoop.io.Text
 import org.locationtech.geomesa.accumulo.AccumuloVersion
 import org.locationtech.geomesa.accumulo.data.AccumuloFeatureWriter.FeatureToMutations
 import org.locationtech.geomesa.accumulo.data._
+import org.locationtech.geomesa.accumulo.data.tables.GeoMesaTable
 import org.locationtech.geomesa.accumulo.index.AccumuloWritableIndex
 import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
@@ -131,7 +132,11 @@ trait AttributeWritableIndexV5 extends AccumuloWritableIndex with LazyLogging {
     }
 
   override def configure(sft: SimpleFeatureType, ops: AccumuloDataStore): Unit = {
-    val table = ops.getTableName(sft.getTypeName, AttributeIndex)
+    val table = Try(ops.getTableName(sft.getTypeName, this)).getOrElse {
+      val table = GeoMesaTable.formatTableName(ops.catalogTable, tableSuffix, sft)
+      ops.metadata.insert(sft.getTypeName, tableNameKey, table)
+      table
+    }
     AccumuloVersion.ensureTableExists(ops.connector, table)
     ops.tableOps.setProperty(table, Property.TABLE_BLOCKCACHE_ENABLED.getKey, "true")
     val indexedAttrs = SimpleFeatureTypes.getSecondaryIndexedAttributes(sft)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/geohash/GeoHashIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/geohash/GeoHashIndex.scala
@@ -8,6 +8,7 @@
 
 package org.locationtech.geomesa.accumulo.index.geohash
 
+import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.AccumuloFeatureIndex
 import org.opengis.feature.simple.SimpleFeatureType
 
@@ -16,8 +17,7 @@ object GeoHashIndex extends AccumuloFeatureIndex with GeoHashWritableIndex with 
 
   override val name: String = "st_idx"
 
-  override def supports(sft: SimpleFeatureType): Boolean = {
-    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-    sft.getGeometryDescriptor != null && sft.getSchemaVersion < 8 && sft.isTableEnabled(name)
-  }
+  override val version: Int = 1
+
+  override def supports(sft: SimpleFeatureType): Boolean = sft.getGeometryDescriptor != null
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/id/RecordIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/id/RecordIndex.scala
@@ -13,12 +13,11 @@ import org.opengis.feature.simple.SimpleFeatureType
 
 object RecordIndex extends AccumuloFeatureIndex with RecordWritableIndex with RecordQueryableIndex {
 
+  def getRowKey(rowIdPrefix: String, id: String): String = rowIdPrefix + id
+
   override val name: String = "records"
 
-  override def supports(sft: SimpleFeatureType): Boolean = {
-    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-    sft.isTableEnabled(name)
-  }
+  override val version: Int = 1
 
-  def getRowKey(rowIdPrefix: String, id: String): String = rowIdPrefix + id
+  override def supports(sft: SimpleFeatureType): Boolean = true
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/XZ2Index.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/XZ2Index.scala
@@ -18,8 +18,10 @@ object XZ2Index extends AccumuloFeatureIndex with XZ2WritableIndex with XZ2Query
 
   override val name: String = "xz2"
 
+  override val version: Int = 1
+
   override def supports(sft: SimpleFeatureType): Boolean = {
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-    sft.getSchemaVersion > 9 && sft.nonPoints && sft.isTableEnabled(name)
+    sft.nonPoints
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/XZ2WritableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/XZ2WritableIndex.scala
@@ -18,9 +18,12 @@ import org.apache.accumulo.core.data.Mutation
 import org.apache.hadoop.io.Text
 import org.locationtech.geomesa.accumulo.AccumuloVersion
 import org.locationtech.geomesa.accumulo.data._
+import org.locationtech.geomesa.accumulo.data.tables.GeoMesaTable
 import org.locationtech.geomesa.accumulo.index.AccumuloWritableIndex
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.opengis.feature.simple.SimpleFeatureType
+
+import scala.util.Try
 
 trait XZ2WritableIndex extends AccumuloWritableIndex {
 
@@ -65,7 +68,11 @@ trait XZ2WritableIndex extends AccumuloWritableIndex {
   override def configure(sft: SimpleFeatureType, ops: AccumuloDataStore): Unit = {
     import scala.collection.JavaConversions._
 
-    val table = ops.getTableName(sft.getTypeName, this)
+    val table = Try(ops.getTableName(sft.getTypeName, this)).getOrElse {
+      val table = GeoMesaTable.formatTableName(ops.catalogTable, tableSuffix, sft)
+      ops.metadata.insert(sft.getTypeName, tableNameKey, table)
+      table
+    }
     AccumuloVersion.ensureTableExists(ops.connector, table)
     ops.tableOps.setProperty(table, Property.TABLE_BLOCKCACHE_ENABLED.getKey, "true")
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/XZ3Index.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/XZ3Index.scala
@@ -17,8 +17,10 @@ object XZ3Index extends AccumuloFeatureIndex with XZ3WritableIndex with XZ3Query
 
   override val name: String = "xz3"
 
+  override val version: Int = 1
+
   override def supports(sft: SimpleFeatureType): Boolean = {
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-    sft.getSchemaVersion > 9 && sft.nonPoints && sft.getDtgField.isDefined && sft.isTableEnabled(name)
+    sft.nonPoints && sft.getDtgField.isDefined
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/Z3Index.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/Z3Index.scala
@@ -8,9 +8,16 @@
 
 package org.locationtech.geomesa.accumulo.index.z3
 
+import org.apache.accumulo.core.data.Mutation
+import org.apache.hadoop.io.Text
+import org.locationtech.geomesa.accumulo.data.AccumuloFeatureWriter._
+import org.locationtech.geomesa.accumulo.data._
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.AccumuloFeatureIndex
+import org.locationtech.geomesa.accumulo.index.AccumuloWritableIndex._
+import org.locationtech.geomesa.curve.{BinnedTime, Z3SFC}
 import org.opengis.feature.simple.SimpleFeatureType
 
+// current version - deprecated polygon support in favor of xz
 object Z3Index extends AccumuloFeatureIndex with Z3WritableIndex with Z3QueryableIndex {
 
   val Z3IterPriority = 23
@@ -34,10 +41,215 @@ object Z3Index extends AccumuloFeatureIndex with Z3WritableIndex with Z3Queryabl
 
   override val name: String = "z3"
 
+  override val version: Int = 4
+
   override def supports(sft: SimpleFeatureType): Boolean = {
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-    val schema = sft.getSchemaVersion
-    sft.getDtgField.isDefined && sft.isTableEnabled(name) &&
-        ((sft.isPoints && schema > 4) || (sft.nonPoints && schema > 6 && schema < 10))
+    sft.getDtgField.isDefined && sft.isPoints
+  }
+
+  override def writer(sft: SimpleFeatureType, ops: AccumuloDataStore): FeatureToMutations = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
+    val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
+    val sfc = Z3SFC(sft.getZ3Interval)
+
+    (wf: WritableFeature) => {
+      val rows = getPointRowKey(timeToIndex, sfc)(wf, dtgIndex)
+      rows.map { row =>
+        val mutation = new Mutation(row)
+        wf.fullValues.foreach { value => mutation.put(value.cf, value.cq, value.vis, value.value) }
+        wf.binValues.foreach { value => mutation.put(value.cf, value.cq, value.vis, value.value) }
+        mutation
+      }
+    }
+  }
+
+  override def remover(sft: SimpleFeatureType, ops: AccumuloDataStore): FeatureToMutations = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
+    val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
+    val sfc = Z3SFC(sft.getZ3Interval)
+
+    (wf: WritableFeature) => {
+      val rows = getPointRowKey(timeToIndex, sfc)(wf, dtgIndex)
+      rows.map { row =>
+        val mutation = new Mutation(row)
+        wf.fullValues.foreach { value => mutation.putDelete(value.cf, value.cq, value.vis) }
+        wf.binValues.foreach { value => mutation.putDelete(value.cf, value.cq, value.vis) }
+        mutation
+      }
+    }
+  }
+}
+
+// ids in row key, per-attribute vis
+object Z3IndexV3 extends AccumuloFeatureIndex with Z3WritableIndex with Z3QueryableIndex {
+
+  override val name: String = "z3"
+
+  override val version: Int = 3
+
+  override def supports(sft: SimpleFeatureType): Boolean = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    sft.getDtgField.isDefined && sft.getGeometryDescriptor != null
+  }
+
+  override def writer(sft: SimpleFeatureType, ops: AccumuloDataStore): FeatureToMutations = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
+    val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
+    val sfc = Z3SFC(sft.getZ3Interval)
+    val getRowKeys: (WritableFeature, Int) => Seq[Array[Byte]] =
+      if (sft.isPoints) { getPointRowKey(timeToIndex, sfc) } else { getGeomRowKeys(timeToIndex, sfc) }
+
+    (wf: WritableFeature) => {
+      val rows = getRowKeys(wf, dtgIndex)
+      // store the duplication factor in the column qualifier for later use
+      val duplication = Integer.toHexString(rows.length)
+      rows.map { row =>
+        val mutation = new Mutation(row)
+        wf.fullValues.foreach { value =>
+          val cq = new Text(s"$duplication,${value.cq.toString}")
+          mutation.put(value.cf, cq, value.vis, value.value)
+        }
+        wf.binValues.foreach { value =>
+          val cq = new Text(s"$duplication,${value.cq.toString}")
+          mutation.put(value.cf, cq, value.vis, value.value)
+        }
+        mutation
+      }
+    }
+  }
+
+  override def remover(sft: SimpleFeatureType, ops: AccumuloDataStore): FeatureToMutations = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
+    val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
+    val sfc = Z3SFC(sft.getZ3Interval)
+    val getRowKeys: (WritableFeature, Int) => Seq[Array[Byte]] =
+      if (sft.isPoints) { getPointRowKey(timeToIndex, sfc) } else { getGeomRowKeys(timeToIndex, sfc) }
+
+    (wf: WritableFeature) => {
+      val rows = getRowKeys(wf, dtgIndex)
+      val duplication = Integer.toHexString(rows.length)
+      rows.map { row =>
+        val mutation = new Mutation(row)
+        wf.fullValues.foreach { value =>
+          val cq = new Text(s"$duplication,${value.cq.toString}")
+          mutation.putDelete(value.cf, cq, value.vis)
+        }
+        wf.binValues.foreach { value =>
+          val cq = new Text(s"$duplication,${value.cq.toString}")
+          mutation.putDelete(value.cf, cq, value.vis)
+        }
+        mutation
+      }
+    }
+  }
+}
+
+// polygon support and splits
+object Z3IndexV2 extends AccumuloFeatureIndex with Z3WritableIndex with Z3QueryableIndex {
+
+  override val name: String = "z3"
+
+  override val version: Int = 2
+
+  override def supports(sft: SimpleFeatureType): Boolean = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    sft.getDtgField.isDefined && sft.getGeometryDescriptor != null
+  }
+
+  override def writer(sft: SimpleFeatureType, ops: AccumuloDataStore): FeatureToMutations = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
+    val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
+    val sfc = Z3SFC(sft.getZ3Interval)
+    val getRowKeys: (WritableFeature, Int) => Seq[Array[Byte]] =
+      if (sft.isPoints) { getPointRowKey(timeToIndex, sfc) } else { getGeomRowKeys(timeToIndex, sfc) }
+
+    (wf: WritableFeature) => {
+      val rows = getRowKeys(wf, dtgIndex)
+      // store the duplication factor in the column qualifier for later use
+      val cq = if (rows.length > 1) new Text(Integer.toHexString(rows.length)) else EMPTY_TEXT
+      rows.map { row =>
+        val mutation = new Mutation(row)
+        wf.fullValues.foreach(value => mutation.put(FullColumnFamily, cq, value.vis, value.value))
+        wf.binValues.foreach(value => mutation.put(BinColumnFamily, cq, value.vis, value.value))
+        mutation
+      }
+    }
+  }
+
+  override def remover(sft: SimpleFeatureType, ops: AccumuloDataStore): FeatureToMutations = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
+    val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
+    val sfc = Z3SFC(sft.getZ3Interval)
+    val getRowKeys: (WritableFeature, Int) => Seq[Array[Byte]] =
+      if (sft.isPoints) { getPointRowKey(timeToIndex, sfc) } else { getGeomRowKeys(timeToIndex, sfc) }
+
+    (wf: WritableFeature) => {
+      val rows = getRowKeys(wf, dtgIndex)
+      val cq = if (rows.length > 1) new Text(Integer.toHexString(rows.length)) else EMPTY_TEXT
+      rows.map { row =>
+        val mutation = new Mutation(row)
+        wf.fullValues.foreach(value => mutation.putDelete(FullColumnFamily, cq, value.vis))
+        wf.binValues.foreach(value => mutation.putDelete(BinColumnFamily, cq, value.vis))
+        mutation
+      }
+    }
+  }
+}
+
+// initial z3 implementation - only supports points
+object Z3IndexV1 extends AccumuloFeatureIndex with Z3WritableIndex with Z3QueryableIndex {
+
+  override val name: String = "z3"
+
+  override val version: Int = 1
+
+  override def supports(sft: SimpleFeatureType): Boolean = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    sft.getDtgField.isDefined && sft.isPoints
+  }
+
+  override def writer(sft: SimpleFeatureType, ops: AccumuloDataStore): FeatureToMutations = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
+    val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
+    val sfc = Z3SFC(sft.getZ3Interval)
+    val getRowKeys: (WritableFeature, Int) => Seq[Array[Byte]] =
+      (wf, i) => getPointRowKey(timeToIndex, sfc)(wf, i).map(_.drop(1))
+
+    (wf: WritableFeature) => {
+      val rows = getRowKeys(wf, dtgIndex)
+      rows.map { row =>
+        val mutation = new Mutation(row)
+        wf.fullValues.foreach(value => mutation.put(FullColumnFamily, EMPTY_TEXT, value.vis, value.value))
+        wf.binValues.foreach(value => mutation.put(BinColumnFamily, EMPTY_TEXT, value.vis, value.value))
+        mutation
+      }
+    }
+  }
+
+  override def remover(sft: SimpleFeatureType, ops: AccumuloDataStore): FeatureToMutations = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+    val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
+    val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
+    val sfc = Z3SFC(sft.getZ3Interval)
+    val getRowKeys: (WritableFeature, Int) => Seq[Array[Byte]] =
+      (ftw, i) => getPointRowKey(timeToIndex, sfc)(ftw, i).map(_.drop(1))
+
+    (wf: WritableFeature) => {
+      val rows = getRowKeys(wf, dtgIndex)
+      rows.map { row =>
+        val mutation = new Mutation(row)
+        wf.fullValues.foreach(value => mutation.putDelete(FullColumnFamily, EMPTY_TEXT, value.vis))
+        wf.binValues.foreach(value => mutation.putDelete(BinColumnFamily, EMPTY_TEXT, value.vis))
+        mutation
+      }
+    }
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/legacy/AttributeIndexIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/legacy/AttributeIndexIterator.scala
@@ -12,7 +12,7 @@ import org.apache.accumulo.core.data._
 import org.apache.accumulo.core.iterators.{IteratorEnvironment, SortedKeyValueIterator}
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.locationtech.geomesa.accumulo._
-import org.locationtech.geomesa.accumulo.index.attribute.AttributeIndex.AttributeIndexV5
+import org.locationtech.geomesa.accumulo.index.attribute.AttributeIndexV1
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.locationtech.geomesa.utils.stats.IndexCoverage
@@ -152,7 +152,7 @@ class AttributeIndexIterator
    */
   def setAttributeFromRow(key: Key, sf: SimpleFeature) = {
     val row = key.getRow.toString
-    val decoded = AttributeIndexV5.decodeAttributeIndexRow(attributeRowPrefix, attributeType, row)
+    val decoded = AttributeIndexV1.decodeAttributeIndexRow(attributeRowPrefix, attributeType, row)
     decoded match {
       case Success(att) => sf.setAttribute(att.attributeName, att.attributeValue)
       case Failure(e)   => logger.error(s"Error decoding attribute row: row: $row, error: ${e.toString}")

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithDataStore.scala
@@ -18,7 +18,7 @@ import org.geotools.factory.Hints
 import org.geotools.feature.DefaultFeatureCollection
 import org.geotools.filter.text.ecql.ECQL
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
-import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.AccumuloFeatureIndex
+import org.locationtech.geomesa.accumulo.index.AccumuloWritableIndex
 import org.locationtech.geomesa.index.utils.ExplainString
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
@@ -108,7 +108,7 @@ trait TestWithDataStore extends Specification {
 
   def explain(filter: String): String = explain(new Query(sftName, ECQL.toFilter(filter)))
 
-  def scanner(table: AccumuloFeatureIndex): Scanner =
+  def scanner(table: AccumuloWritableIndex): Scanner =
     connector.createScanner(ds.getTableName(sftName, table), new Authorizations())
 
   def rowToString(key: Key) = bytesToString(key.getRow.copyBytes())

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithMultipleSfts.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithMultipleSfts.scala
@@ -20,6 +20,7 @@ import org.locationtech.geomesa.accumulo.index._
 import org.locationtech.geomesa.index.utils.ExplainString
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.index.IndexMode
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 import org.opengis.filter.identity.FeatureId
@@ -54,7 +55,7 @@ trait TestWithMultipleSfts extends Specification {
   override def map(fragments: => Fragments) = fragments ^ Step {
     val to = connector.tableOperations()
     val tables = Seq(sftBaseName) ++ sfts.flatMap { sft =>
-      Try(AccumuloFeatureIndex.indices(sft).map(ds.getTableName(sft.getTypeName, _))).getOrElse(Seq.empty)
+      Try(AccumuloFeatureIndex.indices(sft, IndexMode.Any).map(ds.getTableName(sft.getTypeName, _))).getOrElse(Seq.empty)
     }
     tables.toSet.filter(to.exists).foreach(to.delete)
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreDeleteTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreDeleteTest.scala
@@ -24,6 +24,7 @@ import org.locationtech.geomesa.accumulo.index.z3.Z3Index
 import org.locationtech.geomesa.accumulo.util.SelfClosingIterator
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.index.IndexMode
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.opengis.filter.Filter
 import org.specs2.mutable.Specification
@@ -58,7 +59,7 @@ class AccumuloDataStoreDeleteTest extends Specification with TestWithMultipleSft
       val typeName = sft.getTypeName
 
       // tests that tables exist before being deleted
-      val tables = AccumuloFeatureIndex.indices(sft)
+      val tables = AccumuloFeatureIndex.indices(sft, IndexMode.Any)
       val tableNames = tables.map(ds.getTableName(typeName, _))
       tables must containTheSameElementsAs(Seq(AttributeIndex, RecordIndex, Z2Index, Z3Index))
       forall(tableNames)(tableOps.exists(_) must beTrue)
@@ -88,12 +89,12 @@ class AccumuloDataStoreDeleteTest extends Specification with TestWithMultipleSft
       val typeName2 = sft2.getTypeName
 
       // tests that tables exist before being deleted
-      val tables1 = AccumuloFeatureIndex.indices(sft1)
+      val tables1 = AccumuloFeatureIndex.indices(sft1, IndexMode.Any)
       val tableNames1 = tables1.map(ds.getTableName(typeName1, _))
       tables1 must containTheSameElementsAs(Seq(AttributeIndex, RecordIndex, Z2Index, Z3Index))
       forall(tableNames1)(tableOps.exists(_) must beTrue)
 
-      val tables2 = AccumuloFeatureIndex.indices(sft2)
+      val tables2 = AccumuloFeatureIndex.indices(sft2, IndexMode.Any)
       val tableNames2 = tables2.map(ds.getTableName(typeName2, _))
       tables2 must containTheSameElementsAs(Seq(AttributeIndex, RecordIndex, Z2Index, Z3Index))
       forall(tableNames2)(tableOps.exists(_) must beTrue)
@@ -131,7 +132,7 @@ class AccumuloDataStoreDeleteTest extends Specification with TestWithMultipleSft
       val typeName = sft.getTypeName
 
       // tests that tables exist before being deleted
-      val tables = AccumuloFeatureIndex.indices(sft)
+      val tables = AccumuloFeatureIndex.indices(sft, IndexMode.Any)
       val tableNames = tables.map(ds.getTableName(typeName, _))
       tables must containTheSameElementsAs(Seq(AttributeIndex, RecordIndex, Z2Index, Z3Index))
       forall(tableNames)(tableOps.exists(_) must beTrue)
@@ -170,12 +171,12 @@ class AccumuloDataStoreDeleteTest extends Specification with TestWithMultipleSft
       val typeName2 = sft2.getTypeName
 
       // tests that tables exist before being deleted
-      val tables1 = AccumuloFeatureIndex.indices(sft1)
+      val tables1 = AccumuloFeatureIndex.indices(sft1, IndexMode.Any)
       val tableNames1 = tables1.map(ds.getTableName(typeName1, _))
       tables1 must containTheSameElementsAs(Seq(AttributeIndex, RecordIndex, Z2Index, Z3Index))
       forall(tableNames1)(tableOps.exists(_) must beTrue)
 
-      val tables2 = AccumuloFeatureIndex.indices(sft2)
+      val tables2 = AccumuloFeatureIndex.indices(sft2, IndexMode.Any)
       val tableNames2 = tables2.map(ds.getTableName(typeName2, _))
       tables2 must containTheSameElementsAs(Seq(AttributeIndex, RecordIndex, Z2Index, Z3Index))
       forall(tableNames2)(tableOps.exists(_) must beTrue)
@@ -263,7 +264,7 @@ class AccumuloDataStoreDeleteTest extends Specification with TestWithMultipleSft
       val ds = DataStoreFinder.getDataStore(Map("connector" -> connector, "tableName" -> catalog)).asInstanceOf[AccumuloDataStore]
       val sft = SimpleFeatureTypes.createType(catalog, "name:String:index=true,dtg:Date,*geom:Point:srid=4326")
       ds.createSchema(sft)
-      val tables = AccumuloFeatureIndex.indices(sft).map(ds.getTableName(sft.getTypeName, _)) ++ Seq(catalog, s"${catalog}_stats")
+      val tables = AccumuloFeatureIndex.indices(sft, IndexMode.Any).map(ds.getTableName(sft.getTypeName, _)) ++ Seq(catalog, s"${catalog}_stats")
       tables must haveSize(6)
       forall(tables)(tableOps.exists(_) must beTrue)
       ds.delete()

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
@@ -145,10 +145,10 @@ class AccumuloDataStoreQueryTest extends Specification with TestWithMultipleSfts
       }
 
       planNull must haveLength(1)
-      planNull.head.table must endWith(Z2Index.name)
+      planNull.head.table must endWith(Z2Index.tableSuffix)
 
       planEmpty must haveLength(1)
-      planEmpty.head.table must endWith(Z2Index.name)
+      planEmpty.head.table must endWith(Z2Index.tableSuffix)
 
       explainNull must contain("Filter plan: FilterPlan[Z2Index[BBOX(geom, 40.0,44.0,50.0,54.0)][None]]")
       explainEmpty must contain("Filter plan: FilterPlan[Z2Index[BBOX(geom, 40.0,44.0,50.0,54.0)][None]]")

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
@@ -27,6 +27,7 @@ import org.locationtech.geomesa.accumulo.index.{AccumuloFeatureIndex, AccumuloSt
 import org.locationtech.geomesa.features.avro.AvroSimpleFeatureFactory
 import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
 import org.locationtech.geomesa.utils.geotools.Conversions._
+import org.locationtech.geomesa.utils.index.IndexMode
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.opengis.filter.Filter
 import org.specs2.mutable.Specification
@@ -161,7 +162,7 @@ class AccumuloFeatureWriterTest extends Specification with TestWithDataStore wit
       val features = fs.getFeatures(Filter.INCLUDE).features().toSeq
       features must beEmpty
 
-      forall(AccumuloFeatureIndex.indices(sft).map(ds.getTableName(sft.getTypeName, _))) { name =>
+      forall(AccumuloFeatureIndex.indices(sft, IndexMode.Any).map(ds.getTableName(sft.getTypeName, _))) { name =>
         val scanner = connector.createScanner(name, new Authorizations())
         try {
           scanner.iterator().hasNext must beFalse
@@ -445,7 +446,7 @@ class AccumuloFeatureWriterTest extends Specification with TestWithDataStore wit
   }
 
   def clearTablesHard(): Unit = {
-    AccumuloFeatureIndex.indices(sft).map(ds.getTableName(sft.getTypeName, _)).foreach { name =>
+    AccumuloFeatureIndex.indices(sft, IndexMode.Any).map(ds.getTableName(sft.getTypeName, _)).foreach { name =>
       val deleter = connector.createBatchDeleter(name, new Authorizations(), 5, new BatchWriterConfig())
       deleter.setRanges(Seq(new aRange()))
       deleter.delete()

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/ConfigurableIndexesTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/ConfigurableIndexesTest.scala
@@ -8,56 +8,108 @@
 
 package org.locationtech.geomesa.accumulo.index
 
-import org.geotools.factory.CommonFactoryFinder
+import org.apache.accumulo.core.security.Authorizations
+import org.geotools.data.{Query, Transaction}
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
+import org.locationtech.geomesa.accumulo.TestWithDataStore
+import org.locationtech.geomesa.accumulo.index.z2.Z2Index
 import org.locationtech.geomesa.accumulo.index.z3.Z3Index
-import org.locationtech.geomesa.index.api.FilterSplitter
-import org.locationtech.geomesa.utils.geotools.SftBuilder
-import org.opengis.filter.Filter
+import org.locationtech.geomesa.accumulo.util.SelfClosingIterator
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.utils.index.IndexMode
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
-import scala.collection.JavaConversions._
+import scala.util.Try
 
 @RunWith(classOf[JUnitRunner])
-class ConfigurableIndexesTest extends Specification {
+class ConfigurableIndexesTest extends Specification with TestWithDataStore {
 
-  val sft = new SftBuilder()
-    .date("dtg", default = true)
-    .point("geom", default = true)
-    .withIndexes(AccumuloFeatureIndex.Schemes.Z3TableScheme)
-    .build("ConfigurableIndexesTest")
+  sequential
 
-  val splitter = new FilterSplitter(sft, AccumuloFeatureIndex.indices(sft))
+  override val spec = s"name:String,dtg:Date,*geom:Point:srid=4326;geomesa.indices.enabled='${Z3Index.name}'"
 
-  val ff = CommonFactoryFinder.getFilterFactory2
-
-  val geom                = "BBOX(geom,40,40,50,50)"
-  val geom2               = "BBOX(geom,60,60,70,70)"
-  val indexedAttr         = "attr2 = 'test'"
-  val dtg                 = "dtg DURING 2014-01-01T00:00:00Z/2014-01-01T23:59:59Z"
-
-  def and(clauses: String*) = ff.and(clauses.map(ECQL.toFilter))
-  def or(clauses: String*)  = ff.or(clauses.map(ECQL.toFilter))
-  def f(filter: String)     = ECQL.toFilter(filter)
-
-  def testFallback(filter: Filter) = {
-    val options = splitter.getQueryOptions(filter)
-    options must haveLength(1)
-    options.head.strategies must haveLength(1)
-    options.head.strategies.head.index mustEqual Z3Index
-    options.head.strategies.head.primary must beNone
-    options.head.strategies.head.secondary must beSome(filter)
+  val features = (0 until 10).map { i =>
+    val sf = new ScalaSimpleFeature(s"f-$i", sft)
+    sf.setAttribute(0, s"name-$i")
+    sf.setAttribute(1, s"2016-01-01T0$i:01:00.000Z")
+    sf.setAttribute(2, s"POINT(4$i 5$i)")
+    sf
   }
+  addFeatures(features)
 
   "AccumuloDataStore" should {
-    "be able to use z3 for everything" >> {
-      "spatial" >>                            { testFallback(f(geom)) }
-      "spatial ands" >>                       { testFallback(and(geom, geom2)) }
-      "spatial ors" >>                        { testFallback(or(geom, geom2)) }
-      "spatial and attribute ors" >>          { testFallback(or(geom, indexedAttr)) }
-      "spatial temporal and attribute ors" >> { testFallback(or(geom, dtg, indexedAttr)) }
+    "only create the z3 index" >> {
+      ds.tableOps.exists(ds.getTableName(sft.getTypeName, Z3Index)) must beTrue
+      forall(AccumuloFeatureIndex.AllIndices.filter(i => i != Z3Index)) { i =>
+        Try(ds.getTableName(sft.getTypeName, i)).map(ds.tableOps.exists).getOrElse(false) must beFalse
+      }
+    }
+
+    "be able to use z3 for spatial queries" >> {
+      val filter = "BBOX(geom,40,50,50,60)"
+      val query = new Query(sftName, ECQL.toFilter(filter))
+      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList
+      results must haveSize(10)
+      results.map(_.getID) must containTheSameElementsAs((0 until 10).map(i => s"f-$i"))
+    }
+
+    "be able to use z3 for spatial ors" >> {
+      val filter = "BBOX(geom,40,50,45,55) OR BBOX(geom,44,54,50,60) "
+      val query = new Query(sftName, ECQL.toFilter(filter))
+      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList
+      results must haveSize(10)
+      results.map(_.getID) must containTheSameElementsAs((0 until 10).map(i => s"f-$i"))
+    }
+
+    "be able to use z3 for spatial and attribute ors" >> {
+      val filter = "BBOX(geom,40,50,45,55) OR name IN ('name-6', 'name-7', 'name-8', 'name-9')"
+      val query = new Query(sftName, ECQL.toFilter(filter))
+      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList
+      results must haveSize(10)
+      results.map(_.getID) must containTheSameElementsAs((0 until 10).map(i => s"f-$i"))
+    }
+
+    "add another empty index" >> {
+      import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+      sft.setIndices(sft.getIndices :+ (Z2Index.name, Z2Index.version, IndexMode.ReadWrite))
+      ds.updateSchema(sftName, sft)
+      forall(Seq(Z3Index, Z2Index))(i => ds.tableOps.exists(ds.getTableName(sft.getTypeName, i)) must beTrue)
+      forall(AccumuloFeatureIndex.AllIndices.filter(i => i != Z3Index && i != Z2Index)) { i =>
+        Try(ds.getTableName(sft.getTypeName, i)).map(ds.tableOps.exists).getOrElse(false) must beFalse
+      }
+      val scanner = connector.createScanner(ds.getTableName(sft.getTypeName, Z2Index), new Authorizations)
+      try {
+        scanner.iterator.hasNext must beFalse
+      } finally {
+        scanner.close()
+      }
+    }
+
+    "use another index" >> {
+      val filter = "BBOX(geom,40,50,51,61)"
+      val query = new Query(sftName, ECQL.toFilter(filter))
+      var results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList
+      results must beEmpty
+
+      val sf = new ScalaSimpleFeature(s"f-10", ds.getSchema(sftName))
+      sf.setAttribute(0, "name-10")
+      sf.setAttribute(1, "2016-01-01T10:01:00.000Z")
+      sf.setAttribute(2, "POINT(50 60)")
+      addFeatures(Seq(sf))
+
+      results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList
+      results must haveSize(1)
+      results.head.getID mustEqual "f-10"
+    }
+
+    "use the original index" >> {
+      val filter = "BBOX(geom,40,50,51,61) AND dtg DURING 2016-01-01T00:00:00.000Z/2016-01-02T00:00:00.000Z"
+      val query = new Query(sftName, ECQL.toFilter(filter))
+      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList
+      results must haveSize(11)
+      results.map(_.getID) must containTheSameElementsAs((0 until 11).map(i => s"f-$i"))
     }
   }
 }

--- a/geomesa-filter/src/main/java/org/locationtech/geomesa/filter/HotfixExtractBoundsFilterVisitor.java
+++ b/geomesa-filter/src/main/java/org/locationtech/geomesa/filter/HotfixExtractBoundsFilterVisitor.java
@@ -170,6 +170,7 @@ public class HotfixExtractBoundsFilterVisitor extends NullFilterVisitor {
         ReferencedEnvelope bbox = bbox( data );
 
         // consider doing reprojection here into data CRS?
+        @SuppressWarnings("deprecation")
         Envelope bounds = new Envelope(filter.getMinX(), filter.getMaxX(), filter.getMinY(), filter
                 .getMaxY());
         if(bbox != null) {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
@@ -24,6 +24,13 @@ trait GeoMesaFeatureIndex[Ops <: HasGeoMesaStats, FeatureWrapper, Result, Plan] 
   def name: String
 
   /**
+    * Current version of the index
+    *
+    * @return
+    */
+  def version: Int
+
+  /**
     * Is the index compatible with the given feature type
     *
     * @param sft simple feature type

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/index/AttributeIndexJob.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/index/AttributeIndexJob.scala
@@ -98,15 +98,12 @@ class AttributeIndexJob extends Tool {
     val result = job.waitForCompletion(true)
 
     if (result) {
-      // update the metadata
+      // update the metadata and splits
       // reload the sft, as we nulled out the index flags earlier
       val sft = ds.getSchema(typeName)
       def wasIndexed(ad: AttributeDescriptor) = attributes.contains(ad.getLocalName)
       sft.getAttributeDescriptors.filter(wasIndexed).foreach(_.setIndexCoverage(coverage))
-      val updatedSpec = SimpleFeatureTypes.encodeType(sft)
-      ds.updateIndexedAttributes(typeName, updatedSpec)
-      // configure the table splits
-      AttributeIndex.configure(sft, ds)
+      ds.updateSchema(typeName, sft)
       // schedule a table compaction to clean up the table
       ds.connector.tableOperations().compact(tableName, null, null, true, false)
     }

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaInputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaInputFormat.scala
@@ -30,6 +30,7 @@ import org.locationtech.geomesa.features.SerializationOption.SerializationOption
 import org.locationtech.geomesa.features.SerializationType.SerializationType
 import org.locationtech.geomesa.features.{ScalaSimpleFeature, SimpleFeatureDeserializers, SimpleFeatureSerializer}
 import org.locationtech.geomesa.jobs.{GeoMesaConfigurator, JobUtils}
+import org.locationtech.geomesa.utils.index.IndexMode
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 
@@ -125,9 +126,9 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with LazyLoggi
     encoding = ds.getFeatureEncoding(sft)
     desiredSplitCount = GeoMesaConfigurator.getDesiredSplits(conf)
     val tableName = GeoMesaConfigurator.getTable(conf)
-    table = AccumuloFeatureIndex.indices(sft).find(t => tableName.endsWith(t.name)).getOrElse {
-      throw new RuntimeException(s"Couldn't find input table $tableName")
-    }
+    table = AccumuloFeatureIndex.indices(sft, IndexMode.Read)
+        .find(t => ds.getTableName(sft.getTypeName, t) == tableName)
+        .getOrElse(throw new RuntimeException(s"Couldn't find input table $tableName"))
     ds.dispose()
   }
 

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
@@ -31,6 +31,7 @@ import org.locationtech.geomesa.features.SerializationOption.SerializationOption
 import org.locationtech.geomesa.features.SerializationType.SerializationType
 import org.locationtech.geomesa.features.SimpleFeatureDeserializers
 import org.locationtech.geomesa.jobs.{GeoMesaConfigurator, JobUtils}
+import org.locationtech.geomesa.utils.index.IndexMode
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 
@@ -157,9 +158,9 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with LazyLoggi
     encoding = ds.getFeatureEncoding(sft)
     desiredSplitCount = GeoMesaConfigurator.getDesiredSplits(conf)
     val tableName = GeoMesaConfigurator.getTable(conf)
-    table = AccumuloFeatureIndex.indices(sft).find(t => tableName.endsWith(t.name)).getOrElse {
-      throw new RuntimeException(s"Couldn't find input table $tableName")
-    }
+    table = AccumuloFeatureIndex.indices(sft, IndexMode.Read)
+        .find(t => ds.getTableName(sft.getTypeName, t) == tableName)
+        .getOrElse(throw new RuntimeException(s"Couldn't find input table $tableName"))
     ds.dispose()
   }
 

--- a/geomesa-native-api/src/main/scala/org/locationtech/geomesa/api/AccumuloGeoMesaIndex.scala
+++ b/geomesa-native-api/src/main/scala/org/locationtech/geomesa/api/AccumuloGeoMesaIndex.scala
@@ -210,17 +210,5 @@ object AccumuloGeoMesaIndex {
     builder.build(name)
   }
 
-  def getTableNames[T](name: String): JList[String] =
-    getTableNames[T](name, new DefaultSimpleFeatureView[T](name))
-
-  def getTableNames[T](name: String, view: SimpleFeatureView[T]): JList[String] = {
-    val sft = buildSimpleFeatureType(name)(view)
-    val tables = AccumuloFeatureIndex.indices(sft).map {
-      case Z3Index => GeoMesaTable.formatSoloTableName(name, Z3Index.name, sft.getTypeName)
-      case index   => GeoMesaTable.formatTableName(name, index.name, sft)
-    }
-    (tables :+ name :+ s"${name}_stats").asJava
-  }
-
   final val VISIBILITY = "visibility"
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/TableConfCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/TableConfCommand.scala
@@ -17,6 +17,7 @@ import org.locationtech.geomesa.tools.accumulo.AccumuloRunner.mkSubCommand
 import org.locationtech.geomesa.tools.accumulo.commands.TableConfCommand._
 import org.locationtech.geomesa.tools.accumulo.{DataStoreHelper, GeoMesaConnectionParams}
 import org.locationtech.geomesa.tools.common.FeatureTypeNameParam
+import org.locationtech.geomesa.utils.index.IndexMode
 
 import scala.collection.JavaConversions._
 
@@ -96,7 +97,7 @@ object TableConfCommand {
     }
   
   def getTableName(ds: AccumuloDataStore, params: ListParams) =
-    AccumuloFeatureIndex.indices(ds.getSchema(params.featureName))
+    AccumuloFeatureIndex.indices(ds.getSchema(params.featureName), IndexMode.Any)
         .find(_.name == params.tableSuffix)
         .map(ds.getTableName(params.featureName, _))
         .getOrElse(throw new Exception(s"Invalid table suffix: ${params.tableSuffix}"))

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SftBuilder.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SftBuilder.scala
@@ -111,7 +111,7 @@ abstract class InitBuilder[T] {
   def attributeDescriptor(ad: AttributeDescriptor) =
     append(ad.getLocalName, Opts(), ad.getType.getBinding.getCanonicalName)
 
-  def withIndexes(indexSuffixes: List[String]): T = userData(ENABLED_INDEXES, indexSuffixes.mkString(","))
+  def withIndexes(indexSuffixes: List[String]): T = userData(ENABLED_INDEXES.head, indexSuffixes.mkString(","))
 
   def userData(key: String, value: String): T = {
     options.append(s"$key='$value'")

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
@@ -31,12 +31,12 @@ object SimpleFeatureTypes {
 
   val TABLE_SPLITTER           = "table.splitter.class"
   val TABLE_SPLITTER_OPTIONS   = "table.splitter.options"
-  val ENABLED_INDEXES          = "geomesa.indexes.enabled"
+  val INDEX_VERSIONS           = "geomesa.indices"
   val MIXED_GEOMETRIES         = "geomesa.mixed.geometries"
   val RESERVED_WORDS           = "override.reserved.words" // note: doesn't start with geomesa so we don't persist it
 
-  @deprecated
-  val ENABLED_INDEXES_OLD      = "table.indexes.enabled"
+  // keep around old values for back compatibility
+  val ENABLED_INDEXES          = Seq("geomesa.indices.enabled", "geomesa.indexes.enabled", "table.indexes.enabled")
 
   val OPT_DEFAULT              = "default"
   val OPT_SRID                 = "srid"
@@ -746,7 +746,7 @@ object SimpleFeatureTypes {
     private val EQ = "="
 
     def optValue = quotedString | nonQuotedString
-    def fOptKey = "[a-zA-Z0-9\\.]+".r
+    def fOptKey = "[a-zA-Z0-9\\._]+".r
     def fOptKeyValue =  (fOptKey <~ EQ) ~ optValue ^^ {  x => x._1 -> x._2 }
 
     def fOptList = repsep(fOptKeyValue, ",") ^^ { case optPairs =>
@@ -757,7 +757,7 @@ object SimpleFeatureTypes {
         Splitter(ts, tsOpts)
       }
 
-      val enabledOpt = optMap.get(ENABLED_INDEXES).map(new ListSplitter().parse).map(EnabledIndexes)
+      val enabledOpt = ENABLED_INDEXES.flatMap(optMap.get).headOption.map(new ListSplitter().parse).map(EnabledIndexes)
 
       // other arbitrary options
       val known = Seq(TABLE_SPLITTER, TABLE_SPLITTER_OPTIONS, ENABLED_INDEXES)

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/IndexMode.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/IndexMode.scala
@@ -1,0 +1,29 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.utils.index
+
+/**
+  * BitSet for indicating read/write mode of an index
+  */
+object IndexMode {
+
+  private val ReadBit  = 1 // 01
+  private val WriteBit = 2 // 10
+
+  val Any       = new IndexMode(0)
+  val Read      = new IndexMode(ReadBit)
+  val Write     = new IndexMode(WriteBit)
+  val ReadWrite = new IndexMode(ReadBit | WriteBit)
+
+  class IndexMode(val flag: Int) extends AnyRef {
+    def read: Boolean =  (flag & ReadBit)  != 0
+    def write: Boolean = (flag & WriteBit) != 0
+    def supports(m: IndexMode): Boolean = (this.read || !m.read) && (this.write || !m.write)
+  }
+}


### PR DESCRIPTION
~~Note: stacks on top of #1013~~

* Indices can be enabled/disabled by calling AccumuloDataStore.updateSchema
* Indices can be marked as read-only, write-only, or read-write
* Currently no handling of overlapping indices in query planning
* Removed AccumuloDataStore.updateAttributes in favor of updateSchema

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>