### PR TITLE
GEOMESA-1899 Fixing binning in z-curves, adding configurable precision

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z2/Z2QueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z2/Z2QueryableIndex.scala
@@ -19,7 +19,7 @@ import org.locationtech.geomesa.accumulo.AccumuloFilterStrategyType
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloFeature}
 import org.locationtech.geomesa.accumulo.index._
 import org.locationtech.geomesa.accumulo.iterators.{Z2DensityIterator, _}
-import org.locationtech.geomesa.curve.Z2SFC
+import org.locationtech.geomesa.curve.LegacyZ2SFC
 import org.locationtech.geomesa.index.conf.QueryProperties
 import org.locationtech.geomesa.index.strategies.SpatialFilterStrategy
 import org.locationtech.geomesa.index.utils.{Explainer, KryoLazyStatsUtils, SplitArrays}
@@ -118,9 +118,9 @@ trait Z2QueryableIndex extends AccumuloFeatureIndex
       val xy = geometries.values.map(GeometryUtils.bounds)
       val rangeTarget = QueryProperties.SCAN_RANGES_TARGET.option.map(_.toInt)
       val zRanges = if (sft.isPoints) {
-        Z2SFC.ranges(xy, 64, rangeTarget).map(r => (Longs.toByteArray(r.lower), Longs.toByteArray(r.upper)))
+        LegacyZ2SFC.ranges(xy, 64, rangeTarget).map(r => (Longs.toByteArray(r.lower), Longs.toByteArray(r.upper)))
       } else {
-        Z2SFC.ranges(xy, 8 * GEOM_Z_NUM_BYTES, rangeTarget).map { r =>
+        LegacyZ2SFC.ranges(xy, 8 * GEOM_Z_NUM_BYTES, rangeTarget).map { r =>
           (Longs.toByteArray(r.lower).take(GEOM_Z_NUM_BYTES), Longs.toByteArray(r.upper).take(GEOM_Z_NUM_BYTES))
         }
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3IndexV1.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3IndexV1.scala
@@ -12,7 +12,7 @@ import org.apache.accumulo.core.data.Mutation
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloFeature, EMPTY_TEXT}
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.{BinColumnFamily, FullColumnFamily}
-import org.locationtech.geomesa.curve.{BinnedTime, Z3SFC}
+import org.locationtech.geomesa.curve.{BinnedTime, LegacyZ3SFC}
 import org.locationtech.geomesa.index.utils.SplitArrays
 import org.opengis.feature.simple.SimpleFeatureType
 
@@ -40,7 +40,7 @@ case object Z3IndexV1 extends AccumuloFeatureIndex with Z3WritableIndex with Z3Q
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
     val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
     val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
-    val sfc = Z3SFC(sft.getZ3Interval)
+    val sfc = LegacyZ3SFC(sft.getZ3Interval)
     val splitArray = SplitArrays.apply(sft.getZShards)
     val getRowKeys: (AccumuloFeature, Int) => Seq[Array[Byte]] =
       (wf, i) => getPointRowKey(timeToIndex, sfc, splitArray)(wf, i).map(_.drop(1))
@@ -60,7 +60,7 @@ case object Z3IndexV1 extends AccumuloFeatureIndex with Z3WritableIndex with Z3Q
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
     val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
     val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
-    val sfc = Z3SFC(sft.getZ3Interval)
+    val sfc = LegacyZ3SFC(sft.getZ3Interval)
     val splitArray = SplitArrays.apply(sft.getZShards)
     val getRowKeys: (AccumuloFeature, Int) => Seq[Array[Byte]] =
       (ftw, i) => getPointRowKey(timeToIndex, sfc, splitArray)(ftw, i).map(_.drop(1))

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3IndexV2.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3IndexV2.scala
@@ -13,7 +13,7 @@ import org.apache.hadoop.io.Text
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloFeature, EMPTY_TEXT}
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.{BinColumnFamily, FullColumnFamily}
-import org.locationtech.geomesa.curve.{BinnedTime, Z3SFC}
+import org.locationtech.geomesa.curve.{BinnedTime, LegacyZ3SFC}
 import org.locationtech.geomesa.index.utils.SplitArrays
 import org.opengis.feature.simple.SimpleFeatureType
 
@@ -55,7 +55,7 @@ case object Z3IndexV2 extends AccumuloFeatureIndex with Z3WritableIndex with Z3Q
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
     val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
     val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
-    val sfc = Z3SFC(sft.getZ3Interval)
+    val sfc = LegacyZ3SFC(sft.getZ3Interval)
     val splitArray = SplitArrays.apply(sft.getZShards)
     val getRowKeys: (AccumuloFeature, Int) => Seq[Array[Byte]] =
       if (sft.isPoints) { getPointRowKey(timeToIndex, sfc, splitArray) }
@@ -78,7 +78,7 @@ case object Z3IndexV2 extends AccumuloFeatureIndex with Z3WritableIndex with Z3Q
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
     val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
     val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
-    val sfc = Z3SFC(sft.getZ3Interval)
+    val sfc = LegacyZ3SFC(sft.getZ3Interval)
     val splitArray = SplitArrays.apply(sft.getZShards)
     val getRowKeys: (AccumuloFeature, Int) => Seq[Array[Byte]] =
       if (sft.isPoints) { getPointRowKey(timeToIndex, sfc, splitArray) }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3IndexV3.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3IndexV3.scala
