### PR TITLE
GEOMESA-1552 Fixing check for join query against BIN non-default geometries

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/attribute/AttributeQueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/attribute/AttributeQueryableIndex.scala
@@ -117,6 +117,7 @@ trait AttributeQueryableIndex extends AccumuloWritableIndex with LazyLogging {
         // check to see if we can execute against the index values
         val indexSft = IndexValueEncoder.getIndexSft(sft)
         if (indexSft.indexOf(hints.getBinTrackIdField) != -1 &&
+            hints.getBinGeomField.forall(indexSft.indexOf(_) != -1) &&
             hints.getBinLabelField.forall(indexSft.indexOf(_) != -1) &&
             filter.secondary.forall(IteratorTrigger.supportsFilter(indexSft, _))) {
           val iter = BinAggregatingIterator.configureDynamic(indexSft, this, filter.secondary, hints, hasDupes)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/encoders/BinEncoder.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/encoders/BinEncoder.scala
@@ -36,7 +36,7 @@ class BinEncoder(sft: SimpleFeatureType, trackIdField: String) {
     val (lat, lon) = getLatLon(sf)
     val dtg = getDtg(sf)
     val trackIdVal = sf.getAttribute(trackIdIndex)
-    val trackId = if (trackIdVal == null) "" else trackIdVal.toString
+    val trackId = if (trackIdVal == null) { 0 } else { trackIdVal.hashCode }
     Convert2ViewerFunction.encodeToByteArray(BasicValues(lat, lon, dtg, trackId))
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/BinAggregatingIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/BinAggregatingIterator.scala
@@ -594,9 +594,9 @@ object BinAggregatingIterator extends LazyLogging {
 
   }
 
-  private def getTrack(sf: SimpleFeature, i: Int): String = {
+  private def getTrack(sf: SimpleFeature, i: Int): Int = {
     val t = sf.getAttribute(i)
-    if (t == null) "" else t.toString
+    if (t == null) { 0 } else { t.hashCode }
   }
 
   // get a single geom

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
@@ -389,7 +389,7 @@ class AccumuloDataStoreQueryTest extends Specification with TestWithMultipleSfts
       forall(results)(_ must beAnInstanceOf[Array[Byte]])
       val bins = results.flatMap(_.asInstanceOf[Array[Byte]].grouped(16).map(Convert2ViewerFunction.decode))
       bins must haveSize(2)
-      bins.map(_.trackId) must containAllOf(Seq("name1", "name2").map(_.hashCode.toString))
+      bins.map(_.trackId) must containAllOf(Seq("name1", "name2").map(_.hashCode))
     }
 
     "support bin queries with linestrings" in {
@@ -418,13 +418,13 @@ class AccumuloDataStoreQueryTest extends Specification with TestWithMultipleSfts
         val bins = bytes.flatMap(_.asInstanceOf[Array[Byte]].grouped(16).map(Convert2ViewerFunction.decode))
         bins must haveSize(7)
         val sorted = bins.sortBy(_.dtg)
-        sorted(0) mustEqual BasicValues(41, 40, dtgs1(0).getTime, "name1".hashCode.toString)
-        sorted(1) mustEqual BasicValues(43, 42, dtgs1(1).getTime, "name1".hashCode.toString)
-        sorted(2) mustEqual BasicValues(45, 44, dtgs1(2).getTime, "name1".hashCode.toString)
-        sorted(3) mustEqual BasicValues(47, 46, dtgs1(3).getTime, "name1".hashCode.toString)
-        sorted(4) mustEqual BasicValues(50, 50, dtgs2(0).getTime, "name2".hashCode.toString)
-        sorted(5) mustEqual BasicValues(51, 51, dtgs2(1).getTime, "name2".hashCode.toString)
-        sorted(6) mustEqual BasicValues(52, 52, dtgs2(2).getTime, "name2".hashCode.toString)
+        sorted(0) mustEqual BasicValues(41, 40, dtgs1(0).getTime, "name1".hashCode)
+        sorted(1) mustEqual BasicValues(43, 42, dtgs1(1).getTime, "name1".hashCode)
+        sorted(2) mustEqual BasicValues(45, 44, dtgs1(2).getTime, "name1".hashCode)
+        sorted(3) mustEqual BasicValues(47, 46, dtgs1(3).getTime, "name1".hashCode)
+        sorted(4) mustEqual BasicValues(50, 50, dtgs2(0).getTime, "name2".hashCode)
+        sorted(5) mustEqual BasicValues(51, 51, dtgs2(1).getTime, "name2".hashCode)
+        sorted(6) mustEqual BasicValues(52, 52, dtgs2(2).getTime, "name2".hashCode)
       }
     }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/AttributeIndexStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/AttributeIndexStrategyTest.scala
@@ -42,10 +42,11 @@ class AttributeIndexStrategyTest extends Specification with TestWithDataStore {
 
   override val spec = "name:String:index=full,age:Integer:index=true,count:Long:index=true," +
       "weight:Double:index=true,height:Float:index=true,admin:Boolean:index=true," +
-      "geom:Point:srid=4326,dtg:Date,indexedDtg:Date:index=true,fingers:List[String]:index=true," +
-      "toes:List[Double]:index=true,track:String;geomesa.indexes.enabled='attr_idx,records'"
+      "*geom:Point:srid=4326,dtg:Date,indexedDtg:Date:index=true,fingers:List[String]:index=true," +
+      "toes:List[Double]:index=true,track:String,geom2:Point:srid=4326;geomesa.indexes.enabled='attr_idx,records'"
 
-  val geom = WKTUtils.read("POINT(45.0 49.0)")
+  val geom  = WKTUtils.read("POINT(45.0 49.0)")
+  val geom2 = WKTUtils.read("POINT(55.0 59.0)")
 
   val df = ISODateTimeFormat.dateTime()
 
@@ -60,10 +61,10 @@ class AttributeIndexStrategyTest extends Specification with TestWithDataStore {
   val charlesFingers = List("thumb", "ring", "index", "pinkie", "middle")
 
   val features = Seq(
-    Array("alice",   20,   1, 5.0, 10.0F, true,  geom, aliceDate, aliceDate, aliceFingers, List(1.0), "track1"),
-    Array("bill",    21,   2, 6.0, 11.0F, false, geom, billDate, billDate, billFingers, List(1.0, 2.0), "track2"),
-    Array("bob",     30,   3, 6.0, 12.0F, false, geom, bobDate, bobDate, bobFingers, List(3.0, 2.0, 5.0), "track1"),
-    Array("charles", null, 4, 7.0, 12.0F, false, geom, charlesDate, charlesDate, charlesFingers, List(), "track1")
+    Array("alice",   20,   1, 5.0, 10.0F, true,  geom, aliceDate, aliceDate, aliceFingers, List(1.0), "track1", geom2),
+    Array("bill",    21,   2, 6.0, 11.0F, false, geom, billDate, billDate, billFingers, List(1.0, 2.0), "track2", geom2),
+    Array("bob",     30,   3, 6.0, 12.0F, false, geom, bobDate, bobDate, bobFingers, List(3.0, 2.0, 5.0), "track1", geom2),
+    Array("charles", null, 4, 7.0, 12.0F, false, geom, charlesDate, charlesDate, charlesFingers, List(), "track1", geom2)
   ).map { entry =>
     val feature = new ScalaSimpleFeature(entry.head.toString, sft)
     feature.setAttributes(entry.asInstanceOf[Array[AnyRef]])
@@ -107,12 +108,12 @@ class AttributeIndexStrategyTest extends Specification with TestWithDataStore {
       val query = new Query(sftName, ECQL.toFilter("count>=2"))
       query.getHints.put(BIN_TRACK, "name")
       query.getHints.put(BIN_BATCH_SIZE, 1000)
-      explain(query).split("\n").map(_.trim).filter(_.startsWith("Join Plan:")) must haveLength(1)
+      forall(ds.getQueryPlan(query))(_ must beAnInstanceOf[JoinPlan])
       val results = runQuery(query).map(_.getAttribute(BIN_ATTRIBUTE_INDEX)).toList
       forall(results)(_ must beAnInstanceOf[Array[Byte]])
       val bins = results.flatMap(_.asInstanceOf[Array[Byte]].grouped(16).map(Convert2ViewerFunction.decode))
       bins must haveSize(3)
-      bins.map(_.trackId) must containAllOf(Seq("bill", "bob", "charles").map(_.hashCode.toString))
+      bins.map(_.trackId) must containAllOf(Seq("bill", "bob", "charles").map(_.hashCode))
     }
 
     "support bin queries against index values" in {
@@ -120,12 +121,12 @@ class AttributeIndexStrategyTest extends Specification with TestWithDataStore {
       val query = new Query(sftName, ECQL.toFilter("count>=2"))
       query.getHints.put(BIN_TRACK, "dtg")
       query.getHints.put(BIN_BATCH_SIZE, 1000)
-      explain(query).split("\n").filter(_.startsWith("Join Table:")) must beEmpty
+      forall(ds.getQueryPlan(query))(_ must beAnInstanceOf[BatchScanPlan])
       val results = runQuery(query).map(_.getAttribute(BIN_ATTRIBUTE_INDEX)).toList
       forall(results)(_ must beAnInstanceOf[Array[Byte]])
       val bins = results.flatMap(_.asInstanceOf[Array[Byte]].grouped(16).map(Convert2ViewerFunction.decode))
       bins must haveSize(3)
-      bins.map(_.trackId) must containAllOf(Seq(billDate, bobDate, charlesDate).map(_.hashCode.toString))
+      bins.map(_.trackId) must containAllOf(Seq(billDate, bobDate, charlesDate).map(_.hashCode))
     }
 
     "support bin queries against full values" in {
@@ -133,12 +134,28 @@ class AttributeIndexStrategyTest extends Specification with TestWithDataStore {
       val query = new Query(sftName, ECQL.toFilter("name>'amy'"))
       query.getHints.put(BIN_TRACK, "count")
       query.getHints.put(BIN_BATCH_SIZE, 1000)
-      explain(query).split("\n").filter(_.startsWith("Join Table:")) must beEmpty
+      forall(ds.getQueryPlan(query))(_ must beAnInstanceOf[BatchScanPlan])
       val results = runQuery(query).map(_.getAttribute(BIN_ATTRIBUTE_INDEX)).toList
       forall(results)(_ must beAnInstanceOf[Array[Byte]])
       val bins = results.flatMap(_.asInstanceOf[Array[Byte]].grouped(16).map(Convert2ViewerFunction.decode))
       bins must haveSize(3)
-      bins.map(_.trackId) must containAllOf(Seq(2, 3, 4).map(_.hashCode.toString))
+      bins.map(_.trackId) must containAllOf(Seq(2, 3, 4).map(_.hashCode))
+    }
+
+    "support bin queries against non-default geoms with index-value track" in {
+      import BinAggregatingIterator.BIN_ATTRIBUTE_INDEX
+      val query = new Query(sftName, ECQL.toFilter("count>=2"))
+      query.getHints.put(BIN_GEOM, "geom2")
+      query.getHints.put(BIN_TRACK, "count")
+      query.getHints.put(BIN_BATCH_SIZE, 1000)
+      forall(ds.getQueryPlan(query))(_ must beAnInstanceOf[JoinPlan])
+      val results = runQuery(query).map(_.getAttribute(BIN_ATTRIBUTE_INDEX)).toList
+      forall(results)(_ must beAnInstanceOf[Array[Byte]])
+      val bins = results.flatMap(_.asInstanceOf[Array[Byte]].grouped(16).map(Convert2ViewerFunction.decode))
+      bins must haveSize(3)
+      bins.map(_.trackId) must containAllOf(Seq(2, 3, 4).map(_.hashCode))
+      forall(bins.map(_.lat))(_ mustEqual 59f)
+      forall(bins.map(_.lon))(_ mustEqual 55f)
     }
 
     "correctly query equals with date ranges" in {
@@ -787,6 +804,5 @@ class AttributeIndexStrategyTest extends Specification with TestWithDataStore {
       val res = FilterSplitter.tryMergeAttrStrategy(qf1, qf2)
       res must beNull
     }
-
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/BinLineStringTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/BinLineStringTest.scala
@@ -84,7 +84,7 @@ class BinLineStringTest extends Specification with TestWithDataStore {
       val bins = runQuery(query)
 
       bins must haveLength(40)
-      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode.toString)
+      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode)
       forall(0 until 10) { i =>
         bins.map(_.dtg) must contain(features(i).getAttribute("dtg").asInstanceOf[Date].getTime).exactly(4.times)
         bins.map(_.lat) must contain(60.0f + i).exactly(4.times)
@@ -104,7 +104,7 @@ class BinLineStringTest extends Specification with TestWithDataStore {
       val bins = runQuery(query)
 
       bins must haveLength(40)
-      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode.toString)
+      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode)
       forall(0 until 10) { i =>
         bins.map(_.dtg) must contain(features(i).getAttribute("dtg").asInstanceOf[Date].getTime).exactly(4.times)
         bins.map(_.lat) must contain(60.0f + i).exactly(4.times)
@@ -124,7 +124,7 @@ class BinLineStringTest extends Specification with TestWithDataStore {
 
       bins must haveLength(40)
       forall(bins)(_ must beAnInstanceOf[ExtendedValues])
-      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode.toString)
+      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode)
       forall(0 until 10) { i =>
         bins.map(_.dtg) must contain(features(i).getAttribute("dtg").asInstanceOf[Date].getTime).exactly(4.times)
         bins.map(_.lat) must contain(60.0f + i).exactly(4.times)
@@ -146,7 +146,7 @@ class BinLineStringTest extends Specification with TestWithDataStore {
 
       bins must haveLength(40)
       forall(bins)(_ must beAnInstanceOf[ExtendedValues])
-      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode.toString)
+      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode)
       forall(0 until 10) { i =>
         bins.map(_.dtg) must contain(features(i).getAttribute("dtg").asInstanceOf[Date].getTime).exactly(4.times)
         bins.map(_.lat) must contain(60.0f + i).exactly(4.times)
@@ -166,7 +166,7 @@ class BinLineStringTest extends Specification with TestWithDataStore {
       val bins = runQuery(query)
 
       bins must haveLength(40)
-      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode.toString)
+      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode)
       forall(0 until 10) { i =>
         val baseDate = features(i).getAttribute("dtg").asInstanceOf[Date].getTime
         bins.map(_.dtg) must containAllOf(Seq(baseDate, baseDate + 60000, baseDate + 120000, baseDate + 180000))
@@ -187,7 +187,7 @@ class BinLineStringTest extends Specification with TestWithDataStore {
       val bins = runQuery(query)
 
       bins must haveLength(40)
-      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode.toString)
+      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode)
       forall(0 until 10) { i =>
         val baseDate = features(i).getAttribute("dtg").asInstanceOf[Date].getTime
         bins.map(_.dtg) must containAllOf(Seq(baseDate, baseDate + 60000, baseDate + 120000, baseDate + 180000))
@@ -208,7 +208,7 @@ class BinLineStringTest extends Specification with TestWithDataStore {
 
       bins must haveLength(40)
       forall(bins)(_ must beAnInstanceOf[ExtendedValues])
-      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode.toString)
+      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode)
       forall(0 until 10) { i =>
         val baseDate = features(i).getAttribute("dtg").asInstanceOf[Date].getTime
         bins.map(_.dtg) must containAllOf(Seq(baseDate, baseDate + 60000, baseDate + 120000, baseDate + 180000))
@@ -231,7 +231,7 @@ class BinLineStringTest extends Specification with TestWithDataStore {
 
       bins must haveLength(40)
       forall(bins)(_ must beAnInstanceOf[ExtendedValues])
-      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode.toString)
+      forall(bins.map(_.trackId))(_ mustEqual "track1".hashCode)
       forall(0 until 10) { i =>
         val baseDate = features(i).getAttribute("dtg").asInstanceOf[Date].getTime
         bins.map(_.dtg) must containAllOf(Seq(baseDate, baseDate + 60000, baseDate + 120000, baseDate + 180000))

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/RecordIdxStrategyTest.scala
@@ -78,7 +78,7 @@ class RecordIdxStrategyTest extends Specification with TestWithDataStore {
       forall(results)(_ must beAnInstanceOf[Array[Byte]])
       val bins = results.flatMap(_.asInstanceOf[Array[Byte]].grouped(16).map(Convert2ViewerFunction.decode))
       bins must haveSize(2)
-      bins.map(_.trackId) must containTheSameElementsAs(Seq("name2", "name3").map(_.hashCode.toString))
+      bins.map(_.trackId) must containTheSameElementsAs(Seq("name2", "name3").map(_.hashCode))
     }
 
     "support sampling" in {
@@ -135,7 +135,7 @@ class RecordIdxStrategyTest extends Specification with TestWithDataStore {
       forall(results)(_ must beAnInstanceOf[Array[Byte]])
       val bins = results.flatMap(_.asInstanceOf[Array[Byte]].grouped(16).map(Convert2ViewerFunction.decode))
       bins must haveSize(3)
-      bins.map(_.trackId) must containTheSameElementsAs(Seq("track1", "track2", "track2").map(_.hashCode.toString))
+      bins.map(_.trackId) must containTheSameElementsAs(Seq("track1", "track2", "track2").map(_.hashCode))
     }
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/XZ2IdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/XZ2IdxStrategyTest.scala
@@ -159,7 +159,7 @@ class XZ2IdxStrategyTest extends Specification with TestWithDataStore {
       aggregates.size must beLessThan(10) // ensure some aggregation was done
       val bin = aggregates.flatMap(a => a.grouped(16).map(Convert2ViewerFunction.decode))
       bin must haveSize(10)
-      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode.toString))
+      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode))
       bin.map(_.dtg) must
           containAllOf((0 until 10).map(i => features(i).getAttribute("dtg").asInstanceOf[Date].getTime))
       bin.map(_.lat) must containAllOf((0 until 10).map(_ + 60.0))
@@ -179,7 +179,7 @@ class XZ2IdxStrategyTest extends Specification with TestWithDataStore {
       aggregates.size must beLessThan(10) // ensure some aggregation was done
       val bin = aggregates.flatMap(a => a.grouped(24).map(Convert2ViewerFunction.decode))
       bin must haveSize(10)
-      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode.toString))
+      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode))
       bin.map(_.dtg) must
           containAllOf((0 until 10).map(i => features(i).getAttribute("dtg").asInstanceOf[Date].getTime))
       bin.map(_.lat) must containAllOf((0 until 10).map(_ + 60.0))
@@ -231,7 +231,7 @@ class XZ2IdxStrategyTest extends Specification with TestWithDataStore {
       val bins = results.flatMap(_.asInstanceOf[Array[Byte]].grouped(16).map(Convert2ViewerFunction.decode))
       bins must haveLength(4)
       bins.map(_.trackId) must containTheSameElementsAs {
-        Seq("track1", "track1", "track2", "track2").map(_.hashCode.toString)
+        Seq("track1", "track1", "track2", "track2").map(_.hashCode)
       }
     }
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z2IdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z2IdxStrategyTest.scala
@@ -174,7 +174,7 @@ class Z2IdxStrategyTest extends Specification with TestWithDataStore {
       aggregates.size must beLessThan(10) // ensure some aggregation was done
       val bin = aggregates.flatMap(a => a.grouped(16).map(Convert2ViewerFunction.decode))
       bin must haveSize(10)
-      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode.toString))
+      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode))
       bin.map(_.dtg) must
           containAllOf((0 until 10).map(i => features(i).getAttribute("dtg").asInstanceOf[Date].getTime))
       bin.map(_.lat) must containAllOf((0 until 10).map(_ + 60.0))
@@ -203,7 +203,7 @@ class Z2IdxStrategyTest extends Specification with TestWithDataStore {
       }
       val bin = aggregates.flatMap(a => a.grouped(16).map(Convert2ViewerFunction.decode))
       bin must haveSize(10)
-      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode.toString))
+      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode))
       bin.map(_.dtg) must
           containAllOf((0 until 10).map(i => features(i).getAttribute("dtg").asInstanceOf[Date].getTime))
       bin.map(_.lat) must containAllOf((0 until 10).map(_ + 60.0))
