### PR TITLE
1.2 - GEOMESA-1550 Improve performance of KryoBufferSimpleFeature

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoLazyFilterTransformIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoLazyFilterTransformIterator.scala
@@ -69,11 +69,12 @@ class KryoLazyFilterTransformIterator extends
     val transform = Option(options.get(TRANSFORM_DEFINITIONS_OPT))
     val transformSchema = Option(options.get(TRANSFORM_SCHEMA_OPT))
     for { t <- transform; ts <- transformSchema } {
-      reusablesf.setTransforms(t, SimpleFeatureTypes.createType("", ts))
+      reusableSf.setTransforms(t, IteratorCache.sft(ts))
     }
     hasTransform = transform.isDefined
 
     val cql = Option(options.get(CQL_OPT)).map(IteratorCache.filter(spec, _))
+    // TODO: can we optimize the configuration of sampling
     val sampling = sample(options)
 
     filter = (cql, sampling) match {

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/KryoBufferSimpleFeature.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/KryoBufferSimpleFeature.scala
@@ -128,11 +128,11 @@ class KryoBufferSimpleFeature(sft: SimpleFeatureType,
     }
 
     val shouldReserialize = indices.contains(-1)
-    val mutableOffsetsAndLength = Array.ofDim[(Int,Int)](indices.length)
 
     // if we are just returning a subset of attributes, we can copy the bytes directly and avoid creating
     // new objects, reserializing, etc
     binaryTransform = if (!shouldReserialize) {
+      val mutableOffsetsAndLength = Array.ofDim[(Int,Int)](indices.length)
       () => {
         val buf = input.getBuffer
         var length = offsets(0) // space for version, offset block and ID


### PR DESCRIPTION
* Avoid calling `contains`
* Use a mutable buffer for the offsets and lengths

Signed-off-by: Anthony Fox <anthonyfox@ccri.com>