@@ -12,7 +12,7 @@ import org.apache.accumulo.core.data.Mutation
 import org.apache.hadoop.io.Text
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloFeature}
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
-import org.locationtech.geomesa.curve.{BinnedTime, Z3SFC}
+import org.locationtech.geomesa.curve.{BinnedTime, LegacyZ3SFC}
 import org.locationtech.geomesa.index.utils.SplitArrays
 import org.opengis.feature.simple.SimpleFeatureType
 
@@ -49,7 +49,7 @@ case object Z3IndexV3 extends AccumuloFeatureIndex with Z3WritableIndex with Z3Q
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
     val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
     val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
-    val sfc = Z3SFC(sft.getZ3Interval)
+    val sfc = LegacyZ3SFC(sft.getZ3Interval)
     val splitArray = SplitArrays.apply(sft.getZShards)
 
     (wf: AccumuloFeature) => {
@@ -67,7 +67,7 @@ case object Z3IndexV3 extends AccumuloFeatureIndex with Z3WritableIndex with Z3Q
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
     val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 writer requires a valid date"))
     val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
-    val sfc = Z3SFC(sft.getZ3Interval)
+    val sfc = LegacyZ3SFC(sft.getZ3Interval)
     val splitArray = SplitArrays.apply(sft.getZShards)
 
     (wf: AccumuloFeature) => {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3QueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3QueryableIndex.scala
@@ -17,7 +17,7 @@ import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloFeatur
 import org.locationtech.geomesa.accumulo.index._
 import org.locationtech.geomesa.accumulo.iterators.{Z3DensityIterator, _}
 import org.locationtech.geomesa.accumulo.{AccumuloFeatureIndexType, AccumuloFilterStrategyType}
-import org.locationtech.geomesa.curve.{BinnedTime, Z3SFC}
+import org.locationtech.geomesa.curve.{BinnedTime, LegacyZ3SFC}
 import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.index.conf.QueryProperties
 import org.locationtech.geomesa.index.strategies.SpatioTemporalFilterStrategy
@@ -120,7 +120,7 @@ trait Z3QueryableIndex extends AccumuloFeatureIndexType
     val z3table = getTableName(sft.getTypeName, ds)
     val numThreads = ds.config.queryThreads
 
-    val sfc = Z3SFC(sft.getZ3Interval)
+    val sfc = LegacyZ3SFC(sft.getZ3Interval)
     val minTime = sfc.time.min.toLong
     val maxTime = sfc.time.max.toLong
     val wholePeriod = Seq((minTime, maxTime))

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z2DensityIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z2DensityIterator.scala
@@ -13,7 +13,7 @@ import org.apache.accumulo.core.client.IteratorSetting
 import org.geotools.factory.Hints
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
 import org.locationtech.geomesa.accumulo.index.legacy.z2.Z2IndexV1
-import org.locationtech.geomesa.curve.Z2SFC
+import org.locationtech.geomesa.curve.LegacyZ2SFC
 import org.locationtech.geomesa.index.iterators.DensityScan
 import org.locationtech.geomesa.index.iterators.DensityScan.DensityResult
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
@@ -61,7 +61,7 @@ class Z2DensityIterator extends KryoLazyDensityIterator {
           zBytes(i) = row.byteAt(zOffset + i)
           i += 1
         }
-        val (x, y) = Z2SFC.invert(Z2(Longs.fromByteArray(zBytes)))
+        val (x, y) = LegacyZ2SFC.invert(Z2(Longs.fromByteArray(zBytes)))
         DensityScan.writePointToResult(x, y, weight, gridSnap, result)
       }
     }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z2Iterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z2Iterator.scala
