### PR TITLE
GEOMESA-1811 GeoMesa classpath command can hang and prints duplicate …

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-tools/bin/geomesa
+++ b/geomesa-accumulo/geomesa-accumulo-tools/bin/geomesa
@@ -109,9 +109,7 @@ if  [[ $1 = configure ]]; then
   geomesaConfigure
 elif [[ $1 = classpath ]]; then
   CLASSPATH="$GEOMESA_CP:$ACCUMULO_CP:$HADOOP_CP:${ZOOKEEPER_JAR}"
-  for element in ${CLASSPATH//:/ } ; do
-    echo ${element}
-  done
+  echo $CLASSPATH | tr ':' '\n' | xargs ls -di | sort -u -k1,1 | awk '{print $2}' | sort
 else
   CLASSPATH="$GEOMESA_CP:$ACCUMULO_CP:$HADOOP_CP:${ZOOKEEPER_JAR}"
   if [[ $1 = debug ]]; then

--- a/geomesa-cassandra/geomesa-cassandra-tools/bin/geomesa-cassandra
+++ b/geomesa-cassandra/geomesa-cassandra-tools/bin/geomesa-cassandra
@@ -38,9 +38,7 @@ if  [[ $1 = configure ]]; then
   geomesaConfigure
 elif [[ $1 = classpath ]]; then
   CLASSPATH="$GEOMESA_CP:$CASSANDRA_CP"
-  for element in ${CLASSPATH//:/ } ; do
-    echo ${element}
-  done
+  echo $CLASSPATH | tr ':' '\n' | xargs ls -di | sort -u -k1,1 | awk '{print $2}' | sort
 else
   CLASSPATH="$GEOMESA_CP:$CASSANDRA_CP"
   if [[ $1 = debug ]]; then

--- a/geomesa-hbase/geomesa-bigtable-tools/bin/geomesa-bigtable
+++ b/geomesa-hbase/geomesa-bigtable-tools/bin/geomesa-bigtable
@@ -92,9 +92,7 @@ if  [[ $1 = configure ]]; then
   geomesaConfigure
 elif [[ $1 = classpath ]]; then
   CLASSPATH="$GEOMESA_CP:$HADOOP_CP"
-  for element in ${CLASSPATH//:/ } ; do
-    echo ${element}
-  done
+  echo $CLASSPATH | tr ':' '\n' | xargs ls -di | sort -u -k1,1 | awk '{print $2}' | sort
 else
   if [[ $1 = debug ]]; then
     GEOMESA_OPTS="$GEOMESA_OPTS $GEOMESA_DEBUG_OPTS"

--- a/geomesa-hbase/geomesa-hbase-tools/bin/geomesa-hbase
+++ b/geomesa-hbase/geomesa-hbase-tools/bin/geomesa-hbase
@@ -104,9 +104,7 @@ if  [[ $1 = configure ]]; then
   geomesaConfigure
 elif [[ $1 = classpath ]]; then
   CLASSPATH="$GEOMESA_CP:$HBASE_CP:$HADOOP_CP"
-  for element in ${CLASSPATH//:/ } ; do
-    echo ${element}
-  done
+  echo $CLASSPATH | tr ':' '\n' | xargs ls -di | sort -u -k1,1 | awk '{print $2}' | sort
 else
   CLASSPATH="$GEOMESA_CP:$HBASE_CP:$HADOOP_CP"
   if [[ $1 = debug ]]; then

--- a/geomesa-kafka/geomesa-kafka-tools/bin/geomesa-kafka
+++ b/geomesa-kafka/geomesa-kafka-tools/bin/geomesa-kafka
@@ -41,9 +41,7 @@ if  [[ $1 = configure ]]; then
   geomesaConfigure
 elif [[ $1 = classpath ]]; then
   CLASSPATH="$GEOMESA_CP"
-  for element in ${CLASSPATH//:/ } ; do
-    echo ${element}
-  done
+  echo $CLASSPATH | tr ':' '\n' | xargs ls -di | sort -u -k1,1 | awk '{print $2}' | sort
 else
   CLASSPATH="$GEOMESA_CP"
   if [[ $1 = debug ]]; then


### PR DESCRIPTION
…files

* The GeoMesa 'classpath' command can print multiple copies of the same file if
it is referenced multiple times on the various Hadoop classpaths.

Additionally, calculating the classpath in Bash can hang in some situations.

Signed-off-by: Jim Hughes <jnh5y@ccri.com>