### PR TITLE
GEOMESA-1986 TubeSelect Modified to Properly Handle IDL

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/process/tube/TubeBinTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/process/tube/TubeBinTest.scala
@@ -35,7 +35,7 @@ class TubeBinTest extends Specification {
 
   val geotimeAttributes = s"geom:Point:srid=4326,$DefaultDtgField:Date,dtg_end_time:Date"
 
-  "NoGapFilll" should {
+  "NoGapFill" should {
 
     "correctly time bin features" in {
       val sftName = "tubetest2"


### PR DESCRIPTION
TubeSelect will now split LineStrings that cross the IDL to prevent queries from wrapping the wrong direction around the globe in the event that a LineString geometry crosses the IDL.