### PR TITLE
GEOMESA-1443 Update parent pom to work around sbt/ivy artifact resolution issue

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -91,8 +91,7 @@ install_zinc() {
 # the build/ folder
 install_scala() {
   # determine the Scala version used in Spark
-  local scala_version=`grep "scala.version" "${_DIR}/../pom.xml" | \
-                       head -1 | cut -f2 -d'>' | cut -f1 -d'<'`
+  local scala_version=`${MVN_BIN} -N help:evaluate -Dexpression=scala.version | grep -v '^\['`
   local scala_bin="${_DIR}/scala-${scala_version}/bin/scala"
 
   install_app \

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
         <geomesa.12.release.version>1.2.6</geomesa.12.release.version>
         <geomesa.devel.version>1.3.0-m1-SNAPSHOT</geomesa.devel.version>
 
+        <!-- this must remain outside of version specific scala profiles for sbt/ivy -->
+        <scala.binary.version>2.11</scala.binary.version>
+
         <scala.xml.version>1.0.5</scala.xml.version>
         <scala.parsers.version>1.0.4</scala.parsers.version>
 
@@ -110,7 +113,6 @@
             </activation>
             <properties>
                 <scala.version>2.11.7</scala.version>
-                <scala.binary.version>2.11</scala.binary.version>
             </properties>
             <dependencyManagement>
                 <dependencies>
@@ -149,6 +151,18 @@
                                                 <exclude>*:*_2.10</exclude>
                                             </excludes>
                                         </bannedDependencies>
+                                        <requireProperty>
+                                            <message>property scala.version must be set</message>
+                                            <property>scala.version</property>
+                                            <regexMessage>property scala.version doesn't match expected compiler version (2.11.*)</regexMessage>
+                                            <regex>2.11.*</regex>
+                                        </requireProperty>
+                                        <requireProperty>
+                                            <message>property scala.binary.version must be set</message>
+                                            <property>scala.binary.version</property>
+                                            <regexMessage>property scala.binary.version doesn't match compiler version</regexMessage>
+                                            <regex>2.11</regex>
+                                        </requireProperty>
                                     </rules>
                                 </configuration>
                             </execution>
@@ -165,7 +179,6 @@
             </activation>
             <properties>
                 <scala.version>2.10.6</scala.version>
-                <scala.binary.version>2.10</scala.binary.version>
             </properties>
             <dependencyManagement>
                 <dependencies>
@@ -194,6 +207,18 @@
                                                 <exclude>*:*_2.11</exclude>
                                             </excludes>
                                         </bannedDependencies>
+                                        <requireProperty>
+                                            <message>property scala.version must be set</message>
+                                            <property>scala.version</property>
+                                            <regexMessage>property scala.version doesn't match expected compiler version (2.10.*)</regexMessage>
+                                            <regex>2.10.*</regex>
+                                        </requireProperty>
+                                        <requireProperty>
+                                            <message>property scala.binary.version must be set</message>
+                                            <property>scala.binary.version</property>
+                                            <regexMessage>property scala.binary.version doesn't match compiler version</regexMessage>
+                                            <regex>2.10</regex>
+                                        </requireProperty>
                                     </rules>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
It appears the placement of `scala.binary.version` inside a profile precludes its use in the resolution of transitive dependencies when geomesa modules are used in sbt builds.  This commit resolves this by pulling the `scala.binary.version` outside of the scala version-specific profiles.  The spark version change script will update the property value as needed.

Signed-off-by: Tom Kunicki <tom.kunicki@ccri.com>