### PR TITLE
GEOMESA-1693 GeoMesa env command without arguments returns a poor error

### DIFF
--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/status/EnvironmentCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/status/EnvironmentCommand.scala
@@ -25,7 +25,11 @@ class EnvironmentCommand extends Command {
 
     if (params.sfts == null && params.converters == null && !params.listSfts &&
       !params.listConverters && !params.describeSfts && !params.describeConverters) {
-      throw new ParameterException("Specific environment was not provided")
+      Command.output.info("No flags given; displaying list of SFTs and Converters.")
+      Command.output.info(s"Use 'help $name' to see complete command options.")
+
+      listSftsNames()
+      listConverterNames()
     } else {
       if (params.listSfts) {
         listSftsNames()


### PR DESCRIPTION
* Changes the 'env' command to output the list of SFTs and Converters by default.

Signed-off-by: Jim Hughes <jnh5y@ccri.com>