### PR TITLE
GEOMESA-1553 Performance improvements for z-iterators

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/Z2QueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z2/Z2QueryableIndex.scala
@@ -140,7 +140,7 @@ trait Z2QueryableIndex extends AccumuloFeatureIndexType
         }
       }
 
-      val zIter = Z2Iterator.configure(xy, sft.isPoints, sft.isTableSharing, Z2Index.Z2IterPriority)
+      val zIter = Z2Iterator.configure(sft, xy, Z2Index.Z2IterPriority)
 
       (ranges, Some(zIter))
     }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/Z3QueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/z3/Z3QueryableIndex.scala
@@ -175,7 +175,7 @@ trait Z3QueryableIndex extends AccumuloFeatureIndexType
 
       // we know we're only going to scan appropriate periods, so leave out whole periods
       val filteredTimes = timesByBin.filter(_._2 != wholePeriod).toMap
-      val zIter = Z3Iterator.configure(sfc, xy, filteredTimes, sft.isPoints, hasSplits, Z3Index.Z3IterPriority)
+      val zIter = Z3Iterator.configure(sft, sfc, xy, filteredTimes, hasSplits, Z3Index.Z3IterPriority)
       (ranges.toSeq, Some(zIter))
     }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3Iterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3Iterator.scala
@@ -16,29 +16,31 @@ import org.apache.hadoop.io.Text
 import org.locationtech.geomesa.accumulo.index.z3.Z3Index
 import org.locationtech.geomesa.curve.Z3SFC
 import org.locationtech.sfcurve.zorder.Z3
+import org.opengis.feature.simple.SimpleFeatureType
 
 class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
 
   import org.locationtech.geomesa.accumulo.iterators.Z3Iterator._
 
-  var source: SortedKeyValueIterator[Key, Value] = null
+  private var source: SortedKeyValueIterator[Key, Value] = null
 
-  var keyXY: Array[String] = null
-  var keyT: Array[String] = null
+  private var keyXY: String = null
+  private var keyT: String = null
 
-  var xyvals: Array[(Int, Int, Int, Int)] = null
-  var tvals: Array[Array[(Int, Int)]] = null
+  private var xyvals: Array[Array[Int]] = null
+  private var tvals: Array[Array[Array[Int]]] = null
 
-  var minWeek: Short = Short.MinValue
-  var maxWeek: Short = Short.MinValue
+  private var minWeek: Short = Short.MinValue
+  private var maxWeek: Short = Short.MinValue
 
-  var isPoints: Boolean = false
-  var hasSplits: Boolean = false
-  var rowToWeekZ: Array[Byte] => (Short, Long) = null
+  private var zOffset: Int = -1
+  private var zLength: Int = -1
+  private var rowToWeek: Array[Byte] => Short = null
+  private var rowToZ: Array[Byte] => Long = null
 
