### PR TITLE
GEOMESA-1885 Exclude netty and json4s from hbase-spark-runtime.

### DIFF
--- a/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
@@ -151,6 +151,8 @@
                                     <exclude>com.esotericsoftware.kryo:*</exclude>
                                     <exclude>org.ow2.asm:*</exclude>
                                     <exclude>org.scala-lang:*</exclude>
+                                    <exclude>io.netty:*</exclude>
+                                    <exclude>org.json4s:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <filters>


### PR DESCRIPTION
Signed-off-by: Austin Heyne <aheyne@ccri.com>