### PR TITLE
GEOMESA-731 GeoMesaInputFormat - Allow number of mappers per shard to

### DIFF
--- a/docs/user/accumulo/configuration.rst
+++ b/docs/user/accumulo/configuration.rst
@@ -30,6 +30,29 @@ geomesa.batchwriter.timeout.millis
 
 See the `Accumulo API <https://accumulo.apache.org/1.7/apidocs/org/apache/accumulo/core/client/BatchWriterConfig.html#setTimeout(long,%20java.util.concurrent.TimeUnit)>`__
 
+Map Reduce Splits Properties
+----------------------------
+
+The following properties control the configure of Accumulo table splits.
+See the `Accumulo Docs <https://accumulo.apache.org/1.7/accumulo_user_manual#_splitting>`__
+
+geomesa.mapreduce.splits.max
+++++++++++++++++++++++++++++
+
+Set the absolute number of splits when configuring a mapper instead of allowing Accumulo to create a split
+for each range or basing it on the number of tablet servers.
+
+Setting this value overrides geomesa.mapreduce.splits.tserver.max.
+
+geomesa.mapreduce.splits.tserver.max
+++++++++++++++++++++++++++++++++++++
+
+Set the max number of splits per tablet server when configuring a mapper. By default this value is
+calculated using Accumulo's AbstractInputFormat.getSplits method which creates a split for each range. In
+some scenarios this may create an undesirably large number of splits.
+
+This value is overwritten by geomesa.mapreduce.splits.max if it is set.
+
 Zookeeper Session Timeout
 -------------------------
 

--- a/docs/user/accumulo/configuration.rst
+++ b/docs/user/accumulo/configuration.rst
@@ -30,10 +30,10 @@ geomesa.batchwriter.timeout.millis
 
 See the `Accumulo API <https://accumulo.apache.org/1.7/apidocs/org/apache/accumulo/core/client/BatchWriterConfig.html#setTimeout(long,%20java.util.concurrent.TimeUnit)>`__
 
-Map Reduce Splits Properties
-----------------------------
+Map Reduce Input Splits Properties
+----------------------------------
 
-The following properties control the configure of Accumulo table splits.
+The following properties control the number of input splits for a map reduce job.
 See the `Accumulo Docs <https://accumulo.apache.org/1.7/accumulo_user_manual#_splitting>`__
 
 geomesa.mapreduce.splits.max

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/package.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/package.scala
@@ -38,8 +38,8 @@ package object accumulo {
     }
 
     object AccumuloMapperProperties {
-      val DESIRED_SPLITS_PER_TSERVER = SystemProperty("geomesa.mapreduce.split.count.tablet")
-      val DESIRED_ABSOLUTE_SPLITS = SystemProperty("geomesa.mapreduce.split.count.absolute")
+      val DESIRED_SPLITS_PER_TSERVER = SystemProperty("geomesa.mapreduce.splits.tserver.max")
+      val DESIRED_ABSOLUTE_SPLITS = SystemProperty("geomesa.mapreduce.splits.max")
     }
 
     object BatchWriterProperties {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/package.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/package.scala
@@ -37,6 +37,11 @@ package object accumulo {
       val SCAN_BATCH_RANGES    = SystemProperty("geomesa.scan.ranges.batch", "20000")
     }
 
+    object AccumuloMapperProperties {
+      val DESIRED_SPLITS_PER_TSERVER = SystemProperty("geomesa.mapreduce.split.count.tablet")
+      val DESIRED_ABSOLUTE_SPLITS = SystemProperty("geomesa.mapreduce.split.count.absolute")
+    }
+
     object BatchWriterProperties {
       // Measured in millis, default 60 seconds
       val WRITER_LATENCY_MILLIS  = SystemProperty("geomesa.batchwriter.latency.millis", (60 * 1000L).toString)

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
@@ -185,18 +185,18 @@ class GeoMesaAccumuloInputFormat extends InputFormat[Text, SimpleFeature] with L
       }
     }
 
