### PR TITLE
GEOMESA-1509,GEOMESA-1510 Splitting ranges in geomesa-hbase, adding index hint to export and explain command line tools

### DIFF
--- a/docs/user/data_management.rst
+++ b/docs/user/data_management.rst
@@ -498,19 +498,19 @@ up ingestion and queries.
 
 GeoMesa supplies three different table splitter options:
 
-- ``org.locationtech.geomesa.accumulo.data.HexSplitter`` (used by default)
+- ``org.locationtech.geomesa.index.conf.HexSplitter`` (used by default)
 
   Assumes an even distribution of IDs starting with 0-9, a-f, A-F
 
-- ``org.locationtech.geomesa.accumulo.data.AlphaNumericSplitter``
+- ``org.locationtech.geomesa.index.conf.AlphaNumericSplitter``
 
   Assumes an even distribution of IDs starting with 0-9, a-z, A-Z
 
-- ``org.locationtech.geomesa.accumulo.data.DigitSplitter``
+- ``org.locationtech.geomesa.index.conf.DigitSplitter``
 
   Assumes an even distribution of IDs starting with numeric values, which are specified as options
 
-Custom splitters may also be used - any class that extends ``org.locationtech.geomesa.accumulo.data.TableSplitter``.
+Custom splitters may also be used - any class that extends ``org.locationtech.geomesa.index.conf.TableSplitter``.
 
 Specifying a Table Splitter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -526,7 +526,7 @@ the hint to the end of the string, like so:
 
     // append the hints to the end of the string, separated by a semi-colon
     String spec = "name:String,dtg:Date,*geom:Point:srid=4326;" +
-        "table.splitter.class=org.locationtech.geomesa.accumulo.data.AlphaNumericSplitter";
+        "table.splitter.class=org.locationtech.geomesa.index.conf.AlphaNumericSplitter";
     SimpleFeatureType sft = SimpleFeatureTypes.createType("mySft", spec);
 
 If you have an existing simple feature type, or you are not using ``SimpleFeatureTypes.createType``,
@@ -537,7 +537,7 @@ you may set the hint directly in the feature type:
     // set the hint directly
     SimpleFeatureType sft = ...
     sft.getUserData().put("table.splitter.class",
-        "org.locationtech.geomesa.accumulo.data.DigitSplitter");
+        "org.locationtech.geomesa.index.conf.DigitSplitter");
     sft.getUserData().put("table.splitter.options", "fmt:%02d,min:0,max:99");
 
 If you are using TypeSafe configuration files to define your simple feature type, you may include
@@ -554,7 +554,7 @@ a 'user-data' key:
             { name = geom, type = Point, srid = 4326 }
           ]
           user-data = {
-            table.splitter.class = "org.locationtech.geomesa.accumulo.data.DigitSplitter"
+            table.splitter.class = "org.locationtech.geomesa.index.conf.DigitSplitter"
             table.splitter.options = "fmt:%01d,min:0,max:9"
           }
         }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloFeatureIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloFeatureIndex.scala
