### PR TITLE
GEOMESA-1680 Fix Accumulo Spark query plans containing ORs redux

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/accumulo/AccumuloJobUtils.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/accumulo/AccumuloJobUtils.scala
@@ -122,13 +122,7 @@ object AccumuloJobUtils extends LazyLogging {
         // this query has a join, which we can't execute from input formats
         // instead, fall back to a full table scan
         logger.warn("Desired query plan contains joins - falling back to full table scan")
-        val qps = ds.getQueryPlan(query, Some(fallbackIndex))
-        if (qps.length > 1) {
-          logger.error("The query being executed requires multiple scans, which is not currently " +
-            "supported by GeoMesa. Your result set will be partially incomplete. " +
-            s"Query: ${filterToString(query.getFilter)}")
-        }
-        qps
+        ds.getQueryPlan(query, Some(fallbackIndex))
       } else {
         queryPlans
       }

--- a/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
+++ b/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
@@ -108,7 +108,10 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider {
       // can return a union of the RDDs because the query planner *should*
       // be rewriting ORs to make them logically disjoint
       // e.g. "A OR B OR C" -> "A OR (B NOT A) OR ((C NOT A) NOT B)"
-      sc.union(qps.map(queryPlanToRDD(sft, _, new Configuration(conf))))
+      if (qps.length == 1)
+        queryPlanToRDD(sft, qps.head, conf) // no union needed for single query plan
+      else
+        sc.union(qps.map(queryPlanToRDD(sft, _, new Configuration(conf))))
     } finally {
       if (ds != null) {
         ds.dispose()


### PR DESCRIPTION
* Don't do a union if there's only one component in the query plan.
* Remove unneccessary comparison and misleading comment.

Signed-off-by: Matthew Zimmerman <matt.zimmerman@ccri.com>