### PR TITLE
GEOMESA-1662 Clarify description of add-attribute-index command

### DIFF
--- a/docs/user/accumulo/commandline_tools.rst
+++ b/docs/user/accumulo/commandline_tools.rst
@@ -524,10 +524,12 @@ Example usage::
 add-attribute-index
 ~~~~~~~~~~~~~~~~~~~
 
-Add an attribute index for a specified list of attributes.::
+Add attribute indices for a specified list of attributes.::
 
     $ geomesa add-attribute-index -u username -p password -i instance -z zoo1,zoo2,zoo3 -c test_catalog \
-        -f test_feature -a attribute1,attribute2 --coverage full
+      -f test_feature -a attribute1,attribute2 --coverage full
+
+This will launch a map-reduce job creating attribute indices for each attribute listed in ``-a``. This is essentially a convenience wrapper for invoking the job described in :ref:`attribute_indexing_job`.
 
 env
 ~~~

--- a/docs/user/accumulo/jobs.rst
+++ b/docs/user/accumulo/jobs.rst
@@ -92,9 +92,10 @@ GeoMesa provides indexing on attributes to improve certain queries. You
 can indicate attributes that should be indexed when you create your
 schema (simple feature type). If you decide later on that you would like
 to index additional attributes, you can use the attribute indexing job.
-You only need to run this job once.
+You only need to run this job once; the job will create attribute indices
+for each attribute listed in ``--geomesa.index.attributes``.
 
-The job can be invoked through Yarn as follows (JAR version may vary
+The job can be invoked through Yarn as follows (the JAR version may vary
 slightly):
 
 .. code-block:: shell


### PR DESCRIPTION
Make it clear that it (effectively) creates separate indexes for each
attribute listed, not a compound index of all attributes listed.

Signed-off-by: Matthew Zimmerman <matt.zimmerman@ccri.com>