### PR TITLE
GEOMESA-1986,GEOMESA-1987,GEOMESA-1993 IDL Safe TubeSelect, Interpolated GapFill, Binning Fix 

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/process/tube/TubeBinTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/process/tube/TubeBinTest.scala
@@ -63,7 +63,7 @@ class TubeBinTest extends Specification {
 
       ngf.timeBinAndUnion(ngf.transform(new ListFeatureCollection(sft, features), DefaultDtgField).toSeq, 1).size mustEqual 1
 
-      ngf.timeBinAndUnion(ngf.transform(new ListFeatureCollection(sft, features), DefaultDtgField).toSeq, 0).size mustEqual 1
+      ngf.timeBinAndUnion(ngf.transform(new ListFeatureCollection(sft, features), DefaultDtgField).toSeq, 0).size mustEqual 19
     }
 
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/process/tube/TubeBinTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/process/tube/TubeBinTest.scala
@@ -35,7 +35,7 @@ class TubeBinTest extends Specification {
 
   val geotimeAttributes = s"geom:Point:srid=4326,$DefaultDtgField:Date,dtg_end_time:Date"
 
-  "NoGapFilll" should {
+  "NoGapFill" should {
 
     "correctly time bin features" in {
       val sftName = "tubetest2"

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeBuilder.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeBuilder.scala
@@ -161,7 +161,7 @@ class NoGapFill(tubeFeatures: SimpleFeatureCollection,
     val numFeatures = features.size
 
     if (numFeatures == 0) { Iterator.empty } else {
-      //If -1 is passed in then don't bin the features, if 0 then make one bin, otherwise calculate number
+      //If 0 is passed in then don't bin the features, if 1 then make one bin, otherwise calculate number
       //of bins based on numFeatures and maxBins
       val binSize = maxBins match {
         case 0 => 1

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeBuilder.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeBuilder.scala
@@ -251,7 +251,7 @@ class InterpolatedGapFill(tubeFeatures: SimpleFeatureCollection,
   override def createTube: Iterator[SimpleFeature] = {
     import org.locationtech.geomesa.utils.geotools.Conversions.RichGeometry
 
-    logger.debug("Creating tube with line gap fill")
+    logger.debug("Creating tube with line interpolated line gap fill")
 
     val transformed = transform(tubeFeatures, dtgField)
     val sortedTube = transformed.toSeq.sortBy { sf => getStartTime(sf).getTime }

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeBuilder.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeBuilder.scala
@@ -114,11 +114,17 @@ abstract class TubeBuilder(val tubeFeatures: SimpleFeatureCollection,
     * @return a dobule representing the intercept latitude
     */
   def calcIDLIntercept(point1: Coordinate, point2: Coordinate): Double = {
-    if (point2.x > point1.x) {
-      point2.y - (((point2.y - point1.y) / (point2.x-(-180 + point1.x))) * point2.x)
+    if (point1.x > 0) {
+      calcCrossLat(point1, point2, -180)
     } else {
-      point1.y - (((point1.y - point2.y) / (point1.x - (-180 + point2.x))) * point1.x)
+      calcCrossLat(point1, point2, 180)
     }
+  }
+
+  def calcCrossLat(point1: Coordinate, point2: Coordinate, crossLon: Double): Double = {
+    val slope = (point1.y - point2.y) / (point1.x - point2.x);
+    val intercept = point1.y - (slope * point1.y);
+    (slope * crossLon) + intercept;
   }
 
   /**

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeBuilder.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeBuilder.scala
@@ -97,6 +97,55 @@ abstract class TubeBuilder(val tubeFeatures: SimpleFeatureCollection,
     }
   }
 
+  /**
+    * This function checks if a segment crosses the IDL.
+    * @param point1 The first point in the segment
+    * @param point2 The second point in the segment
+    * @return boolean true if the segment crosses the IDL, otherwise false
+    */
+  def crossesIDL(point1:Coordinate,point2:Coordinate): Boolean = {
+    ((point1.x > 0 && point2.x < 0) || (point2.x > 0 && point1.x < 0))
+  }
+
+  /**
+    * Calculate the latitude at which the segment intercepts the IDL.
+    * @param point1 The first point in the segment
+    * @param point2 The second point in the segment
+    * @return a dobule representing the intercept latitude
+    */
+  def calcIDLIntercept(point1: Coordinate, point2: Coordinate): Double = {
+    if(point2.x > point1.x){
+      point2.y - (((point2.y-point1.y)/(point2.x-(-180+point1.x)))*point2.x)
+    }else {
+      point1.y - (((point1.y - point2.y) / (point1.x - (-180 + point2.x))) * point1.x)
+    }
+  }
+
+  /**
+    * Return an Array containing either 1 or 2 LineStrings that straddle but
+    * do not cross the IDL.
+    * @param input1 The first point in the segment
+    * @param input2 The second point in the segment
+    * @return an array of LineString containing either 1 or 2 LineStrings that do not
+    *         span the IDL.
+    */
+  def makeIDLSafeLineString(input1:Coordinate, input2:Coordinate): Geometry = {
+    //If the points cross the IDL we must generate two line segments
+    if(crossesIDL(input1, input2)){
+      //Find the latitude where the segment intercepts the IDL
+      val latIntercept = calcIDLIntercept(input1,input2)
+      val p1 = new Coordinate(-180,latIntercept)
+      val p2 = new Coordinate(180,latIntercept)
+      //This orders the points so that point1 is always the east-most point
+      val (point1, point2) = if(input1.x > 0) (input1, input2) else (input2, input1)
+      val westLine = new LineString(new CoordinateArraySequence(Array(p1, point2)), geoFac)
+      val eastLine = new LineString(new CoordinateArraySequence(Array(point1, p2)), geoFac)
+      new MultiLineString(Array[LineString](westLine,eastLine), geoFac)
+    }else{
+      new LineString(new CoordinateArraySequence(Array(input1, input2)), geoFac)
+    }
+  }
+
   def createTube: Iterator[SimpleFeature]
 }
 
@@ -110,11 +159,14 @@ class NoGapFill(tubeFeatures: SimpleFeatureCollection,
   // Bin ordered features into maxBins that retain order by date then union by geometry
   def timeBinAndUnion(features: Iterable[SimpleFeature], maxBins: Int): Iterator[SimpleFeature] = {
     val numFeatures = features.size
+
     if (numFeatures == 0) { Iterator.empty } else {
-      val binSize = if (maxBins > 0) {
-        numFeatures / maxBins + (if (numFeatures % maxBins == 0 ) 0 else 1)
-      } else {
-        numFeatures
+      //If -1 is passed in then don't bin the features, if 0 then make one bin, otherwise calculate number
+      //of bins based on numFeatures and maxBins
+      val binSize = maxBins match {
+        case 0 => 1
+        case 1 => numFeatures
+        case _ => numFeatures / maxBins + (if (numFeatures % maxBins == 0 ) 0 else 1)
       }
       features.grouped(binSize).zipWithIndex.map { case(bin, idx) => unionFeatures(bin.toSeq, idx.toString) }
     }
@@ -144,6 +196,9 @@ class NoGapFill(tubeFeatures: SimpleFeatureCollection,
   }
 }
 
+
+
+
 /**
  * Build a tube with gap filling that draws a line between time-ordered features
  * from the given tubeFeatures
@@ -164,21 +219,79 @@ class LineGapFill(tubeFeatures: SimpleFeatureCollection,
     val transformed = transform(tubeFeatures, dtgField)
     val sortedTube = transformed.toSeq.sortBy { sf => getStartTime(sf).getTime }
     val pointsAndTimes = sortedTube.map(sf => (getGeom(sf).safeCentroid(), getStartTime(sf)))
-
     val lineFeatures = if (pointsAndTimes.length == 1) {
       val (p1, t1) = pointsAndTimes.head
       logger.debug("Only a single result - can't create a line")
       Iterator(builder.buildFeature(nextId, Array(p1, t1, t1)))
     } else {
       pointsAndTimes.sliding(2).map { case Seq((p1, t1), (p2, t2)) =>
-        val geo = if (p1.equals(p2)) { p1 } else {
-          new LineString(new CoordinateArraySequence(Array(p1.getCoordinate, p2.getCoordinate)), geoFac)
-        }
-        logger.debug(s"Created line-filled geom: ${WKTUtils.write(geo)} from ${WKTUtils.write(p1)} and ${WKTUtils.write(p2)}")
+        val geo = if(p1.equals(p2)) p1 else makeIDLSafeLineString(p1.getCoordinate,p2.getCoordinate)
+        logger.debug(s"Created Line-filled Geometry: ${WKTUtils.write(geo)} From ${WKTUtils.write(p1)} and ${WKTUtils.write(p2)}")
         builder.buildFeature(nextId, Array(geo, t1, t2))
       }
     }
+    buffer(lineFeatures, bufferDistance)
+  }
+}
 
+/**
+  * Class to create an interpolated line-gap filled tube
+  * @param tubeFeatures
+  * @param bufferDistance
+  * @param maxBins
+  */
+class InterpolatedGapFill(tubeFeatures: SimpleFeatureCollection,
+                  bufferDistance: Double,
+                  maxBins: Int) extends TubeBuilder(tubeFeatures, bufferDistance, maxBins) with LazyLogging {
+
+  val id = new AtomicInteger(0)
+
+  def nextId: String = id.getAndIncrement.toString
+
+  override def createTube: Iterator[SimpleFeature] = {
+    import org.locationtech.geomesa.utils.geotools.Conversions.RichGeometry
+
+    logger.debug("Creating tube with line gap fill")
+
+    val transformed = transform(tubeFeatures, dtgField)
+    val sortedTube = transformed.toSeq.sortBy { sf => getStartTime(sf).getTime }
+    val pointsAndTimes = sortedTube.map(sf => (getGeom(sf).safeCentroid(), getStartTime(sf)))
+    val lineFeatures = if (pointsAndTimes.length == 1) {
+      val (p1, t1) = pointsAndTimes.head
+      logger.debug("Only a single result - can't create a line")
+      Iterator(builder.buildFeature(nextId, Array(p1, t1, t1)))
+    } else {
+      pointsAndTimes.sliding(2).flatMap { case Seq((p1, t1), (p2, t2)) =>
+        calc.setStartingGeographicPoint(p1.getX, p1.getY)
+        calc.setDestinationGeographicPoint(p2.getX, p2.getY)
+        val dist = calc.getOrthodromicDistance
+        //If the distance between points is greater than the buffer distance, segment the line
+        //So that no segment is larger than the buffer. This ensures that each segment has an
+        //times and distance.
+        if (dist > bufferDistance) {
+          val heading = calc.getAzimuth
+          val timeDiffMillis = (t2.toInstant.toEpochMilli - t1.toInstant.toEpochMilli)
+          val segCount = (dist / bufferDistance).toInt
+          val segDuration = timeDiffMillis / segCount
+          var segStep = new Coordinate(p1.getX, p1.getY, 0)
+          val segPoints = (t1.toInstant.toEpochMilli to t2.toInstant.toEpochMilli).by(segDuration).sliding(2).map { times =>
+            val segP1 = segStep
+            calc.setStartingGeographicPoint(segP1.x, segP1.y)
+            calc.setDirection(heading, bufferDistance)
+            val destPoint = calc.getDestinationGeographicPoint
+            segStep = new Coordinate(destPoint.getX, destPoint.getY, 0)
+            (makeIDLSafeLineString(segP1, segStep), times)
+          }.toList
+          segPoints.map { case (geo, times) =>
+            builder.buildFeature(nextId, Array(geo, new Date(times(0)), new Date(times(1))))
+          }
+        } else {
+          val geo = if (p1.equals(p2)) p1 else makeIDLSafeLineString(p1.getCoordinate, p2.getCoordinate)
+          logger.debug(s"Created Line-filled Geometry: ${WKTUtils.write(geo)} From ${WKTUtils.write(p1)} and ${WKTUtils.write(p2)}")
+          Seq(builder.buildFeature(nextId, Array(geo, t1, t2)))
+        }
+      }
+    }
     buffer(lineFeatures, bufferDistance)
   }
 }

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeSelectProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeSelectProcess.scala
@@ -108,6 +108,7 @@ object GapFill extends Enumeration{
   type GapFill = Value
   val NOFILL = Value("nofill")
   val LINE = Value("line")
+  val INTERPOLATED = Value("interpolated")
 }
 
 class TubeVisitor(val tubeFeatures: SimpleFeatureCollection,
@@ -144,6 +145,7 @@ class TubeVisitor(val tubeFeatures: SimpleFeatureCollection,
 
     val tubeBuilder = gapFill match {
       case GapFill.LINE => new LineGapFill(tubeFeatures, bufferDistance, maxBins)
+      case GapFill.INTERPOLATED => new InterpolatedGapFill(tubeFeatures, bufferDistance, maxBins)
       case _ => new NoGapFill(tubeFeatures, bufferDistance, maxBins)
     }
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeometryUtils.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeometryUtils.scala
@@ -105,4 +105,41 @@ object GeometryUtils {
   // checks that there aren't any angled lines
   private def allRightAngles(p: Polygon): Boolean =
     p.getCoordinates.sliding(2).forall { case Array(left, right) => left.x == right.x || left.y == right.y }
+
+  /**
+    * This function checks if a segment crosses the IDL.
+    * @param point1 The first point in the segment
+    * @param point2 The second point in the segment
+    * @return boolean true if the segment crosses the IDL, otherwise false
+    */
+  def crossesIDL(point1:Coordinate, point2:Coordinate): Boolean = {
+    Math.abs(point1.x - point2.x) >= 180
+  }
+
+  /**
+    * Calculate the latitude at which the segment intercepts the IDL.
+    * @param point1 The first point in the segment
+    * @param point2 The second point in the segment
+    * @return a double representing the intercept latitude
+    */
+  def calcIDLIntercept(point1: Coordinate, point2: Coordinate): Double = {
+    if (point1.x > 0) {
+      calcCrossLat(point1, point2, -180)
+    } else {
+      calcCrossLat(point1, point2, 180)
+    }
+  }
+
+  /**
+    * Calculate the latitude at which a segment intercepts a given latitude.
+    * @param point1 The first point in the segment
+    * @param point2 The second point in the segment
+    * @param crossLon The longitude of intercept
+    * @return a double representing the intercept latitude
+    */
+  def calcCrossLat(point1: Coordinate, point2: Coordinate, crossLon: Double): Double = {
+    val slope = (point1.y - point2.y) / (point1.x - point2.x);
+    val intercept = point1.y - (slope * point1.y);
+    (slope * crossLon) + intercept;
+  }
 }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeometryUtils.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeometryUtils.scala
@@ -125,9 +125,9 @@ object GeometryUtils {
     */
   def calcIDLIntercept(point1: Coordinate, point2: Coordinate): Double = {
     if (point1.x < 0) {
-      calcCrossLat(point1, new Coordinate(point2.x-360,point2.y) , -180)
+      calcCrossLat(point1, new Coordinate(point2.x - 360, point2.y), -180)
     } else {
-      calcCrossLat(point1, new Coordinate(point2.x+360,point2.y) , 180)
+      calcCrossLat(point1, new Coordinate(point2.x + 360, point2.y), 180)
     }
   }
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeometryUtils.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeometryUtils.scala
@@ -118,15 +118,16 @@ object GeometryUtils {
 
   /**
     * Calculate the latitude at which the segment intercepts the IDL.
+    * This function assumes that the provided points do actually cross the IDL.
     * @param point1 The first point in the segment
     * @param point2 The second point in the segment
     * @return a double representing the intercept latitude
     */
   def calcIDLIntercept(point1: Coordinate, point2: Coordinate): Double = {
-    if (point1.x > 0) {
-      calcCrossLat(point1, point2, -180)
+    if (point1.x < 0) {
+      calcCrossLat(point1, new Coordinate(point2.x-360,point2.y) , -180)
     } else {
-      calcCrossLat(point1, point2, 180)
+      calcCrossLat(point1, new Coordinate(point2.x+360,point2.y) , 180)
     }
   }
 
@@ -139,7 +140,7 @@ object GeometryUtils {
     */
   def calcCrossLat(point1: Coordinate, point2: Coordinate, crossLon: Double): Double = {
     val slope = (point1.y - point2.y) / (point1.x - point2.x);
-    val intercept = point1.y - (slope * point1.y);
+    val intercept = point1.y - (slope * point1.x);
     (slope * crossLon) + intercept;
   }
 }

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GeometryUtilsTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GeometryUtilsTest.scala
@@ -11,15 +11,15 @@ class GeometryUtilsTest extends Specification {
   "Geometry Utils" should {
 
     "calculate intercept of anti-meridian" >> {
-      val p1 = new Coordinate(179,5,0)
-      val p2 = new Coordinate(-179,7,0)
-      (GeometryUtils.calcIDLIntercept(p1,p2).toInt, GeometryUtils.calcIDLIntercept(p2,p1).toInt) mustEqual (6, 6)
+      val p1 = new Coordinate(179, 5, 0)
+      val p2 = new Coordinate(-179, 7, 0)
+      (GeometryUtils.calcIDLIntercept(p1, p2).toInt, GeometryUtils.calcIDLIntercept(p2,p1).toInt) mustEqual (6, 6)
     }
 
     "calculate intercept of arbitrary longitude" >> {
-      val p1 = new Coordinate(170,5,0)
-      val p2 = new Coordinate(172,7,0)
-      (GeometryUtils.calcCrossLat(p1,p2,171).toInt, GeometryUtils.calcCrossLat(p2,p1,171).toInt) mustEqual (6, 6)
+      val p1 = new Coordinate(170, 5, 0)
+      val p2 = new Coordinate(172, 7, 0)
+      (GeometryUtils.calcCrossLat(p1, p2, 171).toInt, GeometryUtils.calcCrossLat(p2, p1, 171).toInt) mustEqual (6, 6)
     }
 
   }

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GeometryUtilsTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GeometryUtilsTest.scala
@@ -1,3 +1,11 @@
+/***********************************************************************
+ * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
 package org.locationtech.geomesa.utils.geotools
 
 import com.vividsolutions.jts.geom.Coordinate

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GeometryUtilsTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GeometryUtilsTest.scala
@@ -1,0 +1,26 @@
+package org.locationtech.geomesa.utils.geotools
+
+import com.vividsolutions.jts.geom.Coordinate
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class GeometryUtilsTest extends Specification {
+
+  "Geometry Utils" should {
+
+    "calculate intercept of anti-meridian" >> {
+      val p1 = new Coordinate(179,5,0)
+      val p2 = new Coordinate(-179,7,0)
+      (GeometryUtils.calcIDLIntercept(p1,p2).toInt, GeometryUtils.calcIDLIntercept(p2,p1).toInt) mustEqual (6, 6)
+    }
+
+    "calculate intercept of arbitrary longitude" >> {
+      val p1 = new Coordinate(170,5,0)
+      val p2 = new Coordinate(172,7,0)
+      (GeometryUtils.calcCrossLat(p1,p2,171).toInt, GeometryUtils.calcCrossLat(p2,p1,171).toInt) mustEqual (6, 6)
+    }
+
+  }
+}


### PR DESCRIPTION
This PR combines changes from the previous PR#1659 as well as the following updates:
GEOMESA-1986 TubeSelect Modified to Properly Handle IDL by segmenting lines crossing the IDL into two lines with proper times that stop at the IDL.
GEOMESA-1987 Fixed binning behavior to be more intuitive. If maxBins is 0 then don't bin the features, if 1 then make one bin, otherwise calculate number of bins based on numFeatures and maxBins
GEOMESA-1993 Added an interpolated gap fill which divides longer gaps into smaller space time interpolated segments based on the passed in buffer size.