@@ -228,7 +228,7 @@ class Z2IdxStrategyTest extends Specification with TestWithDataStore {
       aggregates.size must beLessThan(10) // ensure some aggregation was done
       val bin = aggregates.flatMap(a => a.grouped(24).map(Convert2ViewerFunction.decode))
       bin must haveSize(10)
-      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode.toString))
+      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode))
       bin.map(_.dtg) must
           containAllOf((0 until 10).map(i => features(i).getAttribute("dtg").asInstanceOf[Date].getTime))
       bin.map(_.lat) must containAllOf((0 until 10).map(_ + 60.0))
@@ -293,7 +293,7 @@ class Z2IdxStrategyTest extends Specification with TestWithDataStore {
       val bins = results.flatMap(_.asInstanceOf[Array[Byte]].grouped(16).map(Convert2ViewerFunction.decode))
       bins must haveLength(6)
       bins.map(_.trackId) must containTheSameElementsAs {
-        Seq("track1", "track1", "track2", "track2", "track3", "track3").map(_.hashCode.toString)
+        Seq("track1", "track1", "track2", "track2", "track3", "track3").map(_.hashCode)
       }
     }
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategyTest.scala
@@ -248,7 +248,7 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       aggregates.size must beLessThan(10) // ensure some aggregation was done
       val bin = aggregates.flatMap(a => a.grouped(16).map(Convert2ViewerFunction.decode))
       bin must haveSize(10)
