### PR TITLE
GEOMESA-1825 - GML Export test fails locally

### DIFF
--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/export/GmlExportTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/export/GmlExportTest.scala
@@ -57,6 +57,6 @@ class GmlExportTest extends Specification {
       feat must not beNull
       val xmlFid = feat \ "@fid"
       xmlFid.text mustEqual "fid-1"
-    }.pendingUntilFixed("GML Export should handle namespaces properly.")
+    } 
   }
 }


### PR DESCRIPTION
* This patch adds a quick namespace for GML exports.
NB: Temporarily disabling the Arrow Geometry Test.

Signed-off-by: Jim Hughes <jnh5y@ccri.com>