### PR TITLE
GEOMESA-1650 Docs: fix broken links and other issues

### DIFF
--- a/docs/common.py
+++ b/docs/common.py
@@ -77,6 +77,8 @@ rst_epilog = """
 
 .. _GeoServer: http://geoserver.org/
 
+.. _Java JDK 8: http://www.oracle.com/technetwork/java/javase/downloads/index.html
+
 .. |release_tarball_accumulo| replace:: %(url_locationtech_release)s/geomesa-accumulo-dist_2.11/%(release)s/geomesa-accumulo-dist_2.11-%(release)s-bin.tar.gz
 
 .. |release_tarball_kafka08| replace:: %(url_locationtech_release)s/geomesa-kafka-08-dist_2.11/%(release)s/geomesa-kafka-08-dist_2.11-%(release)s-bin.tar.gz

--- a/docs/developer/introduction.rst
+++ b/docs/developer/introduction.rst
@@ -16,7 +16,7 @@ Building from Source
 
 These development tools are required:
 
-* `Java JDK 8 <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__
+* `Java JDK 8`_
 * `Apache Maven <http://maven.apache.org/>`__ |maven_version|
 * A ``git`` `client <http://git-scm.com/>`__
 

--- a/docs/tutorials/geomesa-examples-gdelt.rst
+++ b/docs/tutorials/geomesa-examples-gdelt.rst
@@ -265,7 +265,7 @@ data.
    :alt: Showing all GDELT events from Jan 1, 2013 to April 30, 2014
 
 The above map is using the `Stamen
-Toner <http://maps.stamen.com/toner>`__ layer as a base layer. For more
+Toner <http://maps.stamen.com/toner/>`__ layer as a base layer. For more
 information about adding multiple layers into one group see the
 `GeoServer
 documentation <http://docs.geoserver.org/stable/en/user/data/webadmin/layergroups.html>`__.
@@ -292,7 +292,7 @@ to the layer. Add the SLD file
 :download:`threat.sld <_static/geomesa-examples-gdelt/threat.sld>`
 to GeoServer (See the GeoServer documentation for `more information
 about adding SLD
-files <http://docs.geoserver.org/stable/en/user/styling/sld-working.html>`__.
+files <http://docs.geoserver.org/2.9.1/user/styling/sld-working.html>`__.
 For the ExternalGraphic in the SLD to work, move the image file to the
 specified location in your GeoServer installation.
 

--- a/docs/tutorials/geomesa-quickstart-accumulo.rst
+++ b/docs/tutorials/geomesa-quickstart-accumulo.rst
@@ -27,7 +27,7 @@ Before you begin, you must have the following:
 -  an instance of Accumulo |accumulo_version| running on Hadoop |hadoop_version|
 -  an Accumulo user that has both create-table and write permissions
 -  the GeoMesa Accumulo distributed runtime installed for your Accumulo instance (see :ref:`install_accumulo_runtime` )
--  a local copy of the `Java <http://java.oracle.com/>`__ JDK 8
+-  a local copy of `Java JDK 8`_
 -  Apache `Maven <http://maven.apache.org/>`__ installed
 -  a GitHub client installed
 

--- a/docs/tutorials/geomesa-raster.rst
+++ b/docs/tutorials/geomesa-raster.rst
@@ -42,13 +42,11 @@ GeoServer plugin.
 Ingest
 ------
 
-First, download and extract the example data set `Natural Earth 2 with
-Shaded Relief, Water, and
-Drainages <http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/raster/NE2_HR_LC_SR_W_DR.zip>`__.
-To ingest the raster image into GeoMesa, you must first produce an image
-pyramid from this file by using ``gdal_retile.py``. For an explanation
-of the parameters used below, see the `gdal\_retile
-documentation <http://www.gdal.org/gdal_retile.html>`__.
+First, download and extract the example data set `NE2_HR_LC_SR_W_DR.zip`_ from `Natural Earth`_ (this is the "large size" raster data for "Natural Earth 2 with Shaded Relief, Water, and Drainages" on `this download page`_). To ingest the raster image into GeoMesa, you must first produce an image pyramid from this file by using ``gdal_retile.py``. For an explanation of the parameters used below, see the `gdal\_retile documentation <http://www.gdal.org/gdal_retile.html>`__.
+
+.. _Natural Earth: http://www.naturalearthdata.com/
+.. _NE2_HR_LC_SR_W_DR.zip: http://naciscdn.org/naturalearth/10m/raster/NE2_HR_LC_SR_W_DR.zip
+.. _this download page: http://www.naturalearthdata.com/downloads/10m-raster-data/10m-natural-earth-2/
 
 .. code-block:: bash
 

--- a/docs/tutorials/geomesa-tubeselect.rst
+++ b/docs/tutorials/geomesa-tubeselect.rst
@@ -172,7 +172,7 @@ The JSON object returned from the tweets stream is documented on the
 site <https://dev.twitter.com/docs/platform-objects/tweets>`__. For this
 tutorial we'll be interested in the following fields:
 
--  ``coordinates``: a `geoJSON <http://www.geojson.org/>`__ object with
+-  ``coordinates``: a `geoJSON <http://geojson.org/>`__ object with
    lat/lon (do not use the deprecated ``geo`` field)
 -  ``user``: the user object
 -  ``id``: the user id
@@ -269,7 +269,7 @@ The Twitter JSON looks something like this:
     }
 
 We parse this object manually with `GSON
-(google-json) <https://code.google.com/p/google-gson/>`__. Optionally,
+(google-json) <https://github.com/google/gson>`__. Optionally,
 you can create Java Object bindings for GSON and parse the entire tweet
 into an object. For more information about connecting to the twitter
 public stream check out the `Twitter Public Stream

--- a/docs/tutorials/spark.rst
+++ b/docs/tutorials/spark.rst
@@ -71,7 +71,7 @@ Clone the geomesa project and build it, if you haven't already:
     $ mvn clean install
 
 This is needed to install the GeoMesa JAR files in your local Maven
-repository. For more information see the :doc:`../developer/index`.
+repository. For more information see the :doc:`/developer/index`.
 
 The code in this tutorial is written in
 `Scala <http://scala-lang.org/>`__, as is much of GeoMesa itself.
@@ -80,7 +80,7 @@ Count Events by Day of Year
 ---------------------------
 
 You will need to have ingested some
-`GDELT <http://www.gdeltproject.org/>`__ data as described in :doc:`geomesa-examples-gdelt` and `GeoMesa tools gdelt confs <https://github.com/locationtech/geomesa/geomesa-tools/conf/sfts/gdelt>`__.
+`GDELT <http://www.gdeltproject.org/>`__ data, as described in :doc:`geomesa-examples-gdelt` or :ref:`gdelt_converter`.
 We have an example analysis in the class
 ``geomesa-accumulo/geomesa-accumulo-compute/src/main/scala/org/locationtech/geomesa/compute/spark/analytics/CountByDay.scala``.
 

--- a/docs/user/accumulo/commandline_tools.rst
+++ b/docs/user/accumulo/commandline_tools.rst
@@ -247,7 +247,7 @@ loaded using the `TypeSafe configuration library <https://github.com/typesafehub
 They can be referenced by name using the ``-s`` and ``-C`` args.
 
 To define new converters for the users can package a ``reference.conf`` file inside a jar and drop it in the
-``$GEOMESA_HOME/lib`` directory or add config definitions to the ``$GEOMESA_TOOLS/conf/application.conf`` file which
+``$GEOMESA_ACCUMULO_HOME/lib`` directory or add config definitions to the ``$GEOMESA_TOOLS/conf/application.conf`` file which
 includes some examples. SFT and Converter specifications should use the path prefixes
 ``geomesa.converters.<convertername>`` and ``geomesa.sfts.<typename>``
 
@@ -265,7 +265,7 @@ For example, here's a simple CSV file to ingest named ``example.csv``::
 To ingest this file, a SimpleFeatureType named ``renegades`` and a converter named ``renegades-csv`` can be placed in
 the ``application.conf`` file::
 
-    # cat $GEOMESA_HOME/conf/application.conf
+    # cat $GEOMESA_ACCUMULO_HOME/conf/application.conf
     geomesa {
       sfts {
         renegades = {

--- a/docs/user/accumulo/examples.rst
+++ b/docs/user/accumulo/examples.rst
@@ -192,7 +192,7 @@ Setting up an Ingest Converter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To use the ``-C`` switch, create (or edit) the file
-``$GEOMESA_HOME/conf/application.conf``, which serves as the converter
+``$GEOMESA_ACCUMULO_HOME/conf/application.conf``, which serves as the converter
 configuration file, to add the ``gdelt`` SimpleFeatureType and a converter
 ``gdelt_csv`` for reading the data from tab-separated value files:
 
@@ -243,17 +243,17 @@ there is an exception, whereas the ``::double`` function will fail (and drop
 the record) if the casting fails.
 
 To confirm that GeoMesa can properly parse your edited
-``$GEOMESA_HOME/conf/application.conf`` file, use ``geomesa env``:
+``$GEOMESA_ACCUMULO_HOME/conf/application.conf`` file, use ``geomesa env``:
 
 .. code::
 
     $ geomesa env -s gdelt --format spec
-    Using GEOMESA_HOME = /opt/geomesa/tools
+    Using GEOMESA_ACCUMULO_HOME = /opt/geomesa/tools
     Simple Feature Types:
     gdelt = globalEventId:String,eventCode:String,actor1:String,actor2:String,dtg:Date:index=join,*geom:Point:srid=4326;geomesa.index.dtg='dtg',geomesa.table.sharing='false'
 
     $ geomesa env -c gdelt_tsv
-    Using GEOMESA_HOME = /opt/geomesa/tools
+    Using GEOMESA_ACCUMULO_HOME = /opt/geomesa/tools
 
     Simple Feature Type Converters:
     converter-name=gdelt_tsv
@@ -319,9 +319,9 @@ Example Usage:
 
 Depending on the desired data, you may be prompted further information to specify desired dates or locations.
 
-The resulting data will then be downloaded to ```$GEOMESA_HOME/data```.
+The resulting data will then be downloaded to ```$GEOMESA_ACCUMULO_HOME/data```.
 
-Configuration files for these data sets are found under ```$GEOMESA_HOME/conf/sfts```. 
+Configuration files for these data sets are found under ```$GEOMESA_ACCUMULO_HOME/conf/sfts```.
 Modifications to them can seen by running ```geomesa env``` and will be reflected in the next run ingest. 
 
 Running an Ingest

--- a/docs/user/accumulo/install.rst
+++ b/docs/user/accumulo/install.rst
@@ -144,8 +144,8 @@ In the ``geomesa-accumulo_2.11-$VERSION`` directory, run ``bin/geomesa configure
 
     ### in geomesa-accumulo_2.11-$VERSION/:
     $ bin/geomesa configure
-    Warning: GEOMESA_HOME is not set, using /path/to/geomesa-accumulo_2.11-$VERSION
-    Using GEOMESA_HOME as set: /path/to/geomesa-accumulo_2.11-$VERSION
+    Warning: GEOMESA_ACCUMULO_HOME is not set, using /path/to/geomesa-accumulo_2.11-$VERSION
+    Using GEOMESA_ACCUMULO_HOME as set: /path/to/geomesa-accumulo_2.11-$VERSION
     Is this intentional? Y\n y
     Warning: GEOMESA_LIB already set, probably by a prior configuration.
     Current value is /path/to/geomesa-accumulo_2.11-$VERSION/lib.
@@ -153,14 +153,14 @@ In the ``geomesa-accumulo_2.11-$VERSION`` directory, run ``bin/geomesa configure
     Is this intentional? Y\n y
 
     To persist the configuration please update your bashrc file to include:
-    export GEOMESA_HOME=/path/to/geomesa-accumulo_2.11-$VERSION
-    export PATH=${GEOMESA_HOME}/bin:$PATH
+    export GEOMESA_ACCUMULO_HOME=/path/to/geomesa-accumulo_2.11-$VERSION
+    export PATH=${GEOMESA_ACCUMULO_HOME}/bin:$PATH
 
-Update and re-source your ``~/.bashrc`` file to include the ``$GEOMESA_HOME`` and ``$PATH`` updates.
+Update and re-source your ``~/.bashrc`` file to include the ``$GEOMESA_ACCUMULO_HOME`` and ``$PATH`` updates.
 
 .. warning::
 
-    Please note that the ``$GEOMESA_HOME`` variable points to the location of the ``geomesa-accumulo_2.11-$VERSION``
+    Please note that the ``$GEOMESA_ACCUMULO_HOME`` variable points to the location of the ``geomesa-accumulo_2.11-$VERSION``
     directory, not the main geomesa binary distribution directory.
 
 .. note::
@@ -195,7 +195,7 @@ Test the command that invokes the GeoMesa Tools:
 .. code::
 
     $ geomesa
-    Using GEOMESA_HOME = /path/to/geomesa-accumulo-dist_2.11-$VERSION
+    Using GEOMESA_ACCUMULO_HOME = /path/to/geomesa-accumulo-dist_2.11-$VERSION
     Usage: geomesa [command] [command options]
       Commands:
       ...
@@ -296,7 +296,7 @@ be specific to your installation that you will also need to copy to GeoServer's
 that match the version of Hadoop you are running.
 
 There is a script in the ``geomesa-accumulo_2.11-$VERSION/bin`` directory
-(``$GEOMESA_HOME/bin/install-hadoop-accumulo.sh``) which will install these
+(``$GEOMESA_ACCUMULO_HOME/bin/install-hadoop-accumulo.sh``) which will install these
 dependencies to a target directory using ``wget`` (requires an internet
 connection).
 
@@ -307,7 +307,7 @@ connection).
 
 .. code-block:: bash
 
-    $ $GEOMESA_HOME/bin/install-hadoop-accumulo.sh /path/to/tomcat/webapps/geoserver/WEB-INF/lib/
+    $ $GEOMESA_ACCUMULO_HOME/bin/install-hadoop-accumulo.sh /path/to/tomcat/webapps/geoserver/WEB-INF/lib/
     Install accumulo and hadoop dependencies to /path/to/tomcat/webapps/geoserver/WEB-INF/lib/?
     Confirm? [Y/n]y
     fetching https://search.maven.org/remotecontent?filepath=org/apache/accumulo/accumulo-core/1.6.5/accumulo-core-1.6.5.jar

--- a/docs/user/bigtable/geoserver.rst
+++ b/docs/user/bigtable/geoserver.rst
@@ -21,4 +21,4 @@ On the "Add Store" page, select "Google Bigtable (GeoMesa)". The Bigtable data s
 
 Other configuration information is taken from ``hbase-site.xml`` (see :ref:`install_bigtable_geoserver`).
 
-Click "Save", and GeoServer will search Bigtable for any GeoMesa-managed feature types.:doc:`./geoserver`.
+Click "Save", and GeoServer will search Bigtable for any GeoMesa-managed feature types.

--- a/docs/user/bigtable/index.rst
+++ b/docs/user/bigtable/index.rst
@@ -2,7 +2,7 @@ Bigtable Data Store
 ===================
 
 The GeoMesa Bigtable Data Store is an implementation of the GeoTools
-``DataStore`` interface that is backed by `Google Cloud Bigtable <https://cloud.google.com/bigtable>`__.
+``DataStore`` interface that is backed by `Google Cloud Bigtable <https://cloud.google.com/bigtable/>`__.
 
 The code for Bigtable support is found in two modules in the source distribution:
 

--- a/docs/user/convert/premade/gdelt.rst
+++ b/docs/user/convert/premade/gdelt.rst
@@ -1,3 +1,5 @@
+.. _gdelt_converter:
+
 Global Database of Events, Language, and Tone (GDELT)
 =====================================================
 
@@ -15,7 +17,7 @@ Getting GDELT data
 ------------------
 
 The GDELT data set can be downloaded using the provided
-``download-data.sh`` script in ``$GEOMESA_HOME/bin/`` as such
+``download-data.sh`` script in ``$GEOMESA_ACCUMULO_HOME/bin/`` as such
 
 ::
 
@@ -47,8 +49,8 @@ tools classpath. This is the default case.
     geomesa env | grep gdelt
 
 If it is not, merge the contents of ``reference.conf`` to
-``$GEOMESA_HOME/conf/application.conf``, or ensure that
-``reference.conf`` is in ``$GEOMESA_HOME/conf/sfts/gdelt``
+``$GEOMESA_ACCUMULO_HOME/conf/application.conf``, or ensure that
+``reference.conf`` is in ``$GEOMESA_ACCUMULO_HOME/conf/sfts/gdelt``.
 
 Run the ingest. You may optionally point to a different accumulo
 instance using ``-i`` and ``-z`` options. See ``geomesa help ingest``
@@ -58,4 +60,4 @@ for more detail.
 
     geomesa ingest -u USERNAME -c CATALOGNAME -s gdelt -C gdelt gdelt_data.csv
 
-Any errors in ingestion will be logged to ``$GEOMESA_HOME/logs``.
+Any errors in ingestion will be logged to ``$GEOMESA_ACCUMULO_HOME/logs``.

--- a/docs/user/convert/premade/geolife.rst
+++ b/docs/user/convert/premade/geolife.rst
@@ -19,7 +19,7 @@ Getting GeoLife data
 --------------------
 
 The GeoLife data set can be downloaded using the provided
-``download-data.sh`` script in ``$GEOMESA_HOME/bin/`` as such
+``download-data.sh`` script in ``$GEOMESA_ACCUMULO_HOME/bin/`` as such
 
 ::
 
@@ -64,8 +64,8 @@ tools classpath. This is the default case.
     geomesa env | grep geolife
 
 If it is not, merge the contents of ``reference.conf`` with
-``$GEOMESA_HOME/conf/application.conf``, or ensure that
-``reference.conf`` is in ``$GEOMESA_HOME/conf/sfts/geolife``
+``$GEOMESA_ACCUMULO_HOME/conf/application.conf``, or ensure that
+``reference.conf`` is in ``$GEOMESA_ACCUMULO_HOME/conf/sfts/geolife``
 
 Run the ingest. You may optionally point to a different accumulo
 instance using ``-i`` and ``-z`` options. See ``geomesa help ingest``
@@ -89,4 +89,4 @@ this dataset:
 #. Yu Zheng, Quannan Li, Yukun Chen, Xing Xie, Wei-Ying Ma. Understanding Mobility Based on GPS Data. In Proceedings of ACM conference on Ubiquitous Computing (UbiComp 2008), Seoul, Korea. ACM Press: 312-321.
 #. Yu Zheng, Xing Xie, Wei-Ying Ma, GeoLife: A Collaborative Social Networking Service among User, location and trajectory. Invited paper, in IEEE Data Engineering Bulletin. 33, 2,2010, pp. 32-40.
 
-Any errors in ingestion will be logged to ``$GEOMESA_HOME/logs``.
+Any errors in ingestion will be logged to ``$GEOMESA_ACCUMULO_HOME/logs``.

--- a/docs/user/convert/premade/geonames.rst
+++ b/docs/user/convert/premade/geonames.rst
@@ -14,7 +14,7 @@ Getting GeoNames data
 ---------------------
 
 The GeoNames data set can be downloaded using the provided
-``download-data.sh`` script in ``$GEOMESA_HOME/bin/`` as such
+``download-data.sh`` script in ``$GEOMESA_ACCUMULO_HOME/bin/`` as such
 
 ::
 
@@ -40,8 +40,8 @@ tools classpath. This is the default case.
     geomesa env | grep geonames
 
 If it is not, merge the contents of ``reference.conf`` with
-``$GEOMESA_HOME/conf/application.conf``, or ensure that
-``reference.conf`` is in ``$GEOMESA_HOME/conf/sfts/geonames``
+``$GEOMESA_ACCUMULO_HOME/conf/application.conf``, or ensure that
+``reference.conf`` is in ``$GEOMESA_ACCUMULO_HOME/conf/sfts/geonames``
 
 Run the ingest. You may optionally point to a different accumulo
 instance using ``-i`` and ``-z`` options. See ``geomesa help ingest``

--- a/docs/user/convert/premade/gtd.rst
+++ b/docs/user/convert/premade/gtd.rst
@@ -48,8 +48,8 @@ classpath. This is the default case.
     geomesa env | grep gtd
 
 If it is not, merge the contents of ``reference.conf`` with
-``$GEOMESA_HOME/conf/application.conf``, or ensure that
-``reference.conf`` is in ``$GEOMESA_HOME/conf/sfts/gtd``.
+``$GEOMESA_ACCUMULO_HOME/conf/application.conf``, or ensure that
+``reference.conf`` is in ``$GEOMESA_ACCUMULO_HOME/conf/sfts/gtd``.
 
 Run the ingest. You may optionally point to a different Accumulo
 instance using ``-i`` and ``-z`` options. See ``geomesa help ingest``

--- a/docs/user/convert/premade/index.rst
+++ b/docs/user/convert/premade/index.rst
@@ -24,8 +24,9 @@ artifact with the ``data`` classifier. For example, for Maven add the following 
 .. note::
 
     The examples in the sections below are often specific to the GeoMesa Accumulo distribution,
-    but the general principle is the same for each distribution. Only the home variable and
-    command-line tool name will differ depending on GeoMesa distribution.
+    but the general principle is the same for each distribution. Only the home variable
+    (e.g. ``$GEOMESA_ACCUMULO_HOME``) and command-line tool name will differ depending on
+    GeoMesa distribution.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/user/convert/premade/nyctaxi.rst
+++ b/docs/user/convert/premade/nyctaxi.rst
@@ -47,8 +47,8 @@ are available on the GeoMesa tools classpath. This is the default case.
     geomesa env | grep 'nyctaxi\|nyctaxi-single'
 
 If they are not, merge the contents of ``reference.conf`` with
-``$GEOMESA_HOME/conf/application.conf``, or ensure that
-``reference.conf`` is in ``$GEOMESA_HOME/conf/sfts/nyctaxi``.
+``$GEOMESA_ACCUMULO_HOME/conf/application.conf``, or ensure that
+``reference.conf`` is in ``$GEOMESA_ACCUMULO_HOME/conf/sfts/nyctaxi``.
 
 Two record method
 ~~~~~~~~~~~~~~~~~

--- a/docs/user/convert/premade/osm-gpx.rst
+++ b/docs/user/convert/premade/osm-gpx.rst
@@ -9,7 +9,7 @@ Getting OSM-GPX data
 --------------------
 
 The OSM-GPX data set can be downloaded using the provided
-``download-data.sh`` script in ``$GEOMESA_HOME/bin/`` as such
+``download-data.sh`` script in ``$GEOMESA_ACCUMULO_HOME/bin/`` as such
 
 ::
 
@@ -41,8 +41,8 @@ tools classpath. This is the default case.
     geomesa env | grep osm-gpx
 
 If it is not, merge the contents of ``reference.conf`` with
-``$GEOMESA_HOME/conf/application.conf``, or ensure that
-``reference.conf`` is in ``$GEOMESA_HOME/conf/sfts/osm-gpx``.
+``$GEOMESA_ACCUMULO_HOME/conf/application.conf``, or ensure that
+``reference.conf`` is in ``$GEOMESA_ACCUMULO_HOME/conf/sfts/osm-gpx``.
 
 Run the ingest. You may optionally point to a different accumulo
 instance using ``-i`` and ``-z`` options. See ``geomesa help ingest``

--- a/docs/user/convert/premade/tdrive.rst
+++ b/docs/user/convert/premade/tdrive.rst
@@ -21,7 +21,7 @@ Getting T-Drive data
 --------------------
 
 The T-Drive data set can be downloaded using the provided
-``download-data.sh`` script in ``$GEOMESA_HOME/bin/`` as such
+``download-data.sh`` script in ``$GEOMESA_ACCUMULO_HOME/bin/`` as such
 
 ::
 
@@ -49,8 +49,8 @@ tools classpath. This is the default case.
     geomesa env | grep tdrive
 
 If it is not, merge the contents of ``reference.conf`` with
-``$GEOMESA_HOME/conf/application.conf``, or ensure that
-``reference.conf`` is in ``$GEOMESA_HOME/conf/sfts/tdrive``.
+``$GEOMESA_ACCUMULO_HOME/conf/application.conf``, or ensure that
+``reference.conf`` is in ``$GEOMESA_ACCUMULO_HOME/conf/sfts/tdrive``.
 
 Run the ingest. You may optionally point to a different accumulo
 instance using ``-i`` and ``-z`` options. See ``geomesa help ingest``
@@ -60,4 +60,4 @@ for more detail.
 
     geomesa ingest -u USERNAME -c CATALOGNAME -s tdrive -C tdrive tdrive_data.txt
 
-Any errors during the ingest will be logged to ``$GEOMESA_HOME/logs``.
+Any errors during the ingest will be logged to ``$GEOMESA_ACCUMULO_HOME/logs``.

--- a/docs/user/convert/premade/twitter.rst
+++ b/docs/user/convert/premade/twitter.rst
@@ -39,8 +39,8 @@ tools classpath. This is the default case.
     geomesa env | grep twitter
 
 If it is not, merge the contents of ``reference.conf`` with
-``$GEOMESA_HOME/conf/application.conf``, or ensure that
-``reference.conf`` is in ``$GEOMESA_HOME/conf/sfts/twitter``.
+``$GEOMESA_ACCUMULO_HOME/conf/application.conf``, or ensure that
+``reference.conf`` is in ``$GEOMESA_ACCUMULO_HOME/conf/sfts/twitter``.
 
 A recommended ingest procedure is to ingest first picking up the
 bounding boxes. Tweets with point geometry may fail this ingest. Then

--- a/docs/user/convert/usage_tools.rst
+++ b/docs/user/convert/usage_tools.rst
@@ -10,7 +10,7 @@ distributions out of the box. See :ref:`prepackaged_converters`.
 
 Users can add additional SFT and converter types by providing a ``reference.conf`` file
 embedded with a JAR within the ``lib`` directory, or by adding the types to the
-``application.conf`` file in the ``$GEOMESA_HOME/conf`` or ``$GEOMESA_KAKFA_HOME/conf``
+``application.conf`` file in the ``$GEOMESA_ACCUMULO_HOME/conf`` or ``$GEOMESA_KAKFA_HOME/conf``
 directory.
 
 .. note::
@@ -29,13 +29,13 @@ Given the following sample CSV file ``example.csv``:
     3233,Severus,30,2015-10-23,"Tom, Riddle, Voldemort",3,-62.23
 
 A "renegades" SFT and "renegades-csv" converter may be specified in
-the GeoMesa Tools configuration file (``$GEOMESA_HOME/conf/application.conf``)
+the GeoMesa Tools configuration file (``$GEOMESA_ACCUMULO_HOME/conf/application.conf``)
 as shown below. By default, SFTs will be loaded from the file
 at the path ``geomesa.sfts`` and converters will be loaded at the path
 ``geomesa.converters``. Each converter and SFT definition is keyed by the name that
 can be referenced in the converter and SFT loaders.
 
-``$GEOMESA_HOME/conf/application.conf``:
+``$GEOMESA_ACCUMULO_HOME/conf/application.conf``:
 
 ::
 


### PR DESCRIPTION
* Fix numerous bad links detected via automated link checking
* Change references to GEOMESA_HOME environment variable
  to GEOMESA_ACCUMULO_HOME.

This will be backported to the 1.3.0 docs rendered on geomesa.org.

Signed-off-by: Matthew Zimmerman <matt.zimmerman@ccri.com>