### PR TITLE
1.3 - GEOMESA-2013 Buffering heatmap image generation to avoid edge effects

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloQueryPlanner.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloQueryPlanner.scala
@@ -8,21 +8,15 @@
 
 package org.locationtech.geomesa.accumulo.index
 
-import org.geotools.data.Query
 import org.geotools.factory.Hints
-import org.geotools.geometry.jts.ReferencedEnvelope
 import org.locationtech.geomesa.accumulo.AccumuloQueryPlannerType
 import org.locationtech.geomesa.accumulo.data._
 import org.locationtech.geomesa.accumulo.iterators._
-import org.locationtech.geomesa.filter._
-import org.locationtech.geomesa.utils.bin.BinaryOutputEncoder
 import org.locationtech.geomesa.index.iterators.DensityScan
 import org.locationtech.geomesa.index.utils.KryoLazyStatsUtils
+import org.locationtech.geomesa.utils.bin.BinaryOutputEncoder
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.SimpleFeatureType
-import org.opengis.filter.Filter
-import org.opengis.filter.spatial.BBOX
-import org.opengis.geometry.BoundingBox
 
 /**
  * Executes a query against geomesa
@@ -30,31 +24,6 @@ import org.opengis.geometry.BoundingBox
 class AccumuloQueryPlanner(ds: AccumuloDataStore) extends AccumuloQueryPlannerType(ds) {
 
   import org.locationtech.geomesa.index.conf.QueryHints.RichHints
-
-  override protected [geomesa] def configureQuery(sft: SimpleFeatureType, original: Query): Query = {
-    val query = super.configureQuery(sft, original)
-    // add the bbox from the density query to the filter
-    if (query.getHints.isDensityQuery) {
-      val env = query.getHints.getDensityEnvelope.get.asInstanceOf[ReferencedEnvelope]
-      val bbox = ff.bbox(ff.property(sft.getGeometryDescriptor.getLocalName), env)
-      if (query.getFilter == Filter.INCLUDE) {
-        query.setFilter(bbox)
-      } else {
-        // add the bbox - try to not duplicate an existing bbox
-        def compareDbls(d1: Double, d2: Double): Boolean = math.abs(d1 - d2) < 0.0001 // our precision
-        def compare(b1: BoundingBox, b2: BoundingBox): Boolean = {
-          compareDbls(b1.getMinX, b2.getMinX) && compareDbls(b1.getMaxX, b2.getMaxX) &&
-              compareDbls(b1.getMinY, b2.getMinY) && compareDbls(b1.getMaxY, b2.getMaxY)
-        }
-        val filters = decomposeAnd(query.getFilter).filter {
-          case b: BBOX if compare(b.getBounds, bbox.getBounds) => false
-          case _ => true
-        }
-        query.setFilter(andFilters(filters ++ Seq(bbox)))
-      }
-    }
-    query
-  }
 
   // This function calculates the SimpleFeatureType of the returned SFs.
   override protected [geomesa] def getReturnSft(sft: SimpleFeatureType, hints: Hints): SimpleFeatureType = {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/DensityIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/DensityIteratorTest.scala
@@ -81,7 +81,7 @@ class DensityIteratorTest extends Specification with TestWithMultipleSfts {
         ok
       }
 
-      "with st index" >> {
+      "with spatial index" >> {
         val q = "BBOX(geom, -1, 33, 6, 40)"
         val density = getDensity(sft.getTypeName, q)
 
@@ -93,7 +93,7 @@ class DensityIteratorTest extends Specification with TestWithMultipleSfts {
         forall(compiled)(_ mustEqual 30)
       }
 
-      "with z3 index" >> {
+      "with spatio-temporal index" >> {
         val q = "BBOX(geom, -1, 33, 6, 40) AND " +
             "dtg between '2012-01-01T18:00:00.000Z' AND '2012-01-01T23:00:00.000Z'"
         val density = getDensity(sft.getTypeName, q)
@@ -136,17 +136,17 @@ class DensityIteratorTest extends Specification with TestWithMultipleSfts {
         ok
       }
 
-      "with st index" >> {
+      "with spatial index" >> {
         val q = "BBOX(geom, -78.598118, 37.992204, -78.337364, 38.091238)"
         val density = getDensity(sft.getTypeName, q)
         density.map(_._3).sum must beGreaterThan(0.0)
       }
 
-      "with z3 index" >> {
+      "with spatio-temporal index" >> {
         val q = "BBOX(geom, -78.598118, 37.992204, -78.337364, 38.091238) AND " +
             "dtg between '2012-01-01T18:00:00.000Z' AND '2012-01-01T23:00:00.000Z'"
         val density = getDensity(sft.getTypeName, q)
-        density.map(_._3).sum must beCloseTo(15.0, 0.1)
+        density.map(_._3).sum must beGreaterThan(0.0)
       }
     }
 
@@ -167,17 +167,17 @@ class DensityIteratorTest extends Specification with TestWithMultipleSfts {
         ok
       }
 
-      "with st index" >> {
+      "with spatial index" >> {
         val q = "BBOX(geom, -78.511236, 38.019947, -78.485830, 38.030265)"
         val density = getDensity(sft.getTypeName, q)
-        density.map(_._3).sum must beCloseTo(15.0, 0.1)
+        density.map(_._3).sum must beGreaterThan(0.0)
       }
 
-      "with z3 index" >> {
+      "with spatio-temporal index" >> {
         val q = "BBOX(geom, -78.511236, 38.019947, -78.485830, 38.030265) AND " +
             "dtg between '2012-01-01T18:00:00.000Z' AND '2012-01-01T23:00:00.000Z'"
         val density = getDensity(sft.getTypeName, q)
-        density.map(_._3).sum must beCloseTo(15.0, 0.1)
+        density.map(_._3).sum must beGreaterThan(0.0)
       }
     }
 
@@ -198,17 +198,17 @@ class DensityIteratorTest extends Specification with TestWithMultipleSfts {
         ok
       }
 
-      "with st index" >> {
+      "with spatial index" >> {
         val q = "BBOX(geom, -78.511236, 38.019947, -78.485830, 38.030265)"
         val density = getDensity(sft.getTypeName, q)
         density.map(_._3).sum must beGreaterThan(0.0)
       }
 
-      "with z3 index" >> {
+      "with spatio-temporal index" >> {
         val q = "BBOX(geom, -78.511236, 38.019947, -78.485830, 38.030265) AND " +
             "dtg between '2012-01-01T18:00:00.000Z' AND '2012-01-01T23:00:00.000Z'"
         val density = getDensity(sft.getTypeName, q)
-        density.map(_._3).sum must beCloseTo(15.0, 0.1)
+        density.map(_._3).sum must beGreaterThan(0.0)
       }
     }
 
@@ -229,17 +229,17 @@ class DensityIteratorTest extends Specification with TestWithMultipleSfts {
         ok
       }
 
-      "with st index" >> {
+      "with spatial index" >> {
         val q = "BBOX(geom, -78.541236, 38.019947, -78.485830, 38.060265)"
         val density = getDensity(sft.getTypeName, q)
         density.map(_._3).sum must beGreaterThan(0.0)
       }
 
-      "with z3 index" >> {
+      "with spatio-temporal index" >> {
         val q = "BBOX(geom, -78.511236, 38.019947, -78.485830, 38.030265) AND " +
           "dtg between '2012-01-01T18:00:00.000Z' AND '2012-01-01T23:00:00.000Z'"
         val density = getDensity(sft.getTypeName, q)
-        density.map(_._3).sum must beCloseTo(15.0, 0.1)
+        density.map(_._3).sum must beGreaterThan(0.0)
       }
     }
 
@@ -260,17 +260,17 @@ class DensityIteratorTest extends Specification with TestWithMultipleSfts {
         ok
       }
 
-      "with st index" >> {
+      "with spatial index" >> {
         val q = "BBOX(geom, 0.0, 0.0, 10.0, 10.0)"
         val density = getDensity(sft.getTypeName, q)
         density.map(_._3).sum must beGreaterThan(0.0)
       }
 
-      "with z3 index" >> {
+      "with spatio-temporal index" >> {
         val q = "BBOX(geom, -1.0, -1.0, 11.0, 11.0) AND " +
             "dtg between '2012-01-01T18:00:00.000Z' AND '2012-01-01T23:00:00.000Z'"
         val density = getDensity(sft.getTypeName, q)
-        density.map(_._3).sum must beCloseTo(15.0, 0.1)
+        density.map(_._3).sum must beGreaterThan(0.0)
       }
     }
 
@@ -291,17 +291,17 @@ class DensityIteratorTest extends Specification with TestWithMultipleSfts {
         ok
       }
 
-      "with st index" >> {
+      "with spatial index" >> {
         val q = "BBOX(geom, 0.0, 0.0, 10.0, 10.0)"
         val density = getDensity(sft.getTypeName, q)
         density.map(_._3).sum must beGreaterThan(0.0)
       }
 
-      "with z3 index" >> {
+      "with spatio-temporal index" >> {
         val q = "BBOX(geom, -1.0, -1.0, 11.0, 11.0) AND " +
             "dtg between '2012-01-01T18:00:00.000Z' AND '2012-01-01T23:00:00.000Z'"
         val density = getDensity(sft.getTypeName, q)
-        density.map(_._3).sum must beCloseTo(15.0, 0.1)
+        density.map(_._3).sum must beGreaterThan(0.0)
       }
     }
   }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GridSnap.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GridSnap.scala
@@ -9,21 +9,24 @@
 
 package org.locationtech.geomesa.utils.geotools
 
-import com.vividsolutions.jts.geom.{Coordinate, Envelope}
-import org.geotools.data.simple.SimpleFeatureSource
-import org.geotools.geometry.jts.ReferencedEnvelope
-import org.geotools.grid.DefaultGridFeatureBuilder
-import org.geotools.grid.oblong.Oblongs
-import org.geotools.referencing.crs.DefaultGeographicCRS
+import com.vividsolutions.jts.geom.{Envelope, Geometry}
 
 import scala.math.abs
 
 class GridSnap(env: Envelope, xSize: Int, ySize: Int) {
 
-  val dx = BigDecimal.apply(env.getWidth)  / xSize
-  val dy = BigDecimal.apply(env.getHeight) / ySize
-  val xOffset = env.getMinX + dx / 2 // offset by half dx to get to center of grid cell
-  val yOffset = env.getMinY + dy / 2 // offset by half dy to get to center of grid cell
+  lazy val envelope: Geometry = GeometryUtils.geoFactory.toGeometry(env)
+
+  private val xMin = env.getMinX
+  private val xMax = env.getMaxX
+  private val yMin = env.getMinY
+  private val yMax = env.getMaxY
+
+  private val dx = (xMax - xMin) / xSize
+  private val dy = (yMax - yMin) / ySize
+
+  private val xOffset = xMin + dx / 2 // offset by half dx to get to center of grid cell
+  private val yOffset = yMin + dy / 2 // offset by half dy to get to center of grid cell
 
   /**
    * Computes the X ordinate of the i'th grid column.
@@ -31,10 +34,7 @@ class GridSnap(env: Envelope, xSize: Int, ySize: Int) {
    * @param i the index of a grid column
    * @return the X ordinate of the column
    */
