### PR TITLE
GEOMESA-1471 SimpleFeatureAttribute should inherit from

### DIFF
--- a/geomesa-memory/src/main/java/org/locationtech/geomesa/memory/cqengine/attribute/SimpleFeatureAttribute.java
+++ b/geomesa-memory/src/main/java/org/locationtech/geomesa/memory/cqengine/attribute/SimpleFeatureAttribute.java
@@ -8,12 +8,12 @@
 
 package org.locationtech.geomesa.memory.cqengine.attribute;
 
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.SimpleNullableAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
-public class SimpleFeatureAttribute<A> extends SimpleAttribute<SimpleFeature, A> {
+public class SimpleFeatureAttribute<A> extends SimpleNullableAttribute<SimpleFeature, A> {
     String fieldName;
     int fieldIndex;
 


### PR DESCRIPTION
SimpleNullableAttribute, not SimpleAttribute, which by CQEngine
contract should not return nulls.

Signed-off-by: Matthew Zimmerman <matt.zimmerman@ccri.com>