### PR TITLE
GEOMESA-1612 Spark SQL should reuse FIDs on write if available

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
+++ b/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
@@ -28,6 +28,7 @@ import org.locationtech.geomesa.jobs.GeoMesaConfigurator
 import org.locationtech.geomesa.jobs.accumulo.AccumuloJobUtils
 import org.locationtech.geomesa.jobs.mapreduce.GeoMesaAccumuloInputFormat
 import org.locationtech.geomesa.spark.SpatialRDDProvider
+import org.locationtech.geomesa.utils.geotools.FeatureUtils
 import org.opengis.feature.simple.SimpleFeature
 import org.opengis.filter.Filter
 
@@ -123,11 +124,9 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider {
     rdd.foreachPartition { iter =>
       val ds = DataStoreFinder.getDataStore(writeDataStoreParams).asInstanceOf[AccumuloDataStore]
       val featureWriter = ds.getFeatureWriterAppend(writeTypeName, Transaction.AUTO_COMMIT)
-      val attrNames = featureWriter.getFeatureType.getAttributeDescriptors.map(_.getLocalName)
       try {
-        iter.foreach { case rawFeature =>
-          val newFeature = featureWriter.next()
-          attrNames.foreach(an => newFeature.setAttribute(an, rawFeature.getAttribute(an)))
+        iter.foreach { rawFeature =>
+          FeatureUtils.copyToWriter(featureWriter, rawFeature, overrideFid = true)
           featureWriter.write()
         }
       } finally {

--- a/geomesa-accumulo/geomesa-accumulo-spark/src/test/scala/org/locationtech/geomesa/accumulo/spark/AccumuloSparkProviderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-spark/src/test/scala/org/locationtech/geomesa/accumulo/spark/AccumuloSparkProviderTest.scala
@@ -4,6 +4,8 @@ import java.util.{Map => JMap}
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql.{DataFrame, SQLContext, SQLTypes, SparkSession}
+import org.geotools.data.{Query, Transaction}
+import org.geotools.factory.CommonFactoryFinder
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.TestWithDataStore
 import org.locationtech.geomesa.spark.SparkSQLTestUtils
@@ -15,6 +17,7 @@ class AccumuloSparkProviderTest extends Specification with TestWithDataStore wit
 
   override lazy val sftName: String = "chicago"
   override def spec: String = SparkSQLTestUtils.ChiSpec
+  private val ff = CommonFactoryFinder.getFilterFactory2
 
   "sql data tests" should {
     sequential
@@ -24,6 +27,8 @@ class AccumuloSparkProviderTest extends Specification with TestWithDataStore wit
 
     var df: DataFrame = null
 
+    val params = dsParams.filterNot { case (k, _) => k == "connector" } ++ Map("useMock" -> true)
+
     // before
     step {
       spark = SparkSQLTestUtils.createSparkSession()
@@ -31,7 +36,6 @@ class AccumuloSparkProviderTest extends Specification with TestWithDataStore wit
       SQLTypes.init(sc)
       SparkSQLTestUtils.ingestChicago(ds)
 
-      val params = dsParams.filterNot { case (k, _) => k == "connector" } ++ Map("useMock" -> true)
       df = spark.read
         .format("geomesa")
         .option("instanceId", mockInstanceId)
@@ -62,6 +66,41 @@ class AccumuloSparkProviderTest extends Specification with TestWithDataStore wit
       ).collect().length must beEqualTo(1)
     }
 
+    "write data and properly index" >> {
+      val subset = sc.sql("select case_number,geom,dtg from chicago")
+      subset.write.format("geomesa")
+        .option("instanceId", mockInstanceId)
+        .option("user", mockUser)
+        .option("password", mockPassword)
+        .options(params.map { case (k, v) => k -> v.toString })
+        .option("geomesa.feature", "chicago2")
+        .save()
+
+      val sft = ds.getSchema("chicago2")
+      val enabledIndexes = sft.getUserData.get("geomesa.indices").asInstanceOf[String]
+      enabledIndexes.indexOf("z3") must be greaterThan -1
+    }
+
+    "handle reuse __fid__ on write if available" >> {
+      val subset = sc.sql("select __fid__,case_number,geom,dtg from chicago")
+      subset.write.format("geomesa")
+        .option("instanceId", mockInstanceId)
+        .option("user", mockUser)
+        .option("password", mockPassword)
+        .options(params.map { case (k, v) => k -> v.toString })
+        .option("geomesa.feature", "fidOnWrite")
+        .save()
+
+      import org.locationtech.geomesa.utils.geotools.Conversions._
+      val filter = ff.equals(ff.property("case_number"), ff.literal(1))
+      val queryOrig = new Query("chicago", filter)
+      val origResults = ds.getFeatureReader(queryOrig, Transaction.AUTO_COMMIT).toIterator.toList
+
+      val query = new Query("fidOnWrite", filter)
+      val results = ds.getFeatureReader(query, Transaction.AUTO_COMMIT).toIterator.toList
+
+      results.head.getID must be equalTo origResults.head.getID
+    }
   }
 
 }

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/GeoMesaSparkSQL.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/GeoMesaSparkSQL.scala
@@ -9,6 +9,7 @@
 package org.locationtech.geomesa.spark
 
 import java.sql.Timestamp
+import java.time.Instant
 import java.util.{Date, UUID}
 
 import com.typesafe.scalalogging.LazyLogging
@@ -21,7 +22,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 import org.geotools.data.{DataStoreFinder, Query}
-import org.geotools.factory.CommonFactoryFinder
+import org.geotools.factory.{CommonFactoryFinder, Hints}
 import org.geotools.feature.simple.{SimpleFeatureBuilder, SimpleFeatureTypeBuilder}
 import org.opengis.feature.`type`._
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -82,6 +83,7 @@ class GeoMesaDataSource extends DataSourceRegister with RelationProvider with Sc
           case DataTypes.DoubleType => builder.add(field.name, classOf[jl.Double])
           case DataTypes.StringType => builder.add(field.name, classOf[jl.String])
           case DataTypes.LongType   => builder.add(field.name, classOf[jl.Long])
+          case DataTypes.TimestampType => builder.add(field.name, classOf[java.util.Date])
 
           case SQLTypes.PointTypeInstance => builder.add(field.name, classOf[com.vividsolutions.jts.geom.Point])
           case SQLTypes.LineStringTypeInstance => builder.add(field.name, classOf[com.vividsolutions.jts.geom.LineString])
@@ -124,6 +126,14 @@ class GeoMesaDataSource extends DataSourceRegister with RelationProvider with Sc
     val newFeatureName: String = parameters("geomesa.feature")
     val sft: SimpleFeatureType = structType2SFT(data.schema, newFeatureName)
 
+    // reuse the __fid__ if available for joins,
+    // otherwise use a random id prefixed with the current time
+    val fidIndex = data.schema.fields.indexWhere(_.name == "__fid__")
+    val fidFn: Row => String =
+      if(fidIndex > -1) (row: Row) => row.getString(fidIndex)
+      else _ => "%d%s".format(Instant.now().getEpochSecond, UUID.randomUUID().toString)
+
+
     val ds = DataStoreFinder.getDataStore(parameters)
     sft.getUserData.put("override.reserved.words", java.lang.Boolean.TRUE)
     ds.createSchema(sft)
@@ -131,8 +141,12 @@ class GeoMesaDataSource extends DataSourceRegister with RelationProvider with Sc
     val rddToSave: RDD[SimpleFeature] = data.rdd.mapPartitions( iterRow => {
       val innerDS = DataStoreFinder.getDataStore(parameters)
       val sft = innerDS.getSchema(newFeatureName)
-      val func: (Row) => SimpleFeature = SparkUtils.row2Sf(sft, _)
-      iterRow.map(func)
+      val builder = new SimpleFeatureBuilder(sft)
+
+      iterRow.map { r =>
+        builder.reset()
+        SparkUtils.row2Sf(sft, r, builder, fidFn(r))
+      }
     })
 
     GeoMesaSpark(parameters).save(rddToSave, parameters, newFeatureName)
@@ -234,9 +248,7 @@ object SparkUtils extends LazyLogging {
   }
 
   // JNH: Fix this.  Seriously.
-  def row2Sf(sft: SimpleFeatureType, row: Row): SimpleFeature = {
-    val builder = new SimpleFeatureBuilder(sft)
-
+  def row2Sf(sft: SimpleFeatureType, row: Row, builder: SimpleFeatureBuilder, id: String): SimpleFeature = {
     import java.{lang => jl}
     sft.getAttributeDescriptors.foreach {
       ad =>
@@ -264,6 +276,7 @@ object SparkUtils extends LazyLogging {
         builder.set(name, value)
     }
 
-    builder.buildFeature(UUID.randomUUID().toString)
+    builder.userData(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+    builder.buildFeature(id)
   }
 }

--- a/geomesa-spark/geomesa-spark-sql/src/test/scala/org/locationtech/geomesa/spark/SparkSQLTestUtils.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/test/scala/org/locationtech/geomesa/spark/SparkSQLTestUtils.scala
@@ -14,6 +14,7 @@ import com.vividsolutions.jts.geom.Coordinate
 import org.apache.spark.sql.SparkSession
 import org.geotools.data.simple.SimpleFeatureStore
 import org.geotools.data.{DataStore, DataUtilities}
+import org.geotools.factory.Hints
 import org.geotools.geometry.jts.JTSFactoryFinder
 import org.joda.time.format.ISODateTimeFormat
 import org.locationtech.geomesa.features.ScalaSimpleFeature
@@ -46,13 +47,15 @@ object SparkSQLTestUtils {
     val parseDate = ISODateTimeFormat.basicDateTime().parseDateTime _
     val createPoint = JTSFactoryFinder.getGeometryFactory.createPoint(_: Coordinate)
 
-    val features = DataUtilities.collection(List(
+    val f = List(
       new ScalaSimpleFeature("1", sft, initialValues = Array("true","1",parseDate("20160101T000000.000Z").toDate, createPoint(new Coordinate(-76.5, 38.5)))),
       new ScalaSimpleFeature("2", sft, initialValues = Array("true","2",parseDate("20160102T000000.000Z").toDate, createPoint(new Coordinate(-77.0, 38.0)))),
       new ScalaSimpleFeature("3", sft, initialValues = Array("true","3",parseDate("20160103T000000.000Z").toDate, createPoint(new Coordinate(-78.0, 39.0))))
-    ))
+    )
 
-    fs.addFeatures(features)
+    f.foreach(_.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE))
+
+    fs.addFeatures(DataUtilities.collection(f))
   }
 }
 


### PR DESCRIPTION
* Better handling of FIDs on write

Signed-off-by: Anthony Fox <anthonyfox@ccri.com>