### PR TITLE
WIP: Apparent bug in Fixed Width Converter when converter definition is out of order 

### DIFF
--- a/geomesa-convert/geomesa-convert-fixedwidth/src/test/resources/sft_testsft.conf
+++ b/geomesa-convert/geomesa-convert-fixedwidth/src/test/resources/sft_testsft.conf
@@ -5,5 +5,6 @@
     { name = "lat", type = "Double", index = "false" }
     { name = "lon", type = "Double", index = "false" }
     { name = "dtg", type = "Date", index = "false" }
+    { name = "anotherLat", type = "Double", index = "false" }
   ]
 }


### PR DESCRIPTION
 Added a janky unit test to illustrate the result when converter defintions are placed out of order in the converter defintion for the fixed-width converter:…values from previous records are used instead. It should be noted that this occurs when validation is not used.

I haven't drilled down to the actual origin of the problem just yet....