@@ -13,7 +13,7 @@ import org.apache.accumulo.core.data.{ByteSequence, Key, Value, Range => AccRang
 import org.apache.accumulo.core.iterators.{IteratorEnvironment, SortedKeyValueIterator}
 import org.apache.hadoop.io.Text
 import org.locationtech.geomesa.accumulo.index.legacy.z2.Z2IndexV1
-import org.locationtech.geomesa.curve.Z2SFC
+import org.locationtech.geomesa.curve.LegacyZ2SFC
 import org.locationtech.geomesa.index.filters.Z2Filter
 import org.locationtech.sfcurve.zorder.Z2
 import org.opengis.feature.simple.SimpleFeatureType
@@ -114,8 +114,8 @@ object Z2Iterator {
     // index space values for comparing in the iterator
     val xyOpts = if (sft.isPoints) {
       bounds.map { case (xmin, ymin, xmax, ymax) =>
-        s"${Z2SFC.lon.normalize(xmin)}$RangeSeparator${Z2SFC.lat.normalize(ymin)}$RangeSeparator" +
-            s"${Z2SFC.lon.normalize(xmax)}$RangeSeparator${Z2SFC.lat.normalize(ymax)}"
+        s"${LegacyZ2SFC.lon.normalize(xmin)}$RangeSeparator${LegacyZ2SFC.lat.normalize(ymin)}$RangeSeparator" +
+            s"${LegacyZ2SFC.lon.normalize(xmax)}$RangeSeparator${LegacyZ2SFC.lat.normalize(ymax)}"
       }
     } else {
       bounds.map { case (xmin, ymin, xmax, ymax) =>
@@ -133,5 +133,5 @@ object Z2Iterator {
   }
 
   private def decodeNonPoints(x: Double, y: Double): (Int, Int) =
-    Z2(Z2SFC.index(x, y).z & Z2IndexV1.GEOM_Z_MASK).decode
+    Z2(LegacyZ2SFC.index(x, y).z & Z2IndexV1.GEOM_Z_MASK).decode
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3DensityIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3DensityIterator.scala
@@ -14,7 +14,7 @@ import org.geotools.factory.Hints
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
 import org.locationtech.geomesa.accumulo.index.legacy.z3.Z3IndexV2
 import org.locationtech.geomesa.accumulo.iterators.Z2DensityIterator.TableSharingKey
-import org.locationtech.geomesa.curve.Z3SFC
+import org.locationtech.geomesa.curve.LegacyZ3SFC
 import org.locationtech.geomesa.index.iterators.DensityScan
 import org.locationtech.geomesa.index.iterators.DensityScan.DensityResult
 import org.locationtech.sfcurve.zorder.Z3
@@ -50,7 +50,7 @@ class Z3DensityIterator extends KryoLazyDensityIterator {
       getWeight = (sf) => normalizeWeight(baseWeight(sf))
 
 
-      val sfc = Z3SFC(sft.getZ3Interval)
+      val sfc = LegacyZ3SFC(sft.getZ3Interval)
       // 1 for split plus optional 1 for table sharing
       val zPrefix = if (options(TableSharingKey).toBoolean) { 2 } else { 1 }
       writeGeom = (_, weight, result) => {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/Z3IteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/Z3IteratorTest.scala
@@ -16,7 +16,7 @@ import org.apache.accumulo.core.iterators.{IteratorEnvironment, SortedKeyValueIt
 import org.apache.hadoop.io.Text
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.index.legacy.z3.Z3IndexV2
-import org.locationtech.geomesa.curve.{TimePeriod, Z3SFC}
+import org.locationtech.geomesa.curve.{LegacyZ3SFC, TimePeriod}
 import org.locationtech.sfcurve.zorder.Z3
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -55,7 +55,7 @@ class Z3IteratorTest extends Specification {
       override def hasTop: Boolean = staged != null
     }
 
-    val sfc = Z3SFC(TimePeriod.Week)
+    val sfc = LegacyZ3SFC(TimePeriod.Week)
 
     "iterate on points" >> {
       val (xmin, ymin, tmin) = sfc.index(lx, ly, lt).decode

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseZ2Index.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseZ2Index.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.hbase.index
 
 import org.apache.hadoop.hbase.client._
 import org.apache.hadoop.hbase.filter.{Filter => HFilter}
-import org.locationtech.geomesa.curve.Z2SFC
+import org.locationtech.geomesa.curve.LegacyZ2SFC
 import org.locationtech.geomesa.hbase.HBaseFilterStrategyType
 import org.locationtech.geomesa.hbase.data._
 import org.locationtech.geomesa.hbase.filters.Z2HBaseFilter
@@ -34,7 +34,8 @@ case object HBaseZ2Index extends HBaseLikeZ2Index with HBasePlatform {
 
   private def configureZ2PushDown(xy: Seq[(Double, Double, Double, Double)], offset: Int): (Int, HFilter) = {
     val normalizedXY = xy.map { case (xmin, ymin, xmax, ymax) =>
-      Array(Z2SFC.lon.normalize(xmin), Z2SFC.lat.normalize(ymin), Z2SFC.lon.normalize(xmax), Z2SFC.lat.normalize(ymax))
+      Array(LegacyZ2SFC.lon.normalize(xmin), LegacyZ2SFC.lat.normalize(ymin),
+        LegacyZ2SFC.lon.normalize(xmax), LegacyZ2SFC.lat.normalize(ymax))
     }.toArray
 
     (Z2HBaseFilter.Priority, new Z2HBaseFilter(new Z2Filter(normalizedXY, 8), offset))

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/Z2Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/Z2Index.scala
@@ -14,7 +14,7 @@ import com.google.common.primitives.{Bytes, Longs}
 import com.typesafe.scalalogging.LazyLogging
 import com.vividsolutions.jts.geom.{Geometry, Point}
 import org.geotools.factory.Hints
-import org.locationtech.geomesa.curve.Z2SFC
+import org.locationtech.geomesa.curve.LegacyZ2SFC
 import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.index.api.{FilterStrategy, GeoMesaFeatureIndex, QueryPlan, WrappedFeature}
 import org.locationtech.geomesa.index.conf.QueryHints._
@@ -137,7 +137,7 @@ object Z2Index extends IndexKeySpace[Z2ProcessingValues] {
       if (geom == null) {
         throw new IllegalArgumentException(s"Null geometry in feature ${feature.getID}")
       }
-      val z = try { Z2SFC.index(geom.getX, geom.getY).z } catch {
+      val z = try { LegacyZ2SFC.index(geom.getX, geom.getY).z } catch {
         case NonFatal(e) => throw new IllegalArgumentException(s"Invalid z value from geometry: $geom", e)
       }
       Longs.toByteArray(z)
@@ -169,7 +169,7 @@ object Z2Index extends IndexKeySpace[Z2ProcessingValues] {
 
     val rangeTarget = QueryProperties.SCAN_RANGES_TARGET.option.map(_.toInt)
 
-    val zs = Z2SFC.ranges(xy, 64, rangeTarget)
+    val zs = LegacyZ2SFC.ranges(xy, 64, rangeTarget)
     zs.iterator.map(r => (Longs.toByteArray(r.lower), ByteArrays.toBytesFollowingPrefix(r.upper)))
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/Z3Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/Z3Index.scala
@@ -16,7 +16,7 @@ import com.typesafe.scalalogging.LazyLogging
 import com.vividsolutions.jts.geom.{Geometry, Point}
 import org.geotools.factory.Hints
 import org.joda.time.DateTime
-import org.locationtech.geomesa.curve.{BinnedTime, Z3SFC}
+import org.locationtech.geomesa.curve.{BinnedTime, LegacyZ3SFC, Z3SFC}
 import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.index.api.{FilterStrategy, GeoMesaFeatureIndex, QueryPlan, WrappedFeature}
 import org.locationtech.geomesa.index.conf.QueryHints._
@@ -133,7 +133,7 @@ object Z3Index extends IndexKeySpace[Z3ProcessingValues] {
   override def supports(sft: SimpleFeatureType): Boolean = sft.getDtgField.isDefined && sft.isPoints
 
   override def toIndexKey(sft: SimpleFeatureType): (SimpleFeature) => Array[Byte] = {
-    val sfc = Z3SFC(sft.getZ3Interval)
+    val sfc = LegacyZ3SFC(sft.getZ3Interval)
     val timeToIndex = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
     val geomIndex = sft.indexOf(sft.getGeometryDescriptor.getLocalName)
     val dtgIndex = sft.getDtgIndex.getOrElse(throw new IllegalStateException("Z3 index requires a valid date"))
@@ -183,7 +183,7 @@ object Z3Index extends IndexKeySpace[Z3ProcessingValues] {
       return Iterator.empty
     }
 
-    val sfc = Z3SFC(sft.getZ3Interval)
+    val sfc = LegacyZ3SFC(sft.getZ3Interval)
     val minTime = sfc.time.min.toLong
     val maxTime = sfc.time.max.toLong
     val wholePeriod = Seq((minTime, maxTime))

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/analytic/TrackLabelProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/analytic/TrackLabelProcess.scala
@@ -20,7 +20,7 @@ import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.util.ProgressListener
 
 /**
- * Stripped down version of org.geotools.process.vector.HeatmapProcess
+ * Returns a single feature that is the head of a track of related simple features
  */
 @DescribeProcess(
   title = "Track Label Process",

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/BinnedArray.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/BinnedArray.scala
@@ -331,7 +331,7 @@ object BinnedStringArray {
   val Base36Lowest  = Base36Chars.head
   val Base36Highest = Base36Chars.last
 
-  def normalize(s: String) = s.toLowerCase(Locale.US).replaceAll("[^0-9a-z]", Base36Lowest.toString)
+  def normalize(s: String): String = s.toLowerCase(Locale.US).replaceAll("[^0-9a-z]", Base36Lowest.toString)
 
   def normalizeBounds(bounds: (String, String)): (String, String) = {
     val length = math.max(bounds._1.length, bounds._2.length)

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/stats/Z3HistogramTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/stats/Z3HistogramTest.scala
@@ -8,6 +8,9 @@
 
 package org.locationtech.geomesa.utils.stats
 
+import java.util.Date
+
+import com.vividsolutions.jts.geom.Geometry
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.curve.TimePeriod
 import org.locationtech.geomesa.utils.geotools.GeoToolsDateFormat
@@ -28,8 +31,8 @@ class Z3HistogramTest extends Specification with StatTestHelper {
 
   def createStat(observe: Boolean = true): Z3Histogram = createStat(1024, observe)
 
-  def toDate(string: String) = java.util.Date.from(java.time.LocalDateTime.parse(string, GeoToolsDateFormat).toInstant(java.time.ZoneOffset.UTC))
-  def toGeom(string: String) = WKTUtils.read(string)
+  def toDate(string: String): Date = Date.from(java.time.LocalDateTime.parse(string, GeoToolsDateFormat).toInstant(java.time.ZoneOffset.UTC))
+  def toGeom(string: String): Geometry = WKTUtils.read(string)
 
   "HistogramZ3 stat" should {
 
@@ -44,7 +47,7 @@ class Z3HistogramTest extends Specification with StatTestHelper {
         stat.isEmpty must beFalse
         forall(0 until 100) { i =>
           val (w, idx) = stat.indexOf(toGeom(s"POINT(-$i ${i / 2})"), toDate(f"2012-01-01T${i%24}%02d:00:00.000Z"))
-          stat.count(w, idx) must beBetween(1L, 12L)
+          stat.count(w, idx) must beBetween(1L, 21L)
         }
       }
 

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/uuid/Z3FeatureIdGeneratorTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/uuid/Z3FeatureIdGeneratorTest.scala
@@ -11,7 +11,7 @@ package org.locationtech.geomesa.utils.uuid
 import java.util.{Date, UUID}
 
 import com.vividsolutions.jts.geom.{Geometry, Point, Polygon}
-import org.geotools.feature.simple.{SimpleFeatureBuilder, SimpleFeatureTypeBuilder}
+import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.curve.TimePeriod._
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
@@ -19,8 +19,6 @@ import org.locationtech.geomesa.utils.text.WKTUtils
 import org.opengis.feature.simple.SimpleFeature
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-
-import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
 class Z3FeatureIdGeneratorTest extends Specification {
@@ -48,7 +46,7 @@ class Z3FeatureIdGeneratorTest extends Specification {
   "Z3UuidGenerator" should {
     "create uuids with correct formats for a Point" >> {
       val id = Z3UuidGenerator.createUuid(point, time, period).toString
-      id.substring(0, 18) mustEqual "109452fb-fd80-4f78"
+      id.substring(0, 18) mustEqual "e09456f9-fc84-4f5c"
       val uuid = UUID.fromString(id)
       uuid.version() mustEqual 4
       uuid.variant() mustEqual 2
@@ -56,7 +54,7 @@ class Z3FeatureIdGeneratorTest extends Specification {
 
     "create uuids with correct formats for a Polygon" >> {
       val id = Z3UuidGenerator.createUuid(polygon.asInstanceOf[Geometry], time, period).toString
-      id.substring(0, 18) mustEqual "609452fb-fd82-4fe9"
+      id.substring(0, 18) mustEqual "909456f9-fc86-4fcd"
       val uuid = UUID.fromString(id)
       uuid.version() mustEqual 4
       uuid.variant() mustEqual 2

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyZ2SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyZ2SFC.scala
@@ -1,0 +1,17 @@
+/***********************************************************************
+ * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.curve
+
+import org.locationtech.geomesa.curve.NormalizedDimension.{SemiNormalizedLat, SemiNormalizedLon}
+
+@deprecated("Z2SFC", "1.3.2")
+object LegacyZ2SFC extends Z2SFC(31) {
+  override val lon = SemiNormalizedLon(math.pow(2, 31).toLong - 1)
+  override val lat = SemiNormalizedLat(math.pow(2, 31).toLong - 1)
+}

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyZ3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyZ3SFC.scala
@@ -1,0 +1,35 @@
+/***********************************************************************
+ * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.curve
+
+import org.locationtech.geomesa.curve.NormalizedDimension.{SemiNormalizedLat, SemiNormalizedLon, SemiNormalizedTime}
+import org.locationtech.geomesa.curve.TimePeriod.TimePeriod
+
+@deprecated("Z3SFC", "1.3.2")
+class LegacyZ3SFC(period: TimePeriod) extends Z3SFC(period, 21) {
+  override val lon  = SemiNormalizedLon(math.pow(2, 21).toLong - 1)
+  override val lat  = SemiNormalizedLat(math.pow(2, 21).toLong - 1)
+  override val time = SemiNormalizedTime(math.pow(2, 20).toLong - 1, BinnedTime.maxOffset(period).toDouble)
+}
+
+@deprecated("Z3SFC", "1.3.2")
+object LegacyZ3SFC {
+
+  private val SfcDay   = new LegacyZ3SFC(TimePeriod.Day)
+  private val SfcWeek  = new LegacyZ3SFC(TimePeriod.Week)
+  private val SfcMonth = new LegacyZ3SFC(TimePeriod.Month)
+  private val SfcYear  = new LegacyZ3SFC(TimePeriod.Year)
+
+  def apply(period: TimePeriod): LegacyZ3SFC = period match {
+    case TimePeriod.Day   => SfcDay
+    case TimePeriod.Week  => SfcWeek
+    case TimePeriod.Month => SfcMonth
+    case TimePeriod.Year  => SfcYear
+  }
+}

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/NormalizedDimension.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/NormalizedDimension.scala
@@ -8,26 +8,87 @@
 
 package org.locationtech.geomesa.curve
 
+/**
+  * Maps a double within a known range to an Int in [0, bins)
+  */
 trait NormalizedDimension {
+
+  /**
+    * Min value considered for normalization range
+    *
+    * @return
+    */
   def min: Double
+
+  /**
+    * Max value considered for normalizing
+    *
+    * @return
+    */
   def max: Double
-  def precision: Long
 
-  def normalize(x: Double): Int = math.ceil((x - min) / (max - min) * precision).toInt
+  /**
+    * Max value to normalize to
+    *
+    * @return
+    */
+  def maxIndex: Int
 
-  def denormalize(x: Int): Double = if (x == 0) { min } else { (x - 0.5d) * (max - min) / precision + min }
+  /**
+    * Normalize the value
+    *
+    * @param x [min, max]
+    * @return [0, maxIndex]
+    */
+  def normalize(x: Double): Int
+
+  /**
+    * Denormalize the value in bin x
+    *
+    * @param x [0, maxIndex]
+    * @return [min, max]
+    */
+  def denormalize(x: Int): Double
 }
 
-case class NormalizedLat(precision: Long) extends NormalizedDimension {
-  override val min = -90.0
-  override val max = 90.0
-}
+object NormalizedDimension {
 
-case class NormalizedLon(precision: Long) extends NormalizedDimension {
-  override val min = -180.0
-  override val max = 180.0
-}
+  class BitNormalizedDimension(val min: Double, val max: Double, precision: Int) extends NormalizedDimension {
 
-case class NormalizedTime(precision: Long, max: Double) extends NormalizedDimension {
-  override val min = 0.0
+    require(precision > 0 && precision < 32, "Precision (bits) must be in [1,31]")
+
+    // (1L << precision) is equivalent to math.pow(2, precision).toLong
+    private val bins = 1L << precision
+    private val normalizer = bins / (max - min)
+    private val denormalizer = (max - min) / bins
+
+    override val maxIndex = (bins - 1).toInt // note: call .toInt after subtracting 1 to avoid sign issues
+
+    override def normalize(x: Double): Int =
+      if (x >= max) { maxIndex } else { math.floor((x - min) * normalizer).toInt }
+
+    override def denormalize(x: Int): Double =
+      if (x >= maxIndex) { min + (maxIndex + 0.5d) * denormalizer } else { min + (x + 0.5d) * denormalizer }
+  }
+
+  case class NormalizedLat(precision: Int) extends BitNormalizedDimension(-90d, 90d, precision)
+
+  case class NormalizedLon(precision: Int) extends BitNormalizedDimension(-180d, 180d, precision)
+
+  case class NormalizedTime(precision: Int, override val max: Double) extends BitNormalizedDimension(0d, max, precision)
+
+
+  // legacy normalization, doesn't correctly bin lower bound
+  class SemiNormalizedDimension(val min: Double, val max: Double, precision: Long) extends NormalizedDimension {
+    override val maxIndex = precision.toInt
+    override def normalize(x: Double): Int = math.ceil((x - min) / (max - min) * precision).toInt
+    override def denormalize(x: Int): Double = if (x == 0) { min } else { (x - 0.5d) * (max - min) / precision + min }
+  }
+
+  case class SemiNormalizedLat(precision: Long) extends SemiNormalizedDimension(-90d, 90d, precision)
+
+  case class SemiNormalizedLon(precision: Long) extends SemiNormalizedDimension(-180d, 180d, precision)
+
+  case class SemiNormalizedTime(precision: Long, override val max: Double)
+      extends SemiNormalizedDimension(0d, max, precision)
 }

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z2SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z2SFC.scala
@@ -8,16 +8,21 @@
 
 package org.locationtech.geomesa.curve
 
+import org.locationtech.geomesa.curve.NormalizedDimension.{NormalizedLat, NormalizedLon}
 import org.locationtech.sfcurve.IndexRange
 import org.locationtech.sfcurve.zorder.{Z2, ZRange}
 
-object Z2SFC extends SpaceFillingCurve[Z2] {
+object Z2SFC extends Z2SFC(31)
 
-  private val xprec: Long = math.pow(2, 31).toLong - 1
-  private val yprec: Long = math.pow(2, 31).toLong - 1
+/**
+  * z2 space-filling curve
+  *
+  * @param precision number of bits used per dimension - note sum must be less than 64
+  */
+class Z2SFC(precision: Int) extends SpaceFillingCurve[Z2] {
 
-  override val lon  = NormalizedLon(xprec)
-  override val lat  = NormalizedLat(yprec)
+  override val lon: NormalizedDimension = NormalizedLon(precision)
+  override val lat: NormalizedDimension = NormalizedLat(precision)
 
   override def index(x: Double, y: Double): Z2 = {
     require(x >= lon.min && x <= lon.max && y >= lat.min && y <= lat.max,

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3SFC.scala
@@ -8,20 +8,24 @@
 
 package org.locationtech.geomesa.curve
 
+import org.locationtech.geomesa.curve.NormalizedDimension._
 import org.locationtech.geomesa.curve.TimePeriod.TimePeriod
 import org.locationtech.sfcurve.IndexRange
 import org.locationtech.sfcurve.zorder.{Z3, ZRange}
 
-class Z3SFC(period: TimePeriod) extends SpaceTimeFillingCurve[Z3] {
+/**
+  * Z3 space filling curve
+  *
+  * @param period time period used to bin results
+  * @param precision bits used per dimension - note all precisions must sum to less than 64
+  */
+class Z3SFC(period: TimePeriod, precision: Int = 21) extends SpaceTimeFillingCurve[Z3] {
 
-  private val xprec: Long = math.pow(2, 21).toLong - 1
-  private val yprec: Long = math.pow(2, 21).toLong - 1
-  private val tprec: Long = math.pow(2, 20).toLong - 1
-  private val tmax: Double = BinnedTime.maxOffset(period).toDouble
+  require(precision > 0 && precision < 22, "Precision (bits) per dimension must be in [1,21]")
 
-  override val lon  = NormalizedLon(xprec)
-  override val lat  = NormalizedLat(yprec)
-  override val time = NormalizedTime(tprec, tmax)
+  override val lon: NormalizedDimension  = NormalizedLon(precision)
+  override val lat: NormalizedDimension  = NormalizedLat(precision)
+  override val time: NormalizedDimension = NormalizedTime(precision, BinnedTime.maxOffset(period).toDouble)
 
   override def index(x: Double, y: Double, t: Long): Z3 = {
     require(x >= lon.min && x <= lon.max && y >= lat.min && y <= lat.max && t >= time.min && t <= time.max,

--- a/geomesa-z3/src/test/scala/org/locationtech/geomesa/curve/Z3Test.scala
+++ b/geomesa-z3/src/test/scala/org/locationtech/geomesa/curve/Z3Test.scala
@@ -20,10 +20,10 @@ import scala.util.Random
 class Z3Test extends Specification {
 
   val rand = new Random(-574)
-  val maxInt = Z3SFC(TimePeriod.Week).lon.precision.toInt
-  def nextDim() = rand.nextInt(maxInt)
+  val maxInt = Z3SFC(TimePeriod.Week).lon.maxIndex
+  def nextDim(): Int = rand.nextInt(maxInt)
 
-  def padTo(s: String) = (new String(Array.fill(63)('0')) + s).takeRight(63)
+  def padTo(s: String): String = (new String(Array.fill(63)('0')) + s).takeRight(63)
 
   "Z3" should {
 
@@ -48,29 +48,31 @@ class Z3Test extends Specification {
     }
 
     "apply and unapply max values" >> {
-      val z3curve = Z3SFC(TimePeriod.Week)
-      val (x, y, t) = (z3curve.lon.precision, z3curve.lat.precision, z3curve.time.precision)
-      val z = Z3(x.toInt, y.toInt, t.toInt)
-      z match { case Z3(zx, zy, zt) =>
-        zx mustEqual x
-        zy mustEqual y
-        zt mustEqual t
+      foreach(Seq(Z3SFC(TimePeriod.Week), LegacyZ3SFC(TimePeriod.Week))) { sfc =>
+        val (x, y, t) = (sfc.lon.maxIndex, sfc.lat.maxIndex, sfc.time.maxIndex)
+        val z = Z3(x.toInt, y.toInt, t.toInt)
+        z match { case Z3(zx, zy, zt) =>
+          zx mustEqual x
+          zy mustEqual y
+          zt mustEqual t
+        }
       }
     }
 
     "fail for out-of-bounds values" >> {
-      val sfc = Z3SFC(TimePeriod.Week)
-      val toFail = Seq(
-        (-180.1, 0d, 0L),
-        (180.1, 0d, 0L),
-        (0d, -90.1, 0L),
-        (0d, 90.1, 0L),
-        (0d, 0d, sfc.time.min.toLong - 1),
-        (0d, 0d, sfc.time.max.toLong + 1),
-        (-181d, -91d, sfc.time.min.toLong - 1),
-        (181d, 91d, sfc.time.max.toLong + 1)
-      )
-      forall(toFail) { case (x, y, t) => sfc.index(x, y, t) must throwAn[IllegalArgumentException] }
+      foreach(Seq(Z3SFC(TimePeriod.Week), LegacyZ3SFC(TimePeriod.Week))) { sfc =>
+        val toFail = Seq(
+          (-180.1, 0d, 0L),
+          (180.1, 0d, 0L),
+          (0d, -90.1, 0L),
+          (0d, 90.1, 0L),
+          (0d, 0d, sfc.time.min.toLong - 1),
+          (0d, 0d, sfc.time.max.toLong + 1),
+          (-181d, -91d, sfc.time.min.toLong - 1),
+          (181d, 91d, sfc.time.max.toLong + 1)
+        )
+        foreach(toFail) { case (x, y, t) => sfc.index(x, y, t) must throwAn[IllegalArgumentException] }
+      }
     }
 
     "split" >> {
@@ -179,40 +181,41 @@ class Z3Test extends Specification {
     }
 
     "return non-empty ranges for a number of cases" >> {
-      val sfc = Z3SFC(TimePeriod.Week)
-      val week = sfc.time.max.toLong
-      val day = sfc.time.max.toLong / 7
-      val hour = sfc.time.max.toLong / 168
+      foreach(Seq(Z3SFC(TimePeriod.Week), LegacyZ3SFC(TimePeriod.Week))) { sfc =>
+        val week = sfc.time.max.toLong
+        val day = sfc.time.max.toLong / 7
+        val hour = sfc.time.max.toLong / 168
 
-      val ranges = Seq(
-        (sfc.index(-180, -90, 0), sfc.index(180, 90, week)), // whole world, full week
-        (sfc.index(-180, -90, day), sfc.index(180, 90, day * 2)), // whole world, 1 day
-        (sfc.index(-180, -90, hour * 10), sfc.index(180, 90, hour * 11)), // whole world, 1 hour
-        (sfc.index(-180, -90, hour * 10), sfc.index(180, 90, hour * 64)), // whole world, 54 hours
-        (sfc.index(-180, -90, day * 2), sfc.index(180, 90, week)), // whole world, 5 day
-        (sfc.index(-90, -45, sfc.time.max.toLong / 4), sfc.index(90, 45, 3 * sfc.time.max.toLong / 4)), // half world, half week
-        (sfc.index(35, 65, 0), sfc.index(45, 75, day)), // 10^2 degrees, 1 day
-        (sfc.index(35, 55, 0), sfc.index(45, 65, week)), // 10^2 degrees, full week
-        (sfc.index(35, 55, day), sfc.index(45, 75, day * 2)), // 10x20 degrees, 1 day
-        (sfc.index(35, 55, day + hour * 6), sfc.index(45, 75, day * 2)), // 10x20 degrees, 18 hours
-        (sfc.index(35, 65, day + hour), sfc.index(45, 75, day * 6)), // 10^2 degrees, 5 days 23 hours
-        (sfc.index(35, 65, day), sfc.index(37, 68, day + hour * 6)), // 2x3 degrees, 6 hours
-        (sfc.index(35, 65, day), sfc.index(40, 70, day + hour * 6)), // 5^2 degrees, 6 hours
-        (sfc.index(39.999, 60.999, day + 3000), sfc.index(40.001, 61.001, day + 3120)), // small bounds
-        (sfc.index(51.0, 51.0, 6000), sfc.index(51.1, 51.1, 6100)), // small bounds
-        (sfc.index(51.0, 51.0, 30000), sfc.index(51.001, 51.001, 30100)), // small bounds
-        (Z3(sfc.index(51.0, 51.0, 30000).z - 1), Z3(sfc.index(51.0, 51.0, 30000).z + 1)) // 62 bits in common
-      )
+        val ranges = Seq(
+          (sfc.index(-180, -90, 0), sfc.index(180, 90, week)), // whole world, full week
+          (sfc.index(-180, -90, day), sfc.index(180, 90, day * 2)), // whole world, 1 day
+          (sfc.index(-180, -90, hour * 10), sfc.index(180, 90, hour * 11)), // whole world, 1 hour
+          (sfc.index(-180, -90, hour * 10), sfc.index(180, 90, hour * 64)), // whole world, 54 hours
+          (sfc.index(-180, -90, day * 2), sfc.index(180, 90, week)), // whole world, 5 day
+          (sfc.index(-90, -45, sfc.time.max.toLong / 4), sfc.index(90, 45, 3 * sfc.time.max.toLong / 4)), // half world, half week
+          (sfc.index(35, 65, 0), sfc.index(45, 75, day)), // 10^2 degrees, 1 day
+          (sfc.index(35, 55, 0), sfc.index(45, 65, week)), // 10^2 degrees, full week
+          (sfc.index(35, 55, day), sfc.index(45, 75, day * 2)), // 10x20 degrees, 1 day
+          (sfc.index(35, 55, day + hour * 6), sfc.index(45, 75, day * 2)), // 10x20 degrees, 18 hours
+          (sfc.index(35, 65, day + hour), sfc.index(45, 75, day * 6)), // 10^2 degrees, 5 days 23 hours
+          (sfc.index(35, 65, day), sfc.index(37, 68, day + hour * 6)), // 2x3 degrees, 6 hours
+          (sfc.index(35, 65, day), sfc.index(40, 70, day + hour * 6)), // 5^2 degrees, 6 hours
+          (sfc.index(39.999, 60.999, day + 3000), sfc.index(40.001, 61.001, day + 3120)), // small bounds
+          (sfc.index(51.0, 51.0, 6000), sfc.index(51.1, 51.1, 6100)), // small bounds
+          (sfc.index(51.0, 51.0, 30000), sfc.index(51.001, 51.001, 30100)), // small bounds
+          (Z3(sfc.index(51.0, 51.0, 30000).z - 1), Z3(sfc.index(51.0, 51.0, 30000).z + 1)) // 62 bits in common
+        )
 
-      def print(l: Z3, u: Z3, size: Int): Unit =
-        println(s"${round(sfc.invert(l))} ${round(sfc.invert(u))}\t$size")
-      def round(z: (Double, Double, Long)): (Double, Double, Long) =
-        (math.round(z._1 * 1000.0) / 1000.0, math.round(z._2 * 1000.0) / 1000.0, z._3)
+        def print(l: Z3, u: Z3, size: Int): Unit =
+          println(s"${round(sfc.invert(l))} ${round(sfc.invert(u))}\t$size")
+        def round(z: (Double, Double, Long)): (Double, Double, Long) =
+          (math.round(z._1 * 1000.0) / 1000.0, math.round(z._2 * 1000.0) / 1000.0, z._3)
 
-      val start = System.currentTimeMillis()
-      forall(ranges) { r =>
-        val ret = Z3.zranges(Array(ZRange(r._1, r._2)), maxRanges = Some(1000))
-        ret.length must beGreaterThan(0)
+        val start = System.currentTimeMillis()
+        foreach(ranges) { r =>
+          val ret = Z3.zranges(Array(ZRange(r._1, r._2)), maxRanges = Some(1000))
+          ret.length must beGreaterThan(0)
+        }
       }
     }
   }


### PR DESCRIPTION
* Old binning code moved to LegacyZ*Curve
* Existing code uses the legacy implementations for back-compatibility
* Precision is specified as bits (per dimension) instead of number of bins

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>