### PR TITLE
GEOMESA-1487 proper generation of accumulo runtime jars for scala 2.10 build

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
@@ -68,7 +68,7 @@
                             <artifactSet>
                                 <excludes>
                                     <exclude>org.slf4j:*</exclude>
-                                    <exclude>org.locationtech.geomesa:geomesa-accumulo-raster_2.11</exclude>
+                                    <exclude>org.locationtech.geomesa:geomesa-accumulo-raster*</exclude>
                                 </excludes>
                             </artifactSet>
                             <filters>
@@ -84,7 +84,7 @@
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             </transformers>
-                            <finalName>geomesa-accumulo-distributed-runtime_2.11-${project.version}</finalName>
+                            <finalName>geomesa-accumulo-distributed-runtime_${scala.binary.version}-${project.version}</finalName>
                         </configuration>
                     </execution>
                     <execution>
@@ -113,7 +113,7 @@
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             </transformers>
-                            <finalName>geomesa-accumulo-distributed-runtime-raster_2.11-${project.version}</finalName>
+                            <finalName>geomesa-accumulo-distributed-runtime-raster_${scala.binary.version}-${project.version}</finalName>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
looked over build, issue is isolated to `geomesa-accumulo-distributed-runtime`