### PR TITLE
GEOMESA-1734 Fix bad GeoJSON when attributes contain single quotes

### DIFF
--- a/geomesa-jupyter/geomesa-jupyter-leaflet/src/main/scala/org/locationtech/geomesa/jupyter/Leaflet.scala
+++ b/geomesa-jupyter/geomesa-jupyter-leaflet/src/main/scala/org/locationtech/geomesa/jupyter/Leaflet.scala
@@ -136,7 +136,7 @@ object L {
     }
 
     def propToJson(ad: AttributeDescriptor, a: Object) =
-      if(a!= null) s""""${ad.getLocalName}": '${StringEscapeUtils.escapeJson(a.toString)}'"""
+      if(a!= null) s""""${ad.getLocalName}": "${StringEscapeUtils.escapeJson(a.toString)}""""
       else s""""${ad.getLocalName}": ''"""
   }
 


### PR DESCRIPTION
geomesa-jupyter-leaflet generates bad GeoJSON when attribute values
contain single quotes, which are not escaped by StringEscapeUtils.escapeJson,
causing Leaflet to fail to render.

Signed-off-by: Matthew Zimmerman <matt.zimmerman@ccri.com>