### PR TITLE
For Comment: Adding JsonPath attribute extractor CQL Function

### DIFF
--- a/geomesa-features/geomesa-feature-kryo/pom.xml
+++ b/geomesa-features/geomesa-feature-kryo/pom.xml
@@ -39,11 +39,11 @@
             <groupId>org.parboiled</groupId>
             <artifactId>parboiled-scala_${scala.binary.version}</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-security_${scala.binary.version}</artifactId>
-            <scope>test</scope>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.locationtech.geomesa</groupId>-->
+            <!--<artifactId>geomesa-security_${scala.binary.version}</artifactId>-->
+            <!--<scope>test</scope>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>org.specs2</groupId>
             <artifactId>specs2_${scala.binary.version}</artifactId>

--- a/geomesa-features/geomesa-feature-kryo/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
+++ b/geomesa-features/geomesa-feature-kryo/src/main/resources/META-INF/services/org.opengis.filter.expression.Function
@@ -1,0 +1,1 @@
+org.locationtech.geomesa.features.kryo.json.JsonAttrFunction

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonAttrFunction.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonAttrFunction.scala
@@ -7,13 +7,13 @@ import org.geotools.filter.capability.FunctionNameImpl.parameter
 import org.geotools.filter.expression.PropertyAccessors
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.SimpleFeature
-import org.opengis.filter.expression.PropertyName
+import org.opengis.filter.expression.{PropertyName, VolatileFunction}
 
 class JsonAttrFunction extends FunctionExpressionImpl(
   new FunctionNameImpl("jsonattr",
     parameter("propertyName", classOf[PropertyName]),
     parameter("string", classOf[String]))
-  ) with LazyLogging {
+  ) with LazyLogging with VolatileFunction {
 
   override def evaluate(obj: java.lang.Object): AnyRef = {
     //new AttributeExpressionImpl("$.json.[foo path]")
@@ -27,17 +27,17 @@ class JsonAttrFunction extends FunctionExpressionImpl(
     // some mojo to ensure our property accessor is picked up -
     // our accumulo iterators are not generally available in the system classloader
     // instead, we can set the context classloader (as that will be checked if set)
-    val contextClassLoader = Thread.currentThread.getContextClassLoader
-    if (contextClassLoader != null) {
-      logger.warn(s"Bypassing context classloader $contextClassLoader for PropertyAccessor loading")
-    }
-    Thread.currentThread.setContextClassLoader(classOf[JsonAttrFunction].getClassLoader)
+//    val contextClassLoader = Thread.currentThread.getContextClassLoader
+//    if (contextClassLoader != null) {
+//      logger.warn(s"Bypassing context classloader $contextClassLoader for PropertyAccessor loading")
+//    }
+//    Thread.currentThread.setContextClassLoader(classOf[JsonAttrFunction].getClassLoader)
     val accessor = try {
       import scala.collection.JavaConversions._
       PropertyAccessors.findPropertyAccessors(sf, path, null, null).find(_.canHandle(sf, path, classOf[AnyRef]))
     } finally {
       // reset the classloader after loading the accessors
-      Thread.currentThread.setContextClassLoader(contextClassLoader)
+//      Thread.currentThread.setContextClassLoader(contextClassLoader)
     }
     accessor match {
       case Some(a) => a.get(sf, path, classOf[AnyRef])

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonAttrFunction.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonAttrFunction.scala
@@ -27,17 +27,17 @@ class JsonAttrFunction extends FunctionExpressionImpl(
     // some mojo to ensure our property accessor is picked up -
     // our accumulo iterators are not generally available in the system classloader
     // instead, we can set the context classloader (as that will be checked if set)
-//    val contextClassLoader = Thread.currentThread.getContextClassLoader
-//    if (contextClassLoader != null) {
-//      logger.warn(s"Bypassing context classloader $contextClassLoader for PropertyAccessor loading")
-//    }
-//    Thread.currentThread.setContextClassLoader(classOf[JsonAttrFunction].getClassLoader)
+    val contextClassLoader = Thread.currentThread.getContextClassLoader
+    if (contextClassLoader != null) {
+      logger.warn(s"Bypassing context classloader $contextClassLoader for PropertyAccessor loading")
+    }
+    Thread.currentThread.setContextClassLoader(classOf[JsonAttrFunction].getClassLoader)
     val accessor = try {
       import scala.collection.JavaConversions._
       PropertyAccessors.findPropertyAccessors(sf, path, null, null).find(_.canHandle(sf, path, classOf[AnyRef]))
     } finally {
       // reset the classloader after loading the accessors
-//      Thread.currentThread.setContextClassLoader(contextClassLoader)
+      Thread.currentThread.setContextClassLoader(contextClassLoader)
     }
     accessor match {
       case Some(a) => a.get(sf, path, classOf[AnyRef])

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonAttrFunction.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonAttrFunction.scala
@@ -1,15 +1,48 @@
 package org.locationtech.geomesa.features.kryo.json
 
+import com.typesafe.scalalogging.LazyLogging
 import org.geotools.filter.{AttributeExpressionImpl, FunctionExpressionImpl}
 import org.geotools.filter.capability.FunctionNameImpl
 import org.geotools.filter.capability.FunctionNameImpl.parameter
+import org.geotools.filter.expression.PropertyAccessors
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.feature.simple.SimpleFeature
 import org.opengis.filter.expression.PropertyName
 
 class JsonAttrFunction extends FunctionExpressionImpl(
   new FunctionNameImpl("jsonattr",
     parameter("propertyName", classOf[PropertyName]),
     parameter("string", classOf[String]))
-  ) {
-  // TODO extract jsonpath
-  override def evaluate(`object`: scala.Any): AnyRef = new AttributeExpressionImpl("$.json.[foo path]")
+  ) with LazyLogging {
+
+  override def evaluate(obj: java.lang.Object): AnyRef = {
+    //new AttributeExpressionImpl("$.json.[foo path]")
+    val sf = try {
+      obj.asInstanceOf[SimpleFeature]
+    } catch {
+      case e: Exception => throw new IllegalArgumentException("Only simple features are supported", e)
+    }
+    //val property = getExpression(0).evaluate(null).asInstanceOf[String]
+    val path = getExpression(0).evaluate(null).asInstanceOf[String]
+    // some mojo to ensure our property accessor is picked up -
+    // our accumulo iterators are not generally available in the system classloader
+    // instead, we can set the context classloader (as that will be checked if set)
+    val contextClassLoader = Thread.currentThread.getContextClassLoader
+    if (contextClassLoader != null) {
+      logger.warn(s"Bypassing context classloader $contextClassLoader for PropertyAccessor loading")
+    }
+    Thread.currentThread.setContextClassLoader(classOf[JsonAttrFunction].getClassLoader)
+    val accessor = try {
+      import scala.collection.JavaConversions._
+      PropertyAccessors.findPropertyAccessors(sf, path, null, null).find(_.canHandle(sf, path, classOf[AnyRef]))
+    } finally {
+      // reset the classloader after loading the accessors
+      Thread.currentThread.setContextClassLoader(contextClassLoader)
+    }
+    accessor match {
+      case Some(a) => a.get(sf, path, classOf[AnyRef])
+      case None    => throw new RuntimeException(s"Can't handle property '$name' for feature type " +
+        s"${sf.getFeatureType.getTypeName} ${SimpleFeatureTypes.encodeType(sf.getFeatureType)}")
+    }
+  }
 }

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonAttrFunction.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonAttrFunction.scala
@@ -1,0 +1,15 @@
+package org.locationtech.geomesa.features.kryo.json
+
+import org.geotools.filter.{AttributeExpressionImpl, FunctionExpressionImpl}
+import org.geotools.filter.capability.FunctionNameImpl
+import org.geotools.filter.capability.FunctionNameImpl.parameter
+import org.opengis.filter.expression.PropertyName
+
+class JsonAttrFunction extends FunctionExpressionImpl(
+  new FunctionNameImpl("jsonattr",
+    parameter("propertyName", classOf[PropertyName]),
+    parameter("string", classOf[String]))
+  ) {
+  // TODO extract jsonpath
+  override def evaluate(`object`: scala.Any): AnyRef = new AttributeExpressionImpl("$.json.[foo path]")
+}

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonPathParser.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonPathParser.scala
@@ -58,6 +58,10 @@ object JsonPathParser {
     override def toString: String = s".$name"
   }
 
+  case class BracketedPathAttribute(name: String) extends PathElement {
+    override def toString: String = s".['$name']"
+  }
+
   // enumerated index: [1]
   case class PathIndex(index: Int) extends PathElement {
     override def toString: String = s"[$index]"
@@ -102,7 +106,7 @@ private class JsonPathParser extends Parser {
   rule { "$" ~ zeroOrMore(Element) ~ optional(Function) ~~> ((e, f) => e ++ f.toSeq) ~ EOI }
 
   def Element: Rule1[PathElement] = rule {
-    Attribute | ArrayIndex | ArrayIndices | ArrayIndexRange | AttributeWildCard | IndexWildCard | DeepScan
+    Attribute | BracketedAttribute | ArrayIndex | ArrayIndices | ArrayIndexRange | AttributeWildCard | IndexWildCard | DeepScan
   }
 
   def IndexWildCard: Rule1[PathElement] = rule { "[*]" ~ push(PathIndexWildCard) }
@@ -111,7 +115,7 @@ private class JsonPathParser extends Parser {
 
   // we have to push the deep scan directly onto the stack as there is no forward matching and
   // it's ridiculous trying to combine Rule1's and Rule2's
-  def DeepScan: Rule1[PathElement] = rule { "." ~ toRunAction(pushDeepScan) ~ (Attribute | AttributeWildCard) }
+  def DeepScan: Rule1[PathElement] = rule { "." ~ toRunAction(pushDeepScan) ~ (Attribute | BracketedAttribute | AttributeWildCard) }
 
   // note: this assumes that we are inside a zeroOrMore, which is currently the case
   // the zeroOrMore will have pushed a single list onto the value stack - we append our value to that
@@ -128,6 +132,8 @@ private class JsonPathParser extends Parser {
 
   def Attribute: Rule1[PathAttribute] = rule { "." ~ oneOrMore(Character) ~> PathAttribute ~ !"()" }
 
+  def BracketedAttribute: Rule1[BracketedPathAttribute] = rule { ".['" ~ oneOrMore(CharacterWithSpace) ~ "']" ~> BracketedPathAttribute ~ !"()" }
+
   def Function: Rule1[PathFunction] = rule {
     "." ~ ("min" | "max" | "avg" | "length") ~> ((f) => PathFunction(JsonPathFunction.withName(f))) ~ "()"
   }
@@ -136,7 +142,9 @@ private class JsonPathParser extends Parser {
 
   def Character: Rule0 = rule { EscapedChar | NormalChar }
 
-  def EscapedChar: Rule0 = rule { "\\" ~ (anyOf("\"\\/bfnrt") | Unicode) }
+  def CharacterWithSpace: Rule0 = rule { Character | " " }
+
+  def EscapedChar: Rule0 = rule { "\\" ~ (anyOf("\"\\/bfnrt ") | Unicode) }
 
   def NormalChar: Rule0 = rule { "a" - "z" | "A" - "Z" | "0" - "9" }
 

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonPathParser.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonPathParser.scala
@@ -106,7 +106,7 @@ private class JsonPathParser extends Parser {
   rule { "$" ~ zeroOrMore(Element) ~ optional(Function) ~~> ((e, f) => e ++ f.toSeq) ~ EOI }
 
   def Element: Rule1[PathElement] = rule {
-    Attribute | BracketedAttribute | ArrayIndex | ArrayIndices | ArrayIndexRange | AttributeWildCard | IndexWildCard | DeepScan
+    Attribute | BracketedAttribute | BracketedAttribute2 | ArrayIndex | ArrayIndices | ArrayIndexRange | AttributeWildCard | IndexWildCard | DeepScan
   }
 
   def IndexWildCard: Rule1[PathElement] = rule { "[*]" ~ push(PathIndexWildCard) }
@@ -115,7 +115,7 @@ private class JsonPathParser extends Parser {
 
   // we have to push the deep scan directly onto the stack as there is no forward matching and
   // it's ridiculous trying to combine Rule1's and Rule2's
-  def DeepScan: Rule1[PathElement] = rule { "." ~ toRunAction(pushDeepScan) ~ (Attribute | BracketedAttribute | AttributeWildCard) }
+  def DeepScan: Rule1[PathElement] = rule { "." ~ toRunAction(pushDeepScan) ~ (Attribute | BracketedAttribute | BracketedAttribute2 | AttributeWildCard) }
 
   // note: this assumes that we are inside a zeroOrMore, which is currently the case
   // the zeroOrMore will have pushed a single list onto the value stack - we append our value to that
@@ -133,6 +133,8 @@ private class JsonPathParser extends Parser {
   def Attribute: Rule1[PathAttribute] = rule { "." ~ oneOrMore(Character) ~> PathAttribute ~ !"()" }
 
   def BracketedAttribute: Rule1[BracketedPathAttribute] = rule { ".['" ~ oneOrMore(CharacterWithSpace) ~> BracketedPathAttribute ~ !"()" ~ "']" }
+
+  def BracketedAttribute2: Rule1[BracketedPathAttribute] = rule { ".[" ~ oneOrMore(CharacterWithSpace) ~> BracketedPathAttribute ~ !"()" ~ "]" }
 
   def Function: Rule1[PathFunction] = rule {
     "." ~ ("min" | "max" | "avg" | "length") ~> ((f) => PathFunction(JsonPathFunction.withName(f))) ~ "()"

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonPathParser.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonPathParser.scala
@@ -132,9 +132,9 @@ private class JsonPathParser extends Parser {
 
   def Attribute: Rule1[PathAttribute] = rule { "." ~ oneOrMore(Character) ~> PathAttribute ~ !"()" }
 
-  def BracketedAttribute: Rule1[BracketedPathAttribute] = rule { ".['" ~ oneOrMore(CharacterWithSpace) ~> BracketedPathAttribute ~ !"()" ~ "']" }
+  def BracketedAttribute: Rule1[BracketedPathAttribute] = rule { ".['" ~ oneOrMore(CharacterWithDelimiter) ~> BracketedPathAttribute ~ !"()" ~ "']" }
 
-  def BracketedAttribute2: Rule1[BracketedPathAttribute] = rule { ".[" ~ oneOrMore(CharacterWithSpace) ~> BracketedPathAttribute ~ !"()" ~ "]" }
+  def BracketedAttribute2: Rule1[BracketedPathAttribute] = rule { ".[" ~ oneOrMore(CharacterWithDelimiter) ~> BracketedPathAttribute ~ !"()" ~ "]" }
 
   def Function: Rule1[PathFunction] = rule {
     "." ~ ("min" | "max" | "avg" | "length") ~> ((f) => PathFunction(JsonPathFunction.withName(f))) ~ "()"
@@ -144,7 +144,7 @@ private class JsonPathParser extends Parser {
 
   def Character: Rule0 = rule { EscapedChar | NormalChar }
 
-  def CharacterWithSpace: Rule0 = rule { Character | " " }
+  def CharacterWithDelimiter: Rule0 = rule { Character | " " | "." }
 
   def EscapedChar: Rule0 = rule { "\\" ~ (anyOf("\"\\/bfnrt ") | Unicode) }
 

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonPathParser.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonPathParser.scala
@@ -132,7 +132,7 @@ private class JsonPathParser extends Parser {
 
   def Attribute: Rule1[PathAttribute] = rule { "." ~ oneOrMore(Character) ~> PathAttribute ~ !"()" }
 
-  def BracketedAttribute: Rule1[BracketedPathAttribute] = rule { ".['" ~ oneOrMore(CharacterWithSpace) ~ "']" ~> BracketedPathAttribute ~ !"()" }
+  def BracketedAttribute: Rule1[BracketedPathAttribute] = rule { ".['" ~ oneOrMore(CharacterWithSpace) ~> BracketedPathAttribute ~ !"()" ~ "']" }
 
   def Function: Rule1[PathFunction] = rule {
     "." ~ ("min" | "max" | "avg" | "length") ~> ((f) => PathFunction(JsonPathFunction.withName(f))) ~ "()"

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/KryoJsonSerialization.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/KryoJsonSerialization.scala
@@ -173,6 +173,7 @@ object KryoJsonSerialization extends LazyLogging {
       while (paths.hasNext && matches.nonEmpty) {
         paths.next match {
           case PathAttribute(name: String)    => matches = matchPathAttribute(in, matches, Some(name))
+          case BracketedPathAttribute(name: String) => matches = matchPathAttribute(in ,matches, Some(name))
           case PathAttributeWildCard          => matches = matchPathAttribute(in, matches, None)
           case PathIndex(index: Int)          => matches = matchPathIndex(in, matches, Some(Seq(index)))
           case PathIndices(indices: Seq[Int]) => matches = matchPathIndex(in, matches, Some(indices))

--- a/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonAttrFunctionTest.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonAttrFunctionTest.scala
@@ -1,0 +1,99 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.features.kryo.json
+
+import org.geotools.factory.CommonFactoryFinder
+import org.geotools.filter.FunctionExpressionImpl
+import org.geotools.filter.text.ecql.ECQL
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class JsonAttrFunctionTest extends Specification {
+
+  val json =
+    """
+      | {
+      |   "foo" : "bar",
+      |   "foo.foo" : "bar",
+      |   "foo foo" : "bar",
+      |   "bar" : {
+      |     "boo" : "hiss",
+      |     "boo.boo" : "hiss",
+      |     "boo boo" : "hiss"
+      |     },
+      |   "bar.bar" : {
+      |     "boo" : "hiss",
+      |     "boo.boo" : "hiss",
+      |     "boo boo" : "hiss"
+      |     },
+      |   "bar bar" : {
+      |     "boo" : "hiss",
+      |     "boo.boo" : "hiss",
+      |     "boo boo" : "hiss"
+      |     },
+      | }
+    """.stripMargin
+  val sft = SimpleFeatureTypes.createType("json", "json:String:json=true,s:String,dtg:Date,*geom:Point:srid=4326")
+  val sf = new ScalaSimpleFeature("", sft)
+  sf.setAttribute(0, json)
+
+  "Json Attr Function" should {
+    "extract root attribute from json" in {
+      ECQL.toFilter("jsonattr('$.json.foo') = 'bar'").evaluate(sf) must beTrue
+    }
+
+    "extract root attribute with period from json" in {
+      ECQL.toFilter("jsonattr('$.json.[foo.foo]') = 'bar'").evaluate(sf) must beTrue
+    }
+
+    "extract root attribute with space from json" in {
+      ECQL.toFilter("jsonattr('$.json.[foo foo]') = 'bar'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json" in {
+      ECQL.toFilter("jsonattr('$.json.bar.boo') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with period in sub attribute name" in {
+      ECQL.toFilter("jsonattr('$.json.bar.[boo.boo]') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with space in sub attribute name" in {
+      ECQL.toFilter("jsonattr('$.json.bar.[boo boo]') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with period in attribute name" in {
+      ECQL.toFilter("jsonattr('$.json.[bar.bar].boo') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with period in attribute and sub attribute name" in {
+      ECQL.toFilter("jsonattr('$.json.[bar.bar].[boo.boo]') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with period in attribute and space in sub attribute name" in {
+      ECQL.toFilter("jsonattr('$.json.[bar.bar].[boo boo]') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with space in attribute name" in {
+      ECQL.toFilter("jsonattr('$.json.[bar bar].boo') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with space in attribute and period in sub attribute name" in {
+      ECQL.toFilter("jsonattr('$.json.[bar bar].[boo.boo]') = 'hiss'").evaluate(sf) must beTrue
+    }
+
+    "extract sub attribute from json with space in attribute and space in sub attribute name" in {
+      ECQL.toFilter("jsonattr('$.json.[bar bar].[boo boo]') = 'hiss'").evaluate(sf) must beTrue
+    }
+  }
+}

--- a/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessorTest.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessorTest.scala
@@ -101,21 +101,6 @@ class JsonPathPropertyAccessorTest extends Specification {
       expression.evaluate(sf) must beFalse
     }
 
-    "accept json path with spaces in ECQL" in {
-      val expression = ECQL.toFilter("""jsonattr('$.json.[foo path]') = 'bar'""")
-
-//      val path = ff.property("$.json.['foo path']")
-//      val expression = ff.equals(path, ff.literal("bar"))
-
-      val sf = new ScalaSimpleFeature("", sft)
-      sf.setAttribute(0, """{ "foo path" : "bar" }""")
-      expression.evaluate(sf) must beTrue
-      sf.setAttribute(0, """{ "foo path" : "baz" }""")
-      expression.evaluate(sf) must beFalse
-    }
-
-
-
     "return null for invalid paths" in {
       val sf0 = {
         val sf = new ScalaSimpleFeature("", sft)

--- a/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessorTest.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessorTest.scala
@@ -95,6 +95,19 @@ class JsonPathPropertyAccessorTest extends Specification {
       expression.evaluate(sf) must beFalse
     }
 
+    "accept json path with spaces in ECQL" in {
+      val expression = ECQL.toFilter("""jsonattr('$.json.[foo path]') = 'bar'""")
+
+//      val path = ff.property("$.json.['foo path']")
+//      val expression = ff.equals(path, ff.literal("bar"))
+
+      val sf = new ScalaSimpleFeature("", sft)
+      sf.setAttribute(0, """{ "foo path" : "bar" }""")
+      expression.evaluate(sf) must beTrue
+      sf.setAttribute(0, """{ "foo path" : "baz" }""")
+      expression.evaluate(sf) must beFalse
+    }
+
 
 
     "return null for invalid paths" in {

--- a/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessorTest.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessorTest.scala
@@ -63,6 +63,7 @@ class JsonPathPropertyAccessorTest extends Specification {
       sf.setAttribute(1, """{ "foo" : "baz" }""")
       property.evaluate(sf) mustEqual "baz"
     }
+
     "access json values in kryo serialized simple features" in {
       val property = ff.property("$.json.foo")
       val serializer = new KryoFeatureSerializer(sft)
@@ -72,6 +73,19 @@ class JsonPathPropertyAccessorTest extends Specification {
       sf.setBuffer(serializer.serialize(new ScalaSimpleFeature("", sft, Array("""{ "foo" : "baz" }""", null, null, null))))
       property.evaluate(sf) mustEqual "baz"
     }
+
+
+    "access json values with spaces in kryo serialized simple features" in {
+      val property = ff.property("$.json.['foo path']")
+      val serializer = new KryoFeatureSerializer(sft)
+      val sf = serializer.getReusableFeature
+      sf.setBuffer(serializer.serialize(new ScalaSimpleFeature("", sft, Array("""{ "foo path" : "bar" }""", null, null, null))))
+      property.evaluate(sf) mustEqual "bar"
+      sf.setBuffer(serializer.serialize(new ScalaSimpleFeature("", sft, Array("""{ "foo path" : "baz" }""", null, null, null))))
+      property.evaluate(sf) mustEqual "baz"
+    }
+
+
     "accept json path in ECQL" in {
       val expression = ECQL.toFilter(""""$.json.foo" = 'bar'""")
       val sf = new ScalaSimpleFeature("", sft)

--- a/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessorTest.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessorTest.scala
@@ -21,6 +21,8 @@ import org.specs2.runner.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class JsonPathPropertyAccessorTest extends Specification {
 
+  sequential
+
   val ff = CommonFactoryFinder.getFilterFactory2
   val sft = SimpleFeatureTypes.createType("json", "json:String:json=true,s:String,dtg:Date,*geom:Point:srid=4326")
 
@@ -40,6 +42,19 @@ class JsonPathPropertyAccessorTest extends Specification {
       sf.setAttribute(0, """{ "foo" : "baz" }""")
       property.evaluate(sf) mustEqual "baz"
     }
+
+    "access json values in simple features with spaces in the json path" in {
+      val property = ff.property("""$.json.['foo path']""")
+
+      val foo = JsonPathParser.parse("""$.json.['foo path']""")
+
+      val sf = new ScalaSimpleFeature("", sft)
+      sf.setAttribute(0, """{ "foo path" : "bar" }""")
+      property.evaluate(sf) mustEqual "bar"
+      sf.setAttribute(0, """{ "foo path" : "baz" }""")
+      property.evaluate(sf) mustEqual "baz"
+    }
+
     "access non-json strings in simple features" in {
       val property = ff.property("$.s.foo")
       val sf = new ScalaSimpleFeature("", sft)
@@ -65,6 +80,9 @@ class JsonPathPropertyAccessorTest extends Specification {
       sf.setAttribute(0, """{ "foo" : "baz" }""")
       expression.evaluate(sf) must beFalse
     }
+
+
+
     "return null for invalid paths" in {
       val sf0 = {
         val sf = new ScalaSimpleFeature("", sft)

--- a/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessorTest.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessorTest.scala
@@ -45,13 +45,19 @@ class JsonPathPropertyAccessorTest extends Specification {
 
     "access json values in simple features with spaces in the json path" in {
       val property = ff.property("""$.json.['foo path']""")
-
-      val foo = JsonPathParser.parse("""$.json.['foo path']""")
-
       val sf = new ScalaSimpleFeature("", sft)
       sf.setAttribute(0, """{ "foo path" : "bar" }""")
       property.evaluate(sf) mustEqual "bar"
       sf.setAttribute(0, """{ "foo path" : "baz" }""")
+      property.evaluate(sf) mustEqual "baz"
+    }
+
+    "access nested json values in simple features with a json path" in {
+      val property = ff.property("""$.json.foo.bar""")
+      val sf = new ScalaSimpleFeature("", sft)
+      sf.setAttribute(0, """{ "foo" : { "bar" : 0 } }""")
+      property.evaluate(sf) mustEqual 0
+      sf.setAttribute(0, """{ "foo" : { "bar" : "baz" } }""")
       property.evaluate(sf) mustEqual "baz"
     }
 


### PR DESCRIPTION
This adds the CQL function 'jsonattr' to allow specifying jsonpaths in a CQL filter function, in particular, through WFS. This allows queries like these, and more, to work. See the unit test for more examples.

`jsonattr('$.data.[FooBar]') = 'baz'`
`jsonattr('$.data.[Foo Bar]') = 'baz'`
`jsonattr('$.data.[Foo.Bar]') = 'baz'`

Any thoughts on a better way to do this? The JsonPath escape in FastPropertyName is necessary because it is called when using 
`val path = getExpression(0).evaluate(null).asInstanceOf[String]`
to extract the function parameter (the passed in path), otherwise FastPropertyName will throw exceptions.