-    lazy val grpSplitsPerTServer: Option[Int] =
-      AccumuloMapperProperties.DESIRED_SPLITS_PER_TSERVER.option match {
-        case Some(desiredSplits) =>
-          val numLocations = accumuloSplits.flatMap(_.getLocations).toArray.distinct.length
-          val splitsPerTServer = try { desiredSplits.toInt } catch {
-            case e: java.lang.NumberFormatException =>
-              logger.warn(s"Unable to parse geomesa.mapreduce.splits.tserver.max = " + s"$desiredSplits is not a valid Int.")
-              1 // Identity, don't split locations
-          }
-          if (numLocations > 0 && splitsPerTServer > 0) Some(numLocations * splitsPerTServer) else None
-        case None => None
-      }
+    lazy val grpSplitsPerTServer: Option[Int] = AccumuloMapperProperties.DESIRED_SPLITS_PER_TSERVER.option match {
+      case Some(desiredSplits) =>
+        val numLocations = accumuloSplits.flatMap(_.getLocations).toArray.distinct.length
+        val splitsPerTServer = try {
+          desiredSplits.toInt
+        } catch {
+          case e: java.lang.NumberFormatException =>
+            throw new IllegalArgumentException(s"Unable to parse geomesa.mapreduce.splits.tserver.max = $desiredSplits contains an invalid Int.", e)
+        }
+        if (numLocations > 0 && splitsPerTServer > 0) Some(numLocations * splitsPerTServer) else None
+      case None => None
+     }
 
     grpSplitsMax.orElse(grpSplitsPerTServer) match {
       case Some(numberOfSplits) =>

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
@@ -206,7 +206,7 @@ class GeoMesaAccumuloInputFormat extends InputFormat[Text, SimpleFeature] with L
             split.splits.append(group.map(_.asInstanceOf[RangeInputSplit]): _*)
             split
           }
-      }.toList
+        }.toList
       case None => logger.debug(s"Using default Accumulo Splits with ${accumuloSplits.length} splits")
         accumuloSplits
     }

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
@@ -179,8 +179,7 @@ class GeoMesaAccumuloInputFormat extends InputFormat[Text, SimpleFeature] with L
     val grpSplitsMax: Option[Int] = AccumuloMapperProperties.DESIRED_ABSOLUTE_SPLITS.option.flatMap { prop =>
       try { Some(prop.toInt).filter(_ > 0) } catch {
         case e: java.lang.NumberFormatException =>
-          AccumuloMapperProperties.DESIRED_ABSOLUTE_SPLITS.option.foreach(value =>
-            logger.warn(s"Unable to parse geomesa.mapreduce.splits.max = $value is not a valid Int."))
+          prop.foreach( value => logger.warn(s"Unable to parse geomesa.mapreduce.splits.max = $value is not a valid Int."))
           None
       }
     }
@@ -191,8 +190,7 @@ class GeoMesaAccumuloInputFormat extends InputFormat[Text, SimpleFeature] with L
           val numLocations = accumuloSplits.flatMap(_.getLocations).toArray.distinct.length
           val splitsPerTServer = try { desiredSplits.toInt } catch {
             case e: java.lang.NumberFormatException =>
-              logger.warn(s"Unable to parse geomesa.mapreduce.splits.tserver.max = " +
-                s"${AccumuloMapperProperties.DESIRED_SPLITS_PER_TSERVER.get} is not a valid Int.")
+              logger.warn(s"Unable to parse geomesa.mapreduce.splits.tserver.max = " + s"$desiredSplits is not a valid Int.")
               1 // Identity, don't split locations
           }
           if (numLocations > 0 && splitsPerTServer > 0) Some(numLocations * splitsPerTServer) else None
@@ -284,8 +282,8 @@ class GroupedSplit extends InputSplit with Writable {
     GeoMesaAccumuloInputFormat.ensureSparkClasspath()
   }
 