-      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode.toString))
+      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode))
       bin.map(_.dtg) must
           containAllOf((0 until 10).map(i => features(i).getAttribute("dtg").asInstanceOf[Date].getTime))
       forall(bin.map(_.lat))(_ mustEqual 60.0)
@@ -277,7 +277,7 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       }
       val bin = aggregates.flatMap(a => a.grouped(16).map(Convert2ViewerFunction.decode))
       bin must haveSize(10)
-      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode.toString))
+      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode))
       bin.map(_.dtg) must
           containAllOf((0 until 10).map(i => features(i).getAttribute("dtg").asInstanceOf[Date].getTime))
       forall(bin.map(_.lat))(_ mustEqual 60.0)
@@ -302,7 +302,7 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       aggregates.size must beLessThan(10) // ensure some aggregation was done
       val bin = aggregates.flatMap(a => a.grouped(24).map(Convert2ViewerFunction.decode))
       bin must haveSize(10)
-      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode.toString))
+      bin.map(_.trackId) must containAllOf((0 until 10).map(i => s"name$i".hashCode))
       bin.map(_.dtg) must
           containAllOf((0 until 10).map(i => features(i).getAttribute("dtg").asInstanceOf[Date].getTime))
       forall(bin.map(_.lat))(_ mustEqual 60.0)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/BinAggregatingIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/BinAggregatingIteratorTest.scala
