### PR TITLE
GEOMESA-1407 Fix Accumulo quick start instructions about time dimension.

### DIFF
--- a/docs/tutorials/geomesa-quickstart-accumulo.rst
+++ b/docs/tutorials/geomesa-quickstart-accumulo.rst
@@ -208,10 +208,6 @@ updated: Data and Dimensions.
 In the Data pane, enter values for the bounding boxes. In this case, you
 can click on the link to compute these values from the data.
 
-In the Dimensions tab, check the "Enabled" checkbox under Time. Then
-select "When" in the Attribute and End Attribute dropdowns, and
-"Continuous Interval" in the Presentation dropdown.
-
 Click on the "Save" button when you are done.
 
 Take a look


### PR DESCRIPTION
Accumulo quickstart says to configure the time dimension. Doing this only allows one point to be visible, diverging experience from the example results.

Signed-off-by: Austin Heyne <aheyne@ccri.com>