### PR TITLE
GEOMESA-1824 GeoJsonQuery updates

### DIFF
--- a/geomesa-geojson/geomesa-geojson-api/src/main/scala/org/locationtech/geomesa/geojson/GeoMesaIndexPropertyTransformer.scala
+++ b/geomesa-geojson/geomesa-geojson-api/src/main/scala/org/locationtech/geomesa/geojson/GeoMesaIndexPropertyTransformer.scala
@@ -1,0 +1,28 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.geojson
+
+import org.locationtech.geomesa.features.kryo.json.JsonPathParser
+import org.locationtech.geomesa.features.kryo.json.JsonPathParser.{PathAttribute, PathElement}
+import org.locationtech.geomesa.geojson.query.PropertyTransformer
+
+class GeoMesaIndexPropertyTransformer(idPath:Option[Seq[PathElement]], dtgPath:Option[Seq[PathElement]]) extends PropertyTransformer {
+  override def useFid(prop: String): Boolean = idPath.contains(JsonPathParser.parse(prop))
+
+  override def transform(prop: String): String = {
+    JsonPathParser.parse(prop) match {
+      case Seq(PathAttribute("geometry")) =>
+        "geom"
+      case `dtgPath` =>
+        "dtg"
+      case x =>
+        JsonPathParser.print(PathAttribute("json") +: x)
+    }
+  }
+}

--- a/geomesa-geojson/geomesa-geojson-api/src/main/scala/org/locationtech/geomesa/geojson/query/GeoJsonQuery.scala
+++ b/geomesa-geojson/geomesa-geojson-api/src/main/scala/org/locationtech/geomesa/geojson/query/GeoJsonQuery.scala
@@ -1,10 +1,10 @@
-/** *********************************************************************
+/***********************************************************************
   * Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
   * All rights reserved. This program and the accompanying materials
   * are made available under the terms of the Apache License, Version 2.0
   * which accompanies this distribution and is available at
   * http://www.opensource.org/licenses/apache2.0.php.
-  * ************************************************************************/
+  *************************************************************************/
 
 package org.locationtech.geomesa.geojson.query
 
@@ -14,7 +14,7 @@ import com.vividsolutions.jts.geom.Geometry
 import org.geotools.geojson.geom.GeometryJSON
 import org.json4s.{JArray, JObject, JValue}
 import org.locationtech.geomesa.features.kryo.json.JsonPathParser
-import org.locationtech.geomesa.features.kryo.json.JsonPathParser.{PathAttribute, PathElement}
+import org.locationtech.geomesa.features.kryo.json.JsonPathParser.PathElement
 import org.opengis.filter.Filter
 
 import scala.util.control.NonFatal

--- a/geomesa-geojson/geomesa-geojson-api/src/main/scala/org/locationtech/geomesa/geojson/query/GeoJsonQuery.scala
+++ b/geomesa-geojson/geomesa-geojson-api/src/main/scala/org/locationtech/geomesa/geojson/query/GeoJsonQuery.scala
@@ -1,10 +1,10 @@
 /***********************************************************************
-  * Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
-  * All rights reserved. This program and the accompanying materials
-  * are made available under the terms of the Apache License, Version 2.0
-  * which accompanies this distribution and is available at
-  * http://www.opensource.org/licenses/apache2.0.php.
-  *************************************************************************/
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 
 package org.locationtech.geomesa.geojson.query
 