@@ -44,7 +44,7 @@ class BinAggregatingIteratorTest extends Specification {
       BasicValues(f.getDefaultGeometry.asInstanceOf[Point].getY.toFloat,
         f.getDefaultGeometry.asInstanceOf[Point].getX.toFloat,
         f.getAttribute("dtg").asInstanceOf[Date].getTime,
-        f.getAttribute("name").asInstanceOf[String])
+        f.getAttribute("name").asInstanceOf[String].hashCode)
     Convert2ViewerFunction.encode(values, out)
   }
   val bin = out.toByteArray
@@ -81,7 +81,7 @@ class BinAggregatingIteratorTest extends Specification {
           ExtendedValues(f.getDefaultGeometry.asInstanceOf[Point].getY.toFloat,
             f.getDefaultGeometry.asInstanceOf[Point].getX.toFloat,
             f.getAttribute("dtg").asInstanceOf[Date].getTime,
-            f.getAttribute("name").asInstanceOf[String],
+            f.getAttribute("name").asInstanceOf[String].hashCode,
             f.getAttribute("dtg").asInstanceOf[Date].getTime * 1000)
         Convert2ViewerFunction.encode(values, out)
       }
@@ -94,7 +94,7 @@ class BinAggregatingIteratorTest extends Specification {
       val maxLength = 8 // anything more than 8 takes too long to run
       val buffer = Array.ofDim[Byte](maxLength * 16)
       val bins = (1 to maxLength).map(i =>
-        Convert2ViewerFunction.encodeToByteArray(BasicValues(0f, 0f, i * 1000, s"name$i")))
+        Convert2ViewerFunction.encodeToByteArray(BasicValues(0f, 0f, i * 1000, s"name$i".hashCode)))
       (1 to maxLength).foreach { i =>
         bins.slice(0, i).permutations.foreach { seq =>
           val right = i * 16 - 16

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/function/BinaryOutputEncoder.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/function/BinaryOutputEncoder.scala
@@ -26,7 +26,7 @@ object BinaryOutputEncoder extends LazyLogging {
   import org.locationtech.geomesa.filter.function.AxisOrder._
   import org.locationtech.geomesa.utils.geotools.Conversions._
 
-  case class ValuesToEncode(lat: Float, lon: Float, dtg: Long, track: String, label: Option[Long])
+  case class ValuesToEncode(lat: Float, lon: Float, dtg: Long, track: Int, label: Option[Long])
 
   case class EncodingOptions(dtgField: String,
                              trackIdField: Option[String],
@@ -128,19 +128,19 @@ object BinaryOutputEncoder extends LazyLogging {
     }
 
     // gets the track id from a feature
-    val getTrackId: (SimpleFeature) => String = options.trackIdField match {
+    val getTrackId: (SimpleFeature) => Int = options.trackIdField match {
       case Some(trackId) if trackId == "id" =>
-        (f) => f.getID
+        (f) => f.getID.hashCode
 
       case Some(trackId) =>
         val trackIndex  = sft.indexOf(trackId)
         (f) => {
           val track = f.getAttribute(trackIndex)
-          if (track == null) null else track.toString
+          if (track == null) { 0 } else { track.hashCode }
         }
 
       case None =>
-        (_) => null
+        (_) => 0
     }
 
     // gets the label from a feature
@@ -175,7 +175,7 @@ object BinaryOutputEncoder extends LazyLogging {
         } else {
           val trackId = getTrackId(sf)
           val label = getLabel(sf)
-          points.indices.map { case i =>
+          points.indices.map { i =>
             val (lat, lon) = points(i)
             ValuesToEncode(lat, lon, dates(i), trackId, label)
           }

--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/function/BinaryOutputEncoderTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/function/BinaryOutputEncoderTest.scala
@@ -52,7 +52,7 @@ class BinaryOutputEncoderTest extends Specification {
           decoded.dtg mustEqual baseDtg - 60 * 1000 * i
           decoded.lat mustEqual 45
           decoded.lon mustEqual 50 + i
-          decoded.trackId mustEqual s"1234-$i".hashCode.toString
+          decoded.trackId mustEqual s"1234-$i".hashCode
           decoded.asInstanceOf[ExtendedValues].label mustEqual java.lang.Long.valueOf(i)
         }
         success
@@ -68,7 +68,7 @@ class BinaryOutputEncoderTest extends Specification {
           decoded.dtg mustEqual baseDtg - 60 * 1000 * i
           decoded.lat mustEqual 45
           decoded.lon mustEqual 50 + i
-          decoded.trackId mustEqual s"1234-$i".hashCode.toString
+          decoded.trackId mustEqual s"1234-$i".hashCode
           decoded must beAnInstanceOf[BasicValues]
         }
         success
@@ -84,7 +84,7 @@ class BinaryOutputEncoderTest extends Specification {
           decoded.dtg mustEqual baseDtg - 60 * 1000 * i
           decoded.lat mustEqual 45
           decoded.lon mustEqual 50 + i
-          decoded.trackId mustEqual s"$i".hashCode.toString
+          decoded.trackId mustEqual s"$i".hashCode
           decoded must beAnInstanceOf[BasicValues]
         }
         success
@@ -100,7 +100,7 @@ class BinaryOutputEncoderTest extends Specification {
           decoded.dtg mustEqual baseDtg - 60 * 1000 * i
           decoded.lat mustEqual 45 + i
           decoded.lon mustEqual 50
-          decoded.trackId mustEqual s"1234-$i".hashCode.toString
+          decoded.trackId mustEqual s"1234-$i".hashCode
           decoded must beAnInstanceOf[BasicValues]
         }
         success
@@ -131,7 +131,7 @@ class BinaryOutputEncoderTest extends Specification {
           decoded.dtg mustEqual dates(i).getTime
           decoded.lat mustEqual line.getCoordinates()(i).x.toFloat
           decoded.lon mustEqual line.getCoordinates()(i).y.toFloat
-          decoded.trackId mustEqual "1234-0".hashCode.toString
+          decoded.trackId mustEqual "1234-0".hashCode
           decoded.asInstanceOf[ExtendedValues].label mustEqual 0
         }
         success
@@ -147,7 +147,7 @@ class BinaryOutputEncoderTest extends Specification {
           decoded.dtg mustEqual dates(i).getTime
           decoded.lat mustEqual line.getCoordinates()(i).x.toFloat
           decoded.lon mustEqual line.getCoordinates()(i).y.toFloat
-          decoded.trackId mustEqual "1234-0".hashCode.toString
+          decoded.trackId mustEqual "1234-0".hashCode
           decoded must beAnInstanceOf[BasicValues]
         }
         success
@@ -163,7 +163,7 @@ class BinaryOutputEncoderTest extends Specification {
           decoded.dtg mustEqual dates(3 - i).getTime
           decoded.lat mustEqual line.getCoordinates()(3 - i).x.toFloat
           decoded.lon mustEqual line.getCoordinates()(3 - i).y.toFloat
-          decoded.trackId mustEqual "1234-0".hashCode.toString
+          decoded.trackId mustEqual "1234-0".hashCode
           decoded must beAnInstanceOf[BasicValues]
         }
         success

--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/function/Convert2ViewerFunctionTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/function/Convert2ViewerFunctionTest.scala
@@ -21,32 +21,32 @@ class Convert2ViewerFunctionTest extends Specification {
   "Convert2ViewerFunction" should {
 
     "encode and decode simple attributes" in {
-      val initial = BasicValues(45.0f, 49.0f, System.currentTimeMillis(), "1200")
+      val initial = BasicValues(45.0f, 49.0f, System.currentTimeMillis(), 1200)
       val encoded = Convert2ViewerFunction.encodeToByteArray(initial)
       encoded must haveLength(16)
       val decoded = Convert2ViewerFunction.decode(encoded)
       decoded.lat mustEqual initial.lat
       decoded.lon mustEqual initial.lon
       Math.abs(decoded.dtg - initial.dtg) must beLessThan(1000L) // dates get truncated to nearest second
-      decoded.trackId.toInt mustEqual initial.trackId.hashCode
+      decoded.trackId mustEqual initial.trackId
     }
 
     "encode and decode optional simple attributes" in {
-      val initial = BasicValues(45.0f, 49.0f, System.currentTimeMillis(), "")
+      val initial = BasicValues(45.0f, 49.0f, System.currentTimeMillis(), 0)
       val encoded = Convert2ViewerFunction.encodeToByteArray(initial)
       encoded must haveLength(16)
       val decoded = Convert2ViewerFunction.decode(encoded)
       decoded.lat mustEqual initial.lat
       decoded.lon mustEqual initial.lon
       Math.abs(decoded.dtg - initial.dtg) must beLessThan(1000L) // dates get truncated to nearest second
-      decoded.trackId.toInt mustEqual initial.trackId.hashCode
+      decoded.trackId mustEqual initial.trackId
     }
 
     "encode and decode extended attributes" in {
       val initial = ExtendedValues(45.0f,
                                    49.0f,
                                    System.currentTimeMillis(),
-                                   "1200",
+                                   1200,
                                    10)
       val encoded = Convert2ViewerFunction.encodeToByteArray(initial)
       encoded must haveLength(24)
@@ -55,14 +55,14 @@ class Convert2ViewerFunctionTest extends Specification {
       decoded.lat mustEqual initial.lat
       decoded.lon mustEqual initial.lon
       Math.abs(decoded.dtg - initial.dtg) must beLessThan(1000L) // dates get truncated to nearest second
-      decoded.trackId.toInt mustEqual initial.trackId.hashCode
+      decoded.trackId mustEqual initial.trackId
       decoded.asInstanceOf[ExtendedValues].label mustEqual initial.label
     }
 
     "encode and decode to an output stream" in {
       val time = System.currentTimeMillis()
-      val one = ExtendedValues(45.0f, 49.0f, time, "1200", 1000)
-      val two = ExtendedValues(45.0f, 49.0f, time - 100, "1201", 3000)
+      val one = ExtendedValues(45.0f, 49.0f, time, 1200, 1000)
+      val two = ExtendedValues(45.0f, 49.0f, time - 100, 1201, 3000)
       val out = new ByteArrayOutputStream(48)
       Convert2ViewerFunction.encode(one, out)
       Convert2ViewerFunction.encode(two, out)
@@ -74,7 +74,7 @@ class Convert2ViewerFunctionTest extends Specification {
       decodedOne.lat mustEqual one.lat
       decodedOne.lon mustEqual one.lon
       Math.abs(decodedOne.dtg - one.dtg) must beLessThan(1000L) // dates get truncated to nearest second
-      decodedOne.trackId.toInt mustEqual one.trackId.hashCode
+      decodedOne.trackId mustEqual one.trackId
       decodedOne.asInstanceOf[ExtendedValues].label mustEqual one.label
 
       val decodedTwo = Convert2ViewerFunction.decode(array.splitAt(24)._2)
@@ -82,20 +82,20 @@ class Convert2ViewerFunctionTest extends Specification {
       decodedTwo.lat mustEqual two.lat
       decodedTwo.lon mustEqual two.lon
       Math.abs(decodedTwo.dtg - two.dtg) must beLessThan(1000L) // dates get truncated to nearest second
-      decodedTwo.trackId.toInt mustEqual two.trackId.hashCode
+      decodedTwo.trackId mustEqual two.trackId
       decodedTwo.asInstanceOf[ExtendedValues].label mustEqual two.label
     }
 
     "encode faster to an output stream" in {
       skipped("integration")
       val times = 10000
-      val one = ExtendedValues(45.0f, 49.0f, System.currentTimeMillis(), "1200", 10000)
+      val one = ExtendedValues(45.0f, 49.0f, System.currentTimeMillis(), 1200, 10000)
       val out = new ByteArrayOutputStream(24 * times)
 
       // the first test run always takes a long time, even with some initialization...
       // flip the order to get a sense of how long each takes
       val start2 = System.currentTimeMillis()
-      val arrays = (0 to times).map(_ => Convert2ViewerFunction.encodeToByteArray(one))
+      (0 to times).foreach(_ => Convert2ViewerFunction.encodeToByteArray(one))
       val total2 = System.currentTimeMillis() - start2
       println(s"array took $total2 ms")
 


### PR DESCRIPTION
* Changing trackId to be an Int in case classes to remove inconsistency with BinAggregatingIterator

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>