### PR TITLE
GEOMESA-1536, GEOMESA-1525, GEOMESA-1227 Docs fixes

### DIFF
--- a/docs/_static/css/theme_custom.css
+++ b/docs/_static/css/theme_custom.css
@@ -295,3 +295,7 @@ div.admonition.warning, div.admonition.note {
 .wy-table-responsive tr.row-odd td {
    background-color: transparent !important;
 }
+
+.wy-table-responsive table td, .wy-table-responsive table th {
+   white-space: normal;
+}

--- a/docs/tutorials/geohash-substrings.rst
+++ b/docs/tutorials/geohash-substrings.rst
@@ -129,10 +129,12 @@ This discussion of the algorithm is coarse, in part because its role in
 the overall query process has been simplified to streamline the
 explanation in this short note. The full version as used within the
 query planner can be found nested inside the
-`getUniqueGeohashSubstringsInPolygon <https://github.com/locationtech/geomesa/tree/geomesa_2.11-1.3.0-m0/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geohash/GeohashUtils.scala#L937>`__
+`getUniqueGeohashSubstringsInPolygon`_
 method, where it enables GeoMesa to enumerate the unique substrings of
 larger Geohashes quickly and efficiently, expediting the entire
 query-planning process.
+
+.. _getUniqueGeohashSubstringsInPolygon: https://github.com/locationtech/geomesa/blob/geomesa_2.11-1.3.0-m0/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geohash/GeohashUtils.scala#L937
 
 Addendum
 --------

--- a/docs/tutorials/geomesa-examples-authorizations.rst
+++ b/docs/tutorials/geomesa-examples-authorizations.rst
@@ -252,6 +252,11 @@ Pick a reasonable directory on your machine, and run:
     $ git clone https://github.com/geomesa/geomesa-tutorials.git
     $ cd geomesa-tutorials
 
+.. note::
+
+    You may need to download a particular release of the tutorials project
+    to target a particular GeoMesa release. See :ref:`tutorial_versions`.
+
 Cloning the repository should only take a few seconds. To build it, run
 
 .. code-block:: bash
@@ -321,10 +326,10 @@ Insight into How the Authorizations Tutorial Works
 --------------------------------------------------
 
 The code for querying with authorizations is available in the class
-```com.example.geomesa.authorizations.AuthorizationsTutorial`` <https://github.com/geomesa/geomesa-tutorials/blob/master/geomesa-examples-authorizations/src/main/java/com/example/geomesa/authorizations/AuthorizationsTutorial.java>`__.
-
-The interesting code for this tutorial is contained in the ``main``
+`AuthorizationsTutorial`_. The interesting code for this tutorial is contained in the ``main``
 method:
+
+.. _AuthorizationsTutorial: https://github.com/geomesa/geomesa-tutorials/blob/master/geomesa-examples-authorizations/src/main/java/com/example/geomesa/authorizations/AuthorizationsTutorial.java
 
 .. code-block:: java
 
@@ -431,11 +436,10 @@ Create the Accumulo Data Store and Layer in GeoServer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you haven't already, create an AccumuloDataStore and associated Layer
-pointing to the data with visibilities, as described in the `GDELT
-tutorial <../geomesa-examples-gdelt/>`__.
+pointing to the data with visibilities, as described in :doc:`./geomesa-examples-gdelt`.
 
-When configuring the DataStore, leave the ***auths*** field empty and
-set the ***visibilities*** field to what you used when ingesting data
+When configuring the DataStore, leave the **auths** field empty and
+set the **visibilities** field to what you used when ingesting data
 above.
 
 Configure GeoServer for PKI Login

--- a/docs/tutorials/geomesa-examples-avro.rst
+++ b/docs/tutorials/geomesa-examples-avro.rst
@@ -19,6 +19,11 @@ Pick a reasonable directory on your machine, and run:
     $ git clone https://github.com/geomesa/geomesa-tutorials.git
     $ cd geomesa-tutorials
 
+.. note::
+
+    You may need to download a particular release of the tutorials project
+    to target a particular GeoMesa release. See :ref:`tutorial_versions`.
+
 To build, run
 
 .. code-block:: bash

--- a/docs/tutorials/geomesa-examples-featurelevelvis.rst
+++ b/docs/tutorials/geomesa-examples-featurelevelvis.rst
@@ -48,6 +48,11 @@ Pick a reasonable directory on your machine, and run:
     $ git clone https://github.com/geomesa/geomesa-tutorials.git
     $ cd geomesa-tutorials
 
+.. note::
+
+    You may need to download a particular release of the tutorials project
+    to target a particular GeoMesa release. See :ref:`tutorial_versions`.
+
 To build, run
 
 .. code-block:: bash

--- a/docs/tutorials/geomesa-examples-gdelt.rst
+++ b/docs/tutorials/geomesa-examples-gdelt.rst
@@ -78,6 +78,11 @@ Pick a reasonable directory on your machine, and run:
     $ git clone https://github.com/geomesa/geomesa-tutorials.git
     $ cd geomesa-tutorials
 
+.. note::
+
+    You may need to download a particular release of the tutorials project
+    to target a particular GeoMesa release. See :ref:`tutorial_versions`.
+
 To build, run
 
 .. code-block:: bash

--- a/docs/tutorials/geomesa-examples-transformations.rst
+++ b/docs/tutorials/geomesa-examples-transformations.rst
@@ -70,6 +70,11 @@ Pick a reasonable directory on your machine, and run:
     $ git clone https://github.com/geomesa/geomesa-tutorials.git
     $ cd geomesa-tutorials
 
+.. note::
+
+    You may need to download a particular release of the tutorials project
+    to target a particular GeoMesa release. See :ref:`tutorial_versions`.
+
 To build, run
 
 .. code-block:: bash

--- a/docs/tutorials/geomesa-quickstart-accumulo.rst
+++ b/docs/tutorials/geomesa-quickstart-accumulo.rst
@@ -41,6 +41,11 @@ Pick a reasonable directory on your machine, and run:
     $ git clone https://github.com/geomesa/geomesa-tutorials.git
     $ cd geomesa-tutorials
 
+.. note::
+
+    You may need to download a particular release of the tutorials project
+    to target a particular GeoMesa release. See :ref:`tutorial_versions`.
+
 To build, run
 
 .. code-block:: bash

--- a/docs/tutorials/geomesa-quickstart-hbase.rst
+++ b/docs/tutorials/geomesa-quickstart-hbase.rst
@@ -54,6 +54,11 @@ Clone the geomesa-tutorials distribution from GitHub:
     $ git clone https://github.com/geomesa/geomesa-tutorials.git
     $ cd geomesa-tutorials
 
+.. note::
+
+    You may need to download a particular release of the tutorials project
+    to target a particular GeoMesa release. See :ref:`tutorial_versions`.
+
 The ``pom.xml`` file contains an explicit list of dependent libraries
 that will be bundled together into the final tutorial. You should
 confirm that the versions of HBase and Hadoop match what you are

--- a/docs/tutorials/geomesa-quickstart-kafka.rst
+++ b/docs/tutorials/geomesa-quickstart-kafka.rst
@@ -34,9 +34,7 @@ Prerequisites
 -  `Apache Maven <http://maven.apache.org/>`__ |maven_version|, and
 -  a `git <http://git-scm.com/>`__ client.
 
-In order to install the GeoMesa Kafka GeoServer plugin, follow the
-instructions
-`here <https://github.com/locationtech/geomesa/tree/master/geomesa-kafka/geomesa-kafka-gs-plugin>`__.
+In order to install the GeoMesa Kafka GeoServer plugin, follow the instructions here: :ref:`install_kafka_geoserver`.
 
 Ensure your Kafka and Zookeeper instances are running. You can use
 Kafka's
@@ -52,6 +50,11 @@ Pick a reasonable directory on your machine, and run:
 
     $ git clone https://github.com/geomesa/geomesa-tutorials.git
     $ cd geomesa-tutorials
+
+.. note::
+
+    You may need to download a particular release of the tutorials project
+    to target a particular GeoMesa release. See :ref:`tutorial_versions`.
 
 To build, run
 

--- a/docs/tutorials/geomesa-quickstart-storm.rst
+++ b/docs/tutorials/geomesa-quickstart-storm.rst
@@ -23,13 +23,11 @@ You will need access to:
 -  an instance of GeoServer |geoserver_version| with the GeoMesa Accumulo plugin
    installed
 
-In order to install the GeoMesa Accumulo GeoServer plugin, follow the
-instructions
-`here <https://github.com/locationtech/geomesa/tree/master/geomesa-accumulo/geomesa-accumulo-gs-plugin>`__.
+In order to install the GeoMesa Accumulo GeoServer plugin, see :ref:`install_accumulo_geoserver`.
 
 You will also need:
 
--  The `xz <http://tukanni.org/xz/>`__ data compression tool
+-  The `xz <http://tukaani.org/xz/>`__ data compression tool
 -  `Java JDK 8 <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__,
 -  `Apache Maven <http://maven.apache.org>`__ |maven_version|
 -  a `git <http://git-scm.com/>`__ client
@@ -43,6 +41,11 @@ Pick a reasonable directory on your machine, and run:
 
     $ git clone https://github.com/geomesa/geomesa-tutorials.git
     $ cd geomesa-tutorials
+
+.. note::
+
+    You may need to download a particular release of the tutorials project
+    to target a particular GeoMesa release. See :ref:`tutorial_versions`.
 
 To build, run
 

--- a/docs/tutorials/geomesa-raster.rst
+++ b/docs/tutorials/geomesa-raster.rst
@@ -75,10 +75,11 @@ When attempting to ingest your own rasters, tiles should be on the order
 of 128x128 to 1024x1024 pixels.
 
 GeoServer Deployment
-____________________
+--------------------
+
 The GeoMesa GeoServer community module is required to enable registering GeoMesa Raster layers
-in GeoServer. If you have not allready, please follow the Installation and Configuration 
-instructions in the user manual.
+in GeoServer. If you have not already, please follow the instructions
+in :doc:`/user/installation_and_configuration`.
 
 If you have not deployed the community module yet, it can be downloaded from 
 `OpenGeo <http://ares.opengeo.org/geoserver/>`, or can be built from 

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -54,3 +54,46 @@ Indexing and Queries
 
     geohash-substrings
 
+
+.. _tutorial_versions:
+
+About Tutorial Versions
+-----------------------
+
+The tutorials listed in this manual can be obtained from GitHub, by
+cloning the **geomesa-tutorials** project:
+
+.. code-block:: bash
+
+    $ git clone https://github.com/geomesa/geomesa-tutorials.git
+    $ cd geomesa-tutorials
+
+Keep in mind that you may have to download a particular release of
+the tutorials project to match the GeoMesa version that
+you are using. For example, to target GeoMesa 1.2.6, you should download
+version 1.2.6.0 of the **geomesa-tutorials** project:
+
+.. code-block:: bash
+
+    $ git checkout geomesa-tutorials-1.2.6.0
+
+In general, the major, minor, and patch version numbers of the
+tutorials release will match the corresponding numbers of the
+GeoMesa version. The tutorials version contains a fourth digit
+number permitting multiple releases per GeoMesa release.
+
+You may also see the **geomesa-tutorials** releases available, and
+download a tarball of a release on the `geomesa-tutorials releases page`_.
+
+.. _geomesa-tutorials releases page: https://github.com/geomesa/geomesa-tutorials/releases
+
+Hadoop Version
+^^^^^^^^^^^^^^
+
+Most of the tutorials encourage you to update the ``pom.xml``
+to match the versions of the services you are using (Hadoop,
+ZooKeeper, Accumulo, etc.) However, there may be issues when
+incrementing the Hadoop version to 2.6 or above, which can result
+in Apache Curator version conflicts. Leaving the
+Hadoop version set to 2.2 in the tutorials ``pom.xml`` will work
+with all subsequent Hadoop 2.X releases.

--- a/docs/user/accumulo_datastore.rst
+++ b/docs/user/accumulo_datastore.rst
@@ -103,7 +103,15 @@ abstracted as 'tables'. For details on how GeoMesa encodes and indexes data, see
 The :doc:`./data_management` chapter also describes how to optimize these indexes by manipulating
 :ref:`attribute_indices`, :ref:`customizing_z_index`, :ref:`customizing_xz_index`, and :ref:`customizing_index_creation`.
 
-For details on how GeoMesa chooses and executes queries, see the `org.locationtech.geomesa.accumulo.index.QueryPlanner <https://github.com/locationtech/geomesa/blob/master/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/QueryPlanner.scala>`__ and `org.locationtech.geomesa.accumulo.index.QueryStrategyDecider <https://github.com/locationtech/geomesa/blob/master/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/QueryStrategyDecider.scala>`__ classes.
+For details on how GeoMesa chooses and executes queries, see the `QueryPlanner`_ and
+`StrategyDecider`_ classes in the **geomesa-index-api** project. The generic query
+planning API is configured for the Accumulo data store in the `AccumuloQueryPlanner`_ class.
+
+.. _QueryPlanner: https://github.com/locationtech/geomesa/blob/master/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/QueryPlanner.scala
+
+.. _StrategyDecider: https://github.com/locationtech/geomesa/blob/master/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/StrategyDecider.scala
+
+.. _AccumuloQueryPlanner: https://github.com/locationtech/geomesa/blob/master/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloQueryPlanner.scala
 
 .. _explain_query:
 

--- a/docs/user/kafka_datastore.rst
+++ b/docs/user/kafka_datastore.rst
@@ -300,6 +300,83 @@ Finally the Kafka Replay Consumer Feature Source can be queried:
 
     replayFeatureSource.getFeatures(timeFilter);
 
+Listening for Feature Events
+----------------------------
+
+The GeoTools API includes a mechanism to fire off a `FeatureEvent`_ object each time
+that there is an "event," which occur when data are added, changed, or deleted in a
+`SimpleFeatureSource`_. A client may implement a `FeatureListener`_, which has a single
+method called ``changed()`` that is invoked each time that each `FeatureEvent`_ is
+fired.
+
+Three types of messages are produced by a GeoMesa Kafka producer, which can be read
+by a GeoMesa Kafka consumer. For a live consumer feature source, reading each of these
+messages causes a `FeatureEvent`_ to be fired, as summarized in the table below:
+
++----------------+------------------------------------+-----------------------+----------------------+--------------------+
+| Message read   | Meaning                            | Class of event fired  | `FeatureEvent.Type`_ | Filter             |
++================+====================================+=======================+======================+====================+
+| CreateOrUpdate | A single feature with a given id   | ``KafkaFeatureEvent`` | ``CHANGED``          | ``IN (<id>)``      |
+|                | has been added; this               |                       |                      |                    |
+|                | may be a new feature, or an update |                       |                      |                    |
+|                | of an existing feature.            |                       |                      |                    |
++----------------+------------------------------------+-----------------------+----------------------+--------------------+
+| Delete         | The feature with the given id      | ``FeatureEvent``      | ``REMOVED``          | ``IN (<id>)``      |
+|                | has been removed.                  |                       |                      |                    |
++----------------+------------------------------------+-----------------------+----------------------+--------------------+
+| Clear          | All features have been removed.    | ``FeatureEvent``      | ``REMOVED``          | ``Filter.INCLUDE`` |
++----------------+------------------------------------+-----------------------+----------------------+--------------------+
+
+For a CreateOrUpdate message, the `FeatureEvent`_ returned is actually a ``KafkaFeatureEvent``,
+which subclasses `FeatureEvent`_. ``KafkaFeatureEvent`` adds a ``feature()`` method, which returns
+the ``SimpleFeature`` added or updated.
+
+To register a `FeatureListener`_, create the `SimpleFeatureSource`_ from a live GeoMesa
+Kafka consumer data store, and use the ``addFeatureListener()`` method. For example, the
+following listener simply prints out the events it receives:
+
+.. code-block:: java
+
+    // the live consumer must be created before the producer writes features
+    // in order to read streaming data.
+    // i.e. the live consumer will only read data written after its instantiation
+    SimpleFeatureSource consumerFS = consumerDS.getFeatureSource(sftName);
+    FeatureListener listener = new FeatureListener() {
+        @Override
+        public void changed(FeatureEvent featureEvent) {
+            System.out.println("Received FeatureEvent of Type: " + featureEvent.getType());
+
+            if (featureEvent.getType() == FeatureEvent.Type.CHANGED &&
+                    featureEvent instanceof KafkaFeatureEvent) {
+                SimpleFeature feature = ((KafkaFeatureEvent) featureEvent).feature();
+                System.out.println(feature);
+            }
+
+            if (featureEvent.getType() == FeatureEvent.Type.REMOVED) {
+                System.out.println("Received Delete for filter: " + featureEvent.getFilter());
+            }
+        }
+    }
+    consumerFS.addFeatureListener(listener);
+
+At cleanup time, it is important to unregister the feature listener with ``removeFeatureListener()``.
+For example, for code run in a bean in GeoServer, the ``javax.annotation.PreDestroy`` annotation may
+be used to mark the method that does the deregistration:
+
+.. code-block:: java
+
+    @PreDestroy
+    public void dispose() throws Exception {
+        consumerFS.removeFeatureListener(listener);
+        // other cleanup
+    }
+
+.. _FeatureEvent: http://docs.geotools.org/stable/javadocs/org/geotools/data/FeatureEvent.html
+.. _FeatureEvent.Type: http://docs.geotools.org/stable/javadocs/org/geotools/data/FeatureEvent.Type.html
+.. _FeatureListener: http://docs.geotools.org/stable/javadocs/org/geotools/data/FeatureListener.html
+.. _SimpleFeatureSource: http://docs.geotools.org/stable/javadocs/org/geotools/data/simple/SimpleFeatureSource.html
+
+
 Using the Kafka Data Store in GeoServer
 ---------------------------------------
 

--- a/docs/user/kafka_datastore.rst
+++ b/docs/user/kafka_datastore.rst
@@ -304,7 +304,7 @@ Listening for Feature Events
 ----------------------------
 
 The GeoTools API includes a mechanism to fire off a `FeatureEvent`_ object each time
-that there is an "event," which occur when data are added, changed, or deleted in a
+that there is an "event," which occurs when data are added, changed, or deleted in a
 `SimpleFeatureSource`_. A client may implement a `FeatureListener`_, which has a single
 method called ``changed()`` that is invoked each time that each `FeatureEvent`_ is
 fired.

--- a/docs/user/web_data.rst
+++ b/docs/user/web_data.rst
@@ -150,12 +150,13 @@ Registered data stores will persist between geoserver reboots.
 
 -  POST /spark/config - Set spark configurations
 
-Options are passed as parameters. For a list of available options, see:
+Options are passed as parameters. For a list of available options, see the
+following sections of the Spark documentation:
 
-https://spark.apache.org/docs/latest/configuration.html#available-properties
-https://spark.apache.org/docs/latest/running-on-yarn.html#spark-properties
-http://spark.apache.org/docs/latest/sql-programming-guide.html#caching-data-in-memory
-http://spark.apache.org/docs/latest/sql-programming-guide.html#other-configuration-options
+ * http://spark.apache.org/docs/latest/configuration.html#available-properties
+ * http://spark.apache.org/docs/latest/running-on-yarn.html#spark-properties
+ * http://spark.apache.org/docs/latest/sql-programming-guide.html#caching-data-in-memory
+ * http://spark.apache.org/docs/latest/sql-programming-guide.html#other-configuration-options
 
 Configuration changes will not take place until the Spark SQL context is
 restarted. Configuration will persist between geoserver restarts.


### PR DESCRIPTION
    * Add docs about feature events.
    * Fix query planner links in Accumulo chapter.
    * Fix Spark properties links.
    * Fix link to GS install docs, link for XZ tools.
    * Fix links in authorizations tutorials.
    * Fix link in geohash "tutorial".
    * Fix Kafka link.
    * RST-ify geomesa-raster tutorial.
    * Add a note about using the proper GeoMesa tutorials release.
    * Add note about Hadoop 2.6 version.

Signed-off-by: Matthew Zimmerman <matt.zimmerman@ccri.com>