### PR TITLE
GEOMESA-1951 Exclude json4s in geomesa-fs-spark-runtime

### DIFF
--- a/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
@@ -74,6 +74,7 @@
                                     <exclude>com.esotericsoftware.kryo:*</exclude>
                                     <exclude>org.ow2.asm:*</exclude>
                                     <exclude>org.scala-lang:*</exclude>
+                                    <exclude>org.json4s:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <filters>


### PR DESCRIPTION
Allows the spark runtime to work in Zeppelin. Has also been tested with spark-submit to make sure it's not a breaking change.

Signed-off-by: Austin Heyne <aheyne@ccri.com>