-  var topKey: Key = null
-  var topValue: Value = null
-  val row = new Text()
+  private var topKey: Key = null
+  private var topValue: Value = null
+  private val row = new Text()
 
   override def init(source: SortedKeyValueIterator[Key, Value],
                     options: java.util.Map[String, String],
@@ -47,18 +49,22 @@ class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
 
     this.source = source.deepCopy(env)
 
-    isPoints = options.get(PointsKey).toBoolean
+    zOffset = options.get(ZOffsetKey).toInt
+    zLength = options.get(ZLengthKey).toInt
 
-    keyXY = options.get(ZKeyXY).split(RangeSeparator)
-    keyT = options.get(ZKeyT).split(WeekSeparator).filterNot(_.isEmpty)
+    rowToWeek = getRowToWeek(zOffset)
+    rowToZ    = getRowToZ(zOffset, zLength)
 
-    xyvals = keyXY.map(_.toInt).grouped(4).map { case Array(x1, y1, x2, y2) => (x1, y1, x2, y2) }.toArray
+    keyXY = options.get(ZKeyXY)
+    keyT  = options.get(ZKeyT)
+
+    xyvals = keyXY.split(TermSeparator).map(_.split(RangeSeparator).map(_.toInt))
 
     minWeek = Short.MinValue
     maxWeek = Short.MinValue
 
-    val weeksAndTimes = keyT.map { times =>
-      val parts = times.split(RangeSeparator)
+    val weeksAndTimes = keyT.split(WeekSeparator).filterNot(_.isEmpty).map { times =>
+      val parts = times.split(TermSeparator)
       val week = parts(0).toShort
       // set min/max weeks - note: side effect in map
       if (minWeek == Short.MinValue) {
@@ -69,15 +75,11 @@ class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
       } else if (week > maxWeek) {
         maxWeek = week
       }
-      (week, parts.drop(1).grouped(2).map { case Array(t1, t2) => (t1.toInt, t2.toInt) }.toArray)
+      (week, parts.drop(1).map(_.split(RangeSeparator).map(_.toInt)))
     }
 
     tvals = if (minWeek == Short.MinValue) Array.empty else Array.ofDim(maxWeek - minWeek + 1)
     weeksAndTimes.foreach { case (w, times) => tvals(w - minWeek) = times }
-
-    hasSplits = options.get(SplitsKey).toBoolean
-    val count = if (isPoints) 8 else Z3Index.GEOM_Z_NUM_BYTES
-    rowToWeekZ = rowToWeekZ(count, hasSplits)
   }
 
   override def next(): Unit = {
@@ -101,8 +103,8 @@ class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
 
   private def inBounds(k: Key): Boolean = {
     k.getRow(row)
-    val (week, keyZ) = rowToWeekZ(row.getBytes)
-    timeInBounds(week, keyZ) && pointInBounds(keyZ)
+    val keyZ = rowToZ(row.getBytes)
+    pointInBounds(keyZ) && timeInBounds(rowToWeek(row.getBytes), keyZ)
   }
 
   private def pointInBounds(z: Long): Boolean = {
@@ -110,8 +112,8 @@ class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
     val y = Z3(z).d1
     var i = 0
     while (i < xyvals.length) {
-      val (xmin, ymin, xmax, ymax) = xyvals(i)
-      if (x >= xmin && x <= xmax && y >= ymin && y <= ymax) {
+      val xy = xyvals(i)
+      if (x >= xy(0) && x <= xy(2) && y >= xy(1) && y <= xy(3)) {
         return true
       }
       i += 1
@@ -127,28 +129,14 @@ class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
         val t = Z3(z).d2
         var i = 0
         while (i < times.length) {
-          val (tmin, tmax) = times(i)
-          if (t >= tmin && t <= tmax) {
+          val time = times(i)
+          if (t >= time(0) && t <= time(1)) {
             return true
           }
           i += 1
         }
         false
       }
-    }
-  }
-
-  private def rowToWeekZ(count: Int, splits: Boolean): (Array[Byte]) => (Short, Long) = {
-    val zBytes = Longs.fromBytes _
-    val wBytes = Shorts.fromBytes _
-    (count, splits) match {
-      case (3, true)  => (b) => (wBytes(b(1), b(2)), zBytes(b(3), b(4), b(5), 0, 0, 0, 0, 0))
-      case (3, false) => (b) => (wBytes(b(0), b(1)), zBytes(b(2), b(3), b(4), 0, 0, 0, 0, 0))
-      case (4, true)  => (b) => (wBytes(b(1), b(2)), zBytes(b(3), b(4), b(5), b(6), 0, 0, 0, 0))
-      case (4, false) => (b) => (wBytes(b(0), b(1)), zBytes(b(2), b(3), b(4), b(5), 0, 0, 0, 0))
-      case (8, true)  => (b) => (wBytes(b(1), b(2)), zBytes(b(3), b(4), b(5), b(6), b(7), b(8), b(9), b(10)))
-      case (8, false) => (b) => (wBytes(b(0), b(1)), zBytes(b(2), b(3), b(4), b(5), b(6), b(7), b(8), b(9)))
-      case _ => throw new IllegalArgumentException(s"Unhandled number of bytes for z value: $count")
     }
   }
 
@@ -164,10 +152,10 @@ class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
   override def deepCopy(env: IteratorEnvironment): SortedKeyValueIterator[Key, Value] = {
     import scala.collection.JavaConversions._
     val opts = Map(
-      ZKeyXY    -> keyXY.mkString(RangeSeparator),
-      ZKeyT     -> keyT.mkString(WeekSeparator),
-      PointsKey -> isPoints.toString,
-      SplitsKey -> hasSplits.toString
+      ZKeyXY     -> keyXY,
+      ZKeyT      -> keyT,
+      ZOffsetKey -> zOffset.toString,
+      ZLengthKey -> zLength.toString
     )
     val iter = new Z3Iterator
     iter.init(source, opts, env)
@@ -180,23 +168,26 @@ object Z3Iterator {
   val ZKeyXY = "zxy"
   val ZKeyT  = "zt"
 
-  val PointsKey = "points"
-  val SplitsKey = "splits"
+  val ZOffsetKey = "zo"
+  val ZLengthKey = "zl"
 
   val RangeSeparator = ":"
-  val WeekSeparator = ";"
+  val TermSeparator  = ";"
+  val WeekSeparator  = ","
 
-  def configure(sfc: Z3SFC,
+  def configure(sft: SimpleFeatureType,
+                sfc: Z3SFC,
                 bounds: Seq[(Double, Double, Double, Double)],
                 timesByBin: Map[Short, Seq[(Long, Long)]],
-                isPoints: Boolean,
                 hasSplits: Boolean,
                 priority: Int) = {
+
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
     val is = new IteratorSetting(priority, "z3", classOf[Z3Iterator])
 
     // index space values for comparing in the iterator
-    val (xyOpts, tOpts) = if (isPoints) {
+    val (xyOpts, tOpts) = if (sft.isPoints) {
       val xyOpts = bounds.map { case (xmin, ymin, xmax, ymax) =>
         s"${sfc.lon.normalize(xmin)}$RangeSeparator${sfc.lat.normalize(ymin)}$RangeSeparator" +
             s"${sfc.lon.normalize(xmax)}$RangeSeparator${sfc.lat.normalize(ymax)}"
@@ -205,7 +196,7 @@ object Z3Iterator {
         val time = times.map { case (t1, t2) =>
           s"${sfc.time.normalize(t1)}$RangeSeparator${sfc.time.normalize(t2)}"
         }
-        s"$bin$RangeSeparator${time.mkString(RangeSeparator)}"
+        s"$bin$TermSeparator${time.mkString(TermSeparator)}"
       }
       (xyOpts, tOpts)
     } else {
@@ -218,19 +209,47 @@ object Z3Iterator {
         val time = times.map { case (t1, t2) =>
           s"${decodeNonPoints(sfc, 0, 0, t1)._3}$RangeSeparator${decodeNonPoints(sfc, 0, 0, t2)._3}"
         }
-        s"$bin$RangeSeparator${time.mkString(RangeSeparator)}"
+        s"$bin$TermSeparator${time.mkString(TermSeparator)}"
       }
       (normalized, tOpts)
     }
 
-    is.addOption(ZKeyXY, xyOpts.mkString(RangeSeparator))
+    is.addOption(ZKeyXY, xyOpts.mkString(TermSeparator))
     is.addOption(ZKeyT, tOpts.mkString(WeekSeparator))
-    is.addOption(PointsKey, isPoints.toString)
-    is.addOption(SplitsKey, hasSplits.toString)
+    is.addOption(ZOffsetKey, if (hasSplits) { "1" } else { "0" })
+    is.addOption(ZLengthKey, if (sft.isPoints) { "8" } else { Z3Index.GEOM_Z_NUM_BYTES.toString })
 
     is
   }
 
   private def decodeNonPoints(sfc: Z3SFC, x: Double, y: Double, t: Long): (Int, Int, Int) =
     Z3(sfc.index(x, y, t).z & Z3Index.GEOM_Z_MASK).decode
+
+  private def getRowToZ(offset: Int, zLength: Int): (Array[Byte]) => Long = {
+    // account for week - first 2 bytes
+    val z0 = offset + 2
+    val z1 = offset + 3
+    val z2 = offset + 4
+    val z3 = offset + 5
+    val z4 = offset + 6
+    val z5 = offset + 7
+    val z6 = offset + 8
+    val z7 = offset + 9
+
+    if (zLength == 8) {
+      (b) => Longs.fromBytes(b(z0), b(z1), b(z2), b(z3), b(z4), b(z5), b(z6), b(z7))
+    } else if (zLength == 3) {
+      (b) => Longs.fromBytes(b(z0), b(z1), b(z2), 0, 0, 0, 0, 0)
+    } else if (zLength == 4) {
+      (b) => Longs.fromBytes(b(z0), b(z1), b(z2), b(z3), 0, 0, 0, 0)
+    } else {
+      throw new IllegalArgumentException(s"Unhandled number of bytes for z value: $zLength")
+    }
+  }
+
+  private def getRowToWeek(offset: Int): (Array[Byte]) => Short = {
+    val w0 = offset
+    val w1 = offset + 1
+    (b) => Shorts.fromBytes(b(w0), b(w1))
+  }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/Z3IteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/Z3IteratorTest.scala
@@ -63,8 +63,8 @@ class Z3IteratorTest extends Specification {
 
       val iter = new Z3Iterator
 
-      iter.init(srcIter, Map(PointsKey -> "true", SplitsKey -> "false",
-        ZKeyXY -> s"$xmin:$ymin:$xmax:$ymax", ZKeyT -> s"0:$tmin:$tmax"), null)
+      iter.init(srcIter, Map(ZOffsetKey -> "0", ZLengthKey -> "8",
+        ZKeyXY -> s"$xmin:$ymin:$xmax:$ymax", ZKeyT -> s"0;$tmin:$tmax"), null)
 
       "keep in bounds values" >> {
         val test1 = sfc.index(-76.0, 38.5, 500)
@@ -90,8 +90,8 @@ class Z3IteratorTest extends Specification {
       val (xmax, ymax, tmax) = Z3(sfc.index(ux, uy, ut).z & Z3Index.GEOM_Z_MASK).decode
 
       val iter = new Z3Iterator
-      iter.init(srcIter, Map(PointsKey -> "false", SplitsKey -> "false",
-        ZKeyXY -> s"$xmin:$ymin:$xmax:$ymax", ZKeyT -> s"0:$tmin:$tmax"), null)
+      iter.init(srcIter, Map(ZOffsetKey -> "0", ZLengthKey -> Z3Index.GEOM_Z_NUM_BYTES.toString,
+        ZKeyXY -> s"$xmin:$ymin:$xmax:$ymax", ZKeyT -> s"0;$tmin:$tmax"), null)
 
       "keep in bounds values" >> {
         val test1 = sfc.index(-76.0, 38.5, 500)


### PR DESCRIPTION
* Avoids boxing of primitives
* Reduces calculations in 'init'
* Note: contains iterator configuration changes, client and server jars must match

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>