-  def x(i: Int): Double = {
-    val iInBounds = if (i < 0) 0 else if (i > xSize - 1) xSize - 1 else i
-    (xOffset + iInBounds * dx).toDouble
-  }
+  def x(i: Int): Double = xOffset + dx * i
 
   /**
    * Computes the Y ordinate of the i'th grid row.
@@ -42,10 +42,7 @@ class GridSnap(env: Envelope, xSize: Int, ySize: Int) {
    * @param j the index of a grid row
    * @return the Y ordinate of the row
    */
-  def y(j: Int): Double = {
-    val jInBounds = if (j < 0) 0 else if (j > ySize - 1) ySize - 1 else j
-    (yOffset + jInBounds * dy).toDouble
-  }
+  def y(j: Int): Double = yOffset + dy * j
 
   /**
    * Computes the column index of an X ordinate.
@@ -53,14 +50,13 @@ class GridSnap(env: Envelope, xSize: Int, ySize: Int) {
    * @param x the X ordinate
    * @return the column index
    */
-  def i(x: Double): Int =
-    if (x >= env.getMaxX) {
-      xSize - 1
-    } else if (x <= env.getMinX) {
-      0
-    } else {
-      math.min(((x - env.getMinX) / dx).toInt, xSize - 1)
+  def i(x: Double): Int = {
+    if (x < xMin || x > xMax) { -1 } else {
+      val i = math.floor((x - xMin) / dx).toInt
+      // i == length check catches the upper bound
+      if (i < 0 || i > xSize) { -1 } else if (i == xSize) { xSize - 1 } else { i }
     }
+  }
 
   /**
    * Computes the column index of an Y ordinate.
@@ -68,56 +64,57 @@ class GridSnap(env: Envelope, xSize: Int, ySize: Int) {
    * @param y the Y ordinate
    * @return the column index
    */
-  def j(y: Double): Int =
-    if (y >= env.getMaxY)  {
-      ySize - 1
-    } else if (y <= env.getMinY)  {
-      0
-    } else {
-      math.min(((y - env.getMinY) / dy).toInt, ySize - 1)
+  def j(y: Double): Int = {
+    if (y < yMin || y > yMax) { -1 } else {
+      val i = math.floor((y - yMin) / dy).toInt
+      // i == length check catches the upper bound
+      if (i < 0 || i > ySize) { -1 } else if (i == ySize) { ySize - 1 } else { i }
     }
+  }
 
   def snap(x: Double, y: Double): (Double, Double) = (this.x(i(x)), this.y(j(y)))
 
-  /** Generate a Sequence of Coordinates between two given Snap Coordinates using Bresenham's Line Algorithm */
-  def genBresenhamCoordList(x0: Int, y0: Int, x1: Int, y1: Int): List[Coordinate] = {
-    val ( deltaX, deltaY ) = (abs(x1 - x0), abs(y1 - y0))
-    if ((deltaX == 0) && (deltaY == 0)) List[Coordinate]()
-    else {
-      val ( stepX, stepY ) = (if (x0 < x1) 1 else -1, if (y0 < y1) 1 else -1)
-      val (fX, fY) =  ( stepX * x1, stepY * y1 )
-      def iter = new Iterator[Coordinate] {
-        var (xT, yT) = (x0, y0)
-        var error = (if (deltaX > deltaY) deltaX else -deltaY) / 2
-        def next() = {
-          val errorT = error
-          if(errorT > -deltaX){ error -= deltaY; xT += stepX }
-          if(errorT < deltaY){ error += deltaX; yT += stepY }
-          new Coordinate(x(xT), y(yT))
-        }
-        def hasNext = stepX * xT <= fX && stepY * yT <= fY
+  /**
+    * Generate a sequence of snapped points between two given snapped coordinates using Bresenham's Line Algorithm.
+    * Will not return any duplicate points, and will always include the start and end points
+    *
+    * @param x0 x0
+    * @param y0 y0
+    * @param x1 x1
+    * @param y1 y1
+    * @return
+    */
+  def bresenhamLine(x0: Int, y0: Int, x1: Int, y1: Int): Iterator[(Int, Int)] = {
+    val deltaX = abs(x1 - x0)
+    val deltaY = abs(y1 - y0)
+    if (deltaX == 0 && deltaY == 0) { Iterator.single((x0, y0)) } else {
+      val stepX = if (x0 < x1) { 1 } else { -1 }
+      val stepY = if (y0 < y1) { 1 } else { -1 }
+      if (deltaX > deltaY) {
+        val deltaError = deltaY.toDouble / deltaX
+        var error = 0d
+        Iterator.iterate((x0, y0)) { case (x, y) =>
+          error += deltaError
+          if (error >= 0.5) {
+            error -= 1d
+            (x + stepX, y + stepY)
+          } else {
+            (x + stepX, y)
+          }
+        }.take(deltaX)
+      } else {
+        val deltaError = deltaX.toDouble / deltaY
+        var error = 0d
+        Iterator.iterate((x0, y0)) { case (x, y) =>
+          error += deltaError
+          if (error >= 0.5) {
+            error -= 1d
+            (x + stepX, y + stepY)
+          } else {
+            (x, y + stepY)
+          }
+        }.take(deltaY)
       }
-      iter.toList.dropRight(1).distinct
     }
-  }
-
-  /** Generate a Set of Coordinates between two given Snap Coordinates which includes both start and end points*/
-  def generateLineCoordSet(coordOne: Coordinate, coordTwo: Coordinate): Set[Coordinate] = {
-    genBresenhamCoordList(i(coordOne.x), j(coordOne.y), i(coordTwo.x), j(coordTwo.y)).toSet + coordOne + coordTwo
-  }
-
-  /** Generate an ordered List of Coordinates between two given Snap Coordinates which includes both start and end points*/
-  def generateLineCoordList(coordOne: Coordinate, coordTwo: Coordinate): List[Coordinate] = {
-    (coordOne +: genBresenhamCoordList(i(coordOne.x), j(coordOne.y), i(coordTwo.x), j(coordTwo.y)) :+ coordTwo).distinct
-  }
-
-  /** return a SimpleFeatureSource grid the same size and extent as the bbox */
-  lazy val generateCoverageGrid: SimpleFeatureSource = {
-    val dxt = env.getWidth / xSize
-    val dyt = env.getHeight / ySize
-    val gridBounds = new ReferencedEnvelope(env.getMinX, env.getMaxX, env.getMinY, env.getMaxY, DefaultGeographicCRS.WGS84)
-    val gridBuilder = new DefaultGridFeatureBuilder()
-    val grid = Oblongs.createGrid(gridBounds, dxt, dyt, gridBuilder)
-    grid
   }
 }

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GridSnapTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GridSnapTest.scala
@@ -12,7 +12,6 @@ package org.locationtech.geomesa.utils.geotools
 import com.typesafe.scalalogging.LazyLogging
 import com.vividsolutions.jts.geom._
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -70,42 +69,30 @@ class GridSnapTest extends Specification with LazyLogging {
       val bbox = new Envelope(0.0, 10.0, 0.0, 10.0)
       val gridSnap = new GridSnap(bbox, 100, 10)
 
-      gridSnap.i(-1.0) mustEqual 0
-      gridSnap.j(-1.0) mustEqual 0
+      gridSnap.i(-1.0) mustEqual -1
+      gridSnap.j(-1.0) mustEqual -1
 
-      gridSnap.i(11.0) mustEqual 99
-      gridSnap.j(11.0) mustEqual 9
-    }
-
-    "compute a SimpleFeatureSource Grid over the bbox" in {
-      val bbox = new Envelope(0.0, 10.0, 0.0, 10.0)
-      val gridSnap = new GridSnap(bbox, 10, 10)
-
-      val grid = gridSnap.generateCoverageGrid
-
-      grid must not(beNull)
-
-      val featureIterator = SelfClosingIterator(grid.getFeatures.features)
-      featureIterator must haveLength(100)
+      gridSnap.i(11.0) mustEqual -1
+      gridSnap.j(11.0) mustEqual -1
     }
 
     "compute a sequence of points between various sets of coordinates" in {
       val bbox = new Envelope(0.0, 10.0, 0.0, 10.0)
       val gridSnap = new GridSnap(bbox, 10, 10)
 
-      val resultDiagonal = gridSnap.genBresenhamCoordList(0, 0, 9, 9)
+      val resultDiagonal = gridSnap.bresenhamLine(0, 0, 9, 9)
       resultDiagonal must haveLength(9)
 
-      val resultVertical = gridSnap.genBresenhamCoordList(0, 0, 0, 9)
+      val resultVertical = gridSnap.bresenhamLine(0, 0, 0, 9)
       resultVertical must haveLength(9)
 
-      val resultHorizontal = gridSnap.genBresenhamCoordList(0, 0, 9, 0)
+      val resultHorizontal = gridSnap.bresenhamLine(0, 0, 9, 0)
       resultHorizontal must haveLength(9)
 
-      val resultSamePoint = gridSnap.genBresenhamCoordList(0, 0, 0, 0)
-      resultSamePoint must haveLength(0)
+      val resultSamePoint = gridSnap.bresenhamLine(0, 0, 0, 0)
+      resultSamePoint must haveLength(1)
 
-      val resultInverse = gridSnap.genBresenhamCoordList(9, 9, 0, 0)
+      val resultInverse = gridSnap.bresenhamLine(9, 9, 0, 0)
       resultInverse must haveLength(9)
     }
 


### PR DESCRIPTION
* Discarding grid snap points outside the image envelope, instead of moving to the nearest edge
* Using approximated raster instead of centroid for geometries with extents

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>