-  var location: String = null
-  var splits: ArrayBuffer[RangeInputSplit] = ArrayBuffer.empty
+  private[mapreduce] var location: String = null
+  private[mapreduce] val splits: ArrayBuffer[RangeInputSplit] = ArrayBuffer.empty
 
   override def getLength = splits.foldLeft(0L)((l: Long, r: RangeInputSplit) => l + r.getLength)
 

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
@@ -8,21 +8,23 @@
 
 package org.locationtech.geomesa.jobs.mapreduce
 
+import java.io.{DataInput, DataOutput}
 import java.net.{URL, URLClassLoader}
 
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.accumulo.core.client.mapreduce.{AbstractInputFormat, AccumuloInputFormat, InputFormatBase}
+import org.apache.accumulo.core.client.mapreduce.{AbstractInputFormat, AccumuloInputFormat, InputFormatBase, RangeInputSplit}
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
 import org.apache.accumulo.core.data.{Key, Value}
 import org.apache.accumulo.core.security.Authorizations
 import org.apache.accumulo.core.util.{Pair => AccPair}
 import org.apache.commons.collections.map.CaseInsensitiveMap
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.io.Text
+import org.apache.hadoop.io.{Text, Writable}
 import org.apache.hadoop.mapreduce._
 import org.geotools.data.{DataStoreFinder, Query}
 import org.geotools.filter.identity.FeatureIdImpl
 import org.geotools.filter.text.ecql.ECQL
+import org.locationtech.geomesa.accumulo.AccumuloProperties.AccumuloMapperProperties
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloDataStoreParams}
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
 import org.locationtech.geomesa.features.SerializationOption.SerializationOptions
