### PR TITLE
GEOMESA-1526 Synchronizing calls to delete mock accumulo tables

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -147,7 +147,7 @@ class AccumuloDataStore(val connector: Connector, override val config: AccumuloD
     if (sft == null) {
       // check for old-style metadata and re-write it if necessary
       if (oldMetadata.getFeatureTypes.contains(typeName)) {
-        val lock = acquireFeatureLock(typeName)
+        val lock = acquireCatalogLock()
         try {
           if (oldMetadata.getFeatureTypes.contains(typeName)) {
             oldMetadata.migrate(typeName)

--- a/geomesa-accumulo/geomesa-accumulo-spark/src/test/scala/org/locationtech/geomesa/accumulo/spark/AccumuloSparkProviderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-spark/src/test/scala/org/locationtech/geomesa/accumulo/spark/AccumuloSparkProviderTest.scala
@@ -45,7 +45,7 @@ class AccumuloSparkProviderTest extends Specification with TestWithDataStore wit
         .option("geomesa.feature", "chicago")
         .load()
 
-      logger.info(df.schema.treeString)
+      logger.debug(df.schema.treeString)
       df.createOrReplaceTempView("chicago")
     }
 

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/GeoMesaSparkSQL.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/GeoMesaSparkSQL.scala
@@ -189,9 +189,9 @@ object SparkUtils extends LazyLogging {
                 ctx: SparkContext,
                 schema: StructType,
                 params: Map[String, String]): RDD[Row] = {
-    logger.info(s"""Building scan, filt = $filt, filters = ${filters.mkString(",")}, requiredColumns = ${requiredColumns.mkString(",")}""")
+    logger.debug(s"""Building scan, filt = $filt, filters = ${filters.mkString(",")}, requiredColumns = ${requiredColumns.mkString(",")}""")
     val compiledCQL = filters.flatMap(sparkFilterToCQLFilter).foldLeft[org.opengis.filter.Filter](filt) { (l, r) => ff.and(l,r) }
-    logger.info(s"compiledCQL = $compiledCQL")
+    logger.debug(s"compiledCQL = $compiledCQL")
 
     val requiredAttributes = requiredColumns.filterNot(_ == "__fid__")
     val rdd = GeoMesaSpark(params).rdd(

--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/ConvertCommandTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/ConvertCommandTest.scala
@@ -208,7 +208,7 @@ class ConvertCommandTest extends Specification with LazyLogging {
   val formats: Array[String] = DataFormats.values.filter(_ != DataFormats.Null).map(_.toString).toArray
   try {
     for (x <- formats; y <- formats) {
-      logger.info(s"Testing $x to $y converter")
+      logger.debug(s"Testing $x to $y converter")
       testPair(x, y)
     }
   } finally {

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypeLoader.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypeLoader.scala
@@ -78,7 +78,7 @@ class URLSftProvider extends SimpleFeatureTypeProvider with ConfigSftParsing {
   import URLSftProvider._
   override def loadTypes(): JList[SimpleFeatureType] = {
     val urls = configURLs.toList
-    logger.info(s"Loading config from urls: $urls")
+    logger.info(s"Loading config from urls: ${urls.mkString(", ")}")
     urls
       .map(ConfigFactory.parseURL)
       .reduceLeftOption(_.withFallback(_))


### PR DESCRIPTION
* Second attempt at fixing AccumuloDataStoreDeleteTest
* Removed feature-level synchronization in AccumuloDataStore -
  Catalog-level synchronization would need to also obtain each feature lock
* Turned down various test logging

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>