### PR TITLE
GEOMESA-1827 Accumulo Spark Kerberos Support, GEOMESA-1828 Accumulo M…

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/accumulo/GeoMesaArgs.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/accumulo/GeoMesaArgs.scala
@@ -1,5 +1,6 @@
 /***********************************************************************
  * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * Portions Crown Copyright (c) 2017 Dstl
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at
@@ -20,6 +21,7 @@ abstract class GeoMesaArgs(val args: Array[String]) extends ReverseParsable {
 object GeoMesaArgs {
   final val InputUser = "--geomesa.input.user"
   final val InputPassword = "--geomesa.input.password"
+  final val InputKeytabPath = "--geomesa.input.keytabPath"
   final val InputInstanceId = "--geomesa.input.instanceId"
   final val InputZookeepers = "--geomesa.input.zookeepers"
   final val InputTableName = "--geomesa.input.tableName"
@@ -31,6 +33,7 @@ object GeoMesaArgs {
   final val OutputZookeepers = "--geomesa.output.zookeepers"
   final val OutputTableName = "--geomesa.output.tableName"
   final val OutputFeature = "--geomesa.output.feature"
+  final val OutputHdfs = "--geomesa.output.hdfs"
 }
 
 trait ReverseParsable {
@@ -42,8 +45,11 @@ trait InputDataStoreArgs extends ReverseParsable {
   @Parameter(names = Array(GeoMesaArgs.InputUser), description = "Accumulo user name", required = true)
   var inUser: String = null
 
-  @Parameter(names = Array(GeoMesaArgs.InputPassword), description = "Accumulo password", required = true)
+  @Parameter(names = Array(GeoMesaArgs.InputPassword), description = "Accumulo password")
   var inPassword: String = null
+
+  @Parameter(names = Array(GeoMesaArgs.InputKeytabPath), description = "Accumulo Kerberos keytab path")
+  var inKeytabPath: String = null
 
   @Parameter(names = Array(GeoMesaArgs.InputInstanceId), description = "Accumulo instance name", required = true)
   var inInstanceId: String = null
@@ -57,6 +63,7 @@ trait InputDataStoreArgs extends ReverseParsable {
   def inDataStore: Map[String, String] = Map(
     AccumuloDataStoreParams.userParam.getName       -> inUser,
     AccumuloDataStoreParams.passwordParam.getName   -> inPassword,
+    AccumuloDataStoreParams.keytabPathParam.getName -> inKeytabPath,
     AccumuloDataStoreParams.instanceIdParam.getName -> inInstanceId,
     AccumuloDataStoreParams.zookeepersParam.getName -> inZookeepers,
     AccumuloDataStoreParams.tableNameParam.getName  -> inTableName
@@ -69,6 +76,9 @@ trait InputDataStoreArgs extends ReverseParsable {
     }
     if (inPassword != null) {
       buf.append(GeoMesaArgs.InputPassword, inPassword)
+    }
+    if (inKeytabPath != null) {
+      buf.append(GeoMesaArgs.InputKeytabPath, inKeytabPath)
     }
     if (inInstanceId != null) {
       buf.append(GeoMesaArgs.InputInstanceId, inInstanceId)
@@ -179,6 +189,20 @@ trait InputCqlArgs extends ReverseParsable {
   override def unparse(): Array[String] = {
     if (inCql != null) {
       Array(GeoMesaArgs.InputCQL, inCql)
+    } else {
+      Array.empty
+    }
+  }
+}
+
+trait OutputHdfsArgs extends ReverseParsable {
+
+  @Parameter(names = Array(GeoMesaArgs.OutputHdfs), description = "HDFS path", required = true)
+  var outHdfs: String = null
+
+  override def unparse(): Array[String] = {
+    if (outHdfs != null) {
+      Array(GeoMesaArgs.OutputHdfs, outHdfs)
     } else {
       Array.empty
     }

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/accumulo/export/ExportFeaturesJob.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/accumulo/export/ExportFeaturesJob.scala
@@ -1,0 +1,120 @@
+/***********************************************************************
+ * Crown Copyright (c) 2017 Dstl
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+
+package org.locationtech.geomesa.jobs.accumulo.export
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
+import org.apache.hadoop.mapreduce.{Counter, Job, Mapper}
+import org.apache.hadoop.util.{Tool, ToolRunner}
+import org.geotools.data.{DataStoreFinder, Query}
+import org.geotools.filter.text.ecql.ECQL
+import org.locationtech.geomesa.jobs.accumulo._
+import org.locationtech.geomesa.jobs.mapreduce.GeoMesaAccumuloInputFormat
+import org.opengis.feature.simple.SimpleFeature
+
+import scala.collection.JavaConversions._
+
+/**
+ * Class to export features to HDFS. Currently just writes SFTs as plain text using toString.
+ *
+ */
+object ExportFeaturesJob {
+  def main(args: Array[String]): Unit = {
+    val result = ToolRunner.run(new ExportFeaturesJob, args)
+    System.exit(result)
+  }
+}
+
+class ExportFeaturesArgs(args: Array[String]) extends GeoMesaArgs(args)
+    with InputFeatureArgs with InputDataStoreArgs with InputCqlArgs
+    with OutputHdfsArgs {
+
+  override def unparse(): Array[String] = {
+    Array.concat(super[InputFeatureArgs].unparse(),
+                 super[InputDataStoreArgs].unparse(),
+                 super[InputCqlArgs].unparse(),
+                 super[OutputHdfsArgs].unparse()
+    )
+  }
+}
+
+class ExportFeaturesJob extends Tool {
+
+  private var conf: Configuration = new Configuration
+
+  override def run(args: Array[String]): Int = {
+
+    // Parse and extract args
+    val parsedArgs = new ExportFeaturesArgs(args)
+    parsedArgs.parse()
+
+    val featureIn   = parsedArgs.inFeature
+    val dsInParams  = parsedArgs.inDataStore
+    val filter      = Option(parsedArgs.inCql).getOrElse("INCLUDE")
+    val hdfsPath    = parsedArgs.outHdfs
+
+    // validation and initialization - ensure the types exist before launching distributed job
+    val sftIn = {
+      val dsIn = DataStoreFinder.getDataStore(dsInParams)
+      require(dsIn != null, "The specified input data store could not be created - check your job parameters")
+      try {
+        val sft = dsIn.getSchema(featureIn)
+        require(sft != null, s"The feature '$featureIn' does not exist in the input data store")
+        sft
+      } finally {
+        dsIn.dispose()
+      }
+    }
+
+    val conf = new Configuration
+    val job = Job.getInstance(conf, s"GeoMesa Export '${sftIn.getTypeName}' to '${hdfsPath}'")
+
+    // Set up Hadoop job
+    job.setJarByClass(ExportFeaturesJob.getClass)
+    job.setMapperClass(classOf[ExportMapper])
+    job.setInputFormatClass(classOf[GeoMesaAccumuloInputFormat])
+    job.setMapOutputKeyClass(classOf[Text])
+    job.setMapOutputValueClass(classOf[Text])
+    job.setNumReduceTasks(0)
+    FileOutputFormat.setOutputPath(job, new Path(hdfsPath))
+
+    val query = new Query(sftIn.getTypeName, ECQL.toFilter(filter))
+    GeoMesaAccumuloInputFormat.configure(job, dsInParams, query)
+
+    val result = job.waitForCompletion(true)
+
+    if (result) 0 else 1
+  }
+
+  override def getConf: Configuration = conf
+
+  override def setConf(conf: Configuration): Unit = this.conf = conf
+}
+
+class ExportMapper extends Mapper[Text, SimpleFeature, Text, Text] {
+
+  type Context = Mapper[Text, SimpleFeature, Text, Text]#Context
+
+  private val text: Text = new Text
+  private var counter: Counter = null
+
+  override protected def setup(context: Context): Unit = {
+    counter = context.getCounter("org.locationtech.geomesa", "features-exported")
+  }
+
+  override protected def cleanup(context: Context): Unit = {}
+
+  override def map(key: Text, value: SimpleFeature, context: Context) {
+    context.write(text, new Text(value.toString))
+    counter.increment(1)
+  }
+}

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
@@ -1,5 +1,6 @@
 /***********************************************************************
  * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * Portions Crown Copyright (c) 2017 Dstl
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at
@@ -8,19 +9,21 @@
 
 package org.locationtech.geomesa.jobs.mapreduce
 
-import java.io.{DataInput, DataOutput}
+import java.io._
 import java.net.{URL, URLClassLoader}
 
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.accumulo.core.client.impl.{AuthenticationTokenIdentifier, DelegationTokenImpl}
 import org.apache.accumulo.core.client.mapreduce.{AbstractInputFormat, AccumuloInputFormat, InputFormatBase, RangeInputSplit}
-import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.client.security.tokens.{KerberosToken, PasswordToken}
+import org.apache.accumulo.core.client.{ClientConfiguration, ZooKeeperInstance}
 import org.apache.accumulo.core.data.{Key, Value}
 import org.apache.accumulo.core.security.Authorizations
 import org.apache.accumulo.core.util.{Pair => AccPair}
 import org.apache.commons.collections.map.CaseInsensitiveMap
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.{Text, Writable}
 import org.apache.hadoop.mapreduce._
+import org.apache.hadoop.security.token.Token
 import org.geotools.data.{DataStoreFinder, Query}
 import org.geotools.filter.identity.FeatureIdImpl
 import org.geotools.filter.text.ecql.ECQL
@@ -65,18 +68,31 @@ object GeoMesaAccumuloInputFormat extends LazyLogging {
     val ds = DataStoreFinder.getDataStore(dsParams).asInstanceOf[AccumuloDataStore]
     assert(ds != null, "Invalid data store parameters")
 
-    // set up the underlying accumulo input format
-    val user = AccumuloDataStoreParams.userParam.lookUp(dsParams).asInstanceOf[String]
-    val password = AccumuloDataStoreParams.passwordParam.lookUp(dsParams).asInstanceOf[String]
-    InputFormatBaseAdapter.setConnectorInfo(job, user, new PasswordToken(password.getBytes))
-
+    // Set Mock or Zookeeper instance
     val instance = AccumuloDataStoreParams.instanceIdParam.lookUp(dsParams).asInstanceOf[String]
     val zookeepers = AccumuloDataStoreParams.zookeepersParam.lookUp(dsParams).asInstanceOf[String]
-    if (java.lang.Boolean.valueOf(AccumuloDataStoreParams.mockParam.lookUp(dsParams).asInstanceOf[String])) {
+    val keytabPath = AccumuloDataStoreParams.keytabPathParam.lookUp(dsParams).asInstanceOf[String]
+    val mock = java.lang.Boolean.valueOf(AccumuloDataStoreParams.mockParam.lookUp(dsParams).asInstanceOf[String])
+
+    if (mock) {
       AbstractInputFormat.setMockInstance(job, instance)
     } else {
-      InputFormatBaseAdapter.setZooKeeperInstance(job, instance, zookeepers)
+      InputFormatBaseAdapter.setZooKeeperInstance(job, instance, zookeepers, keytabPath!=null)
     }
+
+    // Set connector info
+    val user = AccumuloDataStoreParams.userParam.lookUp(dsParams).asInstanceOf[String]
+    val password = AccumuloDataStoreParams.passwordParam.lookUp(dsParams).asInstanceOf[String]
+
+    val token = if (password != null) {
+      new PasswordToken(password.getBytes)
+    } else {
+      // Must be using Kerberos
+      // Note that setConnectorInfo will create a DelegationToken for us and add it to the Job credentials
+      new KerberosToken(user, new File(keytabPath), true)
+    }
+
+    InputFormatBaseAdapter.setConnectorInfo(job, user, token)
 
     val auths = Option(AccumuloDataStoreParams.authsParam.lookUp(dsParams).asInstanceOf[String])
     auths.foreach(a => InputFormatBaseAdapter.setScanAuthorizations(job, new Authorizations(a.split(","): _*)))
@@ -151,9 +167,76 @@ class GeoMesaAccumuloInputFormat extends InputFormat[Text, SimpleFeature] with L
   var sft: SimpleFeatureType = null
   var table: AccumuloFeatureIndex = null
 
-  private def init(conf: Configuration) = if (sft == null) {
+  private def init(context: JobContext) = if (sft == null) {
+    val conf = context.getConfiguration
     val params = GeoMesaConfigurator.getDataStoreInParams(conf)
-    val ds = DataStoreFinder.getDataStore(new CaseInsensitiveMap(params).asInstanceOf[java.util.Map[_, _]]).asInstanceOf[AccumuloDataStore]
+
+    // Extract password from params to see if we are using Kerberos or not
+    val password = AccumuloDataStoreParams.passwordParam.lookUp(params).asInstanceOf[String]
+
+    // Build a datastore depending on how we are authenticating
+    val ds = if (password!=null) {
+
+      // Accumulo password auth
+      DataStoreFinder.getDataStore(new CaseInsensitiveMap(params).asInstanceOf[java.util.Map[_, _]]).asInstanceOf[AccumuloDataStore]
+
+    } else {
+      // Kerberos auth
+
+      // Look for a delegation token in the context credentials (for MapReduce)
+      val contextCredentialsToken = context.getCredentials.getAllTokens find (_.getKind.toString=="ACCUMULO_AUTH_TOKEN")
+      if (contextCredentialsToken.isDefined) {
+        logger.info("Found ACCUMULO_AUTH_TOKEN in context credentials")
+      } else {
+        logger.info("Could not find ACCUMULO_AUTH_TOKEN in context credentials, will look in configuration")
+      }
+
+      // Look for a delegation token in the configuration (for Spark on YARN)
+      val serialisedToken = context.getConfiguration.get("org.locationtech.geomesa.token")
+      val configToken = if (serialisedToken!=null) {
+        logger.info("Found ACCUMULO_AUTH_TOKEN serialised in configuration")
+        val t = new Token()
+        t.decodeFromUrlString(serialisedToken)
+        Some(t)
+      } else {
+        logger.warn("Could not find ACCUMULO_AUTH_TOKEN serialised in configuration. Continuing anyway...")
+        None
+      }
+
+      // Prefer token from context credentials over configuration
+      val hadoopWrappedToken = contextCredentialsToken  orElse configToken
+
+      // Unwrap token and build connector
+      hadoopWrappedToken match {
+        case Some(hwt) => {
+          val identifier = new AuthenticationTokenIdentifier
+          val token =  try {
+            // Convert to DelegationToken.
+            // See https://github.com/apache/accumulo/blob/f81a8ec7410e789d11941351d5899b8894c6a322/core/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/impl/ConfiguratorBase.java#L485-L500
+            identifier.readFields(new DataInputStream(new ByteArrayInputStream(hwt.getIdentifier)))
+            new DelegationTokenImpl(hwt.getPassword, identifier)
+          } catch {
+            case e: IOException => throw new RuntimeException("Could not construct DelegationToken from JobContext credentials", e)
+          }
+
+          // Build connector
+          val instance = AccumuloDataStoreParams.instanceIdParam.lookUp(params).asInstanceOf[String]
+          val zookeepers = AccumuloDataStoreParams.zookeepersParam.lookUp(params).asInstanceOf[String]
+          val user = AccumuloDataStoreParams.userParam.lookUp(params).asInstanceOf[String]
+          val connector = new ZooKeeperInstance(new ClientConfiguration()
+            .withInstance(instance).withZkHosts(zookeepers).withSasl(true))
+            .getConnector(user, token)
+
+          // Add connector param and remove keytabPath param
+          val updatedParams = params + (AccumuloDataStoreParams.connParam.getName -> connector) - AccumuloDataStoreParams.keytabPathParam.getName
+
+          // Get datastore using updated params
+          DataStoreFinder.getDataStore(new CaseInsensitiveMap(updatedParams).asInstanceOf[java.util.Map[_, _]]).asInstanceOf[AccumuloDataStore]
+        }
+        case _ => throw new IllegalArgumentException("Could not find Hadoop-wrapped Accumulo token in JobContext credentials or Hadoop configuration")
+      }
+    }
+
     sft = ds.getSchema(GeoMesaConfigurator.getFeatureType(conf))
     val tableName = GeoMesaConfigurator.getTable(conf)
     table = AccumuloFeatureIndex.indices(sft, IndexMode.Read)
@@ -170,7 +253,6 @@ class GeoMesaAccumuloInputFormat extends InputFormat[Text, SimpleFeature] with L
    * location assignment of the tablets to tservers to determine the number of splits returned.
    */
   override def getSplits(context: JobContext): java.util.List[InputSplit] = {
-    init(context.getConfiguration)
     val accumuloSplits = delegate.getSplits(context)
     // Get the appropriate number of mapper splits using the following priority
     // 1. Get splits from AccumuloMapperProperties.DESIRED_ABSOLUTE_SPLITS (geomesa.mapreduce.splits.max)
@@ -221,7 +303,7 @@ class GeoMesaAccumuloInputFormat extends InputFormat[Text, SimpleFeature] with L
   }
 
   override def createRecordReader(split: InputSplit, context: TaskAttemptContext) = {
-    init(context.getConfiguration)
+    init(context)
     val reader = delegate.createRecordReader(split, context)
     val schema = GeoMesaConfigurator.getTransformSchema(context.getConfiguration).getOrElse(sft)
     val hasId = table.serializedWithId

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/GeoMesaAccumuloInputFormat.scala
@@ -169,7 +169,7 @@ class GeoMesaAccumuloInputFormat extends InputFormat[Text, SimpleFeature] with L
 
   private def init(context: JobContext) = if (sft == null) {
     val conf = context.getConfiguration
-    val params = GeoMesaConfigurator.getDataStoreInParams(conf)
+    val params = new CaseInsensitiveMap(GeoMesaConfigurator.getDataStoreInParams(conf)).asInstanceOf[java.util.Map[String, String]]
 
     // Extract password from params to see if we are using Kerberos or not
     val password = AccumuloDataStoreParams.passwordParam.lookUp(params).asInstanceOf[String]
@@ -178,7 +178,7 @@ class GeoMesaAccumuloInputFormat extends InputFormat[Text, SimpleFeature] with L
     val ds = if (password!=null) {
 
       // Accumulo password auth
-      DataStoreFinder.getDataStore(new CaseInsensitiveMap(params).asInstanceOf[java.util.Map[_, _]]).asInstanceOf[AccumuloDataStore]
+      DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
 
     } else {
       // Kerberos auth

--- a/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
+++ b/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
@@ -1,5 +1,6 @@
 /***********************************************************************
  * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * Portions Crown Copyright (c) 2017 Dstl
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at
@@ -8,17 +9,21 @@
 
 package org.locationtech.geomesa.spark.accumulo
 
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.accumulo.core.client.ClientConfiguration
+import org.apache.accumulo.core.client.mapred.AbstractInputFormat
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat
 import org.apache.accumulo.core.client.mapreduce.lib.impl.InputConfigurator
-import org.apache.accumulo.core.client.mapreduce.lib.util.ConfiguratorBase
-import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.client.security.tokens.{KerberosToken, PasswordToken}
 import org.apache.accumulo.core.security.Authorizations
 import org.apache.accumulo.core.util.{Pair => AccPair}
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.Text
+import org.apache.hadoop.mapred.JobConf
 import org.apache.spark.SparkContext
-import org.apache.spark.rdd.RDD
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.rdd.{NewHadoopRDD, RDD}
 import org.geotools.data.{DataStoreFinder, Query, Transaction}
 import org.geotools.filter.text.ecql.ECQL
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloDataStoreFactory, AccumuloDataStoreParams}
@@ -27,8 +32,7 @@ import org.locationtech.geomesa.index.conf.QueryHints._
 import org.locationtech.geomesa.jobs.GeoMesaConfigurator
 import org.locationtech.geomesa.jobs.accumulo.AccumuloJobUtils
 import org.locationtech.geomesa.jobs.mapreduce._
-import org.locationtech.geomesa.spark.SpatialRDD
-import org.locationtech.geomesa.spark.SpatialRDDProvider
+import org.locationtech.geomesa.spark.{SpatialRDD, SpatialRDDProvider}
 import org.locationtech.geomesa.utils.geotools.FeatureUtils
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
@@ -36,7 +40,7 @@ import org.opengis.filter.Filter
 import scala.collection.JavaConversions._
 import scala.util.Try
 
-class AccumuloSpatialRDDProvider extends SpatialRDDProvider {
+class AccumuloSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
   import org.locationtech.geomesa.spark.CaseInsensitiveMapFix._
 
   override def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean =
@@ -47,8 +51,6 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider {
                    params: Map[String, String],
                    query: Query): SpatialRDD = {
     val ds = DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
-    val username = AccumuloDataStoreParams.userParam.lookUp(params).toString
-    val password = new PasswordToken(AccumuloDataStoreParams.passwordParam.lookUp(params).toString.getBytes)
 
     lazy val transform = query.getHints.getTransformSchema
 
@@ -56,15 +58,6 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider {
       if (ds == null || sft == null || qp.isInstanceOf[EmptyPlan]) {
         sc.emptyRDD[SimpleFeature]
       } else {
-        val instance = ds.connector.getInstance().getInstanceName
-        val zookeepers = ds.connector.getInstance().getZooKeepers
-
-        ConfiguratorBase.setConnectorInfo(classOf[AccumuloInputFormat], conf, username, password)
-        if (Try(params("useMock").toBoolean).getOrElse(false)){
-          ConfiguratorBase.setMockInstance(classOf[AccumuloInputFormat], conf, instance)
-        } else {
-          ConfiguratorBase.setZooKeeperInstance(classOf[AccumuloInputFormat], conf, instance, zookeepers)
-        }
         InputConfigurator.setInputTableName(classOf[AccumuloInputFormat], conf, qp.table)
         InputConfigurator.setRanges(classOf[AccumuloInputFormat], conf, qp.ranges)
         qp.iterators.foreach(InputConfigurator.addIterator(classOf[AccumuloInputFormat], conf, _))
@@ -95,7 +88,59 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider {
           InputConfigurator.setScanAuthorizations(classOf[AccumuloInputFormat], conf, authorizations)
         }
 
-        sc.newAPIHadoopRDD(conf, classOf[GeoMesaAccumuloInputFormat], classOf[Text], classOf[SimpleFeature]).map(U => U._2)
+        // We soon want to call this
+        // sc.newAPIHadoopRDD(conf, classOf[GeoMesaAccumuloInputFormat], classOf[Text], classOf[SimpleFeature]).map(U => U._2)
+        // But we need access to the JobConf that this creates internally and doesn't expose, so we repeat (most of) the code here
+
+        // From sc.newAPIHadoopRDD, but can't implement this here
+        // assertNotStopped()
+
+        // From sc.newAPIHadoopRDD
+        // Add necessary security credentials to the JobConf. Required to access secure HDFS.
+        val jconf = new JobConf(conf)
+        SparkHadoopUtil.get.addCredentials(jconf)
+
+        // Get username from params
+        val username = AccumuloDataStoreParams.userParam.lookUp(params).toString
+
+        // Get password or keytabPath from params. Precisely one of these should be set due to prior validation
+        val password = AccumuloDataStoreParams.passwordParam.lookUp(params)
+        val keytabPath = AccumuloDataStoreParams.keytabPathParam.lookUp(params)
+
+        // Create authentication token according to password or Kerberos
+        val authToken = if (password != null) {
+          new PasswordToken(password.toString.getBytes)
+        } else {
+          // setConnectorInfo will take care of creating a DelegationToken for us
+          new KerberosToken(username, new java.io.File(keytabPath.toString), true)
+        }
+
+        // Get params and set instance
+        val instance = AccumuloDataStoreParams.instanceIdParam.lookUp(params).asInstanceOf[String]
+        val zookeepers = AccumuloDataStoreParams.zookeepersParam.lookUp(params).asInstanceOf[String]
+        if (Try(params("useMock").toBoolean).getOrElse(false)){
+          AbstractInputFormat.setMockInstance(jconf, instance)
+        } else {
+          AbstractInputFormat.setZooKeeperInstance(jconf, new ClientConfiguration()
+            .withInstance(instance).withZkHosts(zookeepers).withSasl(authToken.isInstanceOf[KerberosToken]))
+        }
+
+        // Set connectorInfo. If needed, this will add a DelegationToken to jconf.getCredentials
+        val user = AccumuloDataStoreParams.userParam.lookUp(params).asInstanceOf[String]
+        AbstractInputFormat.setConnectorInfo(jconf, user, authToken)
+
+        // Iterate over tokens in credentials and add the Accumulo one to the configuration directly
+        // This is because the credentials seem to disappear between here and the YARN executor
+        // See https://stackoverflow.com/questions/44525351/delegation-tokens-with-accumulo-spark
+        for (tok <- jconf.getCredentials.getAllTokens) {
+          if (tok.getKind.toString=="ACCUMULO_AUTH_TOKEN") {
+            logger.info("Adding ACCUMULO_AUTH_TOKEN to configuration")
+            jconf.set("org.locationtech.geomesa.token", tok.encodeToUrlString())
+          }
+        }
+
+        // From sc.newAPIHadoopRDD
+        new NewHadoopRDD(sc, classOf[GeoMesaAccumuloInputFormat], classOf[Text], classOf[SimpleFeature], jconf).map(U => U._2)
       }
     }
 

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/GeoMesaConfigurator.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/GeoMesaConfigurator.scala
@@ -1,5 +1,6 @@
 /***********************************************************************
  * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * Portions Crown Copyright (c) 2017 Dstl
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at
@@ -49,7 +50,7 @@ object GeoMesaConfigurator {
 
   // set/get the connection parameters for an input format
   def setDataStoreInParams(conf: Configuration, params: Map[String, String]): Unit =
-    params.foreach { case (key, value) => conf.set(s"$dsInParams$key", value) }
+    params.foreach { case (key, value) => if (value != null) conf.set(s"$dsInParams$key", value) }
   def getDataStoreInParams(job: Job): Map[String, String] =
     getDataStoreInParams(job.getConfiguration)
   def getDataStoreInParams(conf: Configuration): Map[String, String] =


### PR DESCRIPTION
GEOMESA-1827 Accumulo Spark Kerberos Support, GEOMESA-1828 Accumulo MR Kerberos Support

* Fetch Kerberos tokens and create DelegationTokens as needed. 
* Using non-deprecated API (AccumuloInputFormat statics) with or without Kerberos
* With MapReduce, tokens are stored in the credentials
* With Spark, tokens are serialised and stored in the Hadoop configuration
* New ExportFeaturesJob which writes GeoMesa features to HDFS with optional Kerberos auth via keytab file

Signed-off-by: James Srinivasan <james.srinivasan@gmail.com>

