### PR TITLE
GEOMESA-1976 Upgrade to Arrow 0.6

### DIFF
--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -1,7 +1,7 @@
 asm:asm	3.1	compile
 com.adobe.xmp:xmpcore	5.1.2	compile
 com.beust:jcommander	1.48	compile
-com.carrotsearch:hppc	0.7.1	compile
+com.carrotsearch:hppc	0.7.2	compile
 com.clearspring.analytics:stream	2.9.2	compile
 com.drewnoakes:metadata-extractor	2.8.1	compile
 com.esotericsoftware.kryo:kryo	2.21	compile
@@ -118,9 +118,9 @@ org.antlr:antlr4-runtime	4.5	compile
 org.apache.accumulo:accumulo-core	1.7.2	compile
 org.apache.accumulo:accumulo-fate	1.7.2	compile
 org.apache.accumulo:accumulo-start	1.7.2	compile
-org.apache.arrow:arrow-format	0.4.0	compile
-org.apache.arrow:arrow-memory	0.4.0	compile
-org.apache.arrow:arrow-vector	0.4.0	compile
+org.apache.arrow:arrow-format	0.6.0	compile
+org.apache.arrow:arrow-memory	0.6.0	compile
+org.apache.arrow:arrow-vector	0.6.0	compile
 org.apache.avro:avro	1.7.5	compile
 org.apache.camel:camel-core	2.15.1	compile
 org.apache.camel:camel-scala	2.15.1	compile

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeWriter.scala
@@ -320,43 +320,43 @@ object ArrowAttributeWriter {
 
   class ArrowIntWriter(mutator: NullableIntVector#Mutator) extends ArrowAttributeWriter {
     override def apply(i: Int, value: AnyRef): Unit = if (value != null) {
-      mutator.set(i, value.asInstanceOf[Int])
+      mutator.setSafe(i, value.asInstanceOf[Int])
     }
   }
 
   class ArrowLongWriter(mutator: NullableBigIntVector#Mutator) extends ArrowAttributeWriter {
     override def apply(i: Int, value: AnyRef): Unit = if (value != null) {
-      mutator.set(i, value.asInstanceOf[Long])
+      mutator.setSafe(i, value.asInstanceOf[Long])
     }
   }
 
   class ArrowFloatWriter(mutator: NullableFloat4Vector#Mutator) extends ArrowAttributeWriter {
     override def apply(i: Int, value: AnyRef): Unit = if (value != null) {
-      mutator.set(i, value.asInstanceOf[Float])
+      mutator.setSafe(i, value.asInstanceOf[Float])
     }
   }
 
   class ArrowDoubleWriter(mutator: NullableFloat8Vector#Mutator) extends ArrowAttributeWriter {
     override def apply(i: Int, value: AnyRef): Unit = if (value != null) {
-      mutator.set(i, value.asInstanceOf[Double])
+      mutator.setSafe(i, value.asInstanceOf[Double])
     }
   }
 
   class ArrowBooleanWriter(mutator: NullableBitVector#Mutator) extends ArrowAttributeWriter {
     override def apply(i: Int, value: AnyRef): Unit = if (value != null) {
-      mutator.set(i, if (value.asInstanceOf[Boolean]) { 1 } else { 0 })
+      mutator.setSafe(i, if (value.asInstanceOf[Boolean]) { 1 } else { 0 })
     }
   }
 
   class ArrowDateMillisWriter(mutator: NullableBigIntVector#Mutator) extends ArrowAttributeWriter {
     override def apply(i: Int, value: AnyRef): Unit = if (value != null) {
-      mutator.set(i, value.asInstanceOf[Date].getTime)
+      mutator.setSafe(i, value.asInstanceOf[Date].getTime)
     }
   }
 
   class ArrowDateSecondsWriter(mutator: NullableIntVector#Mutator) extends ArrowAttributeWriter {
     override def apply(i: Int, value: AnyRef): Unit = if (value != null) {
-      mutator.set(i, (value.asInstanceOf[Date].getTime / 1000L).toInt)
+      mutator.setSafe(i, (value.asInstanceOf[Date].getTime / 1000L).toInt)
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/SimpleFeatureVector.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/SimpleFeatureVector.scala
@@ -45,14 +45,6 @@ class SimpleFeatureVector private (val sft: SimpleFeatureType,
   val reader = new Reader(this)
 
   /**
-    * double underlying vector capacity
-    */
-  def expand(): Unit = {
-    underlying.reAlloc()
-    maxIndex = underlying.getValueCapacity - 1
-  }
-
-  /**
     * Clear any simple features currently stored in the vector
     */
   def clear(): Unit = underlying.getMutator.setValueCount(0)
@@ -68,10 +60,6 @@ class SimpleFeatureVector private (val sft: SimpleFeatureType,
     private [arrow] val attributeWriters = ArrowAttributeWriter(sft, vector.underlying, dictionaries, encoding).toArray
 
     def set(index: Int, feature: SimpleFeature): Unit = {
-      // make sure we have space to write the value
-      while (index > vector.maxIndex ) {
-        vector.expand()
-      }
       arrowWriter.setPosition(index)
       arrowWriter.start()
       idWriter.apply(index, feature.getID)

--- a/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/LineStringFloatVector.java
+++ b/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/LineStringFloatVector.java
@@ -69,7 +69,7 @@ public class LineStringFloatVector extends AbstractLineStringVector {
 
     @Override
     protected void writeOrdinal(int index, double ordinal) {
-      mutator.set(index, (float) ordinal);
+      mutator.setSafe(index, (float) ordinal);
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/LineStringVector.java
+++ b/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/LineStringVector.java
@@ -71,7 +71,7 @@ public class LineStringVector extends AbstractLineStringVector {
 
     @Override
     protected void writeOrdinal(int index, double ordinal) {
-      mutator.set(index, ordinal);
+      mutator.setSafe(index, ordinal);
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/MultiLineStringFloatVector.java
+++ b/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/MultiLineStringFloatVector.java
@@ -69,7 +69,7 @@ public class MultiLineStringFloatVector extends AbstractMultiLineStringVector {
 
     @Override
     protected void writeOrdinal(int index, double ordinal) {
-      mutator.set(index, (float) ordinal);
+      mutator.setSafe(index, (float) ordinal);
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/MultiLineStringVector.java
+++ b/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/MultiLineStringVector.java
@@ -71,7 +71,7 @@ public class MultiLineStringVector extends AbstractMultiLineStringVector {
 
     @Override
     protected void writeOrdinal(int index, double ordinal) {
-      mutator.set(index, ordinal);
+      mutator.setSafe(index, ordinal);
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/MultiPointFloatVector.java
+++ b/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/MultiPointFloatVector.java
@@ -69,7 +69,7 @@ public class MultiPointFloatVector extends AbstractMultiPointVector {
 
     @Override
     protected void writeOrdinal(int index, double ordinal) {
-      mutator.set(index, (float) ordinal);
+      mutator.setSafe(index, (float) ordinal);
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/MultiPointVector.java
+++ b/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/MultiPointVector.java
@@ -71,7 +71,7 @@ public class MultiPointVector extends AbstractMultiPointVector {
 
     @Override
     protected void writeOrdinal(int index, double ordinal) {
-      mutator.set(index, ordinal);
+      mutator.setSafe(index, ordinal);
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/MultiPolygonFloatVector.java
+++ b/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/MultiPolygonFloatVector.java
@@ -69,7 +69,7 @@ public class MultiPolygonFloatVector extends AbstractMultiPolygonVector {
 
     @Override
     protected void writeOrdinal(int index, double ordinal) {
-      mutator.set(index, (float) ordinal);
+      mutator.setSafe(index, (float) ordinal);
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/MultiPolygonVector.java
+++ b/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/MultiPolygonVector.java
@@ -71,7 +71,7 @@ public class MultiPolygonVector extends AbstractMultiPolygonVector {
 
     @Override
     protected void writeOrdinal(int index, double ordinal) {
-      mutator.set(index, ordinal);
+      mutator.setSafe(index, ordinal);
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/PointFloatVector.java
+++ b/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/PointFloatVector.java
@@ -69,7 +69,7 @@ public class PointFloatVector extends AbstractPointVector {
 
     @Override
     protected void writeOrdinal(int index, double ordinal) {
-      mutator.set(index, (float) ordinal);
+      mutator.setSafe(index, (float) ordinal);
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/PointVector.java
+++ b/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/PointVector.java
@@ -71,7 +71,7 @@ public class PointVector extends AbstractPointVector {
 
     @Override
     protected void writeOrdinal(int index, double ordinal) {
-      mutator.set(index, ordinal);
+      mutator.setSafe(index, ordinal);
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/PolygonFloatVector.java
+++ b/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/PolygonFloatVector.java
@@ -69,7 +69,7 @@ public class PolygonFloatVector extends AbstractPolygonVector {
 
     @Override
     protected void writeOrdinal(int index, double ordinal) {
-      mutator.set(index, (float) ordinal);
+      mutator.setSafe(index, (float) ordinal);
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/PolygonVector.java
+++ b/geomesa-arrow/geomesa-arrow-jts/src/main/java/org/locationtech/geomesa/arrow/vector/PolygonVector.java
@@ -71,7 +71,7 @@ public class PolygonVector extends AbstractPolygonVector {
 
     @Override
     protected void writeOrdinal(int index, double ordinal) {
-      mutator.set(index, ordinal);
+      mutator.setSafe(index, ordinal);
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <kafka.08.version>0.8.2.1</kafka.08.version>
         <kafka.09.version>0.9.0.1</kafka.09.version>
         <kafka.10.version>0.10.0.1</kafka.10.version>
-        <arrow.version>0.4.0</arrow.version>
+        <arrow.version>0.6.0</arrow.version>
         <netty.version>4.0.41.Final</netty.version>
 
         <!-- Recommended installation versions -->


### PR DESCRIPTION
* Using .setSafe in mutators instead of reAlloc (which doesn't work)
* Fixes offset alignment in arrow output files

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>