--- a/geomesa-geojson/geomesa-geojson-api/src/main/scala/org/locationtech/geomesa/geojson/query/GeoJsonQuery.scala
+++ b/geomesa-geojson/geomesa-geojson-api/src/main/scala/org/locationtech/geomesa/geojson/query/GeoJsonQuery.scala
@@ -361,15 +361,6 @@ object GeoJsonQuery {
     */
   case class Equals(prop: String, value: Any) extends GeoJsonQuery {
     override def toFilter(idPath: Option[Seq[PathElement]], dtgPath: Option[Seq[PathElement]]): Filter = {
-      //      if (idPath.exists(_ == path)) {
-      //        val fids = value match {
-      //          case v: Iterable[_] => v.map(_.toString).toSeq
-      //          case v => Seq(v.toString)
-      //        }
-      //        ff.id(fids.map(ff.featureId): _*)
-      //      } else {
-      //        ff.equals(filterAttribute(path, dtgPath), ff.literal(value))
-      //      }
       ff.equals(ff.property(prop), ff.literal(value))
     }
 

--- a/geomesa-geojson/geomesa-geojson-api/src/main/scala/org/locationtech/geomesa/geojson/query/PropertyTransformer.scala
+++ b/geomesa-geojson/geomesa-geojson-api/src/main/scala/org/locationtech/geomesa/geojson/query/PropertyTransformer.scala
@@ -1,0 +1,23 @@
+/***********************************************************************
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
+
+package org.locationtech.geomesa.geojson.query
+
+trait PropertyTransformer {
+  def useFid(prop: String): Boolean
+
+  def transform(prop: String): String
+}
+
+object PropertyTransformer {
+  val empty = new PropertyTransformer {
+    override def useFid(prop: String): Boolean = false
+
+    override def transform(prop: String): String = prop
+  }
+}

--- a/geomesa-geojson/geomesa-geojson-api/src/test/scala/org/locationtech/geomesa/geojson/GeoJsonGtIndexTest.scala
+++ b/geomesa-geojson/geomesa-geojson-api/src/test/scala/org/locationtech/geomesa/geojson/GeoJsonGtIndexTest.scala
@@ -46,7 +46,7 @@ class GeoJsonGtIndexTest extends Specification {
       result must haveLength(3)
       result must contain(f0, f1, f2)
 
-      val nameResult = index.query(name, """{ "$.properties.name" : "n1" }""").toList
+      val nameResult = index.query(name, """{ "properties.name" : "n1" }""").toList
       nameResult must haveLength(1)
       nameResult must contain(f1)
 
@@ -54,7 +54,7 @@ class GeoJsonGtIndexTest extends Specification {
       bboxResult must haveLength(2)
       bboxResult must contain(f1, f2)
 
-      val idResult0 = index.query(name, """{ "$.properties.id" : "0" }""").toList
+      val idResult0 = index.query(name, """{ "properties.id" : "0" }""").toList
       idResult0 must haveLength(1)
       idResult0 must contain(f0)
 

--- a/geomesa-geojson/geomesa-geojson-api/src/test/scala/org/locationtech/geomesa/geojson/GeoJsonGtIndexTest.scala
+++ b/geomesa-geojson/geomesa-geojson-api/src/test/scala/org/locationtech/geomesa/geojson/GeoJsonGtIndexTest.scala
@@ -46,7 +46,7 @@ class GeoJsonGtIndexTest extends Specification {
       result must haveLength(3)
       result must contain(f0, f1, f2)
 
-      val nameResult = index.query(name, """{ "properties.name" : "n1" }""").toList
+      val nameResult = index.query(name, """{ "$.properties.name" : "n1" }""").toList
       nameResult must haveLength(1)
       nameResult must contain(f1)
 
@@ -54,7 +54,7 @@ class GeoJsonGtIndexTest extends Specification {
       bboxResult must haveLength(2)
       bboxResult must contain(f1, f2)
 
-      val idResult0 = index.query(name, """{ "properties.id" : "0" }""").toList
+      val idResult0 = index.query(name, """{ "$.properties.id" : "0" }""").toList
       idResult0 must haveLength(1)
       idResult0 must contain(f0)
 

--- a/geomesa-geojson/geomesa-geojson-api/src/test/scala/org/locationtech/geomesa/geojson/query/GeoJsonQueryTest.scala
+++ b/geomesa-geojson/geomesa-geojson-api/src/test/scala/org/locationtech/geomesa/geojson/query/GeoJsonQueryTest.scala
@@ -1,10 +1,10 @@
 /***********************************************************************
-* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License, Version 2.0
-* which accompanies this distribution and is available at
-* http://www.opensource.org/licenses/apache2.0.php.
-*************************************************************************/
+  * Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Apache License, Version 2.0
+  * which accompanies this distribution and is available at
+  * http://www.opensource.org/licenses/apache2.0.php.
+  *************************************************************************/
 
 package org.locationtech.geomesa.geojson.query
 
@@ -21,15 +21,15 @@ class GeoJsonQueryTest extends Specification {
 
   "GeoJsonQuery" should {
     "parse json predicates" in {
-      GeoJsonQuery("""{"status":"A"}""") mustEqual Equals(Seq(PathAttribute("status")), "A")
+      GeoJsonQuery("""{"status":"A"}""") mustEqual Equals("status", "A")
       GeoJsonQuery("""{"status":"A","age":{"$lt":30}}""") mustEqual
-          And(Equals(Seq(PathAttribute("status")), "A"), LessThan(Seq(PathAttribute("age")), 30, inclusive = false))
+        And(Equals("status", "A"), LessThan("age", 30, inclusive = false))
       GeoJsonQuery("""{"$or":[{"status":"A"},{"age":{"$lte":30}}]}""") mustEqual
-          Or(Equals(Seq(PathAttribute("status")), "A"), LessThan(Seq(PathAttribute("age")), 30, inclusive = true))
+        Or(Equals("status", "A"), LessThan("age", 30, inclusive = true))
       GeoJsonQuery("""{"loc":{"$within":{"$geometry":{"type":"Polygon","coordinates":[[[0,0],[3,6],[6,1],[0,0]]]}}}}""") mustEqual
-          Within(Seq(PathAttribute("loc")), WKTUtils.read("POLYGON ((0 0, 3 6, 6 1, 0 0))"))
+        Within("loc", WKTUtils.read("POLYGON ((0 0, 3 6, 6 1, 0 0))"))
       GeoJsonQuery("""{"loc":{"$bbox":[-180,-90.0,180,90.0]}}""") mustEqual
-          Bbox(Seq(PathAttribute("loc")), -180.0, -90.0, 180.0, 90.0)
+        Bbox("loc", -180.0, -90.0, 180.0, 90.0)
     }
 
     "unparse json predicates" in {
@@ -46,21 +46,21 @@ class GeoJsonQueryTest extends Specification {
     "apply" in {
       val geom = WKTUtils.read("POINT (10 10)")
       GeoJsonQuery.Include mustEqual GeoJsonQuery.Include
-      GeoJsonQuery.LessThan("age", 30) mustEqual LessThan(Seq(PathAttribute("age")), 30, inclusive = false)
-      GeoJsonQuery.GreaterThan("age", 30) mustEqual GreaterThan(Seq(PathAttribute("age")), 30, inclusive = false)
-      GeoJsonQuery.Bbox(-10, -20, 10, 20) mustEqual Bbox(GeoJsonQuery.GeoJsonGeometryPath, -10, -20, 10, 20)
-      GeoJsonQuery.Contains(geom) mustEqual Contains(GeoJsonQuery.GeoJsonGeometryPath, geom)
-      GeoJsonQuery.Within(geom) mustEqual Within(GeoJsonQuery.GeoJsonGeometryPath, geom)
-      GeoJsonQuery.Intersects(geom) mustEqual Intersects(GeoJsonQuery.GeoJsonGeometryPath, geom)
+      GeoJsonQuery.LessThan("age", 30, inclusive = false) mustEqual LessThan("age", 30, inclusive = false)
+      GeoJsonQuery.GreaterThan("age", 30, inclusive = false) mustEqual GreaterThan("age", 30, inclusive = false)
+      GeoJsonQuery.Bbox(-10, -20, 10, 20) mustEqual Bbox(GeoJsonQuery.defaultGeom, -10, -20, 10, 20)
+      GeoJsonQuery.Contains(geom) mustEqual Contains(GeoJsonQuery.defaultGeom, geom)
+      GeoJsonQuery.Within(geom) mustEqual Within(GeoJsonQuery.defaultGeom, geom)
+      GeoJsonQuery.Intersects(geom) mustEqual Intersects(GeoJsonQuery.defaultGeom, geom)
     }
 
     "translate to CQL" in {
       ECQL.toCQL(GeoJsonQuery("""{"id":"foo"}""").toFilter(None, None)) mustEqual """"$.json.id" = 'foo'"""
       ECQL.toCQL(GeoJsonQuery("""{"id":"foo"}""").toFilter(Some(Seq(PathAttribute("id"))), None)) mustEqual "IN ('foo')"
       ECQL.toCQL(GeoJsonQuery("""{"loc":{"$bbox":[-180,-90.0,180,90.0]}}""").toFilter(None, None)) mustEqual
-          "BBOX($.json.loc, -180.0,-90.0,180.0,90.0)" // TODO this won't work with non-default geoms due to CQL parsing...
+        "BBOX($.json.loc, -180.0,-90.0,180.0,90.0)" // TODO this won't work with non-default geoms due to CQL parsing...
       ECQL.toCQL(GeoJsonQuery("""{"geometry":{"$bbox":[-180,-90.0,180,90.0]}}""").toFilter(None, None)) mustEqual
-          "BBOX(geom, -180.0,-90.0,180.0,90.0)"
+        "BBOX(geom, -180.0,-90.0,180.0,90.0)"
     }
   }
 }

--- a/geomesa-geojson/geomesa-geojson-api/src/test/scala/org/locationtech/geomesa/geojson/query/GeoJsonQueryTest.scala
+++ b/geomesa-geojson/geomesa-geojson-api/src/test/scala/org/locationtech/geomesa/geojson/query/GeoJsonQueryTest.scala
@@ -1,10 +1,10 @@
 /***********************************************************************
-  * Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
-  * All rights reserved. This program and the accompanying materials
-  * are made available under the terms of the Apache License, Version 2.0
-  * which accompanies this distribution and is available at
-  * http://www.opensource.org/licenses/apache2.0.php.
-  *************************************************************************/
+* Copyright (c) 2013-2016 Commonwealth Computer Research, Inc.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License, Version 2.0
+* which accompanies this distribution and is available at
+* http://www.opensource.org/licenses/apache2.0.php.
+*************************************************************************/
 
 package org.locationtech.geomesa.geojson.query
 

--- a/geomesa-geojson/geomesa-geojson-api/src/test/scala/org/locationtech/geomesa/geojson/query/GeoJsonQueryTest.scala
+++ b/geomesa-geojson/geomesa-geojson-api/src/test/scala/org/locationtech/geomesa/geojson/query/GeoJsonQueryTest.scala
@@ -11,6 +11,7 @@ package org.locationtech.geomesa.geojson.query
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.features.kryo.json.JsonPathParser.PathAttribute
+import org.locationtech.geomesa.geojson.GeoMesaIndexPropertyTransformer
 import org.locationtech.geomesa.geojson.query.GeoJsonQuery._
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.specs2.mutable.Specification
@@ -55,11 +56,11 @@ class GeoJsonQueryTest extends Specification {
     }
 
     "translate to CQL" in {
-      ECQL.toCQL(GeoJsonQuery("""{"id":"foo"}""").toFilter(None, None)) mustEqual """"$.json.id" = 'foo'"""
-      ECQL.toCQL(GeoJsonQuery("""{"id":"foo"}""").toFilter(Some(Seq(PathAttribute("id"))), None)) mustEqual "IN ('foo')"
-      ECQL.toCQL(GeoJsonQuery("""{"loc":{"$bbox":[-180,-90.0,180,90.0]}}""").toFilter(None, None)) mustEqual
+      ECQL.toCQL(GeoJsonQuery("""{"id":"foo"}""").toFilter(new GeoMesaIndexPropertyTransformer(None, None))) mustEqual """"$.json.id" = 'foo'"""
+      ECQL.toCQL(GeoJsonQuery("""{"id":"foo"}""").toFilter(new GeoMesaIndexPropertyTransformer(Some(Seq(PathAttribute("id"))), None))) mustEqual "IN ('foo')"
+      ECQL.toCQL(GeoJsonQuery("""{"loc":{"$bbox":[-180,-90.0,180,90.0]}}""").toFilter(new GeoMesaIndexPropertyTransformer(None, None))) mustEqual
         "BBOX($.json.loc, -180.0,-90.0,180.0,90.0)" // TODO this won't work with non-default geoms due to CQL parsing...
-      ECQL.toCQL(GeoJsonQuery("""{"geometry":{"$bbox":[-180,-90.0,180,90.0]}}""").toFilter(None, None)) mustEqual
+      ECQL.toCQL(GeoJsonQuery("""{"geometry":{"$bbox":[-180,-90.0,180,90.0]}}""").toFilter(new GeoMesaIndexPropertyTransformer(None, None))) mustEqual
         "BBOX(geom, -180.0,-90.0,180.0,90.0)"
     }
   }


### PR DESCRIPTION
* Updated GeoJsonQuery to allow parsing from json4s ast objects instead of just strings
* Adding support for DWithin queries through the geo json query parser
* GeoJsonQuery case classes no longer store a Seq[PathAttribute], but instead us a string. That string is verified to be a valid PathAttribute in the case that it starts with "$."