### PR TITLE
GEOMESA-1698 Address Scala parsers memory leak

### DIFF
--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -152,7 +152,7 @@ org.locationtech.spatial4j:spatial4j	0.6	compile
 org.objenesis:objenesis	1.0	compile
 org.parboiled:parboiled-core	1.1.7	compile
 org.parboiled:parboiled-scala_2.11	1.1.7	compile
-org.scala-lang.modules:scala-parser-combinators_2.11	1.0.4	compile
+org.scala-lang.modules:scala-parser-combinators_2.11	1.0.5	compile
 org.scala-lang.modules:scala-xml_2.11	1.0.5	compile
 org.scala-lang:scala-compiler	2.11.7	compile
 org.scala-lang:scala-library	2.11.7	compile

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <scala.binary.version>2.11</scala.binary.version>
 
         <scala.xml.version>1.0.5</scala.xml.version>
-        <scala.parsers.version>1.0.4</scala.parsers.version>
+        <scala.parsers.version>1.0.5</scala.parsers.version>
 
         <geoserver.version>2.9.1</geoserver.version>
         <gt.version>15.1</gt.version>


### PR DESCRIPTION
* Version 1.0.5 of the Scala parsers library addresses a memory leak.

Signed-off-by: Jim Hughes <jnh5y@ccri.com>