@@ -35,6 +37,7 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 
 import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
 
 object GeoMesaAccumuloInputFormat extends LazyLogging {
 
@@ -164,13 +167,55 @@ class GeoMesaAccumuloInputFormat extends InputFormat[Text, SimpleFeature] with L
    *
    * Our delegated AccumuloInputFormat creates a split for each range - because we set a lot of ranges in
    * geomesa, that creates too many mappers. Instead, we try to group the ranges by tservers. We use the
-   * number of shards in the schema as a proxy for number of tservers.
+   * location of the tserver to determine the number of tservers.
    */
   override def getSplits(context: JobContext): java.util.List[InputSplit] = {
     init(context.getConfiguration)
     val accumuloSplits = delegate.getSplits(context)
-    logger.debug(s"Got ${accumuloSplits.length} splits")
-    accumuloSplits
+    // Get the appropriate number of mapper splits using the following priority
+    // 1. Get splits from AccumuloMapperProperties.DESIRED_ABSOLUTE_SPLITS (geomesa.mapreduce.split.count.absolute)
+    // 2. Get splits from #tserver locations * AccumuloMapperProperties.DESIRED_SPLITS_PER_TSERVER (geomesa.mapreduce.split.count.tablet)
+    // 3. Get splits from AccumuloInputFormat.getSplits(context)
+    val grpSplitsAbs: Option[Int] =
+      try {
+        val absSplits = AccumuloMapperProperties.DESIRED_ABSOLUTE_SPLITS.get.toInt
+        if (absSplits > 0) Some(absSplits) else None
+      } catch {
+        case e: java.lang.NumberFormatException =>
+          logger.warn(s"Unable to parse geomesa.mapreduce.split.count.absolute = " +
+            s"${AccumuloMapperProperties.DESIRED_ABSOLUTE_SPLITS.get} is not a valid Int.")
+          None
+      }
+
+    lazy val grpSplitsPerTServer: Option[Int] =
+      if (AccumuloMapperProperties.DESIRED_SPLITS_PER_TSERVER.get == null) None
+      else {
+        val numLocations = accumuloSplits.flatMap(_.getLocations).distinct.head.length
+        val splitsPerTServer =
+          try {
+            AccumuloMapperProperties.DESIRED_SPLITS_PER_TSERVER.get.toInt
+          } catch {
+            case e: java.lang.NumberFormatException =>
+              logger.warn(s"Unable to parse geomesa.mapreduce.split.count.tablet = " +
+                s"${AccumuloMapperProperties.DESIRED_SPLITS_PER_TSERVER.get} is not a valid Int.")
+              1 // Identity, don't split locations
+          }
+        if (numLocations > 0 && splitsPerTServer > 0) Some(numLocations * splitsPerTServer) else None
+      }
+
+    grpSplitsAbs.orElse(grpSplitsPerTServer) match {
+      case Some(size) => logger.debug(s"Using desired splits with result of ${accumuloSplits.length} splits")
+        accumuloSplits.groupBy(_.getLocations()(0)).flatMap{ case (location, splits) =>
+          splits.grouped(size).map{ group =>
+            val split = new GroupedSplit
+            split.location = location
+            split.splits.append(group.map(_.asInstanceOf[RangeInputSplit]): _*)
+            split
+          }
+      }.toList
+      case None => logger.debug(s"Using default Accumulo Splits with ${accumuloSplits.length} splits")
+        accumuloSplits
+    }
   }
 
   override def createRecordReader(split: InputSplit, context: TaskAttemptContext) = {
@@ -229,4 +274,45 @@ class GeoMesaRecordReader(sft: SimpleFeatureType,
   override def getCurrentKey = new Text(currentFeature.getID)
 
   override def close() = { reader.close() }
+}
+
+/**
+ * Input split that groups a series of RangeInputSplits. Has to implement Hadoop Writable, thus the vars and
+ * mutable state.
+ */
+class GroupedSplit extends InputSplit with Writable {
+
+  // if we're running in spark, we need to load the context classpath before anything else,
+  // otherwise we get classloading and serialization issues
+  sys.env.get(GeoMesaAccumuloInputFormat.SYS_PROP_SPARK_LOAD_CP).filter(_.toBoolean).foreach { _ =>
+    GeoMesaAccumuloInputFormat.ensureSparkClasspath()
+  }
+
+  var location: String = null
+  var splits: ArrayBuffer[RangeInputSplit] = ArrayBuffer.empty
+
+  override def getLength =  splits.foldLeft(0L)((l: Long, r: RangeInputSplit) => l + r.getLength)
+
+  override def getLocations = if (location == null) Array.empty else Array(location)
+
+  override def write(out: DataOutput) = {
+    out.writeUTF(location)
+    out.writeInt(splits.length)
+    splits.foreach(_.write(out))
+  }
+
+  override def readFields(in: DataInput) = {
+    location = in.readUTF()
+    splits.clear()
+    var i = 0
+    val size = in.readInt()
+    while (i < size) {
+      val split = new RangeInputSplit()
+      split.readFields(in)
+      splits.append(split)
+      i = i + 1
+    }
+  }
+
+  override def toString = s"mapreduce.GroupedSplit[$location](${splits.length})"
 }

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/GeoMesaConfigurator.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/GeoMesaConfigurator.scala
@@ -118,4 +118,9 @@ object GeoMesaConfigurator {
 
   val serializationString: String = s"$writableSerialization,$simpleFeatureSerialization"
 
+  // set/get the number of mapper splits
+  def setDesiredSplits(conf: Configuration, splits: Int): Unit = conf.set(desiredSplits, splits.toString)
+  def getDesiredSplits(conf: Configuration): Int = conf.get(desiredSplits).toInt
+  def getDesiredSplits(job: Job): Int = getDesiredSplits(job.getConfiguration)
+
 }

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/GeoMesaConfigurator.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/GeoMesaConfigurator.scala
@@ -117,10 +117,4 @@ object GeoMesaConfigurator {
   }
 
   val serializationString: String = s"$writableSerialization,$simpleFeatureSerialization"
-
-  // set/get the number of mapper splits
-  def setDesiredSplits(conf: Configuration, splits: Int): Unit = conf.set(desiredSplits, splits.toString)
-  def getDesiredSplits(conf: Configuration): Int = conf.get(desiredSplits).toInt
-  def getDesiredSplits(job: Job): Int = getDesiredSplits(job.getConfiguration)
-
 }

--- a/geomesa-utils/src/main/resources/org/locationtech/geomesa/geomesa-site.xml.template
+++ b/geomesa-utils/src/main/resources/org/locationtech/geomesa/geomesa-site.xml.template
@@ -16,7 +16,7 @@
 <!-- over system properties set through command line parameters change   -->
 <!-- the <final> tag to true.                                            -->
 
-<!-- By default configuration properties with empty values will not be   -->
+<!-- By default, configuration properties with empty values will not be  -->
 <!-- applied, you can change this by marking a property as final.        -->
 
 <configuration>
@@ -94,6 +94,31 @@
     </property>
 
     <!-- /geomesa.batchwriter -->
+
+    <property>
+        <name>geomesa.mapreduce.split.count.absolute</name>
+        <value></value>
+        <description>Set the absolute number of shards instead of basing it on the number of tablet servers.
+            Setting this value overrides geomesa.mapreduce.split.count.tablet.
+
+            Making this value final without setting a value greater than zero may cause unexpected issues.
+        </description>
+        <final>false</final>
+    </property>
+
+    <property>
+        <name>geomesa.mapreduce.split.count.tablet</name>
+        <value></value>
+        <description>Set the number of shards per tablet server when configuring a mapper. By default this value is
+            calculated using Accumulo's AbstractInputFormat.getSplits method which creates a split for each range. In
+            some scenarios this may create an undesirably large number of splits.
+
+            This value is overwritten by geomesa.mapreduce.split.count.absolute if it is set.
+
+            Making this value final without setting a value greater than zero may cause unexpected issues.
+        </description>
+        <final>false</final>
+    </property>
 
     <property>
         <name>geomesa.convert.config.urls</name>

--- a/geomesa-utils/src/main/resources/org/locationtech/geomesa/geomesa-site.xml.template
+++ b/geomesa-utils/src/main/resources/org/locationtech/geomesa/geomesa-site.xml.template
@@ -96,10 +96,10 @@
     <!-- /geomesa.batchwriter -->
 
     <property>
-        <name>geomesa.mapreduce.split.count.absolute</name>
+        <name>geomesa.mapreduce.splits.max</name>
         <value></value>
         <description>Set the absolute number of shards instead of basing it on the number of tablet servers.
-            Setting this value overrides geomesa.mapreduce.split.count.tablet.
+            Setting this value overrides geomesa.mapreduce.splits.tserver.max.
 
             Making this value final without setting a value greater than zero may cause unexpected issues.
         </description>
@@ -107,13 +107,13 @@
     </property>
 
     <property>
-        <name>geomesa.mapreduce.split.count.tablet</name>
+        <name>geomesa.mapreduce.splits.tserver.max</name>
         <value></value>
-        <description>Set the number of shards per tablet server when configuring a mapper. By default this value is
+        <description>Set the max number of splits per tablet server when configuring a mapper. By default this value is
             calculated using Accumulo's AbstractInputFormat.getSplits method which creates a split for each range. In
             some scenarios this may create an undesirably large number of splits.
 
-            This value is overwritten by geomesa.mapreduce.split.count.absolute if it is set.
+            This value is overwritten by geomesa.mapreduce.splits.max if it is set.
 
             Making this value final without setting a value greater than zero may cause unexpected issues.
         </description>

--- a/geomesa-utils/src/main/resources/org/locationtech/geomesa/geomesa-site.xml.template
+++ b/geomesa-utils/src/main/resources/org/locationtech/geomesa/geomesa-site.xml.template
@@ -98,7 +98,7 @@
     <property>
         <name>geomesa.mapreduce.splits.max</name>
         <value></value>
-        <description>Set the absolute number of shards instead of basing it on the number of tablet servers.
+        <description>Set the absolute number of splits instead of basing it on the number of tablet servers.
             Setting this value overrides geomesa.mapreduce.splits.tserver.max.
 
             Making this value final without setting a value greater than zero may cause unexpected issues.


### PR DESCRIPTION
... be configurable

* Added two new geomesa-site.xml config options:
** geomesa.mapreduce.split.count.absolute set the exact number of splits to use regardless of tserver count or accumulo-site.xml setting
** geomesa.mapreduce.split.count.tablet set the number of splits per tserver to use. Number of splits falls back to default accumulo splits computed by the job context.