@@ -144,14 +144,6 @@ trait AccumuloWritableIndex extends AccumuloFeatureIndexType {
   }
 
   /**
-    * Retrieve an ID from a row. All indices are assumed to encode the feature ID into the row key
-    *
-    * @param sft simple feature type
-    * @return a function to retrieve an ID from a row
-    */
-  def getIdFromRow(sft: SimpleFeatureType): (Text) => String
-
-  /**
     * Indicates whether the ID for each feature is serialized with the feature or in the row
     *
     * @return
@@ -179,12 +171,15 @@ trait AccumuloWritableIndex extends AccumuloFeatureIndexType {
       val deserializer = SimpleFeatureDeserializers(returnSft, SerializationType.KRYO, SerializationOptions.withoutId)
       (kv: Entry[Key, Value]) => {
         val sf = deserializer.deserialize(kv.getValue.get)
-        sf.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(kv.getKey.getRow))
+        val row = kv.getKey.getRow
+        sf.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(row.getBytes, 0, row.getLength))
         AccumuloWritableIndex.applyVisibility(sf, kv.getKey)
         sf
       }
     }
   }
+
+  override def getSplits(sft: SimpleFeatureType): Seq[Array[Byte]] = ???
 
   // back compatibility check for old metadata keys
   abstract override def getTableName(typeName: String, ds: AccumuloDataStore): String = {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/attribute/AttributeQueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/attribute/AttributeQueryableIndex.scala
@@ -225,7 +225,10 @@ trait AttributeQueryableIndex extends AccumuloWritableIndex with LazyLogging {
     // have to pull the feature id from the row
     val prefix = sft.getTableSharingPrefix
     val getId = getIdFromRow(sft)
-    val joinFunction: JoinFunction = (kv) => new AccRange(RecordIndex.getRowKey(prefix, getId(kv.getKey.getRow)))
+    val joinFunction: JoinFunction = (kv) => {
+      val row = kv.getKey.getRow
+      new AccRange(RecordIndex.getRowKey(prefix, getId(row.getBytes, 0, row.getLength)))
+    }
 
     val recordTable = recordIndex.getTableName(sft.getTypeName, ds)
     val recordThreads = ds.config.recordThreads

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/attribute/AttributeWritableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/attribute/AttributeWritableIndex.scala
@@ -58,13 +58,13 @@ trait AttributeWritableIndex extends AccumuloWritableIndex with AttributeSplitta
     }
   }
 
-  override def getIdFromRow(sft: SimpleFeatureType): (Text) => String = {
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int) => String = {
     // drop the encoded value and the date field (12 bytes) if it's present - the rest of the row is the ID
     val from = if (sft.isTableSharing) 3 else 2  // exclude feature byte and index bytes
     val prefix = if (sft.getDtgField.isDefined) 13 else 1
-    (row: Text) => {
-      val offset = row.find(AttributeWritableIndex.NullByte, from) + prefix
-      new String(row.getBytes, offset, row.getLength - offset, StandardCharsets.UTF_8)
+    (row, offset, length) => {
+      val start = row.indexOf(AttributeWritableIndex.NullByteArray.head, from + offset) + prefix
+      new String(row, start, length + offset - start, StandardCharsets.UTF_8)
     }
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/XZ2WritableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/XZ2WritableIndex.scala
@@ -50,9 +50,9 @@ trait XZ2WritableIndex extends AccumuloWritableIndex {
     }
   }
 
-  override def getIdFromRow(sft: SimpleFeatureType): (Text) => String = {
-    val offset = if (sft.isTableSharing) 10 else 9 // table sharing + shard + 8 byte long
-    (row: Text) => new String(row.getBytes, offset, row.getLength - offset, StandardCharsets.UTF_8)
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int) => String = {
+    val start = if (sft.isTableSharing) { 10 } else { 9 } // table sharing + shard + 8 byte long
+    (row, offset, length) => new String(row, offset + start, length - start, StandardCharsets.UTF_8)
   }
 
   // table sharing (0-1 byte), split(1 byte), xz value (8 bytes), id (n bytes)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/Z2WritableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/Z2WritableIndex.scala
@@ -27,9 +27,9 @@ trait Z2WritableIndex extends AccumuloWritableIndex {
   import AccumuloWritableIndex.{BinColumnFamily, FullColumnFamily}
   import Z2Index._
 
-  override def getIdFromRow(sft: SimpleFeatureType): (Text) => String = {
-    val offset = getIdRowOffset(sft)
-    (row: Text) => new String(row.getBytes, offset, row.getLength - offset, StandardCharsets.UTF_8)
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int) => String = {
+    val start = getIdRowOffset(sft)
+    (row, offset, length) => new String(row, offset + start, length - start, StandardCharsets.UTF_8)
   }
 
   // split(1 byte), z value (8 bytes), id (n bytes)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/XZ3WritableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/XZ3WritableIndex.scala
@@ -56,9 +56,9 @@ trait XZ3WritableIndex extends AccumuloWritableIndex {
     }
   }
 
-  override def getIdFromRow(sft: SimpleFeatureType): (Text) => String = {
-    val offset = if (sft.isTableSharing) 12 else 11 // table sharing + shard + 2 byte short + 8 byte long
-    (row: Text) => new String(row.getBytes, offset, row.getLength - offset, StandardCharsets.UTF_8)
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int) => String = {
+    val start = if (sft.isTableSharing) { 12 } else { 11 } // table sharing + shard + 2 byte short + 8 byte long
+    (row, offset, length) => new String(row, offset + start, length - start, StandardCharsets.UTF_8)
   }
 
   // table sharing (0-1 byte), split (1 byte), time interval(2 bytes), z value (8 bytes), id (n bytes)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/Z3WritableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/Z3WritableIndex.scala
@@ -42,9 +42,9 @@ trait Z3WritableIndex extends AccumuloWritableIndex {
     }
   }
 
-  override def getIdFromRow(sft: SimpleFeatureType): (Text) => String = {
-    val offset = getIdRowOffset(sft)
-    (row: Text) => new String(row.getBytes, offset, row.getLength - offset, StandardCharsets.UTF_8)
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int) => String = {
+    val start = getIdRowOffset(sft)
+    (row, offset, length) => new String(row, offset + start, length - start, StandardCharsets.UTF_8)
   }
 
   // split(1 byte), week(2 bytes), z value (8 bytes), id (n bytes)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/BinAggregatingIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/BinAggregatingIterator.scala
@@ -260,13 +260,15 @@ class PrecomputedBinAggregatingIterator extends BinAggregatingIterator {
         (sf, long) => sf.setAttribute(dtgIndex, new Date(long))
       }
       (_) => {
-        sf.getIdentifier.setID(getId(source.getTopKey.getRow))
+        val row = source.getTopKey.getRow
+        sf.getIdentifier.setID(getId(row.getBytes, 0, row.getLength))
         setValuesFromBin(sf, gf)
         sf
       }
     } else if (sample && dedupe) {
       (_) => {
-        sf.getIdentifier.setID(getId(source.getTopKey.getRow))
+        val row = source.getTopKey.getRow
+        sf.getIdentifier.setID(getId(row.getBytes, 0, row.getLength))
         setTrackIdFromBin(sf)
         sf
       }
@@ -277,7 +279,8 @@ class PrecomputedBinAggregatingIterator extends BinAggregatingIterator {
       }
     } else if (dedupe) {
       (_) => {
-        sf.getIdentifier.setID(getId(source.getTopKey.getRow))
+        val row = source.getTopKey.getRow
+        sf.getIdentifier.setID(getId(row.getBytes, 0, row.getLength))
         sf
       }
     } else {
@@ -582,7 +585,8 @@ object BinAggregatingIterator extends LazyLogging {
       val deserializer = SimpleFeatureDeserializers(returnSft, serializationType, SerializationOptions.withoutId)
       (e: Entry[Key, Value]) => {
         val deserialized = deserializer.deserialize(e.getValue.get())
-        deserialized.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(e.getKey.getRow))
+        val row = e.getKey.getRow
+        deserialized.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(row.getBytes, 0, row.getLength))
         // set the value directly in the array, as we don't support byte arrays as properties
         new ScalaSimpleFeature(deserialized.getID, BIN_SFT, Array(encode(deserialized), zeroPoint))
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoLazyAggregatingIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoLazyAggregatingIterator.scala
@@ -74,7 +74,8 @@ abstract class KryoLazyAggregatingIterator[T <: AnyRef { def isEmpty: Boolean; d
       getId = (_) => reusableSf.getID
       reusableSf = new KryoFeatureSerializer(sft).getReusableFeature
     } else {
-      getId = index.getIdFromRow(sft)
+      val getIdFromRow = index.getIdFromRow(sft)
+      getId = (row) => getIdFromRow(row.getBytes, 0, row.getLength)
       reusableSf = new KryoFeatureSerializer(sft, SerializationOptions.withoutId).getReusableFeature
     }
     val filt = options.get(CQL_OPT).map(FastFilterFactory.toFilter).orNull

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilder.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilder.scala
@@ -8,7 +8,7 @@
 
 package org.locationtech.geomesa.accumulo.util
 
-import org.locationtech.geomesa.accumulo.data.TableSplitter
+import org.locationtech.geomesa.index.conf.TableSplitter
 import org.locationtech.geomesa.utils.geotools.SftBuilder._
 import org.locationtech.geomesa.utils.geotools.{InitBuilder, SimpleFeatureTypes}
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTest.scala
@@ -35,6 +35,7 @@ import org.locationtech.geomesa.accumulo.{AccumuloVersion, TestWithMultipleSfts}
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.features.avro.AvroSimpleFeatureFactory
 import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
+import org.locationtech.geomesa.index.conf.DigitSplitter
 import org.locationtech.geomesa.index.geotools.CachingFeatureCollection
 import org.locationtech.geomesa.index.utils.ExplainString
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
@@ -435,7 +435,7 @@ class AccumuloFeatureWriterTest extends Specification with TestWithDataStore wit
       // ensure that the second part of the UUID is random
       rowKeys.map(_.substring(19)).toSet must haveLength(5)
 
-      val ids = rows.map(e => RecordIndex.getIdFromRow(sft)(e.getKey.getRow))
+      val ids = rows.map(e => RecordIndex.getIdFromRow(sft)(e.getKey.getRow.getBytes, 0, e.getKey.getRow.getLength))
       ids must haveLength(5)
       forall(ids)(_ must not(beMatching("fid\\d")))
       // ensure they share a common prefix, since they have the same dtg/geom

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/AccumuloSftBuilderTest.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.accumulo.util
 
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.accumulo.data.DigitSplitter
+import org.locationtech.geomesa.index.conf.DigitSplitter
 import org.opengis.feature.simple.SimpleFeatureType
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaAccumuloInputFormat.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapred/GeoMesaAccumuloInputFormat.scala
@@ -236,7 +236,10 @@ class GeoMesaRecordReader(sft: SimpleFeatureType,
   override def next(key: Text, value: SimpleFeature) =
     if (nextInternal()) {
       val sf = decoder.deserialize(delegateValue.get())
-      val id = if (hasId) sf.getID else getId(delegateKey.getRow)
+      val id = if (hasId) { sf.getID } else {
+        val row = delegateKey.getRow
+        getId(row.getBytes, 0, row.getLength)
+      }
       // copy the decoded sf into the reused one passed in to this method
       key.set(id)
       value.getIdentifier.asInstanceOf[FeatureIdImpl].setID(id) // value will be a ScalaSimpleFeature

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
@@ -273,7 +273,8 @@ class GeoMesaRecordReader(sft: SimpleFeatureType,
         if (reader.nextKeyValue()) {
           currentFeature = decoder.deserialize(reader.getCurrentValue.get())
           if (!hasId) {
-            currentFeature.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(reader.getCurrentKey.getRow))
+            val row = reader.getCurrentKey.getRow
+            currentFeature.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(row.getBytes, 0, row.getLength))
           }
           true
         } else {

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterHelper.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterHelper.scala
@@ -42,6 +42,13 @@ object FilterHelper {
 
   private val SafeGeomString = "gm-safe"
 
+  private lazy val logger = FilterHelperLogger.log
+
+  // helper shim to let other classes avoid importing FilterHelper.logger
+  object FilterHelperLogger extends LazyLogging {
+    def log = logger
+  }
+
   /**
     * Creates a new filter with valid bounds and attribute
     *
@@ -111,7 +118,7 @@ object FilterHelper {
 
   private def tryGetIdlSafeGeom(geom: Geometry): Geometry = getInternationalDateLineSafeGeometry(geom) match {
     case Success(g) => g
-    case Failure(e) => FilterHelperLogger.log.warn(s"Error splitting geometry on IDL for $geom", e); geom
+    case Failure(e) => logger.warn(s"Error splitting geometry on IDL for $geom", e); geom
   }
 
   private def recreateAsIdlSafeFilter(op: BinarySpatialOperator,
@@ -314,7 +321,7 @@ object FilterHelper {
           }
         } catch {
           case e: Exception =>
-            FilterHelperLogger.log.warn(s"Unable to extract bounds from filter '${filterToString(f)}'", e)
+            logger.warn(s"Unable to extract bounds from filter '${filterToString(f)}'", e)
             None
         }
 
@@ -402,7 +409,7 @@ object FilterHelper {
           }
         } catch {
           case e: Exception =>
-            FilterHelperLogger.log.warn(s"Unable to extract bounds from filter '${filterToString(f)}'", e)
+            logger.warn(s"Unable to extract bounds from filter '${filterToString(f)}'", e)
             None
         }
 
@@ -416,7 +423,7 @@ object FilterHelper {
           }
         } catch {
           case e: Exception =>
-            FilterHelperLogger.log.warn(s"Unable to extract bounds from filter '${filterToString(f)}'", e)
+            logger.warn(s"Unable to extract bounds from filter '${filterToString(f)}'", e)
             None
         }
 
@@ -458,9 +465,4 @@ object FilterHelper {
     filter.accept(new IdDetectingFilterVisitor, false).asInstanceOf[Boolean]
 
   def filterListAsAnd(filters: Seq[Filter]): Option[Filter] = andOption(filters)
-}
-
-// helper shim to let other classes avoid importing FilterHelper.logger
-object FilterHelperLogger extends LazyLogging {
-  def log = logger
 }

--- a/geomesa-hbase/geomesa-bigtable-datastore/pom.xml
+++ b/geomesa-hbase/geomesa-bigtable-datastore/pom.xml
@@ -13,7 +13,7 @@
     <name>GeoMesa Bigtable DataStore</name>
 
     <properties>
-        <bigtable.version>0.9.3</bigtable.version>
+        <bigtable.version>0.9.4</bigtable.version>
         <tcnative.version>1.1.33.Fork19</tcnative.version>
     </properties>
 

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStore.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStore.scala
@@ -39,10 +39,14 @@ class HBaseDataStore(val connection: Connection, config: HBaseDataStoreConfig)
     new HBaseModifyFeatureWriter(sft, this, indices, filter)
 
   override def createSchema(sft: SimpleFeatureType): Unit = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
     // TODO GEOMESA-1322 support tilde in feature name
     if (sft.getTypeName.contains("~")) {
       throw new IllegalArgumentException("AccumuloDataStore does not currently support '~' in feature type names")
     }
+    // we are only allowed to set splits at table creation
+    // disable table sharing to allow for decent pre-splitting
+    sft.setTableSharing(false)
     super.createSchema(sft)
   }
 

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreTest.scala
@@ -87,7 +87,7 @@ class HBaseDataStoreTest extends Specification with LazyLogging {
 
       ds.getSchema(typeName) must beNull
 
-      ds.createSchema(SimpleFeatureTypes.createType(typeName, "name:String,dtg:Date,*geom:Polygon:srid=4326"))
+      ds.createSchema(SimpleFeatureTypes.createType(typeName, "name:String:index=true,dtg:Date,*geom:Polygon:srid=4326"))
 
       val sft = ds.getSchema(typeName)
 
@@ -111,6 +111,7 @@ class HBaseDataStoreTest extends Specification with LazyLogging {
       testQuery(ds, typeName, "IN('0', '2')", null, Seq(toAdd(0), toAdd(2)))
       testQuery(ds, typeName, "bbox(geom,-126,38,-119,52) and dtg DURING 2014-01-01T00:00:00.000Z/2014-01-01T07:59:59.000Z", null, toAdd.dropRight(2))
       testQuery(ds, typeName, "bbox(geom,-126,42,-119,45)", null, toAdd.dropRight(4))
+      testQuery(ds, typeName, "name < 'name5'", null, toAdd.take(5))
     }
   }
 

--- a/geomesa-index-api/pom.xml
+++ b/geomesa-index-api/pom.xml
@@ -43,6 +43,11 @@
             <artifactId>specs2_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/geomesa-index-api/src/main/java/org/locationtech/geomesa/index/conf/TableSplitter.java
+++ b/geomesa-index-api/src/main/java/org/locationtech/geomesa/index/conf/TableSplitter.java
@@ -6,12 +6,10 @@
 * http://www.opensource.org/licenses/apache2.0.php.
 *************************************************************************/
 
