### PR TITLE
GEOMESA-1422 Allow GeoMesaInputFormat to use Accumulo mock connection

### DIFF
--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaInputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaInputFormat.scala
@@ -12,7 +12,7 @@ import java.io._
 import java.lang.Float.isNaN
 
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.accumulo.core.client.mapred.{AccumuloInputFormat, InputFormatBase, RangeInputSplit}
+import org.apache.accumulo.core.client.mapred.{AccumuloInputFormat, AbstractInputFormat, InputFormatBase, RangeInputSplit}
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
 import org.apache.accumulo.core.data.{Key, Value}
 import org.apache.accumulo.core.security.Authorizations
@@ -68,7 +68,10 @@ object GeoMesaInputFormat extends LazyLogging {
 
     val instance = AccumuloDataStoreParams.instanceIdParam.lookUp(dsParams).asInstanceOf[String]
     val zookeepers = AccumuloDataStoreParams.zookeepersParam.lookUp(dsParams).asInstanceOf[String]
-    InputFormatBaseAdapter.setZooKeeperInstance(job, instance, zookeepers)
+    if (AccumuloDataStoreParams.mockParam.lookUp(dsParams).asInstanceOf[String] == "true")
+      AbstractInputFormat.setMockInstance(job, instance)
+    else
+      InputFormatBaseAdapter.setZooKeeperInstance(job, instance, zookeepers)
 
     val auths = Option(AccumuloDataStoreParams.authsParam.lookUp(dsParams).asInstanceOf[String])
     auths.foreach(a => InputFormatBaseAdapter.setScanAuthorizations(job, new Authorizations(a.split(","): _*)))

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
@@ -71,7 +71,7 @@ object GeoMesaInputFormat extends LazyLogging {
 
     val instance = AccumuloDataStoreParams.instanceIdParam.lookUp(dsParams).asInstanceOf[String]
     val zookeepers = AccumuloDataStoreParams.zookeepersParam.lookUp(dsParams).asInstanceOf[String]
-    if(AccumuloDataStoreParams.mockParam.lookUp(dsParams).asInstanceOf[String] == "true")
+    if (AccumuloDataStoreParams.mockParam.lookUp(dsParams).asInstanceOf[String] == "true")
       AbstractInputFormat.setMockInstance(job, instance)
     else
       InputFormatBaseAdapter.setZooKeeperInstance(job, instance, zookeepers)

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaInputFormat.scala
@@ -13,7 +13,8 @@ import java.lang.Float._
 import java.net.{URL, URLClassLoader}
 
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.accumulo.core.client.mapreduce.{AccumuloInputFormat, InputFormatBase, RangeInputSplit}
+import org.apache.accumulo.core.client.mapreduce.{AccumuloInputFormat, AbstractInputFormat, InputFormatBase, RangeInputSplit}
+import org.apache.accumulo.core.client.mock.MockInstance
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
 import org.apache.accumulo.core.data.{Key, Value}
 import org.apache.accumulo.core.security.Authorizations
@@ -61,17 +62,32 @@ object GeoMesaInputFormat extends LazyLogging {
    */
   def configure(job: Job, dsParams: Map[String, String], query: Query): Unit = {
 
-    val ds = DataStoreFinder.getDataStore(dsParams).asInstanceOf[AccumuloDataStore]
+    val user = AccumuloDataStoreParams.userParam.lookUp(dsParams).asInstanceOf[String]
+    val password = AccumuloDataStoreParams.passwordParam.lookUp(dsParams).asInstanceOf[String]
+    val isMock = AccumuloDataStoreParams.mockParam.lookUp(dsParams).asInstanceOf[String].toBoolean
+
+    val params: Map[String, Any] =
+      if(isMock) {
+        val connector = new MockInstance("fake").getConnector(user, new PasswordToken(password))
+        connector.securityOperations().changeUserAuthorizations(user, new Authorizations("admin", "user"))
+
+        Map(
+          "connector" -> connector,
+          "caching"   -> false,
+          "tableName" -> AccumuloDataStoreParams.tableNameParam.lookUp(dsParams).asInstanceOf[String]
+        )
+      } else dsParams
+
+    val ds = DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
     assert(ds != null, "Invalid data store parameters")
 
     // set up the underlying accumulo input format
-    val user = AccumuloDataStoreParams.userParam.lookUp(dsParams).asInstanceOf[String]
-    val password = AccumuloDataStoreParams.passwordParam.lookUp(dsParams).asInstanceOf[String]
     InputFormatBaseAdapter.setConnectorInfo(job, user, new PasswordToken(password.getBytes))
 
     val instance = AccumuloDataStoreParams.instanceIdParam.lookUp(dsParams).asInstanceOf[String]
     val zookeepers = AccumuloDataStoreParams.zookeepersParam.lookUp(dsParams).asInstanceOf[String]
-    InputFormatBaseAdapter.setZooKeeperInstance(job, instance, zookeepers)
+    if(isMock) AbstractInputFormat.setMockInstance(job, instance)
+    else InputFormatBaseAdapter.setZooKeeperInstance(job, instance, zookeepers)
 
     val auths = Option(AccumuloDataStoreParams.authsParam.lookUp(dsParams).asInstanceOf[String])
     auths.foreach(a => InputFormatBaseAdapter.setScanAuthorizations(job, new Authorizations(a.split(","): _*)))
@@ -151,7 +167,23 @@ class GeoMesaInputFormat extends InputFormat[Text, SimpleFeature] with LazyLoggi
   var table: GeoMesaTable = null
 
   private def init(conf: Configuration) = if (sft == null) {
-    val params = GeoMesaConfigurator.getDataStoreInParams(conf)
+    val dsParams = GeoMesaConfigurator.getDataStoreInParams(conf)
+    val user = AccumuloDataStoreParams.userParam.lookUp(dsParams).asInstanceOf[String]
+    val password = AccumuloDataStoreParams.passwordParam.lookUp(dsParams).asInstanceOf[String]
+    val isMock = AccumuloDataStoreParams.mockParam.lookUp(dsParams).asInstanceOf[String].toBoolean
+
+    val params =
+    if(isMock) {
+      val connector = new MockInstance("fake").getConnector(user, new PasswordToken(password))
+      connector.securityOperations().changeUserAuthorizations(user, new Authorizations("admin", "user"))
+
+      Map(
+        "connector" -> connector,
+        "caching"   -> false,
+        "tableName" -> AccumuloDataStoreParams.tableNameParam.lookUp(dsParams).asInstanceOf[String]
+      )
+    } else dsParams
+
     val ds = DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
     sft = ds.getSchema(GeoMesaConfigurator.getFeatureType(conf))
     encoding = ds.getFeatureEncoding(sft)


### PR DESCRIPTION
This pr allows `GeoMesaInputFormat` to work with Accumulo mock connection.

Signed-off-by: Grigory Pomadchin gr.pomadchin@gmail.com