### PR TITLE
GEOMESA-1980 Add ability to explain plan & strategy

### DIFF
--- a/geomesa-cassandra/geomesa-cassandra-tools/conf/logback.xml
+++ b/geomesa-cassandra/geomesa-cassandra-tools/conf/logback.xml
@@ -40,7 +40,11 @@
   <logger name="org.locationtech.geomesa.tools.output" level="INFO">
     <appender-ref ref="output" />
   </logger>
-
+  <!--
+  <logger name="org.locationtech.geomesa.index.utils.Explainer" level="TRACE">
+    <appender-ref ref="output" />
+  </logger>
+  -->
   <logger name="org.locationtech.geomesa" level="INFO"/>
 
   <logger name="hsqldb.db" level="WARN"/>


### PR DESCRIPTION
Add ability to explain plan & strategy during a query by commenting out the ```org.locationtech.geomesa.index.utils.Explainer```. Output is set as default appender.