### PR TITLE
GEOMESA-1617 Removing Spark SQL module from Scala 2.10 build

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-spark/src/test/scala/org/locationtech/geomesa/accumulo/spark/AccumuloSparkProviderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-spark/src/test/scala/org/locationtech/geomesa/accumulo/spark/AccumuloSparkProviderTest.scala
@@ -27,6 +27,9 @@ class AccumuloSparkProviderTest extends Specification with TestWithDataStore wit
   override def spec: String = SparkSQLTestUtils.ChiSpec
   private val ff = CommonFactoryFinder.getFilterFactory2
 
+  // spark sql requires scala 2.11, so skip tests during 2.10 build
+  skipAllIf(scala.util.Properties.versionNumberString.startsWith("2.10"))
+
   "sql data tests" should {
     sequential
 

--- a/geomesa-spark/pom.xml
+++ b/geomesa-spark/pom.xml
@@ -17,7 +17,19 @@
         <module>geomesa-spark-converter</module>
         <module>geomesa-spark-core</module>
         <module>geomesa-spark-geotools</module>
-        <module>geomesa-spark-sql</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>scala-2.11</id>
+            <activation>
+                <property><name>!scala-2.10</name></property>
+            </activation>
+            <modules>
+                <!-- spark sql requires spark 2.0 and scala 2.11 -->
+                <module>geomesa-spark-sql</module>
+            </modules>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
* Skipping Spark SQL Accumulo tests in 2.10

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>