### PR TITLE
GEOMESA-1427 Support Scala 2.10 and 2.11 profiles

### DIFF
--- a/dev/change-scala-version.sh
+++ b/dev/change-scala-version.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+VALID_VERSIONS=( 2.10 2.11 )
+
+usage() {
+  echo "Usage: $(basename $0) [-h|--help] <version>
+where :
+  -h| --help Display this help text
+  valid version values : ${VALID_VERSIONS[*]}
+" 1>&2
+  exit 1
+}
+
+if [[ ($# -ne 1) || ( $1 == "--help") ||  $1 == "-h" ]]; then
+  usage
+fi
+
+TO_VERSION=$1
+
+check_scala_version() {
+  for i in ${VALID_VERSIONS[*]}; do [ $i = "$1" ] && return 0; done
+  echo "Invalid Scala version: $1. Valid versions: ${VALID_VERSIONS[*]}" 1>&2
+  exit 1
+}
+
+check_scala_version "$TO_VERSION"
+
+if [ $TO_VERSION = "2.11" ]; then
+  FROM_VERSION="2.10"
+else
+  FROM_VERSION="2.11"
+fi
+
+sed_i() {
+  sed -e "$1" "$2" > "$2.tmp" && mv "$2.tmp" "$2"
+}
+
+export -f sed_i
+
+BASEDIR=$(dirname $0)/..
+find "$BASEDIR" -name 'pom.xml' -not -path '*target*' -print \
+  -exec bash -c "sed_i 's/\(artifactId.*\)_'$FROM_VERSION'/\1_'$TO_VERSION'/g' {}" \;
+
+# Also update <scala.binary.version> in parent POM
+# Match any scala binary version to ensure idempotency
+sed_i '1,/<scala\.binary\.version>[0-9]*\.[0-9]*</s/<scala\.binary\.version>[0-9]*\.[0-9]*</<scala.binary.version>'$TO_VERSION'</' \
+  "$BASEDIR/pom.xml"
+

--- a/dev/change-version-to-2.10.sh
+++ b/dev/change-version-to-2.10.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script exists for backwards compability. Use change-scala-version.sh instead.
+echo "This script is deprecated. Please instead run: change-scala-version.sh 2.10"
+
+$(dirname $0)/change-scala-version.sh 2.10

--- a/dev/change-version-to-2.11.sh
+++ b/dev/change-version-to-2.11.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script exists for backwards compability. Use change-scala-version.sh instead.
+echo "This script is deprecated. Please instead run: change-scala-version.sh 2.11"
+
+$(dirname $0)/change-scala-version.sh 2.11

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -11,7 +11,7 @@
 
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -11,7 +11,7 @@
 
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
@@ -9,13 +9,13 @@
         
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-accumulo</artifactId>
+        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-accumulo-compute</artifactId>
+    <artifactId>geomesa-accumulo-compute_${scala.binary.version}</artifactId>
     <name>GeoMesa Compute</name>
 
     <properties>
@@ -36,11 +36,17 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-jobs</artifactId>
+            <artifactId>geomesa-accumulo-jobs_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-wkt</artifactId>
+            <version>${gt.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
@@ -79,24 +85,24 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.11</artifactId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-catalyst_2.11</artifactId>
+            <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.11</artifactId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-yarn_2.11</artifactId>
+            <artifactId>spark-yarn_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -122,7 +128,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
@@ -9,13 +9,13 @@
         
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-accumulo-compute_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-accumulo-compute_2.11</artifactId>
     <name>GeoMesa Compute</name>
 
     <properties>
@@ -36,11 +36,11 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-jobs_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-jobs_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
@@ -11,11 +11,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-accumulo</artifactId>
+        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>geomesa-accumulo-datastore</artifactId>
+    <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
     <name>GeoMesa Accumulo DataStore</name>
 
     <properties>
@@ -25,29 +25,27 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-index-api</artifactId>
+            <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter</artifactId>
+            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security</artifactId>
+            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all</artifactId>
-            <version>${project.version}</version>
+            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-z3</artifactId>
-            <version>${project.version}</version>
+            <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
@@ -132,10 +130,6 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
-        </dependency>
-        <dependency>
             <!-- 'works with' due to license issues -->
             <groupId>javax.media</groupId>
             <artifactId>jai_core</artifactId>
@@ -152,7 +146,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
@@ -11,11 +11,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-accumulo_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
     <name>GeoMesa Accumulo DataStore</name>
 
     <properties>
@@ -25,27 +25,27 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-index-api_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-filter_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-security_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-all_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-z3_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/stats/GeoMesaMetadataStats.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/stats/GeoMesaMetadataStats.scala
@@ -158,7 +158,7 @@ class GeoMesaMetadataStats(val ds: AccumuloDataStore, statsTable: String, genera
       val geomDtgOption = for {
         geom <- Option(sft.getGeomField)
         dtg  <- sft.getDtgField
-        if toRetrieve.contains(geom) && toRetrieve.contains(dtg)
+        if toRetrieve.exists(_ == geom) && toRetrieve.exists(_ == dtg)
       } yield {
         (geom, dtg)
       }
@@ -510,7 +510,7 @@ object GeoMesaMetadataStats {
       attach(Map(sftKey -> sftOpt, "all" -> "true"))
     } else {
       val existingSfts = existing.getOptions.filter(_._1.startsWith(StatsCombiner.SftOption))
-      if (!existingSfts.get(sftKey).contains(sftOpt)) {
+      if (!existingSfts.get(sftKey).exists(_ == sftOpt)) {
         tableOps.removeIterator(table, CombinerName, java.util.EnumSet.allOf(classOf[IteratorScope]))
         attach(existingSfts.toMap ++ Map(sftKey -> sftOpt, "all" -> "true"))
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/XZ2QueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/XZ2QueryableIndex.scala
@@ -37,7 +37,7 @@ trait XZ2QueryableIndex extends AccumuloFeatureIndex
                             explain: Explainer): QueryPlan = {
 
     import QueryHints.RichHints
-    import org.locationtech.geomesa.filter.FilterHelper._
+    import org.locationtech.geomesa.filter.FilterHelper.{logger => _, _}
     import org.locationtech.geomesa.filter._
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType._
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/Z2QueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/Z2QueryableIndex.scala
@@ -41,7 +41,7 @@ trait Z2QueryableIndex extends AccumuloFeatureIndex
 
     import AccumuloWritableIndex.{BinColumnFamily, FullColumnFamily}
     import QueryHints.{LOOSE_BBOX, RichHints}
-    import org.locationtech.geomesa.filter.FilterHelper._
+    import org.locationtech.geomesa.filter.FilterHelper.{logger => _, _}
     import org.locationtech.geomesa.filter._
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/XZ3QueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/XZ3QueryableIndex.scala
@@ -39,7 +39,7 @@ trait XZ3QueryableIndex extends AccumuloFeatureIndex
                             hints: Hints,
                             explain: Explainer): QueryPlan = {
     import QueryHints.RichHints
-    import org.locationtech.geomesa.filter.FilterHelper._
+    import org.locationtech.geomesa.filter.FilterHelper.{logger => _, _}
 
     // note: z3 requires a date field
     val dtgField = sft.getDtgField.getOrElse {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/Z3QueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/Z3QueryableIndex.scala
@@ -44,7 +44,7 @@ trait Z3QueryableIndex extends AccumuloFeatureIndex
     import AccumuloWritableIndex.{BinColumnFamily, FullColumnFamily}
     import Z3Index.GEOM_Z_NUM_BYTES
     import org.locationtech.geomesa.accumulo.index.QueryHints.{LOOSE_BBOX, RichHints}
-    import org.locationtech.geomesa.filter.FilterHelper._
+    import org.locationtech.geomesa.filter.FilterHelper.{logger => _, _}
 
     // note: z3 requires a date field
     val dtgField = sft.getDtgField.getOrElse {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/BinAggregatingIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/BinAggregatingIterator.scala
@@ -399,7 +399,7 @@ object BinAggregatingIterator extends LazyLogging {
     is.addOption(GEOM_OPT, sft.indexOf(geom).toString)
     val dtgIndex = dtg.map(sft.indexOf).getOrElse(-1)
     is.addOption(DATE_OPT, dtgIndex.toString)
-    if (sft.isLines && dtgIndex != -1 && sft.getDescriptor(dtgIndex).getListType().contains(classOf[Date])) {
+    if (sft.isLines && dtgIndex != -1 && sft.getDescriptor(dtgIndex).getListType().exists(_ == classOf[Date])) {
       is.addOption(DATE_ARRAY_OPT, "true")
     }
     label.foreach(l => is.addOption(LABEL_OPT, sft.indexOf(l).toString))
@@ -412,7 +412,7 @@ object BinAggregatingIterator extends LazyLogging {
    * Determines if the requested fields match the precomputed bin data
    */
   def canUsePrecomputedBins(sft: SimpleFeatureType, hints: Hints): Boolean = {
-    sft.getBinTrackId.contains(hints.getBinTrackIdField) &&
+    sft.getBinTrackId.exists(_ == hints.getBinTrackIdField) &&
         hints.getBinGeomField.forall(_ == sft.getGeomField) &&
         hints.getBinDtgField == sft.getDtgField &&
         hints.getBinLabelField.isEmpty &&

--- a/geomesa-accumulo/geomesa-accumulo-dist/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-dist/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-accumulo_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-accumulo-dist_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-accumulo-dist_2.11</artifactId>
     <name>GeoMesa Accumulo Distribution</name>
 
     <properties>
@@ -28,40 +28,40 @@
         <!-- Accumulo (dist) -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-distributed-runtime_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-distributed-runtime_2.11</artifactId>
         </dependency>
 
         <!-- Spark (dist)-->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-compute_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-compute_2.11</artifactId>
             <classifier>shaded</classifier>
         </dependency>
 
         <!-- Yarn (dist)-->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-jobs_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-jobs_2.11</artifactId>
         </dependency>
 
         <!-- GeoServer Plugins (dist) -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-gs-plugin_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-gs-plugin_2.11</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-gs-plugin_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-blobstore-gs-plugin_2.11</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-stream-gs-plugin_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-stream-gs-plugin_2.11</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
@@ -71,17 +71,17 @@
         <!-- want to force people to install WPS -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-process_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-process_2.11</artifactId>
         </dependency>
 
         <!-- Web Services (dist) -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-web-core_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-web-core_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-web-data_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-web-data_2.11</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
@@ -90,21 +90,21 @@
         <!-- Tools (bin,lib,etc)-->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-tools_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-tools_2.11</artifactId>
         </dependency>
 
         <!-- additional deps to manage in for deploying to lib dir-->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-raster_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-raster_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>com.clearspring.analytics</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-dist/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-dist/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-accumulo</artifactId>
+        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-accumulo-dist</artifactId>
+    <artifactId>geomesa-accumulo-dist_${scala.binary.version}</artifactId>
     <name>GeoMesa Accumulo Distribution</name>
 
     <properties>
@@ -28,40 +28,40 @@
         <!-- Accumulo (dist) -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-distributed-runtime</artifactId>
+            <artifactId>geomesa-accumulo-distributed-runtime_${scala.binary.version}</artifactId>
         </dependency>
 
         <!-- Spark (dist)-->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-compute</artifactId>
+            <artifactId>geomesa-accumulo-compute_${scala.binary.version}</artifactId>
             <classifier>shaded</classifier>
         </dependency>
 
         <!-- Yarn (dist)-->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-jobs</artifactId>
+            <artifactId>geomesa-accumulo-jobs_${scala.binary.version}</artifactId>
         </dependency>
 
         <!-- GeoServer Plugins (dist) -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-gs-plugin</artifactId>
+            <artifactId>geomesa-accumulo-gs-plugin_${scala.binary.version}</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-gs-plugin</artifactId>
+            <artifactId>geomesa-blobstore-gs-plugin_${scala.binary.version}</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-stream-gs-plugin</artifactId>
+            <artifactId>geomesa-stream-gs-plugin_${scala.binary.version}</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
@@ -71,17 +71,17 @@
         <!-- want to force people to install WPS -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-process</artifactId>
+            <artifactId>geomesa-process_${scala.binary.version}</artifactId>
         </dependency>
 
         <!-- Web Services (dist) -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-web-core</artifactId>
+            <artifactId>geomesa-web-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-web-data</artifactId>
+            <artifactId>geomesa-web-data_${scala.binary.version}</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
@@ -90,25 +90,21 @@
         <!-- Tools (bin,lib,etc)-->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-tools</artifactId>
+            <artifactId>geomesa-accumulo-tools_${scala.binary.version}</artifactId>
         </dependency>
 
         <!-- additional deps to manage in for deploying to lib dir-->
         <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-xml_2.11</artifactId>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-raster_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-raster</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.clearspring.analytics</groupId>
@@ -141,6 +137,22 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>scala-2.11</id>
+            <activation>
+                <property><name>!scala-2.10</name></property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <!-- needed in the lib dir -->
+                    <groupId>org.scala-lang.modules</groupId>
+                    <artifactId>scala-xml_${scala.binary.version}</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -155,7 +167,7 @@
                         <phase>package</phase>
                         <configuration>
                             <attach>true</attach>
-                            <finalName>geomesa-accumulo-${project.version}</finalName>
+                            <finalName>geomesa-accumulo_${scala.binary.version}-${project.version}</finalName>
                             <tarLongFileMode>posix</tarLongFileMode>
                             <descriptors>
                                 <descriptor>src/main/assemblies/binary-release.xml</descriptor>

--- a/geomesa-accumulo/geomesa-accumulo-dist/src/main/assemblies/binary-release.xml
+++ b/geomesa-accumulo/geomesa-accumulo-dist/src/main/assemblies/binary-release.xml
@@ -7,7 +7,7 @@
     <format>tar.gz</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
-  <baseDirectory>geomesa-accumulo-${project.version}</baseDirectory>
+  <baseDirectory>geomesa-accumulo_${scala.binary.version}-${project.version}</baseDirectory>
   <componentDescriptors>
     <componentDescriptor>src/main/assemblies/component.xml</componentDescriptor>
   </componentDescriptors>

--- a/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
@@ -11,11 +11,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-accumulo</artifactId>
+        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>geomesa-accumulo-distributed-runtime</artifactId>
+    <artifactId>geomesa-accumulo-distributed-runtime_${scala.binary.version}</artifactId>
     <name>GeoMesa Accumulo Distributed Runtime</name>
 
     <properties>
@@ -25,11 +25,11 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-raster</artifactId>
+            <artifactId>geomesa-accumulo-raster_${scala.binary.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.geotools</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
@@ -11,11 +11,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-accumulo_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>geomesa-accumulo-distributed-runtime_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-accumulo-distributed-runtime_2.11</artifactId>
     <name>GeoMesa Accumulo Distributed Runtime</name>
 
     <properties>
@@ -25,11 +25,11 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-raster_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-raster_2.11</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.geotools</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-jobs/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/pom.xml
@@ -10,12 +10,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-accumulo_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-accumulo-jobs_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-accumulo-jobs_2.11</artifactId>
     <name>GeoMesa Jobs</name>
 
     <properties>
@@ -25,19 +25,19 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-all_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-all_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-security_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-jobs/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/pom.xml
@@ -10,12 +10,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-accumulo</artifactId>
+        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-accumulo-jobs</artifactId>
+    <artifactId>geomesa-accumulo-jobs_${scala.binary.version}</artifactId>
     <name>GeoMesa Jobs</name>
 
     <properties>
@@ -25,19 +25,19 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all</artifactId>
+            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-all</artifactId>
+            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security</artifactId>
+            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>
@@ -54,10 +54,6 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -80,7 +76,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-accumulo/geomesa-accumulo-raster/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-raster/pom.xml
@@ -11,12 +11,12 @@
 
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-accumulo</artifactId>
+        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-accumulo-raster</artifactId>
+    <artifactId>geomesa-accumulo-raster_${scala.binary.version}</artifactId>
     <name>GeoMesa Raster</name>
 
     <properties>
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -75,7 +75,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-accumulo/geomesa-accumulo-raster/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-raster/pom.xml
@@ -11,12 +11,12 @@
 
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-accumulo_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-accumulo-raster_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-accumulo-raster_2.11</artifactId>
     <name>GeoMesa Raster</name>
 
     <properties>
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
@@ -11,12 +11,12 @@
 
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-accumulo_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-accumulo-tools_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-accumulo-tools_2.11</artifactId>
     <name>GeoMesa Accumulo Tools</name>
 
     <properties>
@@ -26,39 +26,39 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-security_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-z3_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-jobs_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-jobs_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-filter_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-raster_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-raster_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-all_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-tools-common_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
@@ -11,12 +11,12 @@
 
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-accumulo</artifactId>
+        <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-accumulo-tools</artifactId>
+    <artifactId>geomesa-accumulo-tools_${scala.binary.version}</artifactId>
     <name>GeoMesa Accumulo Tools</name>
 
     <properties>
@@ -26,39 +26,39 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security</artifactId>
+            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-z3</artifactId>
+            <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-jobs</artifactId>
+            <artifactId>geomesa-accumulo-jobs_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter</artifactId>
+            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-raster</artifactId>
+            <artifactId>geomesa-accumulo-raster_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-all</artifactId>
+            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools-common</artifactId>
+            <artifactId>geomesa-tools-common_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
@@ -92,10 +92,6 @@
             <artifactId>gt-xml</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-start</artifactId>
         </dependency>
@@ -121,7 +117,8 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/EnvironmentCommand.scala
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/EnvironmentCommand.scala
@@ -83,7 +83,7 @@ class EnvironmentCommand(parent: JCommander) extends Command(parent) with LazyLo
     } else {
       val options = ConfigRenderOptions.defaults().setJson(false).setOriginComments(false)
       def render(c: Config) = c.root().render(options)
-      filtered.map { case (name, conf)=> s"converter-name=$name\n${render(conf)}\n"}.toArray.sortBy(_.self).foreach(println)
+      filtered.map { case (name, conf)=> s"converter-name=$name\n${render(conf)}\n"}.toArray.sorted.foreach(println)
     }
   }
 
@@ -95,7 +95,7 @@ class EnvironmentCommand(parent: JCommander) extends Command(parent) with LazyLo
   def listConverterNames(): Unit = {
     println("\nSimple Feature Type Converters:")
     val all = ConverterConfigLoader.confs
-    all.map { case (name, conf) => s"$name"}.toArray.sortBy(_.self).foreach(println)
+    all.map { case (name, conf) => s"$name"}.toArray.sorted.foreach(println)
   }
 }
 

--- a/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/KeywordCommand.scala
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/KeywordCommand.scala
@@ -9,12 +9,11 @@
 package org.locationtech.geomesa.tools.accumulo.commands
 
 import com.beust.jcommander._
-import org.locationtech.geomesa.tools.accumulo.commands.KeywordCommand.KeywordParameters
 import org.locationtech.geomesa.tools.accumulo.GeoMesaConnectionParams
+import org.locationtech.geomesa.tools.accumulo.commands.KeywordCommand.KeywordParameters
 import org.locationtech.geomesa.tools.common.{FeatureTypeNameParam, KeywordParamSplitter}
 
 import scala.collection.JavaConversions._
-import scala.io.StdIn
 
 class KeywordCommand(parent: JCommander) extends CommandWithCatalog(parent) {
   import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType._
@@ -34,7 +33,7 @@ class KeywordCommand(parent: JCommander) extends CommandWithCatalog(parent) {
     }
 
     if (params.removeAll) {
-      val confirm = StdIn.readLine("Remove all keywords? (y/n): ").toLowerCase
+      val confirm = System.console().readLine("Remove all keywords? (y/n): ").toLowerCase()
       if (confirm.equals("y") || confirm.equals("yes")) {
         sft.removeAllKeywords()
       } else {

--- a/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/stats/StatsHistogramCommand.scala
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/tools/accumulo/commands/stats/StatsHistogramCommand.scala
@@ -20,7 +20,6 @@ import org.locationtech.geomesa.utils.stats.{Histogram, MinMax, Stat}
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
-import scala.io.StdIn
 import scala.reflect.ClassTag
 import scala.util.Try
 
@@ -53,7 +52,7 @@ class StatsHistogramCommand(parent: JCommander) extends CommandWithCatalog(paren
                 "  3. Manually enter bounds\n" +
                 "  4. Cancel operation\n")
         while (response == null) {
-          val in = StdIn.readLine("Please enter the number of your choice: ")
+          val in = System.console().readLine("Please enter the number of your choice: ")
           response = Try(in.toInt.asInstanceOf[Integer]).filter(r => r > 0 && r < 5).getOrElse(null)
           if (response == null) {
             logger.error("Invalid input. Please enter 1-4.")
@@ -75,13 +74,13 @@ class StatsHistogramCommand(parent: JCommander) extends CommandWithCatalog(paren
             var lower: Any = null
             var upper: Any = null
             while (lower == null) {
-              lower = Converters.convert(StdIn.readLine(s"Enter initial lower bound for '$attribute': "), ct)
+              lower = Converters.convert(System.console().readLine(s"Enter initial lower bound for '$attribute': "), ct)
               if (lower == null) {
                 logger.error(s"Couldn't convert input to appropriate type: ${ct.getSimpleName}")
               }
             }
             while (upper == null) {
-              upper = Converters.convert(StdIn.readLine(s"Enter initial upper bound for '$attribute': "), ct)
+              upper = Converters.convert(System.console().readLine(s"Enter initial upper bound for '$attribute': "), ct)
               if (upper == null) {
                 logger.error(s"Couldn't convert input to appropriate type: ${ct.getSimpleName}")
               }

--- a/geomesa-accumulo/pom.xml
+++ b/geomesa-accumulo/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-accumulo</artifactId>
+    <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
     <name>GeoMesa Accumulo</name>
     <packaging>pom</packaging>
 

--- a/geomesa-accumulo/pom.xml
+++ b/geomesa-accumulo/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-accumulo_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-accumulo_2.11</artifactId>
     <name>GeoMesa Accumulo</name>
     <packaging>pom</packaging>
 

--- a/geomesa-blobstore/geomesa-blobstore-accumulo/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-accumulo/pom.xml
@@ -9,23 +9,23 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-blobstore_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-accumulo_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-blobstore-accumulo_2.11</artifactId>
     <name>GeoMesa Blobstore Accumulo Implementation</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-api_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-blobstore-api_2.11</artifactId>
         </dependency>
 
         <!-- provided dependencies -->

--- a/geomesa-blobstore/geomesa-blobstore-accumulo/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-accumulo/pom.xml
@@ -9,23 +9,23 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-blobstore</artifactId>
+        <artifactId>geomesa-blobstore_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-accumulo</artifactId>
+    <artifactId>geomesa-blobstore-accumulo_${scala.binary.version}</artifactId>
     <name>GeoMesa Blobstore Accumulo Implementation</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-api</artifactId>
+            <artifactId>geomesa-blobstore-api_${scala.binary.version}</artifactId>
         </dependency>
 
         <!-- provided dependencies -->
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/geomesa-blobstore/geomesa-blobstore-api/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-api/pom.xml
@@ -9,23 +9,23 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-blobstore_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-api_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-blobstore-api_2.11</artifactId>
     <name>GeoMesa Blobstore API</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-filter_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
         </dependency>
 
         <!--test dependencies-->

--- a/geomesa-blobstore/geomesa-blobstore-api/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-api/pom.xml
@@ -9,23 +9,23 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-blobstore</artifactId>
+        <artifactId>geomesa-blobstore_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-api</artifactId>
+    <artifactId>geomesa-blobstore-api_${scala.binary.version}</artifactId>
     <name>GeoMesa Blobstore API</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter</artifactId>
+            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
         </dependency>
 
         <!--test dependencies-->
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-exif-handler/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-exif-handler/pom.xml
@@ -9,20 +9,20 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-blobstore-handlers_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-blobstore-handlers_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-exif-handler_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-blobstore-exif-handler_2.11</artifactId>
     <name>GeoMesa Blobstore EXIF Metadata Handler</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-api_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-blobstore-api_2.11</artifactId>
         </dependency>
 
         <dependency>

--- a/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-exif-handler/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-exif-handler/pom.xml
@@ -9,20 +9,20 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-blobstore-handlers</artifactId>
+        <artifactId>geomesa-blobstore-handlers_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-exif-handler</artifactId>
+    <artifactId>geomesa-blobstore-exif-handler_${scala.binary.version}</artifactId>
     <name>GeoMesa Blobstore EXIF Metadata Handler</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-api</artifactId>
+            <artifactId>geomesa-blobstore-api_${scala.binary.version}</artifactId>
         </dependency>
 
         <dependency>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-gdal-handler/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-gdal-handler/pom.xml
@@ -9,20 +9,20 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-blobstore-handlers_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-blobstore-handlers_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-gdal-handler_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-blobstore-gdal-handler_2.11</artifactId>
     <name>GeoMesa Blobstore GDAL File Handler</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-api_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-blobstore-api_2.11</artifactId>
         </dependency>
 
         <dependency>

--- a/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-gdal-handler/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-gdal-handler/pom.xml
@@ -9,20 +9,20 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-blobstore-handlers</artifactId>
+        <artifactId>geomesa-blobstore-handlers_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-gdal-handler</artifactId>
+    <artifactId>geomesa-blobstore-gdal-handler_${scala.binary.version}</artifactId>
     <name>GeoMesa Blobstore GDAL File Handler</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-api</artifactId>
+            <artifactId>geomesa-blobstore-api_${scala.binary.version}</artifactId>
         </dependency>
 
         <dependency>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/geomesa-blobstore/geomesa-blobstore-handlers/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-blobstore_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-handlers_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-blobstore-handlers_2.11</artifactId>
     <name>GeoMesa Blobstore Handlers Parent</name>
     <packaging>pom</packaging>
 

--- a/geomesa-blobstore/geomesa-blobstore-handlers/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-blobstore</artifactId>
+        <artifactId>geomesa-blobstore_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-handlers</artifactId>
+    <artifactId>geomesa-blobstore-handlers_${scala.binary.version}</artifactId>
     <name>GeoMesa Blobstore Handlers Parent</name>
     <packaging>pom</packaging>
 

--- a/geomesa-blobstore/geomesa-blobstore-web/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-web/pom.xml
@@ -9,32 +9,32 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-blobstore</artifactId>
+        <artifactId>geomesa-blobstore_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-web</artifactId>
+    <artifactId>geomesa-blobstore-web_${scala.binary.version}</artifactId>
     <name>GeoMesa Blobstore Rest Api</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-api</artifactId>
+            <artifactId>geomesa-blobstore-api_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-accumulo</artifactId>
+            <artifactId>geomesa-blobstore-accumulo_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-web-core</artifactId>
+            <artifactId>geomesa-web-core_${scala.binary.version}</artifactId>
         </dependency>
 
         <!-- provided dependencies -->
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/geomesa-blobstore/geomesa-blobstore-web/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-web/pom.xml
@@ -9,32 +9,32 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-blobstore_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-web_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-blobstore-web_2.11</artifactId>
     <name>GeoMesa Blobstore Rest Api</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-api_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-blobstore-api_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-accumulo_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-blobstore-accumulo_2.11</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-web-core_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-web-core_2.11</artifactId>
         </dependency>
 
         <!-- provided dependencies -->

--- a/geomesa-blobstore/pom.xml
+++ b/geomesa-blobstore/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-blobstore_2.11</artifactId>
     <name>GeoMesa Blobstore Parent</name>
     <packaging>pom</packaging>
 

--- a/geomesa-blobstore/pom.xml
+++ b/geomesa-blobstore/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore</artifactId>
+    <artifactId>geomesa-blobstore_${scala.binary.version}</artifactId>
     <name>GeoMesa Blobstore Parent</name>
     <packaging>pom</packaging>
 

--- a/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-cassandra_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-cassandra_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-cassandra-datastore_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-cassandra-datastore_2.11</artifactId>
     <name>GeoMesa Cassandra DataStore</name>
 
     <dependencies>
@@ -29,19 +29,19 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-z3_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-all_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-filter_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
@@ -51,7 +51,7 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-all_2.11</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-cassandra</artifactId>
+        <artifactId>geomesa-cassandra_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-cassandra-datastore</artifactId>
+    <artifactId>geomesa-cassandra-datastore_${scala.binary.version}</artifactId>
     <name>GeoMesa Cassandra DataStore</name>
 
     <dependencies>
@@ -29,19 +29,19 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-z3</artifactId>
+            <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all</artifactId>
+            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter</artifactId>
+            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
@@ -51,7 +51,7 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-all</artifactId>
+            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -107,7 +107,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/geomesa-cassandra/geomesa-cassandra-dist/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-dist/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-cassandra_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-cassandra_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-dist-cassandra_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-dist-cassandra_2.11</artifactId>
     <name>GeoMesa Cassandra Distribution</name>
 
     <properties>
@@ -28,7 +28,7 @@
         <!-- GeoServer Plugins -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-cassandra-gs-plugin_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-cassandra-gs-plugin_2.11</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>

--- a/geomesa-cassandra/geomesa-cassandra-dist/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-dist/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-cassandra</artifactId>
+        <artifactId>geomesa-cassandra_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-dist-cassandra</artifactId>
+    <artifactId>geomesa-dist-cassandra_${scala.binary.version}</artifactId>
     <name>GeoMesa Cassandra Distribution</name>
 
     <properties>
@@ -28,7 +28,7 @@
         <!-- GeoServer Plugins -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-cassandra-gs-plugin</artifactId>
+            <artifactId>geomesa-cassandra-gs-plugin_${scala.binary.version}</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
@@ -50,7 +50,7 @@
                         <phase>package</phase>
                         <configuration>
                             <attach>true</attach>
-                            <finalName>geomesa-cassandra-${project.version}</finalName>
+                            <finalName>geomesa-cassandra_${scala.binary.version}-${project.version}</finalName>
                             <tarLongFileMode>posix</tarLongFileMode>
                             <descriptors>
                                 <descriptor>src/main/assemblies/binary-release.xml</descriptor>

--- a/geomesa-cassandra/geomesa-cassandra-dist/src/main/assemblies/binary-release.xml
+++ b/geomesa-cassandra/geomesa-cassandra-dist/src/main/assemblies/binary-release.xml
@@ -7,7 +7,7 @@
     <format>tar.gz</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
-  <baseDirectory>geomesa-cassandra-${project.version}</baseDirectory>
+  <baseDirectory>geomesa-cassandra_${scala.binary.version}-${project.version}</baseDirectory>
   <componentDescriptors>
     <componentDescriptor>src/main/assemblies/component.xml</componentDescriptor>
   </componentDescriptors>

--- a/geomesa-cassandra/pom.xml
+++ b/geomesa-cassandra/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-cassandra_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-cassandra_2.11</artifactId>
     <name>GeoMesa Cassandra</name>
     <packaging>pom</packaging>
 
@@ -24,7 +24,7 @@
         <dependencies>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-cassandra-datastore_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-cassandra-datastore_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/geomesa-cassandra/pom.xml
+++ b/geomesa-cassandra/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-cassandra</artifactId>
+    <artifactId>geomesa-cassandra_${scala.binary.version}</artifactId>
     <name>GeoMesa Cassandra</name>
     <packaging>pom</packaging>
 
@@ -24,7 +24,7 @@
         <dependencies>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-cassandra-datastore</artifactId>
+                <artifactId>geomesa-cassandra-datastore_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/geomesa-convert/geomesa-convert-all/pom.xml
+++ b/geomesa-convert/geomesa-convert-all/pom.xml
@@ -9,47 +9,47 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert</artifactId>
+        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-all</artifactId>
+    <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
     <name>GeoMesa Convert All</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common</artifactId>
+            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-avro</artifactId>
+            <artifactId>geomesa-convert-avro_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-fixedwidth</artifactId>
+            <artifactId>geomesa-convert-fixedwidth_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-json</artifactId>
+            <artifactId>geomesa-convert-json_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-text</artifactId>
+            <artifactId>geomesa-convert-text_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-xml</artifactId>
+            <artifactId>geomesa-convert-xml_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-scripting</artifactId>
+            <artifactId>geomesa-convert-scripting_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-convert/geomesa-convert-all/pom.xml
+++ b/geomesa-convert/geomesa-convert-all/pom.xml
@@ -9,43 +9,43 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-convert-all_2.11</artifactId>
     <name>GeoMesa Convert All</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-common_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-avro_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-avro_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-fixedwidth_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-fixedwidth_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-json_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-json_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-text_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-text_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-xml_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-xml_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-scripting_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-scripting_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>

--- a/geomesa-convert/geomesa-convert-avro/pom.xml
+++ b/geomesa-convert/geomesa-convert-avro/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert</artifactId>
+        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-avro</artifactId>
+    <artifactId>geomesa-convert-avro_${scala.binary.version}</artifactId>
     <name>GeoMesa Convert Avro</name>
 
     <dependencies>
@@ -33,17 +33,17 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all</artifactId>
+            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common</artifactId>
+            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-convert/geomesa-convert-avro/pom.xml
+++ b/geomesa-convert/geomesa-convert-avro/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-avro_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-convert-avro_2.11</artifactId>
     <name>GeoMesa Convert Avro</name>
 
     <dependencies>
@@ -33,11 +33,11 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-all_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-common_2.11</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/geomesa-convert/geomesa-convert-common/pom.xml
+++ b/geomesa-convert/geomesa-convert-common/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-convert-common_2.11</artifactId>
     <name>GeoMesa Convert Common</name>
 
     <dependencies>
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-all_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.media</groupId>

--- a/geomesa-convert/geomesa-convert-common/pom.xml
+++ b/geomesa-convert/geomesa-convert-common/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert</artifactId>
+        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-common</artifactId>
+    <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
     <name>GeoMesa Convert Common</name>
 
     <dependencies>
@@ -24,12 +24,8 @@
             <artifactId>config</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-parser-combinators_2.11</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all</artifactId>
+            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -37,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.media</groupId>
@@ -45,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -54,5 +50,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>scala-2.11</id>
+            <activation>
+                <property><name>!scala-2.10</name></property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.scala-lang.modules</groupId>
+                    <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
+++ b/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
@@ -9,19 +9,19 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-fixedwidth_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-convert-fixedwidth_2.11</artifactId>
     <name>GeoMesa Convert Fixed Width</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-common_2.11</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
+++ b/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
@@ -9,25 +9,25 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert</artifactId>
+        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-fixedwidth</artifactId>
+    <artifactId>geomesa-convert-fixedwidth_${scala.binary.version}</artifactId>
     <name>GeoMesa Convert Fixed Width</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common</artifactId>
+            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-convert/geomesa-convert-json/pom.xml
+++ b/geomesa-convert/geomesa-convert-json/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-json_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-convert-json_2.11</artifactId>
     <name>GeoMesa Convert Json</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-common_2.11</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/geomesa-convert/geomesa-convert-json/pom.xml
+++ b/geomesa-convert/geomesa-convert-json/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert</artifactId>
+        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-json</artifactId>
+    <artifactId>geomesa-convert-json_${scala.binary.version}</artifactId>
     <name>GeoMesa Convert Json</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common</artifactId>
+            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -32,7 +32,7 @@
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-convert/geomesa-convert-scripting/pom.xml
+++ b/geomesa-convert/geomesa-convert-scripting/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-scripting_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-convert-scripting_2.11</artifactId>
     <name>GeoMesa Convert Scripting</name>
 
     <dependencies>
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-common_2.11</artifactId>
         </dependency>
 
         <dependency>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-text_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-text_2.11</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-convert/geomesa-convert-scripting/pom.xml
+++ b/geomesa-convert/geomesa-convert-scripting/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert</artifactId>
+        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-scripting</artifactId>
+    <artifactId>geomesa-convert-scripting_${scala.binary.version}</artifactId>
     <name>GeoMesa Convert Scripting</name>
 
     <dependencies>
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common</artifactId>
+            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
         </dependency>
 
         <dependency>
@@ -42,12 +42,12 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-text</artifactId>
+            <artifactId>geomesa-convert-text_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/geomesa-convert/geomesa-convert-text/pom.xml
+++ b/geomesa-convert/geomesa-convert-text/pom.xml
@@ -9,19 +9,19 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert</artifactId>
+        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-text</artifactId>
+    <artifactId>geomesa-convert-text_${scala.binary.version}</artifactId>
     <name>GeoMesa Convert Text</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common</artifactId>
+            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-convert/geomesa-convert-text/pom.xml
+++ b/geomesa-convert/geomesa-convert-text/pom.xml
@@ -9,19 +9,19 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-text_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-convert-text_2.11</artifactId>
     <name>GeoMesa Convert Text</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-common_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/geomesa-convert/geomesa-convert-xml/pom.xml
+++ b/geomesa-convert/geomesa-convert-xml/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert</artifactId>
+        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-xml</artifactId>
+    <artifactId>geomesa-convert-xml_${scala.binary.version}</artifactId>
     <name>GeoMesa Convert XML</name>
 
     <dependencies>
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common</artifactId>
+            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -39,7 +39,7 @@
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-convert/geomesa-convert-xml/pom.xml
+++ b/geomesa-convert/geomesa-convert-xml/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert-xml_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-convert-xml_2.11</artifactId>
     <name>GeoMesa Convert XML</name>
 
     <dependencies>
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-common_2.11</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/geomesa-convert/pom.xml
+++ b/geomesa-convert/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert</artifactId>
+    <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
     <name>GeoMesa Convert</name>
     <packaging>pom</packaging>
 

--- a/geomesa-convert/pom.xml
+++ b/geomesa-convert/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-convert_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-convert_2.11</artifactId>
     <name>GeoMesa Convert</name>
     <packaging>pom</packaging>
 

--- a/geomesa-features/geomesa-feature-all/pom.xml
+++ b/geomesa-features/geomesa-feature-all/pom.xml
@@ -1,39 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-features</artifactId>
+        <artifactId>geomesa-features_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-feature-all</artifactId>
+    <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
     <name>GeoMesa Features All</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-common</artifactId>
-            <version>${project.version}</version>
+            <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-kryo</artifactId>
-            <version>${project.version}</version>
+            <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-avro</artifactId>
-            <version>${project.version}</version>
+            <artifactId>geomesa-feature-avro_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-nio</artifactId>
-            <version>${project.version}</version>
+            <artifactId>geomesa-feature-nio_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security</artifactId>
+            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -43,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/geomesa-features/geomesa-feature-all/pom.xml
+++ b/geomesa-features/geomesa-feature-all/pom.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-features_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-feature-all_2.11</artifactId>
     <name>GeoMesa Features All</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-common_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-kryo_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-avro_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-avro_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-nio_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-nio_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-security_2.11</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-features/geomesa-feature-avro/pom.xml
+++ b/geomesa-features/geomesa-feature-avro/pom.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-features_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-feature-avro_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-feature-avro_2.11</artifactId>
     <name>GeoMesa Features Avro</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-common_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-security_2.11</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-features/geomesa-feature-avro/pom.xml
+++ b/geomesa-features/geomesa-feature-avro/pom.xml
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-features</artifactId>
+        <artifactId>geomesa-features_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-feature-avro</artifactId>
+    <artifactId>geomesa-feature-avro_${scala.binary.version}</artifactId>
     <name>GeoMesa Features Avro</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-common</artifactId>
-            <version>${project.version}</version>
+            <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -48,12 +47,12 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security</artifactId>
+            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/geomesa-features/geomesa-feature-common/pom.xml
+++ b/geomesa-features/geomesa-feature-common/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-features</artifactId>
+        <artifactId>geomesa-features_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-feature-common</artifactId>
+    <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
     <name>GeoMesa Features Common</name>
 
     <dependencies>
@@ -17,11 +17,11 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/geomesa-features/geomesa-feature-common/pom.xml
+++ b/geomesa-features/geomesa-feature-common/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-features_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-feature-common_2.11</artifactId>
     <name>GeoMesa Features Common</name>
 
     <dependencies>
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>

--- a/geomesa-features/geomesa-feature-kryo/pom.xml
+++ b/geomesa-features/geomesa-feature-kryo/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-features_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-feature-kryo_2.11</artifactId>
     <name>GeoMesa Features Kryo</name>
 
     <dependencies>
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-common_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-security_2.11</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-features/geomesa-feature-kryo/pom.xml
+++ b/geomesa-features/geomesa-feature-kryo/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-features</artifactId>
+        <artifactId>geomesa-features_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-feature-kryo</artifactId>
+    <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
     <name>GeoMesa Features Kryo</name>
 
     <dependencies>
@@ -17,8 +17,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-common</artifactId>
-            <version>${project.version}</version>
+            <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
@@ -30,12 +29,12 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security</artifactId>
+            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/geomesa-features/geomesa-feature-nio/pom.xml
+++ b/geomesa-features/geomesa-feature-nio/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-features</artifactId>
+        <artifactId>geomesa-features_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-feature-nio</artifactId>
+    <artifactId>geomesa-feature-nio_${scala.binary.version}</artifactId>
     <name>GeoMesa Features NIO</name>
 
     <dependencies>
@@ -21,18 +21,17 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-common</artifactId>
-            <version>${project.version}</version>
+            <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/geomesa-features/geomesa-feature-nio/pom.xml
+++ b/geomesa-features/geomesa-feature-nio/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-features_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-feature-nio_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-feature-nio_2.11</artifactId>
     <name>GeoMesa Features NIO</name>
 
     <dependencies>
@@ -21,12 +21,12 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-common_2.11</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geomesa-features/pom.xml
+++ b/geomesa-features/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-features</artifactId>
+    <artifactId>geomesa-features_${scala.binary.version}</artifactId>
     <name>GeoMesa Features</name>
     <packaging>pom</packaging>
 

--- a/geomesa-features/pom.xml
+++ b/geomesa-features/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-features_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-features_2.11</artifactId>
     <name>GeoMesa Features</name>
     <packaging>pom</packaging>
 

--- a/geomesa-filter/pom.xml
+++ b/geomesa-filter/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-filter</artifactId>
+    <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
     <name>GeoMesa Filters and Functions</name>
 
     <properties>
@@ -49,17 +49,17 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
         </dependency>
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all</artifactId>
+            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/geomesa-filter/pom.xml
+++ b/geomesa-filter/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-filter_2.11</artifactId>
     <name>GeoMesa Filters and Functions</name>
 
     <properties>
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
         </dependency>
         <!-- test deps -->
         <dependency>
@@ -59,7 +59,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-all_2.11</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/geomesa-gs-plugin/geomesa-accumulo-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-accumulo-gs-plugin/pom.xml
@@ -11,11 +11,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-gs-plugin</artifactId>
+        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>geomesa-accumulo-gs-plugin</artifactId>
+    <artifactId>geomesa-accumulo-gs-plugin_${scala.binary.version}</artifactId>
     <name>GeoMesa Accumulo Geoserver Plugin</name>
 
     <properties>
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.geotools</groupId>
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-raster</artifactId>
+            <artifactId>geomesa-accumulo-raster_${scala.binary.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.geotools</groupId>

--- a/geomesa-gs-plugin/geomesa-accumulo-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-accumulo-gs-plugin/pom.xml
@@ -11,11 +11,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-gs-plugin_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>geomesa-accumulo-gs-plugin_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-accumulo-gs-plugin_2.11</artifactId>
     <name>GeoMesa Accumulo Geoserver Plugin</name>
 
     <properties>
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.geotools</groupId>
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-raster_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-raster_2.11</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.geotools</groupId>

--- a/geomesa-gs-plugin/geomesa-bigtable-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-bigtable-gs-plugin/pom.xml
@@ -3,18 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-gs-plugin_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-bigtable-gs-plugin_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-bigtable-gs-plugin_2.11</artifactId>
     <name>GeoMesa Bigtable GeoServer Plugin</name>
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-bigtable-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-bigtable-datastore_2.11</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>

--- a/geomesa-gs-plugin/geomesa-bigtable-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-bigtable-gs-plugin/pom.xml
@@ -3,18 +3,18 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-gs-plugin</artifactId>
+        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-bigtable-gs-plugin</artifactId>
+    <artifactId>geomesa-bigtable-gs-plugin_${scala.binary.version}</artifactId>
     <name>GeoMesa Bigtable GeoServer Plugin</name>
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-bigtable-datastore</artifactId>
+            <artifactId>geomesa-bigtable-datastore_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>

--- a/geomesa-gs-plugin/geomesa-blobstore-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-blobstore-gs-plugin/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-gs-plugin</artifactId>
+        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-gs-plugin</artifactId>
+    <artifactId>geomesa-blobstore-gs-plugin_${scala.binary.version}</artifactId>
     <name>GeoMesa BlobStore GeoServer Plugin</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-web</artifactId>
+            <artifactId>geomesa-blobstore-web_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-gs-plugin/geomesa-blobstore-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-blobstore-gs-plugin/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-gs-plugin_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-blobstore-gs-plugin_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-blobstore-gs-plugin_2.11</artifactId>
     <name>GeoMesa BlobStore GeoServer Plugin</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-blobstore-web_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-blobstore-web_2.11</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-gs-plugin/geomesa-cassandra-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-cassandra-gs-plugin/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-gs-plugin</artifactId>
+        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-cassandra-gs-plugin</artifactId>
+    <artifactId>geomesa-cassandra-gs-plugin_${scala.binary.version}</artifactId>
     <name>GeoMesa Cassandra GeoServer Plugin</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-cassandra-datastore</artifactId>
+            <artifactId>geomesa-cassandra-datastore_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/geomesa-gs-plugin/geomesa-cassandra-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-cassandra-gs-plugin/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-gs-plugin_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-cassandra-gs-plugin_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-cassandra-gs-plugin_2.11</artifactId>
     <name>GeoMesa Cassandra GeoServer Plugin</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-cassandra-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-cassandra-datastore_2.11</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/geomesa-gs-plugin/geomesa-hbase-gs-plugin/assembly.xml
+++ b/geomesa-gs-plugin/geomesa-hbase-gs-plugin/assembly.xml
@@ -19,7 +19,7 @@
             <useProjectAttachments>true</useProjectAttachments>
             <scope>runtime</scope>
             <includes>
-                <include>org.locationtech.geomesa:geomesa-hbase-gs-plugin:jar:shaded</include>
+                <include>org.locationtech.geomesa:geomesa-hbase-gs-plugin_${scala.binary.version}:jar:shaded</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/geomesa-gs-plugin/geomesa-hbase-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-hbase-gs-plugin/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-gs-plugin_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <name>GeoMesa HBase GeoServer Plugin</name>
-    <artifactId>geomesa-hbase-gs-plugin_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-hbase-gs-plugin_2.11</artifactId>
     <modelVersion>4.0.0</modelVersion>
 
     <!--
@@ -28,7 +28,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-hbase-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-hbase-datastore_2.11</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>

--- a/geomesa-gs-plugin/geomesa-hbase-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-hbase-gs-plugin/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-gs-plugin</artifactId>
+        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <name>GeoMesa HBase GeoServer Plugin</name>
-    <artifactId>geomesa-hbase-gs-plugin</artifactId>
+    <artifactId>geomesa-hbase-gs-plugin_${scala.binary.version}</artifactId>
     <modelVersion>4.0.0</modelVersion>
 
     <!--
@@ -28,7 +28,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-hbase-datastore</artifactId>
+            <artifactId>geomesa-hbase-datastore_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>

--- a/geomesa-gs-plugin/geomesa-kafka-gs-plugin/geomesa-kafka-08-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-kafka-gs-plugin/geomesa-kafka-08-gs-plugin/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-kafka-gs-plugin</artifactId>
+        <artifactId>geomesa-kafka-gs-plugin_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-08-gs-plugin</artifactId>
+    <artifactId>geomesa-kafka-08-gs-plugin_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka 08 Geoserver Plugin</name>
 
     <dependencyManagement>
@@ -24,7 +24,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-08-datastore</artifactId>
+            <artifactId>geomesa-kafka-08-datastore_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-gs-plugin/geomesa-kafka-gs-plugin/geomesa-kafka-08-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-kafka-gs-plugin/geomesa-kafka-08-gs-plugin/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-kafka-gs-plugin_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-kafka-gs-plugin_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-08-gs-plugin_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-08-gs-plugin_2.11</artifactId>
     <name>GeoMesa Kafka 08 Geoserver Plugin</name>
 
     <dependencyManagement>
@@ -24,7 +24,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-08-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-08-datastore_2.11</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-gs-plugin/geomesa-kafka-gs-plugin/geomesa-kafka-09-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-kafka-gs-plugin/geomesa-kafka-09-gs-plugin/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-kafka-gs-plugin</artifactId>
+        <artifactId>geomesa-kafka-gs-plugin_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-09-gs-plugin</artifactId>
+    <artifactId>geomesa-kafka-09-gs-plugin_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka 09 Geoserver Plugin</name>
 
     <dependencyManagement>
@@ -24,7 +24,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-09-datastore</artifactId>
+            <artifactId>geomesa-kafka-09-datastore_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-gs-plugin/geomesa-kafka-gs-plugin/geomesa-kafka-09-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-kafka-gs-plugin/geomesa-kafka-09-gs-plugin/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-kafka-gs-plugin_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-kafka-gs-plugin_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-09-gs-plugin_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-09-gs-plugin_2.11</artifactId>
     <name>GeoMesa Kafka 09 Geoserver Plugin</name>
 
     <dependencyManagement>
@@ -24,7 +24,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-09-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-09-datastore_2.11</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-gs-plugin/geomesa-kafka-gs-plugin/geomesa-kafka-10-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-kafka-gs-plugin/geomesa-kafka-10-gs-plugin/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-kafka-gs-plugin</artifactId>
+        <artifactId>geomesa-kafka-gs-plugin_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-10-gs-plugin</artifactId>
+    <artifactId>geomesa-kafka-10-gs-plugin_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka 10 Geoserver Plugin</name>
 
     <dependencyManagement>
@@ -24,7 +24,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-10-datastore</artifactId>
+            <artifactId>geomesa-kafka-10-datastore_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-gs-plugin/geomesa-kafka-gs-plugin/geomesa-kafka-10-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-kafka-gs-plugin/geomesa-kafka-10-gs-plugin/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-kafka-gs-plugin_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-kafka-gs-plugin_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-10-gs-plugin_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-10-gs-plugin_2.11</artifactId>
     <name>GeoMesa Kafka 10 Geoserver Plugin</name>
 
     <dependencyManagement>
@@ -24,7 +24,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-10-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-10-datastore_2.11</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-gs-plugin/geomesa-kafka-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-kafka-gs-plugin/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-gs-plugin_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-kafka-gs-plugin_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-gs-plugin_2.11</artifactId>
     <name>GeoMesa Kafka GeoServer Plugins Parent</name>
 
     <properties>

--- a/geomesa-gs-plugin/geomesa-kafka-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-kafka-gs-plugin/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-gs-plugin</artifactId>
+        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-kafka-gs-plugin</artifactId>
+    <artifactId>geomesa-kafka-gs-plugin_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka GeoServer Plugins Parent</name>
 
     <properties>

--- a/geomesa-gs-plugin/geomesa-stats-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-stats-gs-plugin/pom.xml
@@ -11,11 +11,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-gs-plugin_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>geomesa-stats-gs-plugin_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-stats-gs-plugin_2.11</artifactId>
     <name>GeoMesa Statistics Geoserver Plugin</name>
 
     <properties>
@@ -36,7 +36,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-metrics_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-metrics_2.11</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.geotools</groupId>
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-web-stats_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-web-stats_2.11</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>

--- a/geomesa-gs-plugin/geomesa-stats-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-stats-gs-plugin/pom.xml
@@ -11,11 +11,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-gs-plugin</artifactId>
+        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>geomesa-stats-gs-plugin</artifactId>
+    <artifactId>geomesa-stats-gs-plugin_${scala.binary.version}</artifactId>
     <name>GeoMesa Statistics Geoserver Plugin</name>
 
     <properties>
@@ -36,7 +36,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-metrics</artifactId>
+            <artifactId>geomesa-metrics_${scala.binary.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.geotools</groupId>
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-web-stats</artifactId>
+            <artifactId>geomesa-web-stats_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>

--- a/geomesa-gs-plugin/geomesa-stream-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-stream-gs-plugin/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-gs-plugin</artifactId>
+        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-stream-gs-plugin</artifactId>
+    <artifactId>geomesa-stream-gs-plugin_${scala.binary.version}</artifactId>
     <name>GeoMesa Stream GeoServer Plugin</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-stream-datastore</artifactId>
+            <artifactId>geomesa-stream-datastore_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/geomesa-gs-plugin/geomesa-stream-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/geomesa-stream-gs-plugin/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-gs-plugin_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-stream-gs-plugin_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-stream-gs-plugin_2.11</artifactId>
     <name>GeoMesa Stream GeoServer Plugin</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-stream-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-stream-datastore_2.11</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/geomesa-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-gs-plugin</artifactId>
+    <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
     <name>GeoMesa Geoserver Plugin</name>
     <packaging>pom</packaging>
 

--- a/geomesa-gs-plugin/pom.xml
+++ b/geomesa-gs-plugin/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-gs-plugin_2.11</artifactId>
     <name>GeoMesa Geoserver Plugin</name>
     <packaging>pom</packaging>
 

--- a/geomesa-hbase/geomesa-bigtable-datastore/pom.xml
+++ b/geomesa-hbase/geomesa-bigtable-datastore/pom.xml
@@ -11,13 +11,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-hbase</artifactId>
+        <artifactId>geomesa-hbase_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-bigtable-datastore</artifactId>
+    <artifactId>geomesa-bigtable-datastore_${scala.binary.version}</artifactId>
     <name>GeoMesa Bigtable DataStore</name>
 
     <properties>
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-hbase-datastore</artifactId>
+            <artifactId>geomesa-hbase-datastore_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/geomesa-hbase/geomesa-bigtable-datastore/pom.xml
+++ b/geomesa-hbase/geomesa-bigtable-datastore/pom.xml
@@ -11,13 +11,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-hbase_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-bigtable-datastore_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-bigtable-datastore_2.11</artifactId>
     <name>GeoMesa Bigtable DataStore</name>
 
     <properties>
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-hbase-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-hbase-datastore_2.11</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/geomesa-hbase/geomesa-dist-bigtable/pom.xml
+++ b/geomesa-hbase/geomesa-dist-bigtable/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-dist</artifactId>
+        <artifactId>geomesa-dist_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-dist-bigtable</artifactId>
+    <artifactId>geomesa-dist-bigtable_${scala.binary.version}</artifactId>
     <name>GeoMesa BigTable Distribution</name>
 
     <properties>
@@ -29,7 +29,7 @@
         <!-- GeoServer Plugins -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-bigtable-gs-plugin</artifactId>
+            <artifactId>geomesa-bigtable-gs-plugin_${scala.binary.version}</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
@@ -51,7 +51,7 @@
                         <phase>package</phase>
                         <configuration>
                             <attach>true</attach>
-                            <finalName>geomesa-bigtable-${project.version}</finalName>
+                            <finalName>geomesa-bigtable_${scala.binary.version}-${project.version}</finalName>
                             <tarLongFileMode>posix</tarLongFileMode>
                             <descriptors>
                                 <descriptor>src/main/assemblies/binary-release.xml</descriptor>

--- a/geomesa-hbase/geomesa-dist-bigtable/pom.xml
+++ b/geomesa-hbase/geomesa-dist-bigtable/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-dist_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-dist_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-dist-bigtable_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-dist-bigtable_2.11</artifactId>
     <name>GeoMesa BigTable Distribution</name>
 
     <properties>
@@ -29,7 +29,7 @@
         <!-- GeoServer Plugins -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-bigtable-gs-plugin_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-bigtable-gs-plugin_2.11</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>

--- a/geomesa-hbase/geomesa-dist-bigtable/src/main/assemblies/binary-release.xml
+++ b/geomesa-hbase/geomesa-dist-bigtable/src/main/assemblies/binary-release.xml
@@ -7,7 +7,7 @@
     <format>tar.gz</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
-  <baseDirectory>geomesa-bigtable-${project.version}</baseDirectory>
+  <baseDirectory>geomesa-bigtable_${scala.binary.version}-${project.version}</baseDirectory>
   <componentDescriptors>
     <componentDescriptor>src/main/assemblies/component.xml</componentDescriptor>
   </componentDescriptors>

--- a/geomesa-hbase/geomesa-dist-hbase/pom.xml
+++ b/geomesa-hbase/geomesa-dist-hbase/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-hbase</artifactId>
+        <artifactId>geomesa-hbase_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-dist-hbase</artifactId>
+    <artifactId>geomesa-dist-hbase_${scala.binary.version}</artifactId>
     <name>GeoMesa HBase Distribution</name>
 
     <properties>
@@ -29,7 +29,7 @@
         <!-- GeoServer Plugins -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-hbase-gs-plugin</artifactId>
+            <artifactId>geomesa-hbase-gs-plugin_${scala.binary.version}</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
@@ -51,7 +51,7 @@
                         <phase>package</phase>
                         <configuration>
                             <attach>true</attach>
-                            <finalName>geomesa-hbase-${project.version}</finalName>
+                            <finalName>geomesa-hbase_${scala.binary.version}-${project.version}</finalName>
                             <tarLongFileMode>posix</tarLongFileMode>
                             <descriptors>
                                 <descriptor>src/main/assemblies/binary-release.xml</descriptor>

--- a/geomesa-hbase/geomesa-dist-hbase/pom.xml
+++ b/geomesa-hbase/geomesa-dist-hbase/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-hbase_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-hbase_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-dist-hbase_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-dist-hbase_2.11</artifactId>
     <name>GeoMesa HBase Distribution</name>
 
     <properties>
@@ -29,7 +29,7 @@
         <!-- GeoServer Plugins -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-hbase-gs-plugin_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-hbase-gs-plugin_2.11</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>

--- a/geomesa-hbase/geomesa-dist-hbase/src/main/assemblies/binary-release.xml
+++ b/geomesa-hbase/geomesa-dist-hbase/src/main/assemblies/binary-release.xml
@@ -7,7 +7,7 @@
     <format>tar.gz</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
-  <baseDirectory>geomesa-hbase-${project.version}</baseDirectory>
+  <baseDirectory>geomesa-hbase_${scala.binary.version}-${project.version}</baseDirectory>
   <componentDescriptors>
     <componentDescriptor>src/main/assemblies/component.xml</componentDescriptor>
   </componentDescriptors>

--- a/geomesa-hbase/geomesa-hbase-datastore/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-datastore/pom.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-hbase</artifactId>
+        <artifactId>geomesa-hbase_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-hbase-datastore</artifactId>
+    <artifactId>geomesa-hbase-datastore_${scala.binary.version}</artifactId>
     <name>GeoMesa HBase DataStore</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-z3</artifactId>
+            <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter</artifactId>
+            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-kryo</artifactId>
+            <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
@@ -49,7 +49,7 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-hbase/geomesa-hbase-datastore/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-datastore/pom.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-hbase_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-hbase-datastore_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-hbase-datastore_2.11</artifactId>
     <name>GeoMesa HBase DataStore</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-z3_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-filter_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-kryo_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>

--- a/geomesa-hbase/pom.xml
+++ b/geomesa-hbase/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-hbase</artifactId>
+    <artifactId>geomesa-hbase_${scala.binary.version}</artifactId>
     <name>GeoMesa HBase Parent</name>
     <packaging>pom</packaging>
 

--- a/geomesa-hbase/pom.xml
+++ b/geomesa-hbase/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-hbase_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-hbase_2.11</artifactId>
     <name>GeoMesa HBase Parent</name>
     <packaging>pom</packaging>
 

--- a/geomesa-index-api/pom.xml
+++ b/geomesa-index-api/pom.xml
@@ -4,19 +4,19 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-index-api_2.11</artifactId>
     <name>GeoMesa Index API</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-filter_2.11</artifactId>
         </dependency>
 
         <!-- test dependencies -->

--- a/geomesa-index-api/pom.xml
+++ b/geomesa-index-api/pom.xml
@@ -4,25 +4,25 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-index-api</artifactId>
+    <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
     <name>GeoMesa Index API</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter</artifactId>
+            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
         </dependency>
 
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/stats/StatsBasedEstimator.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/stats/StatsBasedEstimator.scala
@@ -229,7 +229,7 @@ class CountEstimator(sft: SimpleFeatureType, stats: GeoMesaStats) extends LazyLo
 
     if (attribute == sft.getGeomField) {
       estimateSpatialCount(filter)
-    } else if (sft.getDtgField.contains(attribute)) {
+    } else if (sft.getDtgField.exists(_ == attribute)) {
       estimateTemporalCount(filter)
     } else {
       // we have an attribute filter
@@ -241,7 +241,7 @@ class CountEstimator(sft: SimpleFeatureType, stats: GeoMesaStats) extends LazyLo
         bounds.bounds.map(_.bounds)
       }
       extractedBounds.flatMap { bounds =>
-        if (bounds.contains((None, None))) {
+        if (bounds.exists(_ == (None, None))) {
           estimateCount(Filter.INCLUDE, loDate, hiDate) // inclusive filter
         } else {
           val (equalsBounds, rangeBounds) = bounds.partition { case (l, r) => l == r }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/utils/Explainer.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/utils/Explainer.scala
@@ -8,7 +8,7 @@
 
 package org.locationtech.geomesa.index.utils
 
-import com.typesafe.scalalogging.Logger
+import org.locationtech.geomesa.util.logging.Logger
 import org.slf4j.LoggerFactory
 
 trait Explainer {

--- a/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-08-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-08-datastore/pom.xml
@@ -8,13 +8,13 @@
 *********************************************************************-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-kafka-datastore_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-kafka-datastore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-08-datastore_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-08-datastore_2.11</artifactId>
     <name>GeoMesa Kafka 08 Data Store</name>
 
     <dependencyManagement>
@@ -58,15 +58,15 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-kryo_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-filter_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-security_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-08-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-08-datastore/pom.xml
@@ -8,20 +8,20 @@
 *********************************************************************-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-kafka-datastore</artifactId>
+        <artifactId>geomesa-kafka-datastore_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-08-datastore</artifactId>
+    <artifactId>geomesa-kafka-08-datastore_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka 08 Data Store</name>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka_2.11</artifactId>
+                <artifactId>kafka_${scala.binary.version}</artifactId>
                 <version>${kafka.08.version}</version>
                 <scope>provided</scope>
                 <exclusions>
@@ -58,15 +58,15 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-kryo</artifactId>
+            <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter</artifactId>
+            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security</artifactId>
+            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -85,7 +85,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>
@@ -93,11 +93,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.08.version}</version>
             <classifier>test</classifier>
             <scope>test</scope>

--- a/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-09-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-09-datastore/pom.xml
@@ -8,13 +8,13 @@
 *********************************************************************-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-kafka-datastore_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-kafka-datastore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-09-datastore_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-09-datastore_2.11</artifactId>
     <name>GeoMesa Kafka 09 Data Store</name>
 
     <dependencyManagement>
@@ -58,15 +58,15 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-kryo_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-filter_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-security_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-09-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-09-datastore/pom.xml
@@ -8,20 +8,20 @@
 *********************************************************************-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-kafka-datastore</artifactId>
+        <artifactId>geomesa-kafka-datastore_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-09-datastore</artifactId>
+    <artifactId>geomesa-kafka-09-datastore_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka 09 Data Store</name>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka_2.11</artifactId>
+                <artifactId>kafka_${scala.binary.version}</artifactId>
                 <version>${kafka.09.version}</version>
                 <scope>provided</scope>
                 <exclusions>
@@ -58,15 +58,15 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-kryo</artifactId>
+            <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter</artifactId>
+            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security</artifactId>
+            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -85,7 +85,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>
@@ -93,11 +93,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.09.version}</version>
             <classifier>test</classifier>
             <scope>test</scope>

--- a/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-10-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-10-datastore/pom.xml
@@ -8,13 +8,13 @@
 *********************************************************************-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-kafka-datastore_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-kafka-datastore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-10-datastore_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-10-datastore_2.11</artifactId>
     <name>GeoMesa Kafka 10 Data Store</name>
 
     <dependencyManagement>
@@ -75,15 +75,15 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-kryo_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-filter_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-security_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-10-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-10-datastore/pom.xml
@@ -21,7 +21,7 @@
         <dependencies>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
-		<artifactId>kafka_${scala.binary.version}</artifactId>
+		        <artifactId>kafka_${scala.binary.version}</artifactId>
                 <version>${kafka.10.version}</version>
                 <scope>provided</scope>
                 <exclusions>
@@ -102,7 +102,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-	    <artifactId>kafka_${scala.binary.version}</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>
@@ -110,11 +110,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-	    <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-	    <artifactId>kafka_${scala.binary.version}</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.10.version}</version>
             <classifier>test</classifier>
             <scope>test</scope>

--- a/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-10-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/geomesa-kafka-10-datastore/pom.xml
@@ -8,20 +8,20 @@
 *********************************************************************-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-kafka-datastore</artifactId>
+        <artifactId>geomesa-kafka-datastore_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-10-datastore</artifactId>
+    <artifactId>geomesa-kafka-10-datastore_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka 10 Data Store</name>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka_2.11</artifactId>
+		<artifactId>kafka_${scala.binary.version}</artifactId>
                 <version>${kafka.10.version}</version>
                 <scope>provided</scope>
                 <exclusions>
@@ -75,15 +75,15 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-kryo</artifactId>
+            <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter</artifactId>
+            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security</artifactId>
+            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -102,7 +102,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+	    <artifactId>kafka_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>
@@ -110,11 +110,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+	    <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+	    <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.10.version}</version>
             <classifier>test</classifier>
             <scope>test</scope>

--- a/geomesa-kafka/geomesa-kafka-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-kafka_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-kafka_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-kafka-datastore_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-datastore_2.11</artifactId>
     <name>GeoMesa Kafka Datastore Parent</name>
 
     <properties>

--- a/geomesa-kafka/geomesa-kafka-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-kafka</artifactId>
+        <artifactId>geomesa-kafka_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-kafka-datastore</artifactId>
+    <artifactId>geomesa-kafka-datastore_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka Datastore Parent</name>
 
     <properties>

--- a/geomesa-kafka/geomesa-kafka-dist/assemblies/binary-release.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/assemblies/binary-release.xml
@@ -7,7 +7,7 @@
     <format>tar.gz</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
-  <baseDirectory>geomesa-kafka-${kafka.maj.version}-${project.version}</baseDirectory>
+  <baseDirectory>geomesa-kafka-${kafka.maj.version}_${scala.binary.version}-${project.version}</baseDirectory>
   <componentDescriptors>
     <componentDescriptor>../assemblies/component.xml</componentDescriptor>
   </componentDescriptors>

--- a/geomesa-kafka/geomesa-kafka-dist/assemblies/component.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/assemblies/component.xml
@@ -77,7 +77,7 @@
     </fileSets>
     <files>
         <file>
-            <source>../../geomesa-kafka-tools/target/geomesa-kafka-tools-${project.version}.jar</source>
+            <source>../../geomesa-kafka-tools/target/geomesa-kafka-tools_${scala.binary.version}-${project.version}.jar</source>
             <outputDirectory>lib</outputDirectory>
             <fileMode>0644</fileMode>
         </file>

--- a/geomesa-kafka/geomesa-kafka-dist/geomesa-kafka-08-dist/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/geomesa-kafka-08-dist/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-kafka-dist</artifactId>
+        <artifactId>geomesa-kafka-dist_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-kafka-08-dist</artifactId>
+    <artifactId>geomesa-kafka-08-dist_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka 08 Distribution</name>
 
     <properties>
@@ -29,7 +29,7 @@
         <!-- Kafka Tools -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-tools</artifactId>
+            <artifactId>geomesa-kafka-tools_${scala.binary.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
@@ -37,7 +37,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
-                    <artifactId>kafka_2.11</artifactId>
+                    <artifactId>kafka_${scala.binary.version}</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -45,14 +45,14 @@
         <!-- Correct for excluded kafka -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.08.version}</version>
         </dependency>
 
         <!-- Kafka Datastore -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-08-datastore</artifactId>
+            <artifactId>geomesa-kafka-08-datastore_${scala.binary.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
@@ -64,7 +64,7 @@
         <!-- GeoServer Plugins -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-08-gs-plugin</artifactId>
+            <artifactId>geomesa-kafka-08-gs-plugin_${scala.binary.version}</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
@@ -91,7 +91,7 @@
                         <phase>package</phase>
                         <configuration>
                             <attach>true</attach>
-                            <finalName>geomesa-kafka-${kafka.maj.version}-${project.version}</finalName>
+                            <finalName>geomesa-kafka-${kafka.maj.version}_${scala.binary.version}-${project.version}</finalName>
                             <tarLongFileMode>posix</tarLongFileMode>
                             <delimiters>
                                 <delimiter>%%</delimiter>

--- a/geomesa-kafka/geomesa-kafka-dist/geomesa-kafka-08-dist/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/geomesa-kafka-08-dist/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-kafka-dist_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-kafka-dist_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-kafka-08-dist_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-08-dist_2.11</artifactId>
     <name>GeoMesa Kafka 08 Distribution</name>
 
     <properties>
@@ -29,7 +29,7 @@
         <!-- Kafka Tools -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-tools_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-tools_2.11</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
@@ -52,7 +52,7 @@
         <!-- Kafka Datastore -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-08-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-08-datastore_2.11</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
@@ -64,7 +64,7 @@
         <!-- GeoServer Plugins -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-08-gs-plugin_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-08-gs-plugin_2.11</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>

--- a/geomesa-kafka/geomesa-kafka-dist/geomesa-kafka-09-dist/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/geomesa-kafka-09-dist/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-kafka-dist_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-kafka-dist_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-kafka-09-dist_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-09-dist_2.11</artifactId>
     <name>GeoMesa Kafka 09 Distribution</name>
 
     <properties>
@@ -29,7 +29,7 @@
         <!-- Kafka Tools -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-tools_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-tools_2.11</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
@@ -53,7 +53,7 @@
         <!-- Kafka Datastore (shaded includes kafka-utils) -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-09-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-09-datastore_2.11</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
@@ -65,7 +65,7 @@
         <!-- GeoServer Plugins -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-09-gs-plugin_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-09-gs-plugin_2.11</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>

--- a/geomesa-kafka/geomesa-kafka-dist/geomesa-kafka-09-dist/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/geomesa-kafka-09-dist/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-kafka-dist</artifactId>
+        <artifactId>geomesa-kafka-dist_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-kafka-09-dist</artifactId>
+    <artifactId>geomesa-kafka-09-dist_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka 09 Distribution</name>
 
     <properties>
@@ -29,7 +29,7 @@
         <!-- Kafka Tools -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-tools</artifactId>
+            <artifactId>geomesa-kafka-tools_${scala.binary.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
@@ -37,7 +37,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
-                    <artifactId>kafka_2.11</artifactId>
+                    <artifactId>kafka_${scala.binary.version}</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -46,14 +46,14 @@
         <!-- Correct for excluded kafka -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.09.version}</version>
         </dependency>
 
         <!-- Kafka Datastore (shaded includes kafka-utils) -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-09-datastore</artifactId>
+            <artifactId>geomesa-kafka-09-datastore_${scala.binary.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
@@ -65,7 +65,7 @@
         <!-- GeoServer Plugins -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-09-gs-plugin</artifactId>
+            <artifactId>geomesa-kafka-09-gs-plugin_${scala.binary.version}</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
@@ -75,12 +75,6 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <!-- Additional jars needed -->
-        <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
         </dependency>
 
     </dependencies>
@@ -99,7 +93,7 @@
                         <phase>package</phase>
                         <configuration>
                             <attach>true</attach>
-                            <finalName>geomesa-kafka-${kafka.maj.version}-${project.version}</finalName>
+                            <finalName>geomesa-kafka-${kafka.maj.version}_${scala.binary.version}-${project.version}</finalName>
                             <tarLongFileMode>posix</tarLongFileMode>
                             <delimiters>
                                 <delimiter>%%</delimiter>

--- a/geomesa-kafka/geomesa-kafka-dist/geomesa-kafka-10-dist/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/geomesa-kafka-10-dist/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-kafka-dist_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-kafka-dist_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-kafka-10-dist_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-10-dist_2.11</artifactId>
     <name>GeoMesa Kafka 10 Distribution</name>
 
     <properties>
@@ -29,7 +29,7 @@
         <!-- Kafka Tools -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-tools_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-tools_2.11</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
@@ -53,7 +53,7 @@
         <!-- Kafka Datastore (shaded includes kafka-utils) -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-10-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-10-datastore_2.11</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
@@ -65,7 +65,7 @@
         <!-- GeoServer Plugins -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-10-gs-plugin_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-10-gs-plugin_2.11</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>

--- a/geomesa-kafka/geomesa-kafka-dist/geomesa-kafka-10-dist/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/geomesa-kafka-10-dist/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-kafka-dist</artifactId>
+        <artifactId>geomesa-kafka-dist_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-kafka-10-dist</artifactId>
+    <artifactId>geomesa-kafka-10-dist_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka 10 Distribution</name>
 
     <properties>
@@ -29,7 +29,7 @@
         <!-- Kafka Tools -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-tools</artifactId>
+            <artifactId>geomesa-kafka-tools_${scala.binary.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
@@ -37,7 +37,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
-                    <artifactId>kafka_2.11</artifactId>
+                    <artifactId>kafka_${scala.binary.version}</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -46,14 +46,14 @@
         <!-- Correct for excluded kafka -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.10.version}</version>
         </dependency>
 
         <!-- Kafka Datastore (shaded includes kafka-utils) -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-10-datastore</artifactId>
+            <artifactId>geomesa-kafka-10-datastore_${scala.binary.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
@@ -65,7 +65,7 @@
         <!-- GeoServer Plugins -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-10-gs-plugin</artifactId>
+            <artifactId>geomesa-kafka-10-gs-plugin_${scala.binary.version}</artifactId>
             <classifier>install</classifier>
             <version>${project.version}</version>
             <type>tar.gz</type>
@@ -75,12 +75,6 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <!-- Additional jars needed -->
-        <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
         </dependency>
 
     </dependencies>
@@ -99,7 +93,7 @@
                         <phase>package</phase>
                         <configuration>
                             <attach>true</attach>
-                            <finalName>geomesa-kafka-${kafka.maj.version}-${project.version}</finalName>
+                            <finalName>geomesa-kafka-${kafka.maj.version}_${scala.binary.version}-${project.version}</finalName>
                             <tarLongFileMode>posix</tarLongFileMode>
                             <delimiters>
                                 <delimiter>%%</delimiter>

--- a/geomesa-kafka/geomesa-kafka-dist/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-kafka</artifactId>
+        <artifactId>geomesa-kafka_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-kafka-dist</artifactId>
+    <artifactId>geomesa-kafka-dist_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka Distributions Parent</name>
 
     <properties>
@@ -38,13 +38,8 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools-common</artifactId>
+            <artifactId>geomesa-tools-common_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-kafka/geomesa-kafka-dist/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/pom.xml
@@ -10,13 +10,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-kafka_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-kafka_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-    <artifactId>geomesa-kafka-dist_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-dist_2.11</artifactId>
     <name>GeoMesa Kafka Distributions Parent</name>
 
     <properties>
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-tools-common_2.11</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-kafka/geomesa-kafka-tools/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-tools/pom.xml
@@ -11,12 +11,12 @@
 
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-kafka</artifactId>
+        <artifactId>geomesa-kafka_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-tools</artifactId>
+    <artifactId>geomesa-kafka-tools_${scala.binary.version}</artifactId>
     <name>GeoMesa Kafka Tools</name>
 
     <properties>
@@ -26,19 +26,19 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security</artifactId>
+            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter</artifactId>
+            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools-common</artifactId>
+            <artifactId>geomesa-tools-common_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
@@ -50,17 +50,17 @@
         <!-- Compile against 08 and make sure they are excluded later -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-08-datastore</artifactId>
+            <artifactId>geomesa-kafka-08-datastore_${scala.binary.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
-                    <artifactId>geomesa-feature-kryo</artifactId>
+                    <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.08.version}</version>
             <exclusions>
                 <exclusion>
@@ -72,18 +72,6 @@
                     <artifactId>snappy-java</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <!-- needed in the lib dir -->
-        <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-xml_2.11</artifactId>
-        </dependency>
-
-        <!-- provided dependencies -->
-        <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
         </dependency>
 
         <dependency>
@@ -118,13 +106,29 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-test</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>scala-2.11</id>
+            <activation>
+                <property><name>!scala-2.10</name></property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <!-- needed in the lib dir -->
+                    <groupId>org.scala-lang.modules</groupId>
+                    <artifactId>scala-xml_${scala.binary.version}</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <build>
         <resources>

--- a/geomesa-kafka/geomesa-kafka-tools/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-tools/pom.xml
@@ -11,12 +11,12 @@
 
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa-kafka_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-kafka_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka-tools_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka-tools_2.11</artifactId>
     <name>GeoMesa Kafka Tools</name>
 
     <properties>
@@ -26,19 +26,19 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-security_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-filter_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-tools-common_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
@@ -50,11 +50,11 @@
         <!-- Compile against 08 and make sure they are excluded later -->
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-kafka-08-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-kafka-08-datastore_2.11</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
-                    <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+                    <artifactId>geomesa-feature-kryo_2.11</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/geomesa-kafka/geomesa-kafka-tools/src/main/scala/org/locationtech/geomesa/tools/kafka/commands/KeywordCommand.scala
+++ b/geomesa-kafka/geomesa-kafka-tools/src/main/scala/org/locationtech/geomesa/tools/kafka/commands/KeywordCommand.scala
@@ -15,7 +15,6 @@ import org.locationtech.geomesa.tools.common.{FeatureTypeNameParam, KeywordParam
 import org.locationtech.geomesa.tools.kafka.ProducerKDSConnectionParams
 
 import scala.collection.JavaConversions._
-import scala.io.StdIn
 
 class KeywordCommand(parent: JCommander) extends CommandWithKDS(parent) {
 
@@ -40,7 +39,7 @@ class KeywordCommand(parent: JCommander) extends CommandWithKDS(parent) {
     }
 
     if (params.removeAll) {
-      val confirm = StdIn.readLine("Remove all keywords? (y/n): ").toLowerCase
+      val confirm = System.console().readLine("Remove all keywords? (y/n): ").toLowerCase
       if (confirm.equals("y") || confirm.equals("yes")) {
         sft.removeAllKeywords()
         keywordsModified = true

--- a/geomesa-kafka/pom.xml
+++ b/geomesa-kafka/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka</artifactId>
+    <artifactId>geomesa-kafka_${scala.binary.version}</artifactId>
     <packaging>pom</packaging>
     <name>GeoMesa Kafka Parent</name>
     <modules>

--- a/geomesa-kafka/pom.xml
+++ b/geomesa-kafka/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-kafka_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-kafka_2.11</artifactId>
     <packaging>pom</packaging>
     <name>GeoMesa Kafka Parent</name>
     <modules>

--- a/geomesa-logger/pom.xml
+++ b/geomesa-logger/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <groupId>org.locationtech.geomesa</groupId>
+        <version>1.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>geomesa-logger_${scala.binary.version}</artifactId>
+    <name>GeoMesa Logger</name>
+
+    <profiles>
+        <profile>
+            <id>scala-2.11</id>
+            <activation>
+                <property><name>!scala-2.10</name></property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.typesafe.scala-logging</groupId>
+                    <artifactId>scala-logging_${scala.binary.version}</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>scala-2.10</id>
+            <activation>
+                <property><name>scala-2.10</name></property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.typesafe.scala-logging</groupId>
+                    <artifactId>scala-logging-slf4j_${scala.binary.version}</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+</project>

--- a/geomesa-logger/pom.xml
+++ b/geomesa-logger/pom.xml
@@ -6,12 +6,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>geomesa-logger_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-logger_2.11</artifactId>
     <name>GeoMesa Logger</name>
 
     <profiles>

--- a/geomesa-logger/src/main/scala_2.10/com/typesafe/scalalogging/Logging.scala
+++ b/geomesa-logger/src/main/scala_2.10/com/typesafe/scalalogging/Logging.scala
@@ -1,0 +1,5 @@
+package com.typesafe.scalalogging
+
+import com.typesafe.scalalogging.slf4j.{LazyLogging => Remapped}
+
+trait LazyLogging extends Remapped

--- a/geomesa-logger/src/main/scala_2.10/org/locationtech/geomesa/util/logging/Logger.scala
+++ b/geomesa-logger/src/main/scala_2.10/org/locationtech/geomesa/util/logging/Logger.scala
@@ -1,0 +1,17 @@
+/***********************************************************************
+  * Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Apache License, Version 2.0
+  * which accompanies this distribution and is available at
+  * http://www.opensource.org/licenses/apache2.0.php.
+  *************************************************************************/
+
+package org.locationtech.geomesa.util.logging
+
+import com.typesafe.scalalogging.slf4j.{Logger => Remapped}
+
+import org.slf4j.{ Logger => Underlying }
+
+object Logger {
+  def apply(underlying: Underlying): Remapped = Remapped(underlying)
+}

--- a/geomesa-logger/src/main/scala_2.11/org/locationtech/geomesa/util/logging/Logger.scala
+++ b/geomesa-logger/src/main/scala_2.11/org/locationtech/geomesa/util/logging/Logger.scala
@@ -1,0 +1,17 @@
+/***********************************************************************
+  * Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Apache License, Version 2.0
+  * which accompanies this distribution and is available at
+  * http://www.opensource.org/licenses/apache2.0.php.
+  *************************************************************************/
+
+package org.locationtech.geomesa.util.logging
+
+import com.typesafe.scalalogging.{Logger => Remapped}
+
+import org.slf4j.{ Logger => Underlying }
+
+object Logger {
+  def apply(underlying: Underlying): Remapped = Remapped(underlying)
+}

--- a/geomesa-metrics/pom.xml
+++ b/geomesa-metrics/pom.xml
@@ -3,12 +3,12 @@
 
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-metrics_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-metrics_2.11</artifactId>
     <name>GeoMesa Metrics</name>
 
     <properties>
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-logger_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-logger_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>

--- a/geomesa-metrics/pom.xml
+++ b/geomesa-metrics/pom.xml
@@ -3,12 +3,12 @@
 
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-metrics</artifactId>
+    <artifactId>geomesa-metrics_${scala.binary.version}</artifactId>
     <name>GeoMesa Metrics</name>
 
     <properties>
@@ -28,6 +28,10 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-logger_${scala.binary.version}</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
@@ -55,10 +59,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
-        </dependency>
 
         <!-- provided dependencies -->
         <dependency>
@@ -85,7 +85,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/geomesa-native-api/pom.xml
+++ b/geomesa-native-api/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-native-api</artifactId>
+    <artifactId>geomesa-native-api_${scala.binary.version}</artifactId>
     <name>GeoMesa Native API</name>
 
     <dependencies>
@@ -21,11 +21,11 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-kryo</artifactId>
+            <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>

--- a/geomesa-native-api/pom.xml
+++ b/geomesa-native-api/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-native-api_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-native-api_2.11</artifactId>
     <name>GeoMesa Native API</name>
 
     <dependencies>
@@ -21,11 +21,11 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-kryo_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>

--- a/geomesa-process/pom.xml
+++ b/geomesa-process/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-process_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-process_2.11</artifactId>
     <name>GeoMesa WPS</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>

--- a/geomesa-process/pom.xml
+++ b/geomesa-process/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-process</artifactId>
+    <artifactId>geomesa-process_${scala.binary.version}</artifactId>
     <name>GeoMesa WPS</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>
@@ -40,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/geomesa-security/pom.xml
+++ b/geomesa-security/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-security</artifactId>
+    <artifactId>geomesa-security_${scala.binary.version}</artifactId>
     <name>GeoMesa Security</name>
 
     <dependencies>
@@ -20,12 +20,8 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -34,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>

--- a/geomesa-security/pom.xml
+++ b/geomesa-security/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-security_2.11</artifactId>
     <name>GeoMesa Security</name>
 
     <dependencies>
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>

--- a/geomesa-stream/geomesa-stream-api/pom.xml
+++ b/geomesa-stream/geomesa-stream-api/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-stream</artifactId>
+        <artifactId>geomesa-stream_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-stream-api</artifactId>
+    <artifactId>geomesa-stream-api_${scala.binary.version}</artifactId>
     <name>GeoMesa Stream API</name>
 
     <dependencies>

--- a/geomesa-stream/geomesa-stream-api/pom.xml
+++ b/geomesa-stream/geomesa-stream-api/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-stream_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-stream_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-stream-api_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-stream-api_2.11</artifactId>
     <name>GeoMesa Stream API</name>
 
     <dependencies>

--- a/geomesa-stream/geomesa-stream-datastore/pom.xml
+++ b/geomesa-stream/geomesa-stream-datastore/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-stream_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-stream_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-stream-datastore_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-stream-datastore_2.11</artifactId>
     <name>GeoMesa Stream DataStore</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-stream-generic_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-stream-generic_2.11</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-text_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-text_2.11</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/geomesa-stream/geomesa-stream-datastore/pom.xml
+++ b/geomesa-stream/geomesa-stream-datastore/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-stream</artifactId>
+        <artifactId>geomesa-stream_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-stream-datastore</artifactId>
+    <artifactId>geomesa-stream-datastore_${scala.binary.version}</artifactId>
     <name>GeoMesa Stream DataStore</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-stream-generic</artifactId>
+            <artifactId>geomesa-stream-generic_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -26,7 +26,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-text</artifactId>
+            <artifactId>geomesa-convert-text_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/geomesa-stream/geomesa-stream-generic/pom.xml
+++ b/geomesa-stream/geomesa-stream-generic/pom.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-stream</artifactId>
+        <artifactId>geomesa-stream_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-stream-generic</artifactId>
+    <artifactId>geomesa-stream-generic_${scala.binary.version}</artifactId>
     <name>GeoMesa Stream Generic</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-stream-api</artifactId>
+            <artifactId>geomesa-stream-api_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common</artifactId>
+            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all</artifactId>
+            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -71,7 +71,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-text</artifactId>
+            <artifactId>geomesa-convert-text_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/geomesa-stream/geomesa-stream-generic/pom.xml
+++ b/geomesa-stream/geomesa-stream-generic/pom.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-stream_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-stream_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-stream-generic_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-stream-generic_2.11</artifactId>
     <name>GeoMesa Stream Generic</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-stream-api_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-stream-api_2.11</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-common_2.11</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-all_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -71,7 +71,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-text_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-text_2.11</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/geomesa-stream/pom.xml
+++ b/geomesa-stream/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-stream</artifactId>
+    <artifactId>geomesa-stream_${scala.binary.version}</artifactId>
     <name>GeoMesa Stream</name>
     <packaging>pom</packaging>
 

--- a/geomesa-stream/pom.xml
+++ b/geomesa-stream/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-stream_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-stream_2.11</artifactId>
     <name>GeoMesa Stream</name>
     <packaging>pom</packaging>
 

--- a/geomesa-tools-common/pom.xml
+++ b/geomesa-tools-common/pom.xml
@@ -11,12 +11,12 @@
 
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-tools-common</artifactId>
+    <artifactId>geomesa-tools-common_${scala.binary.version}</artifactId>
     <name>GeoMesa Tools Common</name>
 
     <properties>
@@ -26,22 +26,16 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-all</artifactId>
+            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
             <scope>provided</scope>
-        </dependency>
-
-        <!-- needed in the lib dir -->
-        <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-xml_2.11</artifactId>
         </dependency>
 
         <!-- provided dependencies -->
@@ -56,10 +50,6 @@
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-xml</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -92,9 +82,25 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>scala-2.11</id>
+            <activation>
+                <property><name>!scala-2.10</name></property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <!-- needed in the lib dir -->
+                    <groupId>org.scala-lang.modules</groupId>
+                    <artifactId>scala-xml_${scala.binary.version}</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <build>
         <resources>

--- a/geomesa-tools-common/pom.xml
+++ b/geomesa-tools-common/pom.xml
@@ -11,12 +11,12 @@
 
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-tools-common_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-tools-common_2.11</artifactId>
     <name>GeoMesa Tools Common</name>
 
     <properties>
@@ -26,11 +26,11 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-convert-all_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/geomesa-utils/pom.xml
+++ b/geomesa-utils/pom.xml
@@ -10,12 +10,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-utils_2.11</artifactId>
     <name>GeoMesa Utils</name>
 
     <properties>
@@ -25,11 +25,11 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-logger_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-logger_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-z3_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/geomesa-utils/pom.xml
+++ b/geomesa-utils/pom.xml
@@ -10,12 +10,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-utils</artifactId>
+    <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
     <name>GeoMesa Utils</name>
 
     <properties>
@@ -25,11 +25,11 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-z3</artifactId>
+            <artifactId>geomesa-logger_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-parser-combinators_2.11</artifactId>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -96,10 +96,6 @@
             <artifactId>spatial4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
         </dependency>
@@ -140,7 +136,7 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 
@@ -162,5 +158,20 @@
             </resource>
         </resources>
     </build>
+
+    <profiles>
+        <profile>
+            <id>scala-2.11</id>
+            <activation>
+                <property><name>!scala-2.10</name></property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.scala-lang.modules</groupId>
+                    <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -143,7 +143,7 @@ object RichAttributeDescriptors {
     }
     def isKeepStats(): Boolean = Option(ad.getUserData.get(OPT_STATS)).exists(_ == "true")
 
-    def isIndexValue(): Boolean = Option(ad.getUserData.get(OPT_INDEX_VALUE)).contains("true")
+    def isIndexValue(): Boolean = Option(ad.getUserData.get(OPT_INDEX_VALUE)).exists(_ == "true")
 
     def setCardinality(cardinality: Cardinality): Unit =
       ad.getUserData.put(OPT_CARDINALITY, cardinality.toString)
@@ -154,7 +154,7 @@ object RichAttributeDescriptors {
 
     def setBinTrackId(opt: Boolean): Unit = ad.getUserData.put(OPT_BIN_TRACK_ID, opt.toString)
 
-    def isBinTrackId: Boolean = Option(ad.getUserData.get(OPT_BIN_TRACK_ID)).contains("true")
+    def isBinTrackId: Boolean = Option(ad.getUserData.get(OPT_BIN_TRACK_ID)).exists(_ == "true")
 
     def setCollectionType(typ: Class[_]): Unit = ad.getUserData.put(USER_DATA_LIST_TYPE, typ)
 

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/stats/EnumerationStatTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/stats/EnumerationStatTest.scala
@@ -56,10 +56,10 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(10 until 100)(i => stat.enumeration(f"abc$i%03d") mustEqual 1L)
       }
 
-      "serialize to json" >> {
-        val stat = newStat[String]("strAttr")
-        JSON.parseFull(stat.toJson) must beSome(stat.enumeration)
-      }
+//      "serialize to json" >> {
+//        val stat = newStat[String]("strAttr")
+//        JSON.parseFull(stat.toJson) must beSome(stat.enumeration)
+//      }
 
       "serialize empty to json" >> {
         val stat = newStat[String]("strAttr", observe = false)
@@ -133,12 +133,12 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(0 until 100)(i => stat.enumeration(i) mustEqual 1)
       }
 
-      "serialize to json" >> {
-        val stat = newStat[java.lang.Integer]("intAttr")
-        val s = Stat.stringifier(classOf[java.lang.Integer])
-        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
-        JSON.parseFull(stat.toJson) must beSome(expected)
-      }
+//      "serialize to json" >> {
+//        val stat = newStat[java.lang.Integer]("intAttr")
+//        val s = Stat.stringifier(classOf[java.lang.Integer])
+//        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
+//        JSON.parseFull(stat.toJson) must beSome(expected)
+//      }
 
       "serialize empty to json" >> {
         val stat = newStat[java.lang.Integer]("intAttr", observe = false)
@@ -200,12 +200,12 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(0 until 100)(i => stat.enumeration(i.toLong) mustEqual 1)
       }
 
-      "serialize to json" >> {
-        val stat = newStat[java.lang.Long]("longAttr")
-        val s = Stat.stringifier(classOf[java.lang.Long])
-        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
-        JSON.parseFull(stat.toJson) must beSome(expected)
-      }
+//      "serialize to json" >> {
+//        val stat = newStat[java.lang.Long]("longAttr")
+//        val s = Stat.stringifier(classOf[java.lang.Long])
+//        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
+//        JSON.parseFull(stat.toJson) must beSome(expected)
+//      }
 
       "serialize empty to json" >> {
         val stat = newStat[java.lang.Long]("longAttr", observe = false)
@@ -267,12 +267,12 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(0 until 100)(i => stat.enumeration(i.toFloat) mustEqual 1)
       }
 
-      "serialize to json" >> {
-        val stat = newStat[java.lang.Float]("floatAttr")
-        val s = Stat.stringifier(classOf[java.lang.Float])
-        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
-        JSON.parseFull(stat.toJson) must beSome(expected)
-      }
+//      "serialize to json" >> {
+//        val stat = newStat[java.lang.Float]("floatAttr")
+//        val s = Stat.stringifier(classOf[java.lang.Float])
+//        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
+//        JSON.parseFull(stat.toJson) must beSome(expected)
+//      }
 
       "serialize empty to json" >> {
         val stat = newStat[java.lang.Float]("floatAttr", observe = false)
@@ -334,12 +334,12 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(0 until 100)(i => stat.enumeration(i.toDouble) mustEqual 1)
       }
 
-      "serialize to json" >> {
-        val stat = newStat[java.lang.Double]("doubleAttr")
-        val s = Stat.stringifier(classOf[java.lang.Double])
-        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
-        JSON.parseFull(stat.toJson) must beSome(expected)
-      }
+//      "serialize to json" >> {
+//        val stat = newStat[java.lang.Double]("doubleAttr")
+//        val s = Stat.stringifier(classOf[java.lang.Double])
+//        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
+//        JSON.parseFull(stat.toJson) must beSome(expected)
+//      }
 
       "serialize empty to json" >> {
         val stat = newStat[java.lang.Double]("doubleAttr", observe = false)
@@ -403,12 +403,12 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(dates.drop(4))(d => stat.enumeration(d) mustEqual 4)
       }
 
-      "serialize to json" >> {
-        val stat = newStat[Date]("dtg")
-        val s = Stat.stringifier(classOf[Date])
-        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
-        JSON.parseFull(stat.toJson) must beSome(expected)
-      }
+//      "serialize to json" >> {
+//        val stat = newStat[Date]("dtg")
+//        val s = Stat.stringifier(classOf[Date])
+//        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
+//        JSON.parseFull(stat.toJson) must beSome(expected)
+//      }
 
       "serialize empty to json" >> {
         val stat = newStat[Date]("dtg", observe = false)
@@ -476,12 +476,12 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(0 until 100)(i => stat.enumeration(WKTUtils.read(s"POINT(-$i ${i / 2})")) mustEqual 1)
       }
 
-      "serialize to json" >> {
-        val stat = newStat[Geometry]("geom")
-        val s = Stat.stringifier(classOf[Geometry])
-        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
-        JSON.parseFull(stat.toJson) must beSome(expected)
-      }
+//      "serialize to json" >> {
+//        val stat = newStat[Geometry]("geom")
+//        val s = Stat.stringifier(classOf[Geometry])
+//        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
+//        JSON.parseFull(stat.toJson) must beSome(expected)
+//      }
 
       "serialize empty to json" >> {
         val stat = newStat[Geometry]("geom", observe = false)

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/stats/EnumerationStatTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/stats/EnumerationStatTest.scala
@@ -17,8 +17,6 @@ import org.locationtech.geomesa.utils.text.WKTUtils
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
-import scala.util.parsing.json.JSON
-
 @RunWith(classOf[JUnitRunner])
 class EnumerationStatTest extends Specification with StatTestHelper {
 
@@ -56,10 +54,17 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(10 until 100)(i => stat.enumeration(f"abc$i%03d") mustEqual 1L)
       }
 
-//      "serialize to json" >> {
-//        val stat = newStat[String]("strAttr")
-//        JSON.parseFull(stat.toJson) must beSome(stat.enumeration)
-//      }
+      "serialize to json" >> {
+        val stat = newStat[String]("strAttr")
+        val packed   = StatSerializer(sft).serialize(stat)
+        val unpacked = StatSerializer(sft).deserialize(packed)
+
+        unpacked must beAnInstanceOf[EnumerationStat[String]]
+        unpacked.asInstanceOf[EnumerationStat[String]].attribute mustEqual stat.attribute
+        unpacked.asInstanceOf[EnumerationStat[String]].enumeration mustEqual stat.enumeration
+        unpacked.asInstanceOf[EnumerationStat[String]].size mustEqual stat.size
+        unpacked.asInstanceOf[EnumerationStat[String]].toJson mustEqual stat.toJson
+      }
 
       "serialize empty to json" >> {
         val stat = newStat[String]("strAttr", observe = false)
@@ -133,12 +138,17 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(0 until 100)(i => stat.enumeration(i) mustEqual 1)
       }
 
-//      "serialize to json" >> {
-//        val stat = newStat[java.lang.Integer]("intAttr")
-//        val s = Stat.stringifier(classOf[java.lang.Integer])
-//        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
-//        JSON.parseFull(stat.toJson) must beSome(expected)
-//      }
+      "serialize to json" >> {
+        val stat = newStat[java.lang.Integer]("intAttr")
+        val packed   = StatSerializer(sft).serialize(stat)
+        val unpacked = StatSerializer(sft).deserialize(packed)
+
+        unpacked must beAnInstanceOf[EnumerationStat[java.lang.Integer]]
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Integer]].attribute mustEqual stat.attribute
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Integer]].enumeration mustEqual stat.enumeration
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Integer]].size mustEqual stat.size
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Integer]].toJson mustEqual stat.toJson
+      }
 
       "serialize empty to json" >> {
         val stat = newStat[java.lang.Integer]("intAttr", observe = false)
@@ -200,12 +210,17 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(0 until 100)(i => stat.enumeration(i.toLong) mustEqual 1)
       }
 
-//      "serialize to json" >> {
-//        val stat = newStat[java.lang.Long]("longAttr")
-//        val s = Stat.stringifier(classOf[java.lang.Long])
-//        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
-//        JSON.parseFull(stat.toJson) must beSome(expected)
-//      }
+      "serialize to json" >> {
+        val stat = newStat[java.lang.Long]("longAttr")
+        val packed   = StatSerializer(sft).serialize(stat)
+        val unpacked = StatSerializer(sft).deserialize(packed)
+
+        unpacked must beAnInstanceOf[EnumerationStat[java.lang.Long]]
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Long]].attribute mustEqual stat.attribute
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Long]].enumeration mustEqual stat.enumeration
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Long]].size mustEqual stat.size
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Long]].toJson mustEqual stat.toJson
+      }
 
       "serialize empty to json" >> {
         val stat = newStat[java.lang.Long]("longAttr", observe = false)
@@ -267,12 +282,17 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(0 until 100)(i => stat.enumeration(i.toFloat) mustEqual 1)
       }
 
-//      "serialize to json" >> {
-//        val stat = newStat[java.lang.Float]("floatAttr")
-//        val s = Stat.stringifier(classOf[java.lang.Float])
-//        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
-//        JSON.parseFull(stat.toJson) must beSome(expected)
-//      }
+      "serialize to json" >> {
+        val stat = newStat[java.lang.Float]("floatAttr")
+        val packed   = StatSerializer(sft).serialize(stat)
+        val unpacked = StatSerializer(sft).deserialize(packed)
+
+        unpacked must beAnInstanceOf[EnumerationStat[java.lang.Float]]
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Float]].attribute mustEqual stat.attribute
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Float]].enumeration mustEqual stat.enumeration
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Float]].size mustEqual stat.size
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Float]].toJson mustEqual stat.toJson
+      }
 
       "serialize empty to json" >> {
         val stat = newStat[java.lang.Float]("floatAttr", observe = false)
@@ -334,12 +354,17 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(0 until 100)(i => stat.enumeration(i.toDouble) mustEqual 1)
       }
 
-//      "serialize to json" >> {
-//        val stat = newStat[java.lang.Double]("doubleAttr")
-//        val s = Stat.stringifier(classOf[java.lang.Double])
-//        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
-//        JSON.parseFull(stat.toJson) must beSome(expected)
-//      }
+      "serialize to json" >> {
+        val stat = newStat[java.lang.Double]("doubleAttr")
+        val packed   = StatSerializer(sft).serialize(stat)
+        val unpacked = StatSerializer(sft).deserialize(packed)
+
+        unpacked must beAnInstanceOf[EnumerationStat[java.lang.Double]]
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Double]].attribute mustEqual stat.attribute
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Double]].enumeration mustEqual stat.enumeration
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Double]].size mustEqual stat.size
+        unpacked.asInstanceOf[EnumerationStat[java.lang.Double]].toJson mustEqual stat.toJson
+      }
 
       "serialize empty to json" >> {
         val stat = newStat[java.lang.Double]("doubleAttr", observe = false)
@@ -403,12 +428,17 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(dates.drop(4))(d => stat.enumeration(d) mustEqual 4)
       }
 
