### PR TITLE
GEOMESA-1680 More efficiently handle OR filters in Accumulo Spark

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/accumulo/AccumuloJobUtils.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/accumulo/AccumuloJobUtils.scala
@@ -84,12 +84,53 @@ object AccumuloJobUtils extends LazyLogging {
         val qps = ds.getQueryPlan(query, Some(fallbackIndex))
         if (qps.length > 1) {
           logger.error("The query being executed requires multiple scans, which is not currently " +
-              "supported by geomesa. Your result set will be partially incomplete. " +
+              "supported by GeoMesa. Your result set will be partially incomplete. " +
               s"Query: ${filterToString(query.getFilter)}")
         }
         qps.head
       } else {
         queryPlans.head
+      }
+    } finally {
+      // make sure we reset the thread local
+      AccumuloQueryProperties.SCAN_BATCH_RANGES.threadLocalValue.remove()
+    }
+  }
+
+  /**
+    * Get a sequence of one or more query plans, which is guaranteed not to contain
+    * a JoinPlan (return a fallback in this case). If we get multiple scan plans,
+    * that's groovy.
+    */
+  def getMultipleQueryPlan(ds: AccumuloDataStore, query: Query): Seq[AccumuloQueryPlan] = {
+    // disable range batching for this request
+    AccumuloQueryProperties.SCAN_BATCH_RANGES.threadLocalValue.set(Int.MaxValue.toString)
+
+    try {
+      lazy val fallbackIndex = {
+        val schema = ds.getSchema(query.getTypeName)
+        AccumuloFeatureIndex.indices(schema, IndexMode.Read).headOption.getOrElse {
+          throw new IllegalStateException(s"Schema '${schema.getTypeName}' does not have any readable indices")
+        }
+      }
+
+      val queryPlans: Seq[AccumuloQueryPlan] = ds.getQueryPlan(query)
+
+      if (queryPlans.isEmpty) {
+        Seq(EmptyPlan(FilterStrategy(fallbackIndex, None, Some(Filter.EXCLUDE))))
+      } else if (queryPlans.exists(_.isInstanceOf[JoinPlan])) {
+        // this query has a join, which we can't execute from input formats
+        // instead, fall back to a full table scan
+        logger.warn("Desired query plan contains joins - falling back to full table scan")
+        val qps = ds.getQueryPlan(query, Some(fallbackIndex))
+        if (qps.length > 1) {
+          logger.error("The query being executed requires multiple scans, which is not currently " +
+            "supported by GeoMesa. Your result set will be partially incomplete. " +
+            s"Query: ${filterToString(query.getFilter)}")
+        }
+        qps
+      } else {
+        queryPlans
       }
     } finally {
       // make sure we reset the thread local

--- a/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
+++ b/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
@@ -49,7 +49,7 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider {
     val username = AccumuloDataStoreParams.userParam.lookUp(dsParams).toString
     val password = new PasswordToken(AccumuloDataStoreParams.passwordParam.lookUp(dsParams).toString.getBytes)
 
-    def queryPlanToRDD(sft: => SimpleFeatureType, qp: => AccumuloQueryPlan, conf: Configuration) = {
+    def queryPlanToRDD(sft: SimpleFeatureType, qp: AccumuloQueryPlan, conf: Configuration) = {
       if (ds == null || sft == null || qp.isInstanceOf[EmptyPlan]) {
         sc.emptyRDD[SimpleFeature]
       } else {
@@ -101,9 +101,9 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider {
     try {
       // get the query plan to set up the iterators, ranges, etc
       // getMultipleQueryPlan will return the fallback if any
-      // element of the plan is a JoinPlan
-      lazy val sft = ds.getSchema(query.getTypeName)
-      lazy val qps = AccumuloJobUtils.getMultipleQueryPlan(ds, query)
+      /q/ element of the plan is a JoinPlan
+      val sft = ds.getSchema(query.getTypeName)
+      val qps = AccumuloJobUtils.getMultipleQueryPlan(ds, query)
 
       // can return a union of the RDDs because the query planner *should*
       // be rewriting ORs to make them logically disjoint

--- a/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
+++ b/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
@@ -101,7 +101,7 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider {
     try {
       // get the query plan to set up the iterators, ranges, etc
       // getMultipleQueryPlan will return the fallback if any
-      /q/ element of the plan is a JoinPlan
+      // element of the plan is a JoinPlan
       val sft = ds.getSchema(query.getTypeName)
       val qps = AccumuloJobUtils.getMultipleQueryPlan(ds, query)
 


### PR DESCRIPTION
Extend ``AccumuloSpatialRDDProvider#rdd()`` to efficiently support
OR filters that produce query plans with multiple BatchScanPlan
components, by generating a separate RDD for each component and
returning their union.

Signed-off-by: Matthew Zimmerman <matt.zimmerman@ccri.com>