### PR TITLE
GEOMESA-1596 Accumulo 1.8 needs Thrift 0.9.3

### DIFF
--- a/docs/user/installation_and_configuration.rst
+++ b/docs/user/installation_and_configuration.rst
@@ -571,6 +571,18 @@ Hadoop 2.4-2.7 (adjust versions as needed)
 
 Restart GeoServer after the JARs are installed.
 
+A note about Accumulo 1.8
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+   
+   GeoMesa supports Accumulo 1.8 when built with the accumulo-1.8 profile.  Accumulo 1.8
+   introduced a dependency on libthrift version 0.9.3 which is not compatible with Accumulo
+   1.7/libthrift 0.9.1.  The default supported version for GeoMesa is Accumulo 1.7.x and
+   the published jars and distribution artifacts reflect this version.  To upgrade, build
+   locally using the accumulo-1.8 profile.
+
+
 .. _install_geomesa_process:
 
 A note about GeoMesa Process

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@
             <id>accumulo-1.8</id>
             <properties>
                <accumulo.version>1.8.0</accumulo.version>
+               <thrift.version>0.9.3</thrift.version>
             </properties>
         </profile>
 


### PR DESCRIPTION
* Override version of thrift in Accumulo 1.8 profile
* Added docs about building with 1.8 support

Signed-off-by: Anthony Fox <anthonyfox@ccri.com>