-//      "serialize to json" >> {
-//        val stat = newStat[Date]("dtg")
-//        val s = Stat.stringifier(classOf[Date])
-//        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
-//        JSON.parseFull(stat.toJson) must beSome(expected)
-//      }
+      "serialize to json" >> {
+        val stat = newStat[Date]("dtg")
+        val packed   = StatSerializer(sft).serialize(stat)
+        val unpacked = StatSerializer(sft).deserialize(packed)
+
+        unpacked must beAnInstanceOf[EnumerationStat[Date]]
+        unpacked.asInstanceOf[EnumerationStat[Date]].attribute mustEqual stat.attribute
+        unpacked.asInstanceOf[EnumerationStat[Date]].enumeration mustEqual stat.enumeration
+        unpacked.asInstanceOf[EnumerationStat[Date]].size mustEqual stat.size
+        unpacked.asInstanceOf[EnumerationStat[Date]].toJson mustEqual stat.toJson
+      }
 
       "serialize empty to json" >> {
         val stat = newStat[Date]("dtg", observe = false)
@@ -476,12 +506,17 @@ class EnumerationStatTest extends Specification with StatTestHelper {
         forall(0 until 100)(i => stat.enumeration(WKTUtils.read(s"POINT(-$i ${i / 2})")) mustEqual 1)
       }
 
-//      "serialize to json" >> {
-//        val stat = newStat[Geometry]("geom")
-//        val s = Stat.stringifier(classOf[Geometry])
-//        val expected = stat.enumeration.map { case (k, v) => (s(k), v)}
-//        JSON.parseFull(stat.toJson) must beSome(expected)
-//      }
+      "serialize to json" >> {
+        val stat = newStat[Geometry]("geom")
+        val packed   = StatSerializer(sft).serialize(stat)
+        val unpacked = StatSerializer(sft).deserialize(packed)
+
+        unpacked must beAnInstanceOf[EnumerationStat[Geometry]]
+        unpacked.asInstanceOf[EnumerationStat[Geometry]].attribute mustEqual stat.attribute
+        unpacked.asInstanceOf[EnumerationStat[Geometry]].enumeration mustEqual stat.enumeration
+        unpacked.asInstanceOf[EnumerationStat[Geometry]].size mustEqual stat.size
+        unpacked.asInstanceOf[EnumerationStat[Geometry]].toJson mustEqual stat.toJson
+      }
 
       "serialize empty to json" >> {
         val stat = newStat[Geometry]("geom", observe = false)

--- a/geomesa-web/geomesa-web-core/pom.xml
+++ b/geomesa-web/geomesa-web-core/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-web</artifactId>
+        <artifactId>geomesa-web_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-web-core</artifactId>
+    <artifactId>geomesa-web-core_${scala.binary.version}</artifactId>
     <name>GeoMesa Web Core</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -23,19 +23,19 @@
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra_2.11</artifactId>
+            <artifactId>scalatra_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-auth_2.11</artifactId>
+            <artifactId>scalatra-auth_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-swagger_2.11</artifactId>
+            <artifactId>scalatra-swagger_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>
-            <artifactId>json4s-native_2.11</artifactId>
+            <artifactId>json4s-native_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/geomesa-web/geomesa-web-core/pom.xml
+++ b/geomesa-web/geomesa-web-core/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-web_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-web-core_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-web-core_2.11</artifactId>
     <name>GeoMesa Web Core</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/geomesa-web/geomesa-web-data/pom.xml
+++ b/geomesa-web/geomesa-web-data/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-web</artifactId>
+        <artifactId>geomesa-web_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-web-data</artifactId>
+    <artifactId>geomesa-web-data_${scala.binary.version}</artifactId>
     <name>GeoMesa Web Data</name>
     <description>Provides direct REST access to GeoMesa data</description>
 
@@ -83,71 +83,67 @@
     <dependencies>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra_2.11</artifactId>
+            <artifactId>scalatra_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-json_2.11</artifactId>
+            <artifactId>scalatra-json_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>
-            <artifactId>json4s-native_2.11</artifactId>
+            <artifactId>json4s-native_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-compute</artifactId>
+            <artifactId>geomesa-accumulo-compute_${scala.binary.version}</artifactId>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
-                    <artifactId>geomesa-accumulo-datastore</artifactId>
+                    <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
-                    <artifactId>geomesa-jobs</artifactId>
+                    <artifactId>geomesa-jobs_${scala.binary.version}</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all</artifactId>
+            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.11</artifactId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-yarn_2.11</artifactId>
+            <artifactId>spark-yarn_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.11</artifactId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-catalyst_2.11</artifactId>
+            <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-web-core</artifactId>
+            <artifactId>geomesa-web-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-web/geomesa-web-data/pom.xml
+++ b/geomesa-web/geomesa-web-data/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-web_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-web-data_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-web-data_2.11</artifactId>
     <name>GeoMesa Web Data</name>
     <description>Provides direct REST access to GeoMesa data</description>
 
@@ -95,22 +95,22 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-compute_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-compute_2.11</artifactId>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
-                    <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+                    <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.locationtech.geomesa</groupId>
-                    <artifactId>geomesa-jobs_${scala.binary.version}</artifactId>
+                    <artifactId>geomesa-jobs_2.11</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-feature-all_2.11</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -139,11 +139,11 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-web-core_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-web-core_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-web/geomesa-web-install/pom.xml
+++ b/geomesa-web/geomesa-web-install/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-web_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-web-install_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-web-install_2.11</artifactId>
     <name>GeoMesa Web Install</name>
     <packaging>pom</packaging>
     <description>Provides artifacts for installing GeoMesa Web</description>

--- a/geomesa-web/geomesa-web-install/pom.xml
+++ b/geomesa-web/geomesa-web-install/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-web</artifactId>
+        <artifactId>geomesa-web_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-web-install</artifactId>
+    <artifactId>geomesa-web-install_${scala.binary.version}</artifactId>
     <name>GeoMesa Web Install</name>
     <packaging>pom</packaging>
     <description>Provides artifacts for installing GeoMesa Web</description>
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.11</artifactId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -114,7 +114,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-yarn_2.11</artifactId>
+            <artifactId>spark-yarn_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -142,7 +142,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.11</artifactId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -162,7 +162,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-catalyst_2.11</artifactId>
+            <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -206,7 +206,7 @@
                                 <phase>package</phase>
                                 <configuration>
                                     <attach>true</attach>
-                                    <finalName>spark-${project.version}</finalName>
+                                    <finalName>spark_${scala.binary.version}-${project.version}</finalName>
                                     <tarLongFileMode>posix</tarLongFileMode>
                                     <descriptors>
                                         <descriptor>src/main/assemblies/spark-assembly.xml</descriptor>

--- a/geomesa-web/geomesa-web-stats/pom.xml
+++ b/geomesa-web/geomesa-web-stats/pom.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-web_${scala.binary.version}</artifactId>
+        <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-web-stats_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-web-stats_2.11</artifactId>
     <name>GeoMesa Web Stats REST API</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-web-core_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-web-core_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-tools_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-tools_2.11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/geomesa-web/geomesa-web-stats/pom.xml
+++ b/geomesa-web/geomesa-web-stats/pom.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa-web</artifactId>
+        <artifactId>geomesa-web_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-web-stats</artifactId>
+    <artifactId>geomesa-web-stats_${scala.binary.version}</artifactId>
     <name>GeoMesa Web Stats REST API</name>
 
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-web-core</artifactId>
+            <artifactId>geomesa-web-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-tools</artifactId>
+            <artifactId>geomesa-accumulo-tools_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-accumulo-datastore</artifactId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -31,23 +31,23 @@
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-json_2.11</artifactId>
+            <artifactId>scalatra-json_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>
-            <artifactId>json4s-native_2.11</artifactId>
+            <artifactId>json4s-native_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra_2.11</artifactId>
+            <artifactId>scalatra_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-auth_2.11</artifactId>
+            <artifactId>scalatra-auth_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-swagger_2.11</artifactId>
+            <artifactId>scalatra-swagger_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/geomesa-web/pom.xml
+++ b/geomesa-web/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <name>GeoMesa Web</name>
-    <artifactId>geomesa-web_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-web_2.11</artifactId>
     <packaging>pom</packaging>
 
     <properties>

--- a/geomesa-web/pom.xml
+++ b/geomesa-web/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <name>GeoMesa Web</name>
-    <artifactId>geomesa-web</artifactId>
+    <artifactId>geomesa-web_${scala.binary.version}</artifactId>
     <packaging>pom</packaging>
 
     <properties>
@@ -197,27 +197,27 @@
             </dependency>
             <dependency>
                 <groupId>org.scalatra</groupId>
-                <artifactId>scalatra-swagger_2.11</artifactId>
+                <artifactId>scalatra-swagger_${scala.binary.version}</artifactId>
                 <version>${scalatra.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.scalatra</groupId>
-                <artifactId>scalatra_2.11</artifactId>
+                <artifactId>scalatra_${scala.binary.version}</artifactId>
                 <version>${scalatra.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.scalatra</groupId>
-                <artifactId>scalatra-auth_2.11</artifactId>
+                <artifactId>scalatra-auth_${scala.binary.version}</artifactId>
                 <version>${scalatra.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.scalatra</groupId>
-                <artifactId>scalatra-json_2.11</artifactId>
+                <artifactId>scalatra-json_${scala.binary.version}</artifactId>
                 <version>${scalatra.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.json4s</groupId>
-                <artifactId>json4s-native_2.11</artifactId>
+                <artifactId>json4s-native_${scala.binary.version}</artifactId>
                 <version>${json4s.version}</version>
             </dependency>
             <dependency>

--- a/geomesa-z3/pom.xml
+++ b/geomesa-z3/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa</artifactId>
+        <artifactId>geomesa_${scala.binary.version}</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-z3</artifactId>
+    <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
     <name>GeoMesa Index Z3</name>
 
     <dependencies>
@@ -25,17 +25,17 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.sfcurve</groupId>
-            <artifactId>sfcurve-zorder_2.11</artifactId>
+            <artifactId>sfcurve-zorder_${scala.binary.version}</artifactId>
             <version>0.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-logger_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/geomesa-z3/pom.xml
+++ b/geomesa-z3/pom.xml
@@ -9,13 +9,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>geomesa_${scala.binary.version}</artifactId>
+        <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+    <artifactId>geomesa-z3_2.11</artifactId>
     <name>GeoMesa Index Z3</name>
 
     <dependencies>
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-logger_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-logger_2.11</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,30 @@
     <packaging>pom</packaging>
     <version>1.3.0-SNAPSHOT</version>
 
+    <modules>
+        <module>geomesa-logger</module>
+        <module>geomesa-utils</module>
+        <module>geomesa-security</module>
+        <module>geomesa-features</module>
+        <module>geomesa-filter</module>
+        <module>geomesa-gs-plugin</module>
+        <module>geomesa-kafka</module>
+        <module>geomesa-convert</module>
+        <module>geomesa-tools-common</module>
+        <module>geomesa-web</module>
+        <module>geomesa-process</module>
+        <module>geomesa-stream</module>
+        <module>geomesa-z3</module>
+        <module>geomesa-accumulo</module>
+        <module>geomesa-hbase</module>
+        <module>geomesa-blobstore</module>
+        <module>geomesa-cassandra</module>
+        <module>geomesa-metrics</module>
+        <module>docs</module>
+        <module>geomesa-native-api</module>
+        <module>geomesa-index-api</module>
+    </modules>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -78,37 +102,6 @@
     </properties>
 
     <profiles>
-
-        <profile>
-            <id>default</id>
-            <activation>
-                <property><name>!spark</name></property>
-            </activation>
-            <modules>
-                <module>geomesa-logger</module>
-                <module>geomesa-utils</module>
-                <module>geomesa-security</module>
-                <module>geomesa-features</module>
-                <module>geomesa-filter</module>
-                <module>geomesa-gs-plugin</module>
-                <module>geomesa-kafka</module>
-                <module>geomesa-convert</module>
-                <module>geomesa-tools-common</module>
-                <module>geomesa-web</module>
-                <module>geomesa-process</module>
-                <module>geomesa-stream</module>
-                <module>geomesa-z3</module>
-                <module>geomesa-accumulo</module>
-                <module>geomesa-hbase</module>
-                <module>geomesa-blobstore</module>
-                <module>geomesa-cassandra</module>
-                <module>geomesa-metrics</module>
-                <module>docs</module>
-                <module>geomesa-native-api</module>
-                <module>geomesa-index-api</module>
-            </modules>
-        </profile>
-
         <profile>
             <id>scala-2.11</id>
             <activation>
@@ -157,26 +150,6 @@
                     </dependency>
                 </dependencies>
             </dependencyManagement>
-        </profile>
-
-        <profile>
-            <id>spark</id>
-            <activation>
-                <property><name>spark</name></property>
-            </activation>
-            <modules>
-                <module>geomesa-accumulo/geomesa-accumulo-compute</module>
-                <module>geomesa-accumulo/geomesa-accumulo-datastore</module>
-                <module>geomesa-accumulo/geomesa-accumulo-jobs</module>
-                <module>geomesa-convert</module>
-                <module>geomesa-filter</module>
-                <module>geomesa-features</module>
-                <module>geomesa-index-api</module>
-                <module>geomesa-logger</module>
-                <module>geomesa-security</module>
-                <module>geomesa-utils</module>
-                <module>geomesa-z3</module>
-            </modules>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,31 @@
                     </dependency>
                 </dependencies>
             </dependencyManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-versions</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <bannedDependencies>
+                                            <excludes combine.children="append">
+                                                <exclude>*:*_2.10</exclude>
+                                            </excludes>
+                                        </bannedDependencies>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <profile>
@@ -150,6 +175,31 @@
                     </dependency>
                 </dependencies>
             </dependencyManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-versions</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <bannedDependencies>
+                                            <excludes combine.children="append">
+                                                <exclude>*:*_2.11</exclude>
+                                            </excludes>
+                                        </bannedDependencies>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -14,32 +14,9 @@
     <inceptionYear>2013</inceptionYear>
 
     <groupId>org.locationtech.geomesa</groupId>
-    <artifactId>geomesa</artifactId>
+    <artifactId>geomesa_${scala.binary.version}</artifactId>
     <packaging>pom</packaging>
     <version>1.3.0-SNAPSHOT</version>
-
-    <modules>
-        <module>geomesa-utils</module>
-        <module>geomesa-security</module>
-        <module>geomesa-features</module>
-        <module>geomesa-filter</module>
-        <module>geomesa-gs-plugin</module>
-        <module>geomesa-kafka</module>
-        <module>geomesa-convert</module>
-        <module>geomesa-tools-common</module>
-        <module>geomesa-web</module>
-        <module>geomesa-process</module>
-        <module>geomesa-stream</module>
-        <module>geomesa-z3</module>
-        <module>geomesa-accumulo</module>
-        <module>geomesa-hbase</module>
-        <module>geomesa-blobstore</module>
-        <module>geomesa-cassandra</module>
-        <module>geomesa-metrics</module>
-        <module>docs</module>
-        <module>geomesa-native-api</module>
-        <module>geomesa-index-api</module>
-    </modules>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -48,9 +25,9 @@
         <geomesa.release.version>1.2.6</geomesa.release.version>
         <geomesa.devel.version>1.3.0-SNAPSHOT</geomesa.devel.version>
 
-        <scala.version>2.11.7</scala.version>
         <scala.xml.version>1.0.5</scala.xml.version>
         <scala.parsers.version>1.0.4</scala.parsers.version>
+
         <geoserver.version>2.8.1</geoserver.version>
         <gt.version>15.1</gt.version>
         <jaiext.version>1.0.9</jaiext.version>
@@ -101,6 +78,107 @@
     </properties>
 
     <profiles>
+
+        <profile>
+            <id>default</id>
+            <activation>
+                <property><name>!spark</name></property>
+            </activation>
+            <modules>
+                <module>geomesa-logger</module>
+                <module>geomesa-utils</module>
+                <module>geomesa-security</module>
+                <module>geomesa-features</module>
+                <module>geomesa-filter</module>
+                <module>geomesa-gs-plugin</module>
+                <module>geomesa-kafka</module>
+                <module>geomesa-convert</module>
+                <module>geomesa-tools-common</module>
+                <module>geomesa-web</module>
+                <module>geomesa-process</module>
+                <module>geomesa-stream</module>
+                <module>geomesa-z3</module>
+                <module>geomesa-accumulo</module>
+                <module>geomesa-hbase</module>
+                <module>geomesa-blobstore</module>
+                <module>geomesa-cassandra</module>
+                <module>geomesa-metrics</module>
+                <module>docs</module>
+                <module>geomesa-native-api</module>
+                <module>geomesa-index-api</module>
+            </modules>
+        </profile>
+
+        <profile>
+            <id>scala-2.11</id>
+            <activation>
+                <property><name>!scala-2.10</name></property>
+            </activation>
+            <properties>
+                <scala.version>2.11.7</scala.version>
+                <scala.binary.version>2.11</scala.binary.version>
+            </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.typesafe.scala-logging</groupId>
+                        <artifactId>scala-logging_${scala.binary.version}</artifactId>
+                        <version>${scalalogging.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.scala-lang.modules</groupId>
+                        <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
+                        <version>${scala.parsers.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.scala-lang.modules</groupId>
+                        <artifactId>scala-xml_${scala.binary.version}</artifactId>
+                        <version>${scala.parsers.version}</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+        </profile>
+
+        <profile>
+            <id>scala-2.10</id>
+            <activation>
+                <property><name>scala-2.10</name></property>
+            </activation>
+            <properties>
+                <scala.version>2.10.6</scala.version>
+                <scala.binary.version>2.10</scala.binary.version>
+            </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.typesafe.scala-logging</groupId>
+                        <artifactId>scala-logging-slf4j_${scala.binary.version}</artifactId>
+                        <version>2.1.2</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+        </profile>
+
+        <profile>
+            <id>spark</id>
+            <activation>
+                <property><name>spark</name></property>
+            </activation>
+            <modules>
+                <module>geomesa-accumulo/geomesa-accumulo-compute</module>
+                <module>geomesa-accumulo/geomesa-accumulo-datastore</module>
+                <module>geomesa-accumulo/geomesa-accumulo-jobs</module>
+                <module>geomesa-convert</module>
+                <module>geomesa-filter</module>
+                <module>geomesa-features</module>
+                <module>geomesa-index-api</module>
+                <module>geomesa-logger</module>
+                <module>geomesa-security</module>
+                <module>geomesa-utils</module>
+                <module>geomesa-z3</module>
+            </modules>
+        </profile>
+
         <profile>
             <id>zinc</id>
             <build>
@@ -276,16 +354,6 @@
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scalap</artifactId>
                 <version>${scala.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.scala-lang.modules</groupId>
-                <artifactId>scala-parser-combinators_2.11</artifactId>
-                <version>${scala.parsers.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.scala-lang.modules</groupId>
-                <artifactId>scala-xml_2.11</artifactId>
-                <version>${scala.xml.version}</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>
@@ -1348,143 +1416,163 @@
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-index-api</artifactId>
+                <artifactId>geomesa-logger_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-datastore</artifactId>
+                <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-utils</artifactId>
+                <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-filter</artifactId>
+                <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-distributed-runtime</artifactId>
+                <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-feature-all</artifactId>
+                <artifactId>geomesa-accumulo-distributed-runtime_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-feature-kryo</artifactId>
+                <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-raster</artifactId>
+                <artifactId>geomesa-feature-avro_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-tools-common</artifactId>
+                <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-tools</artifactId>
+                <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-kafka-tools</artifactId>
+                <artifactId>geomesa-feature-nio_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-kafka-08-datastore</artifactId>
+                <artifactId>geomesa-accumulo-raster_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-kafka-09-datastore</artifactId>
+                <artifactId>geomesa-tools-common_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-kafka-10-datastore</artifactId>
+                <artifactId>geomesa-accumulo-tools_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-jobs</artifactId>
+                <artifactId>geomesa-kafka-tools_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-compute</artifactId>
+                <artifactId>geomesa-kafka-08-datastore_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-compute</artifactId>
+                <artifactId>geomesa-kafka-09-datastore_${scala.binary.version}</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.locationtech.geomesa</groupId>
+                <artifactId>geomesa-kafka-10-datastore_${scala.binary.version}</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.locationtech.geomesa</groupId>
+                <artifactId>geomesa-accumulo-jobs_${scala.binary.version}</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.locationtech.geomesa</groupId>
+                <artifactId>geomesa-accumulo-compute_${scala.binary.version}</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.locationtech.geomesa</groupId>
+                <artifactId>geomesa-accumulo-compute_${scala.binary.version}</artifactId>
                 <classifier>shaded</classifier>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-all</artifactId>
+                <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-common</artifactId>
+                <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-avro</artifactId>
+                <artifactId>geomesa-convert-avro_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-fixedwidth</artifactId>
+                <artifactId>geomesa-convert-fixedwidth_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-json</artifactId>
+                <artifactId>geomesa-convert-json_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-text</artifactId>
+                <artifactId>geomesa-convert-text_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-xml</artifactId>
+                <artifactId>geomesa-convert-xml_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-metrics</artifactId>
+                <artifactId>geomesa-metrics_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-blobstore-api</artifactId>
+                <artifactId>geomesa-blobstore-api_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-blobstore-web</artifactId>
+                <artifactId>geomesa-blobstore-web_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-gs-plugin</artifactId>
+                <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <!-- note: accumulo uses guava 17, but geotools uses 11. The methods we use happen to exist
@@ -1513,7 +1601,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.spark</groupId>
-                <artifactId>spark-core_2.11</artifactId>
+                <artifactId>spark-core_${scala.binary.version}</artifactId>
                 <version>${spark.version}</version>
                 <scope>provided</scope>
             </dependency>
@@ -1589,11 +1677,6 @@
                 <version>2.3.0</version>
             </dependency>
             <dependency>
-                <groupId>com.typesafe.scala-logging</groupId>
-                <artifactId>scala-logging_2.11</artifactId>
-                <version>${scalalogging.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
@@ -1636,7 +1719,7 @@
             </dependency>
             <dependency>
                 <groupId>com.twitter</groupId>
-                <artifactId>chill_2.11</artifactId>
+                <artifactId>chill_${scala.binary.version}</artifactId>
                 <version>0.5.2</version>
             </dependency>
             <dependency>
@@ -1804,8 +1887,8 @@
             </dependency>
             <dependency>
                 <groupId>org.specs2</groupId>
-                <artifactId>specs2_2.11</artifactId>
-                <version>2.3.13</version>
+                <artifactId>specs2_${scala.binary.version}</artifactId>
+                <version>${specs2.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -1827,52 +1910,52 @@
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-process</artifactId>
+                <artifactId>geomesa-process_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-web</artifactId>
+                <artifactId>geomesa-web_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-web-csv</artifactId>
+                <artifactId>geomesa-web-csv_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-web-data</artifactId>
+                <artifactId>geomesa-web-data_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-web-core</artifactId>
+                <artifactId>geomesa-web-core_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-security</artifactId>
+                <artifactId>geomesa-security_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-web-security</artifactId>
+                <artifactId>geomesa-web-security_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-web-install</artifactId>
+                <artifactId>geomesa-web-install_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-z3</artifactId>
+                <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-scripting</artifactId>
+                <artifactId>geomesa-convert-scripting_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>
@@ -1947,6 +2030,19 @@
                         <target>1.8</target>
                         <scalaVersion>${scala.version}</scalaVersion>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>add-source</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                            </goals>
+                            <configuration>
+                                <sourceDir>src/main/scala_${scala.binary.version}</sourceDir>
+                                <testSourceDir>src/test/scala_${scala.binary.version}</testSourceDir>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2142,6 +2142,11 @@
                         </includes>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.3.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <inceptionYear>2013</inceptionYear>
 
     <groupId>org.locationtech.geomesa</groupId>
-    <artifactId>geomesa_${scala.binary.version}</artifactId>
+    <artifactId>geomesa_2.11</artifactId>
     <packaging>pom</packaging>
     <version>1.3.0-SNAPSHOT</version>
 
@@ -1416,163 +1416,163 @@
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-logger_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-logger_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-index-api_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-accumulo-datastore_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-utils_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-filter_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-distributed-runtime_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-accumulo-distributed-runtime_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-feature-all_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-feature-avro_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-feature-avro_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-feature-common_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-feature-kryo_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-feature-nio_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-feature-nio_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-raster_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-accumulo-raster_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-tools-common_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-tools-common_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-tools_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-accumulo-tools_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-kafka-tools_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-kafka-tools_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-kafka-08-datastore_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-kafka-08-datastore_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-kafka-09-datastore_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-kafka-09-datastore_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-kafka-10-datastore_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-kafka-10-datastore_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-jobs_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-accumulo-jobs_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-compute_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-accumulo-compute_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-accumulo-compute_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-accumulo-compute_2.11</artifactId>
                 <classifier>shaded</classifier>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-convert-all_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-convert-common_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-avro_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-convert-avro_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-fixedwidth_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-convert-fixedwidth_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-json_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-convert-json_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-text_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-convert-text_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-xml_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-convert-xml_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-metrics_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-metrics_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-blobstore-api_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-blobstore-api_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-blobstore-web_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-blobstore-web_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-gs-plugin_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-gs-plugin_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <!-- note: accumulo uses guava 17, but geotools uses 11. The methods we use happen to exist
@@ -1910,52 +1910,52 @@
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-process_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-process_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-web_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-web_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-web-csv_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-web-csv_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-web-data_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-web-data_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-web-core_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-web-core_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-security_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-web-security_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-web-security_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-web-install_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-web-install_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-z3_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-convert-scripting_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-convert-scripting_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>


### PR DESCRIPTION
This is the first PR towards support for both Scala 2.10 and 2.11 builds.  At this time the only effective change is the addition of _2.11 suffix to `artifactId` for GeoMesa artifacts.  Full support still requires some minor source changes for compatibility w/ Scala 2.10 and a script to convert the build from 2.11 to 2.10.