-package org.locationtech.geomesa.accumulo.data;
-
-import org.apache.hadoop.io.Text;
+package org.locationtech.geomesa.index.conf;
 
 import java.util.Map;
 
 public interface TableSplitter {
-    public Text[] getSplits(Map<String, String> options);
+    public byte[][] getSplits(Map<String, String> options);
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
@@ -94,6 +94,23 @@ trait GeoMesaFeatureIndex[DS <: GeoMesaDataStore[DS, F, WriteResult, QueryResult
   def delete(sft: SimpleFeatureType, ds: DS, shared: Boolean): Unit
 
   /**
+    *
+    * Retrieve an ID from a row. All indices are assumed to encode the feature ID into the row key
+    *
+    * @param sft simple feature type
+    * @return a function to retrieve an ID from a row - (row: Array[Byte], offset: Int, length: Int)
+    */
+  def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int) => String
+
+  /**
+    * Gets the intitial splits for a table
+    *
+    * @param sft simple feature type
+    * @return
+    */
+  def getSplits(sft: SimpleFeatureType): Seq[Array[Byte]]
+
+  /**
     * Gets options for a 'simple' filter, where each OR is on a single attribute, e.g.
     *   (bbox1 OR bbox2) AND dtg
     *   bbox AND dtg AND (attr1 = foo OR attr = bar)

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/Splitters.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/Splitters.scala
@@ -6,11 +6,10 @@
 * http://www.opensource.org/licenses/apache2.0.php.
 *************************************************************************/
 
-package org.locationtech.geomesa.accumulo.data
+package org.locationtech.geomesa.index.conf
 
+import java.nio.charset.StandardCharsets
 import java.util
-
-import org.apache.hadoop.io.Text
 
 import scala.collection.JavaConversions._
 
@@ -19,24 +18,26 @@ class DigitSplitter extends TableSplitter {
    * @param options allowed options are "fmt", "min", and "max"
    * @return
    */
-  override def getSplits(options: util.Map[String, String]): Array[Text] = {
+  override def getSplits(options: java.util.Map[String, String]): Array[Array[Byte]] = {
     val fmt = options.getOrElse("fmt", "%01d")
     val min = options.getOrElse("min", "0").toInt
     val max = options.getOrElse("max", "0").toInt
-    (min to max).map(fmt.format(_)).map(s => new Text(s)).toArray
+    (min to max).map(fmt.format(_).getBytes(StandardCharsets.UTF_8)).toArray
   }
 }
 
 class HexSplitter extends TableSplitter {
-  val hexSplits = "0123456789abcdefABCDEF".map(_.toString).map(new Text(_)).toArray
-  override def getSplits(options: util.Map[String, String]): Array[Text] = hexSplits
+  // note: we don't include 0 to avoid an empty initial tablet
+  val hexSplits = "123456789abcdefABCDEF".map(_.toString.getBytes(StandardCharsets.UTF_8)).toArray
+  override def getSplits(options: util.Map[String, String]): Array[Array[Byte]] = hexSplits
 }
 
 class AlphaNumericSplitter extends TableSplitter {
-  override def getSplits(options: util.Map[String, String]): Array[Text] =
-    (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')).map(c => new Text("" + c)).toArray
+  // note: we don't include 0 to avoid an empty initial tablet
+  override def getSplits(options: util.Map[String, String]): Array[Array[Byte]] =
+    (('1' to '9') ++ ('a' to 'z') ++ ('A' to 'Z')).map(c => Array(c.toByte)).toArray
 }
 
 class NoSplitter extends TableSplitter {
-  override def getSplits(options: util.Map[String, String]): Array[Text] = Array.empty
+  override def getSplits(options: util.Map[String, String]): Array[Array[Byte]] = Array.empty
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreFactory.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreFactory.scala
@@ -30,7 +30,7 @@ object GeoMesaDataStoreFactory {
       p.lookupOpt[T](params).getOrElse(p.getDefaultValue.asInstanceOf[T])
   }
 
-  def queryTimeout(params: java.util.Map[String, Serializable]) = {
+  def queryTimeout(params: java.util.Map[String, Serializable]): Option[Long] = {
     QueryTimeoutParam.lookupOpt[Int](params).map(i => i * 1000L).orElse {
       QueryProperties.QUERY_TIMEOUT_MILLIS.option.map(_.toLong)
     }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/IndexAdapter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/IndexAdapter.scala
@@ -13,6 +13,7 @@
 
 package org.locationtech.geomesa.index.index
 
+import com.typesafe.scalalogging.LazyLogging
 import org.geotools.factory.Hints
 import org.locationtech.geomesa.index.api.{FilterStrategy, QueryPlan, WrappedFeature}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
@@ -21,16 +22,15 @@ import org.opengis.filter.Filter
 
 trait IndexAdapter[DS <: GeoMesaDataStore[DS, F, W, Q], F <: WrappedFeature, W, Q, R] {
 
-  def getIdFromRow(sft: SimpleFeatureType): (Array[Byte]) => String
-
   protected def entriesToFeatures(sft: SimpleFeatureType, returnSft: SimpleFeatureType): (Q) => SimpleFeature
   protected def createInsert(row: Array[Byte], feature: F): W
   protected def createDelete(row: Array[Byte], feature: F): W
 
-  // range with start row included and end row excluded
+  // range with start row included and end row excluded. no start/end is indicated by an empty byte array.
   protected def range(start: Array[Byte], end: Array[Byte]): R
   protected def rangeExact(row: Array[Byte]): R
-  protected def rangePrefix(prefix: Array[Byte]): R
+
+  protected def rangePrefix(prefix: Array[Byte]): R = range(prefix, IndexAdapter.rowFollowingPrefix(prefix))
 
   protected def scanPlan(sft: SimpleFeatureType,
                          ds: DS,
@@ -45,20 +45,30 @@ object IndexAdapter {
   val DefaultNumSplits = 4 // can't be more than Byte.MaxValue (127)
   val DefaultSplitArrays = (0 until DefaultNumSplits).map(_.toByte).toArray.map(Array(_)).toSeq
 
-  /**
+  val ZeroByte: Byte = 0x00.toByte
+  val MaxByte: Byte =  0xff.toByte
+
+  private lazy val logger = IndexAdapterLogger.log
+
+  // helper shim to let other classes avoid importing IndexAdapter.logger
+  object IndexAdapterLogger extends LazyLogging {
+    def log = logger
+  }
+
+    /**
     * Returns a row that sorts just after all rows beginning with a prefix. Copied from Accumulo Range
     *
     * @param prefix to follow
-    * @return prefix that immediately follows the given prefix when sorted, or null if no prefix can follow
+    * @return prefix that immediately follows the given prefix when sorted, or an empty array if no prefix can follow
     *         (i.e., the string is all 0xff bytes)
     */
-  def followingPrefix(prefix: Array[Byte]): Array[Byte] = {
+  def rowFollowingPrefix(prefix: Array[Byte]): Array[Byte] = {
     // find the last byte in the array that is not 0xff
     var changeIndex = prefix.length - 1
-    while (changeIndex >= 0 && prefix(changeIndex) == 0xff.toByte) {
+    while (changeIndex >= 0 && prefix(changeIndex) == MaxByte) {
       changeIndex -= 1
     }
-    if (changeIndex < 0) { null } else {
+    if (changeIndex < 0) { Array.empty } else {
       // copy prefix bytes into new array
       val following = Array.ofDim[Byte](changeIndex + 1)
       System.arraycopy(prefix, 0, following, 0, changeIndex + 1)
@@ -74,10 +84,50 @@ object IndexAdapter {
     * @param row row
     * @return
     */
-  def followingRow(row: Array[Byte]): Array[Byte] = {
+  def rowFollowingRow(row: Array[Byte]): Array[Byte] = {
     val following = Array.ofDim[Byte](row.length + 1)
     System.arraycopy(row, 0, following, 0, row.length)
-    following(row.length) = 0x00.toByte
+    following(row.length) = ZeroByte
     following
   }
+
+  /**
+    * Splits a range up into equal parts.
+    *
+    * Note: currently only handles prefix ranges, which should mainly the the ones we want to expand.
+    *
+    * @param start start value, inclusive
+    * @param stop stop value, exclusive
+    * @param splits hint for the number of parts to split into
+    * @return sequence of new ranges
+    */
+  def splitRange(start: Array[Byte], stop: Array[Byte], splits: Int): Seq[(Array[Byte], Array[Byte])] = {
+    require(splits > 0 && splits < 256, "Splits must be greater than 0 and less than 256")
+    if (splits == 1) {
+      Seq((start, stop))
+    } else if ((start.length == 0 && stop.length == 0) || java.util.Arrays.equals(rowFollowingPrefix(start), stop)) {
+      val increment = 256 / splits
+      val bytes = (1 until splits).map(i => start :+ ((i * increment) & MaxByte).toByte)
+      val first = (start, bytes.head)
+      val last = (bytes.last, stop)
+      val middle = if (bytes.length == 1) {
+        Seq.empty
+      } else {
+        bytes.sliding(2).map { case Seq(l, r) => (l, r) }
+      }
+      Seq(first) ++ middle :+ last
+    } else {
+      logger.warn(s"Not splitting range [${start.map(toHex).mkString},${stop.map(toHex).mkString}] - " +
+          "may want to consider implementing further split logic")
+      Seq((start, stop))
+    }
+  }
+
+  /**
+    * Converts an unsigned byte into a hex string
+    *
+    * @param b unsigned byte
+    * @return
+    */
+  def toHex(b: Byte): String = f"${(b & 0xff) >>> 4}%01x${b & 0x0f}%01x"
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/XZ2Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/XZ2Index.scala
@@ -54,10 +54,20 @@ trait XZ2Index[DS <: GeoMesaDataStore[DS, F, W, Q], F <: WrappedFeature, W, Q, R
     Bytes.concat(sharing, split, Longs.toByteArray(xz), id)
   }
 
-  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte]) => String = {
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int) => String = {
+    val start = if (sft.isTableSharing) { 10 } else { 9 } // table sharing + shard + 8 byte long
+    (row, offset, length) => new String(row, offset + start, length - start, StandardCharsets.UTF_8)
+  }
+
+  override def getSplits(sft: SimpleFeatureType): Seq[Array[Byte]] = {
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-    val start = if (sft.isTableSharing) { 10 } else { 9 }
-    (row: Array[Byte]) => new String(row, start, row.length - start, StandardCharsets.UTF_8)
+    val splits = DefaultSplitArrays.drop(1) // drop the first so we don't get an empty tablet
+    if (sft.isTableSharing) {
+      val sharing = sft.getTableSharingBytes
+      splits.map(s => Bytes.concat(sharing, s))
+    } else {
+      splits
+    }
   }
 
   override def getQueryPlan(sft: SimpleFeatureType,
@@ -94,7 +104,7 @@ trait XZ2Index[DS <: GeoMesaDataStore[DS, F, W, Q], F <: WrappedFeature, W, Q, R
 
       prefixes.flatMap { prefix =>
         zs.map { case (lo, hi) =>
-          range(concat(prefix, lo), IndexAdapter.followingRow(concat(prefix, hi)))
+          range(concat(prefix, lo), IndexAdapter.rowFollowingRow(concat(prefix, hi)))
         }
       }
     }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/utils/Explainer.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/utils/Explainer.scala
@@ -8,6 +8,8 @@
 
 package org.locationtech.geomesa.index.utils
 
+import java.io.PrintStream
+
 import org.slf4j.LoggerFactory
 
 trait Explainer {
@@ -25,8 +27,8 @@ trait Explainer {
   protected def output(s: => String)
 }
 
-class ExplainPrintln extends Explainer {
-  override def output(s: => String): Unit = println(s)
+class ExplainPrintln(out: PrintStream = System.out) extends Explainer {
+  override def output(s: => String): Unit = out.println(s)
 }
 
 object ExplainNull extends Explainer {

--- a/geomesa-index-api/src/test/resources/log4j.xml
+++ b/geomesa-index-api/src/test/resources/log4j.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.EnhancedPatternLayout">
+            <param name="ConversionPattern" value="[%d] %5p %c{1}: %m%n"/>
+        </layout>
+    </appender>
+
+    <category name="org.apache.zookeeper">
+        <priority value="warn"/>
+    </category>
+    <category name="org.apache.accumulo">
+        <priority value="warn"/>
+    </category>
+    <category name="org.apache.hadoop">
+        <priority value="warn"/>
+    </category>
+    <category name="hsqldb">
+        <priority value="warn"/>
+    </category>
+
+    <!-- un-comment the following line to enable verbose log messages
+         from the index query-planner; this can be helpful in debugging
+         query plans -->
+    <!--
+    <category name="org.locationtech.geomesa.index.utils.Explainer">
+        <priority value="trace"/>
+    </category>
+    -->
+
+    <root>
+        <priority value="info"/>
+        <appender-ref ref="CONSOLE" />
+    </root>
+</log4j:configuration>
+

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/IndexAdapterTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/IndexAdapterTest.scala
@@ -1,0 +1,50 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.index.index
+
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class IndexAdapterTest extends Specification {
+
+  "IndexAdapter" should {
+    "split empty ranges" in {
+      forall(Seq(2, 4, 8, 16)) { count =>
+        val splits = IndexAdapter.splitRange(Array.empty, Array.empty, count)
+        splits must haveLength(count)
+        splits.head._1 mustEqual Array.empty
+        splits.last._2 mustEqual Array.empty
+        forall(Seq(splits.head._2, splits.last._1) ++ splits.slice(1, splits.length - 1).flatMap { case (s, e) => Seq(s, e) })(_ must haveLength(1))
+      }
+    }
+    "split prefix ranges" in {
+      val start = Array[Byte](0)
+      val stop = IndexAdapter.rowFollowingPrefix(start)
+
+      forall(Seq(2, 4, 8, 16)) { count =>
+        val splits = IndexAdapter.splitRange(start, stop, count)
+        splits must haveLength(count)
+        splits.head._1 mustEqual start
+        splits.last._2 mustEqual stop
+        forall(Seq(splits.head._2, splits.last._1) ++ splits.slice(1, splits.length - 1).flatMap { case (s, e) => Seq(s, e) }) { split =>
+          split must haveLength(2)
+          split.head mustEqual 0
+        }
+      }
+    }
+    "not split complex ranges" in {
+      val start = Array[Byte](1, 2, 3)
+      val stop = Array[Byte](4, 5, 6)
+      val splits = IndexAdapter.splitRange(start, stop, 16)
+      splits mustEqual Seq((start, stop))
+    }
+  }
+}

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Runner.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/Runner.scala
@@ -23,7 +23,7 @@ trait Runner extends LazyLogging {
     try {
       parseCommand(args).execute()
     } catch {
-      case e: ParameterException => println(e.getMessage); sys.exit(-1)
+      case e: ParameterException => System.err.println(e.getMessage); sys.exit(-1)
       case NonFatal(e) => logger.error(e.getMessage, e); sys.exit(-1)
     }
     sys.exit(0)

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ExportCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ExportCommand.scala
@@ -17,29 +17,31 @@ import org.apache.commons.io.IOUtils
 import org.geotools.data.Query
 import org.geotools.data.simple.SimpleFeatureCollection
 import org.geotools.filter.text.ecql.ECQL
+import org.locationtech.geomesa.index.conf.QueryHints
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.tools.DataStoreCommand
 import org.locationtech.geomesa.tools.export.formats.{BinExporter, NullExporter, ShapefileExporter, _}
 import org.locationtech.geomesa.tools.utils.DataFormats
 import org.locationtech.geomesa.tools.utils.DataFormats._
+import org.locationtech.geomesa.utils.index.IndexMode
 import org.locationtech.geomesa.utils.stats.{MethodProfiling, Timing}
 import org.opengis.filter.Filter
 
 import scala.util.control.NonFatal
 
-trait ExportCommand[DS <: GeoMesaDataStore[_, _, _ ,_]] extends DataStoreCommand[DS] with MethodProfiling {
+trait ExportCommand[DS <: GeoMesaDataStore[_, _, _, _]] extends DataStoreCommand[DS] with MethodProfiling {
 
   override val name = "export"
   override def params: ExportParams
 
   override def execute() = {
     implicit val timing = new Timing
-    profile(withDataStore(export))
+    val count = profile(withDataStore(export))
     logger.info(s"Feature export complete to ${Option(params.file).map(_.getPath).getOrElse("standard out")} " +
-        s"in ${timing.time}ms")
+        s"in ${timing.time}ms${count.map(" for " + _ + " features").getOrElse("")}")
   }
 
-  protected def export(ds: DS): Unit = {
+  protected def export(ds: DS): Option[Long] = {
     import ExportCommand._
     import org.locationtech.geomesa.tools.utils.DataFormats._
 
@@ -63,8 +65,9 @@ trait ExportCommand[DS <: GeoMesaDataStore[_, _, _ ,_]] extends DataStoreCommand
     }
 
     try {
-      exporter.export(features)
+      val count = exporter.export(features)
       exporter.flush()
+      count
     } finally {
       IOUtils.closeQuietly(exporter)
     }
@@ -73,7 +76,7 @@ trait ExportCommand[DS <: GeoMesaDataStore[_, _, _ ,_]] extends DataStoreCommand
 
 object ExportCommand extends LazyLogging {
 
-  def getFeatureCollection(ds: GeoMesaDataStore[_, _, _, _],
+  def getFeatureCollection(ds: GeoMesaDataStore[_, _, _ ,_],
                            fmt: DataFormat,
                            params: BaseExportParams): SimpleFeatureCollection = {
     import scala.collection.JavaConversions._
@@ -99,6 +102,10 @@ object ExportCommand extends LazyLogging {
 
     val q = new Query(params.featureName, filter, attributes.map(_.toArray).orNull)
     Option(params.maxFeatures).map(Int.unbox).foreach(q.setMaxFeatures)
+    params.loadIndex(ds, IndexMode.Read).foreach { index =>
+      q.getHints.put(QueryHints.QUERY_INDEX_KEY, index)
+      logger.debug(s"Using index ${index.identifier}")
+    }
 
     // get the feature store used to query the GeoMesa data
     val fs = ds.getFeatureSource(params.featureName)

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ExportParams.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ExportParams.scala
@@ -11,9 +11,9 @@ package org.locationtech.geomesa.tools.export
 import java.io.File
 
 import com.beust.jcommander.{Parameter, Parameters}
-import org.locationtech.geomesa.tools.{CatalogParam, OptionalCqlFilterParam, RequiredTypeNameParam}
+import org.locationtech.geomesa.tools.{CatalogParam, OptionalCqlFilterParam, OptionalIndexParam, RequiredTypeNameParam}
 
-trait BaseExportParams extends CatalogParam with RequiredTypeNameParam with OptionalCqlFilterParam {
+trait BaseExportParams extends CatalogParam with RequiredTypeNameParam with OptionalCqlFilterParam with OptionalIndexParam {
   @Parameter(names = Array("-m", "--max-features"), description = "Maximum number of features to return. default: Unlimited")
   var maxFeatures: Integer = null
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/AvroExporter.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/AvroExporter.scala
@@ -18,7 +18,10 @@ class AvroExporter(sft: SimpleFeatureType, os: OutputStream, compression: Int) e
 
   val writer = new AvroDataFileWriter(os, sft, compression)
 
-  override def export(fc: SimpleFeatureCollection): Unit = writer.append(fc)
+  override def export(fc: SimpleFeatureCollection): Option[Long] = {
+    writer.append(fc)
+    None
+  }
 
   override def flush() = {
     writer.flush()

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/BinExporter.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/BinExporter.scala
@@ -27,8 +27,10 @@ class BinExporter(os: OutputStream,
   val id = idAttribute.orElse(Some("id"))
   val latLon = latAttribute.flatMap(lat => lonAttribute.map(lon => (lat, lon)))
 
-  override def export(fc: SimpleFeatureCollection) =
+  override def export(fc: SimpleFeatureCollection): Option[Long] = {
     encodeFeatureCollection(fc, os, EncodingOptions(dtgAttribute, id, lblAttribute, latLon, AxisOrder.LonLat))
+    None
+  }
 
   override def flush() = os.flush()
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/DelimitedExporter.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/DelimitedExporter.scala
@@ -30,9 +30,8 @@ class DelimitedExporter(writer: Writer, format: DataFormat, withHeader: Boolean 
     case DataFormats.Tsv => CSVFormat.TDF.withQuoteMode(QuoteMode.MINIMAL).print(writer)
   }
 
-  override def export(features: SimpleFeatureCollection): Unit = {
+  override def export(features: SimpleFeatureCollection): Option[Long] = {
     import org.locationtech.geomesa.utils.geotools.Conversions.toRichSimpleFeatureIterator
-
 
     val sft = features.getSchema
 
@@ -57,6 +56,7 @@ class DelimitedExporter(writer: Writer, format: DataFormat, withHeader: Boolean 
       }
     }
     logger.info(s"Exported $count features")
+    Some(count)
   }
 
   def stringify(o: Any): String = {

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/FeatureExporter.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/FeatureExporter.scala
@@ -13,5 +13,5 @@ import java.io.{Closeable, Flushable}
 import org.geotools.data.simple.SimpleFeatureCollection
 
 trait FeatureExporter extends Closeable with Flushable {
-  def export(featureCollection: SimpleFeatureCollection): Unit
+  def export(featureCollection: SimpleFeatureCollection): Option[Long]
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/GeoJsonExporter.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/GeoJsonExporter.scala
@@ -17,7 +17,10 @@ class GeoJsonExporter(writer: Writer) extends FeatureExporter {
 
   val featureJson = new FeatureJSON()
 
-  override def export(features: SimpleFeatureCollection) = featureJson.writeFeatureCollection(features, writer)
+  override def export(features: SimpleFeatureCollection) = {
+    featureJson.writeFeatureCollection(features, writer)
+    None
+  }
 
   override def flush() = writer.flush()
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/GmlExporter.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/GmlExporter.scala
@@ -20,7 +20,10 @@ class GmlExporter(os: OutputStream) extends FeatureExporter {
   // JNH: "location" is unlikely to be a valid namespace.
   encode.setNamespace("location", "location.xsd")
 
-  override def export(features: SimpleFeatureCollection) = encode.encode(os, features)
+  override def export(features: SimpleFeatureCollection): Option[Long] = {
+    encode.encode(os, features)
+    None
+  }
 
   override def flush() = os.flush()
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/NullExporter.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/NullExporter.scala
@@ -11,8 +11,14 @@ package org.locationtech.geomesa.tools.export.formats
 import org.geotools.data.simple.SimpleFeatureCollection
 
 object NullExporter extends FeatureExporter {
-  import org.locationtech.geomesa.utils.geotools.Conversions.toRichSimpleFeatureIterator
-  override def export(features: SimpleFeatureCollection): Unit = features.features().foreach(_ => Unit)
+
+  override def export(features: SimpleFeatureCollection): Option[Long] = {
+    import org.locationtech.geomesa.utils.geotools.Conversions.toRichSimpleFeatureIterator
+    var count = 0L
+    features.features().foreach(_ => count += 1)
+    Some(count)
+  }
+
   override def flush() = {}
   override def close() = {}
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/ShapefileExporter.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/ShapefileExporter.scala
@@ -17,7 +17,7 @@ import org.opengis.feature.simple.SimpleFeatureType
 
 class ShapefileExporter(file: File) extends FeatureExporter {
 
-  override def export(features: SimpleFeatureCollection) = {
+  override def export(features: SimpleFeatureCollection): Option[Long] = {
     val url = DataUtilities.fileToURL(file)
     val factory = new ShapefileDataStoreFactory()
     val newShapeFile = factory.createDataStore(url).asInstanceOf[ShapefileDataStore]
@@ -25,6 +25,7 @@ class ShapefileExporter(file: File) extends FeatureExporter {
     newShapeFile.createSchema(features.getSchema)
     val store = newShapeFile.getFeatureSource.asInstanceOf[SimpleFeatureStore]
     store.addFeatures(features)
+    None
   }
 
   override def flush() = {}

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/status/ExplainCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/status/ExplainCommand.scala
@@ -11,14 +11,16 @@ package org.locationtech.geomesa.tools.status
 import com.beust.jcommander.Parameters
 import org.geotools.data.Query
 import org.geotools.filter.text.ecql.ECQL
+import org.locationtech.geomesa.index.conf.QueryHints
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.utils.ExplainPrintln
 import org.locationtech.geomesa.tools._
+import org.locationtech.geomesa.utils.index.IndexMode
 import org.opengis.filter.Filter
 
 import scala.util.control.NonFatal
 
-trait ExplainCommand[DS <: GeoMesaDataStore[_, _, _ ,_]] extends DataStoreCommand[DS] {
+trait ExplainCommand[DS <: GeoMesaDataStore[DS, _, _, _]] extends DataStoreCommand[DS] {
 
   override def params: ExplainParams
 
@@ -35,9 +37,13 @@ trait ExplainCommand[DS <: GeoMesaDataStore[_, _, _ ,_]] extends DataStoreComman
   protected def explain(ds: DS): Unit = {
     val query = new Query(params.featureName, Option(params.cqlFilter).map(ECQL.toFilter).getOrElse(Filter.INCLUDE))
     Option(params.attributes).filterNot(_.isEmpty).foreach(query.setPropertyNames)
-    ds.getQueryPlan(query, None, new ExplainPrintln)
+    params.loadIndex(ds, IndexMode.Read).foreach { index =>
+      query.getHints.put(QueryHints.QUERY_INDEX_KEY, index)
+      logger.debug(s"Using index ${index.identifier}")
+    }
+    ds.getQueryPlan(query, None, new ExplainPrintln(System.err))
   }
 }
 
 @Parameters(commandDescription = "Explain how a GeoMesa query will be executed")
-class ExplainParams extends QueryParams with RequiredCqlFilterParam
+class ExplainParams extends QueryParams with RequiredCqlFilterParam with OptionalIndexParam


### PR DESCRIPTION
~~Note: stacks on top of #1180~~

* Disabling table-sharing for hbase data stores to allow for pre-configured splits
* Making getIdFromRow part of index-api
* Note: TableSplitter classes have moved to 'org.locationtech.geomesa.index.conf'
    
Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>
