### PR TITLE
1.3 - GEOMESA-1910 Compactions for Parquet FSDS

### DIFF
--- a/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/FileSystemFeatureStore.scala
+++ b/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/FileSystemFeatureStore.scala
@@ -70,7 +70,7 @@ class FileSystemFeatureStore(entry: ContentEntry,
         try {
           storage.updateMetadata(typeName)
         } catch {
-          case e: Throwable => logger.error(s"Error updating metadata for type $typeName")
+          case e: Throwable => logger.error(s"Error updating metadata for type $typeName", e)
         }
       }
     }

--- a/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
+++ b/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
@@ -113,4 +113,7 @@ class ConverterStorage(root: Path,
   override def updateMetadata(typeName: String): Unit =
     throw new UnsupportedOperationException("Cannot append to converter datastore")
 
+  override def compact(typeName: String, partition: String): Unit =
+    throw new UnsupportedOperationException("Converter datastore does not support compactions")
+
 }

--- a/geomesa-fs/geomesa-fs-datastore/src/test/scala/org/locationtech/geomesa/fs/BucketVsLeafStorageTest.scala
+++ b/geomesa-fs/geomesa-fs-datastore/src/test/scala/org/locationtech/geomesa/fs/BucketVsLeafStorageTest.scala
@@ -10,6 +10,8 @@ package org.locationtech.geomesa.fs
 
 import java.nio.file.Files
 import java.time.temporal.ChronoUnit
+import java.util
+import java.util.stream.Collectors
 
 import com.vividsolutions.jts.geom.Coordinate
 import org.apache.commons.io.FileUtils
@@ -78,11 +80,10 @@ class BucketVsLeafStorageTest extends Specification {
         fp.resolve("2016/01").toFile.exists must beTrue
 
         Seq(
-          "2016/01/01_0000.parquet",
-          "2016/01/02_0000.parquet"
-        ).forall { f =>
-          val p = fp.resolve(f)
-          p.toFile.exists() must beTrue
+          "2016/01/01_W[0-9a-f]{32}\\.parquet",
+          "2016/01/02_W[0-9a-f]{32}\\.parquet"
+        ).map(fp.toString + "/" + _).forall { f =>
+          Files.walk(fp).collect(Collectors.toList()).count(_.toString.matches(f)) mustEqual 1
         }
         toList(ds.getFeatureSource(sft.getTypeName).getFeatures.features).size mustEqual 2
 
@@ -90,13 +91,12 @@ class BucketVsLeafStorageTest extends Specification {
           .addFeatures(new ListFeatureCollection(sft, features(sft).drop(2)))
 
         Seq(
-          "2016/01/01_0000.parquet",
-          "2016/01/02_0000.parquet",
-          "2016/01/03_0000.parquet",
-          "2016/01/04_0000.parquet"
-        ).forall { f =>
-          val p = fp.resolve(f)
-          p.toFile.exists() must beTrue
+          "2016/01/01_W[0-9a-f]{32}\\.parquet",
+          "2016/01/02_W[0-9a-f]{32}\\.parquet",
+          "2016/01/03_W[0-9a-f]{32}\\.parquet",
+          "2016/01/04_W[0-9a-f]{32}\\.parquet"
+        ).map(fp.toString + "/" + _).forall { f =>
+          Files.walk(fp).collect(Collectors.toList()).count(_.toString.matches(f)) mustEqual 1
         }
         CloseableIterator(ds.getFeatureSource(sft.getTypeName).getFeatures.features).toSeq.size mustEqual 4
 
@@ -105,17 +105,12 @@ class BucketVsLeafStorageTest extends Specification {
         ds.getFeatureSource(sft.getTypeName).asInstanceOf[SimpleFeatureStore]
           .addFeatures(new ListFeatureCollection(sft, features(sft)))
         Seq(
-          "2016/01/01_0000.parquet",
-          "2016/01/02_0000.parquet",
-          "2016/01/03_0000.parquet",
-          "2016/01/04_0000.parquet",
-          "2016/01/01_0001.parquet",
-          "2016/01/02_0001.parquet",
-          "2016/01/03_0001.parquet",
-          "2016/01/04_0001.parquet"
-        ).forall { f =>
-          val p = fp.resolve(f)
-          p.toFile.exists() must beTrue
+          "2016/01/01_W[0-9a-f]{32}\\.parquet",
+          "2016/01/02_W[0-9a-f]{32}\\.parquet",
+          "2016/01/03_W[0-9a-f]{32}\\.parquet",
+          "2016/01/04_W[0-9a-f]{32}\\.parquet"
+        ).map(fp.toString + "/" + _).forall { f =>
+          Files.walk(fp).collect(Collectors.toList()).count(_.toString.matches(f)) mustEqual 2
         }
         CloseableIterator(ds.getFeatureSource(sft.getTypeName).getFeatures.features).toSeq.size mustEqual 8
 
@@ -137,13 +132,12 @@ class BucketVsLeafStorageTest extends Specification {
         fp.toFile.exists must beTrue
 
         Seq(
-          "2016/01/01/2_0000.parquet",
-          "2016/01/02/3_0000.parquet",
-          "2016/01/03/1_0000.parquet",
-          "2016/01/04/0_0000.parquet"
-        ).forall { f =>
-          val p = fp.resolve(f)
-          p.toFile.exists() must beTrue
+          "2016/01/01/2_W[0-9a-f]{32}\\.parquet",
+          "2016/01/02/3_W[0-9a-f]{32}\\.parquet",
+          "2016/01/03/1_W[0-9a-f]{32}\\.parquet",
+          "2016/01/04/0_W[0-9a-f]{32}\\.parquet"
+        ).map(fp.toString + "/" + _).forall { f =>
+          Files.walk(fp).collect(Collectors.toList()).count(x => x.toString.matches(f)) mustEqual 1
         }
         CloseableIterator(ds.getFeatureSource(sft.getTypeName).getFeatures.features).toList.size mustEqual 4
         // For now adding more features results in a next seq file
@@ -151,17 +145,12 @@ class BucketVsLeafStorageTest extends Specification {
           .addFeatures(new ListFeatureCollection(sft, features(sft)))
 
         Seq(
-          "2016/01/01/2_0000.parquet",
-          "2016/01/02/3_0000.parquet",
-          "2016/01/03/1_0000.parquet",
-          "2016/01/04/0_0000.parquet",
-          "2016/01/01/2_0001.parquet",
-          "2016/01/02/3_0001.parquet",
-          "2016/01/03/1_0001.parquet",
-          "2016/01/04/0_0001.parquet"
-        ).forall { f =>
-          val p = fp.resolve(f)
-          p.toFile.exists() must beTrue
+          "2016/01/01/2_W[0-9a-f]{32}\\.parquet",
+          "2016/01/02/3_W[0-9a-f]{32}\\.parquet",
+          "2016/01/03/1_W[0-9a-f]{32}\\.parquet",
+          "2016/01/04/0_W[0-9a-f]{32}\\.parquet"
+        ).map(fp.toString + "/" + _).forall { f =>
+          Files.walk(fp).collect(Collectors.toList()).count(x => x.toString.matches(f)) mustEqual 2
         }
         CloseableIterator(ds.getFeatureSource(sft.getTypeName).getFeatures.features).toList.size mustEqual 8
       }
@@ -181,11 +170,10 @@ class BucketVsLeafStorageTest extends Specification {
         val fp = tempDir.resolve("bucket-one")
 
         Seq(
-          "2016/01/01/0000.parquet",
-          "2016/01/02/0000.parquet"
-        ).forall { f =>
-          val p = fp.resolve(f)
-          p.toFile.exists() must beTrue
+          "2016/01/01/W[0-9a-f]{32}\\.parquet",
+          "2016/01/02/W[0-9a-f]{32}\\.parquet"
+        ).map(fp.toString + "/" + _).forall { f =>
+          Files.walk(fp).collect(Collectors.toList()).count(_.toString.matches(f)) mustEqual 1
         }
         toList(ds.getFeatureSource(sft.getTypeName).getFeatures.features).size mustEqual 2
 
@@ -193,13 +181,12 @@ class BucketVsLeafStorageTest extends Specification {
           .addFeatures(new ListFeatureCollection(sft, features(sft).drop(2)))
 
         Seq(
-          "2016/01/01/0000.parquet",
-          "2016/01/02/0000.parquet",
-          "2016/01/03/0000.parquet",
-          "2016/01/04/0000.parquet"
-        ).forall { f =>
-          val p = fp.resolve(f)
-          p.toFile.exists() must beTrue
+          "2016/01/01/W[0-9a-f]{32}\\.parquet",
+          "2016/01/02/W[0-9a-f]{32}\\.parquet",
+          "2016/01/03/W[0-9a-f]{32}\\.parquet",
+          "2016/01/04/W[0-9a-f]{32}\\.parquet"
+        ).map(fp.toString + "/" + _).forall { f =>
+          Files.walk(fp).collect(Collectors.toList()).count(_.toString.matches(f)) mustEqual 1
         }
         CloseableIterator(ds.getFeatureSource(sft.getTypeName).getFeatures.features).toSeq.size mustEqual 4
 
@@ -208,17 +195,16 @@ class BucketVsLeafStorageTest extends Specification {
         ds.getFeatureSource(sft.getTypeName).asInstanceOf[SimpleFeatureStore]
           .addFeatures(new ListFeatureCollection(sft, features(sft)))
         Seq(
-          "2016/01/01/0000.parquet",
-          "2016/01/02/0000.parquet",
-          "2016/01/03/0000.parquet",
-          "2016/01/04/0000.parquet",
-          "2016/01/01/0001.parquet",
-          "2016/01/02/0001.parquet",
-          "2016/01/03/0001.parquet",
-          "2016/01/04/0001.parquet"
-        ).forall { f =>
-          val p = fp.resolve(f)
-          p.toFile.exists() must beTrue
+          "2016/01/01/W[0-9a-f]{32}\\.parquet",
+          "2016/01/02/W[0-9a-f]{32}\\.parquet",
+          "2016/01/03/W[0-9a-f]{32}\\.parquet",
+          "2016/01/04/W[0-9a-f]{32}\\.parquet",
+          "2016/01/01/W[0-9a-f]{32}\\.parquet",
+          "2016/01/02/W[0-9a-f]{32}\\.parquet",
+          "2016/01/03/W[0-9a-f]{32}\\.parquet",
+          "2016/01/04/W[0-9a-f]{32}\\.parquet"
+        ).map(fp.toString + "/" + _).forall { f =>
+          Files.walk(fp).collect(Collectors.toList()).count(_.toString.matches(f)) mustEqual 2
         }
         CloseableIterator(ds.getFeatureSource(sft.getTypeName).getFeatures.features).toSeq.size mustEqual 8
       }
@@ -240,13 +226,12 @@ class BucketVsLeafStorageTest extends Specification {
         fp.toFile.exists must beTrue
 
         Seq(
-          "2016/01/01/2/0000.parquet",
-          "2016/01/02/3/0000.parquet",
-          "2016/01/03/1/0000.parquet",
-          "2016/01/04/0/0000.parquet"
-        ).forall { f =>
-          val p = fp.resolve(f)
-          p.toFile.exists() must beTrue
+          "2016/01/01/2/W[0-9a-f]{32}\\.parquet",
+          "2016/01/02/3/W[0-9a-f]{32}\\.parquet",
+          "2016/01/03/1/W[0-9a-f]{32}\\.parquet",
+          "2016/01/04/0/W[0-9a-f]{32}\\.parquet"
+        ).map(fp.toString + "/" + _).forall { f =>
+          Files.walk(fp).collect(Collectors.toList()).count(_.toString.matches(f)) mustEqual 1
         }
         CloseableIterator(ds.getFeatureSource(sft.getTypeName).getFeatures.features).toList.size mustEqual 4
         // For now adding more features results in a next seq file
@@ -254,17 +239,16 @@ class BucketVsLeafStorageTest extends Specification {
           .addFeatures(new ListFeatureCollection(sft, features(sft)))
 
         Seq(
-          "2016/01/01/2/0000.parquet",
-          "2016/01/02/3/0000.parquet",
-          "2016/01/03/1/0000.parquet",
-          "2016/01/04/0/0000.parquet",
-          "2016/01/01/2/0001.parquet",
-          "2016/01/02/3/0001.parquet",
-          "2016/01/03/1/0001.parquet",
-          "2016/01/04/0/0001.parquet"
-        ).forall { f =>
-          val p = fp.resolve(f)
-          p.toFile.exists() must beTrue
+          "2016/01/01/2/W[0-9a-f]{32}\\.parquet",
+          "2016/01/02/3/W[0-9a-f]{32}\\.parquet",
+          "2016/01/03/1/W[0-9a-f]{32}\\.parquet",
+          "2016/01/04/0/W[0-9a-f]{32}\\.parquet",
+          "2016/01/01/2/W[0-9a-f]{32}\\.parquet",
+          "2016/01/02/3/W[0-9a-f]{32}\\.parquet",
+          "2016/01/03/1/W[0-9a-f]{32}\\.parquet",
+          "2016/01/04/0/W[0-9a-f]{32}\\.parquet"
+        ).map(fp.toString + "/" + _).forall { f =>
+          Files.walk(fp).collect(Collectors.toList()).count(_.toString.matches(f)) mustEqual 2
         }
         CloseableIterator(ds.getFeatureSource(sft.getTypeName).getFeatures.features).toList.size mustEqual 8
       }

--- a/geomesa-fs/geomesa-fs-datastore/src/test/scala/org/locationtech/geomesa/fs/FileSystemDataStoreTest.scala
+++ b/geomesa-fs/geomesa-fs-datastore/src/test/scala/org/locationtech/geomesa/fs/FileSystemDataStoreTest.scala
@@ -64,11 +64,13 @@ class FileSystemDataStoreTest extends Specification {
       conf.hasPath("partitions") must beTrue
       val p1 = conf.getConfig("partitions").getStringList("2017/06/05")
       p1.size() mustEqual 1
-      p1.get(0) mustEqual "0000.parquet"
+      p1.get(0).matches("W[0-9a-f]{32}\\.parquet") must beTrue
 
       // Metadata, schema, and partition file checks
-      new File(dir, "test/2017/06/05/0000.parquet").exists() must beTrue
-      new File(dir, "test/2017/06/05/0000.parquet").isFile must beTrue
+      new File(dir, "test/2017/06/05").exists() must beTrue
+      new File(dir, "test/2017/06/05").isDirectory must beTrue
+      new File(dir, s"test/2017/06/05/${p1.get(0)}").exists() must beTrue
+      new File(dir, s"test/2017/06/05/${p1.get(0)}").isFile must beTrue
 
       ds.getTypeNames must have size 1
       val fs = ds.getFeatureSource("test")

--- a/geomesa-fs/geomesa-fs-storage-api/src/main/java/org/locationtech/geomesa/fs/storage/api/FileSystemStorage.java
+++ b/geomesa-fs/geomesa-fs-storage-api/src/main/java/org/locationtech/geomesa/fs/storage/api/FileSystemStorage.java
@@ -29,7 +29,16 @@ public interface FileSystemStorage {
     FileSystemWriter getWriter(String typeName, String partition);
 
     List<URI> getPaths(String typeName, String partition);
+    void compact(String typeName, String partition);
 
+    /**
+     * Update the metadata for this filesystem - This should leave the metadata in a
+     * consistent and correct state. Currently this is not a thread-safe operation should
+     * only be invoked by a single thread.
+     *
+     * @param typeName
+     */
     void updateMetadata(String typeName);
+
     Metadata getMetadata(String typeName);
 }

--- a/geomesa-fs/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/FileMetadata.scala
+++ b/geomesa-fs/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/FileMetadata.scala
@@ -136,8 +136,10 @@ object FileMetadata extends LazyLogging {
     // Load encoding
     val encoding = config.getString("encoding")
 
-    // Load partition scheme
+    // Load partition scheme - note we currently have to reload the SFT user data manually
+    // which is why we have to add the partition scheme back to the SFT.
     val scheme = PartitionScheme(sft, config.getConfig("partitionScheme"))
+    PartitionScheme.addToSft(sft, scheme)
 
     // Load Partitions
     val partitions = {

--- a/geomesa-fs/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/StorageUtils.scala
+++ b/geomesa-fs/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/StorageUtils.scala
@@ -8,18 +8,43 @@
 
 package org.locationtech.geomesa.fs.storage.common
 
-import org.apache.hadoop.fs.{FileSystem, Path}
+import java.util.UUID
+
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.locationtech.geomesa.fs.storage.api.PartitionScheme
+import org.locationtech.geomesa.fs.storage.common.FileType.FileType
 
 import scala.collection.mutable
 
 object StorageUtils {
 
+  /**
+    * Get the partition name for a datafile path. Datafile contain sequence numbers indicating
+    * how they were ingested
+    *
+    * @param typePath - the path at which this type lives
+    * @param filePath - the full path of the data file
+    * @param isLeaf - is this a leaf storage file
+    * @param fileExtension - the file extension (without a period)
+    * @return the partition as a string
+    */
+  def getPartition(typePath: Path, filePath: Path, isLeaf: Boolean, fileExtension: String): String = {
+    if (isLeaf) {
+      val pathWithoutExt = filePath.toUri.getPath.dropRight(1 + fileExtension.length)
+      val seqNumDropped = pathWithoutExt.substring(0, pathWithoutExt.lastIndexOf('_'))
+
+      val prefixToRemove = typePath.toUri.getPath + "/"
+      seqNumDropped.replaceAllLiterally(prefixToRemove, "")
+    } else {
+      val prefixToRemove = typePath.toUri.getPath + "/"
+      filePath.getParent.toUri.getPath.replaceAllLiterally(prefixToRemove, "")
+    }
+  }
+
   def partitionsAndFiles(root: Path,
                          fs: FileSystem,
                          typeName: String,
                          partitionScheme: PartitionScheme,
-                         fileSequenceLength: Int,
                          fileExtension: String): java.util.Map[String, java.util.List[String]] = {
     val typePath = new Path(root, typeName)
     val files = fs.listFiles(typePath, true)
@@ -33,17 +58,8 @@ object StorageUtils {
     val isLeaf = partitionScheme.isLeafStorage
 
     import scala.collection.JavaConversions._
-    dataFiles.map { f =>
-      if (isLeaf) {
-        val prefixToRemove = typePath.toUri.getPath + "/"
-        val partition = f.toUri.getPath.dropRight(fileSequenceLength + 1 + fileExtension.length).replaceAllLiterally(prefixToRemove, "")
-        val file = f.getName
-        (partition, file)
-      } else {
-        val prefixToRemove = typePath.toUri.getPath + "/"
-        (f.getParent.toUri.getPath.replaceAllLiterally(prefixToRemove, ""), f.getName)
-      }
-    }.groupBy(_._1).map { case (k, iter) =>
+    dataFiles.map(f => (getPartition(typePath, f, isLeaf, fileExtension), f.getName))
+      .groupBy(_._1).map { case (k, iter) =>
       import scala.collection.JavaConverters._
       k -> iter.map(_._2).toList.asJava
     }
@@ -69,49 +85,60 @@ object StorageUtils {
     if (isLeafStorage) files.filter(_.getName.startsWith(partition.split('/').last)) else files
   }
 
+  def listFileStatuses(fs: FileSystem, dir: Path, ext: String): Seq[FileStatus] = {
+    if (fs.exists(dir)) {
+      fs.listStatus(dir).filter(_.getPath.getName.endsWith(ext)).toSeq
+    } else {
+      Seq.empty[FileStatus]
+    }
+  }
+
+  def listFileStatus(fs: FileSystem,
+                     root: Path,
+                     typeName: String,
+                     partition: String,
+                     ext: String,
+                     isLeafStorage: Boolean): Seq[FileStatus] = {
+    val pp = partitionPath(root, typeName, partition)
+    val dir = if (isLeafStorage) pp.getParent else pp
+    val files = listFileStatuses(fs, dir, ext)
+    if (isLeafStorage) files.filter(_.getPath.getName.startsWith(partition.split('/').last)) else files
+  }
+
   def partitionPath(root: Path, typeName: String, partitionName: String): Path =
     new Path(new Path(root, typeName), partitionName)
 
-
-  val SequenceLength = 5
-  def formatLeafFile(prefix: String, i: Int, ext: String): String = f"${prefix}_$i%04d.$ext"
-  def formatBucketFile(i: Int, ext: String): String = f"$i%04d.$ext"
+  private def randomName: String = UUID.randomUUID().toString.replaceAllLiterally("-", "")
+  def createLeafName(prefix: String, ext: String, fileType: FileType): String = f"${prefix}_$fileType$randomName.$ext"
+  def createBucketName(ext: String, fileType: FileType): String = f"$fileType$randomName.$ext"
 
   def nextFile(fs: FileSystem,
                root: Path,
                typeName: String,
                partitionName: String,
                isLeafStorage: Boolean,
-               extension: String): Path = {
+               extension: String,
+               fileType: FileType): Path = {
 
     val components = partitionName.split('/')
     val baseFileName = components.last
 
     if (isLeafStorage) {
       val dir = partitionPath(root, typeName, partitionName).getParent
-      val existingFiles = listFiles(fs, dir, extension).map(_.getName)
-
-      var i = 0
-      var name = formatLeafFile(baseFileName, i, extension)
-      while (existingFiles.contains(name)) {
-        i += 1
-        name = formatLeafFile(baseFileName, i, extension)
-      }
-
+      val name = createLeafName(baseFileName, extension, fileType)
       new Path(dir, name)
     } else {
       val dir = partitionPath(root, typeName, partitionName)
-      val existingFiles = listFiles(fs, dir, extension).map(_.getName)
-
-      var i = 0
-      var name = formatBucketFile(i, extension)
-      while (existingFiles.contains(name)) {
-        i += 1
-        name = formatBucketFile(i, extension)
-      }
-
+      val name = createBucketName(extension, fileType)
       new Path(dir, name)
     }
   }
 
+}
+
+object FileType extends Enumeration {
+  type FileType = Value
+  val Written   = Value("W")
+  val Compacted = Value("C")
+  val Imported  = Value("I")
 }

--- a/geomesa-fs/geomesa-fs-storage-common/src/test/scala/org/locationtech/geomesa/fs/storage/common/StorageUtilsTest.scala
+++ b/geomesa-fs/geomesa-fs-storage-common/src/test/scala/org/locationtech/geomesa/fs/storage/common/StorageUtilsTest.scala
@@ -45,7 +45,7 @@ class StorageUtilsTest extends Specification with AllExpectations {
       val sft = SimpleFeatureTypes.createType(typeName, "age:Int,date:Date,*geom:Point:srid=4326")
       val scheme = new DateTimeScheme(DateTimeScheme.Formats.Hourly, ChronoUnit.HOURS, 1, "date", true)
       import scala.collection.JavaConversions._
-      val partitionsAndFiles = StorageUtils.partitionsAndFiles(new Path(tempDir), fs, typeName, scheme, 3, "parquet")
+      val partitionsAndFiles = StorageUtils.partitionsAndFiles(new Path(tempDir), fs, typeName, scheme, "parquet")
       val list = partitionsAndFiles.keySet().toList
       list.size mustEqual 7
       val expected = List(

--- a/geomesa-fs/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/ParquetFileSystemStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/ParquetFileSystemStorage.scala
@@ -9,6 +9,7 @@
 
 package org.locationtech.geomesa.parquet
 
+import java.io.IOException
 import java.net.URI
 import java.util.Collections
 import java.util.concurrent.Callable
@@ -24,7 +25,7 @@ import org.geotools.data.Query
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.locationtech.geomesa.filter.FilterHelper
 import org.locationtech.geomesa.fs.storage.api._
-import org.locationtech.geomesa.fs.storage.common.{FileMetadata, PartitionScheme, StorageUtils}
+import org.locationtech.geomesa.fs.storage.common.{FileMetadata, FileType, PartitionScheme, StorageUtils}
 import org.locationtech.geomesa.parquet.ParquetFileSystemStorage._
 import org.locationtech.geomesa.utils.io.CloseQuietly
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -95,15 +96,20 @@ class ParquetFileSystemStorage(root: Path,
   override def getFeatureType(typeName: String): SimpleFeatureType =
     metadata(typeName).getSimpleFeatureType
 
+  private def createFileMetadata(sft: SimpleFeatureType) = {
+    val typeName = sft.getTypeName
+    val typePath = new Path(root, typeName)
+    val scheme = PartitionScheme.extractFromSft(sft)
+    val metaPath = new Path(typePath, MetadataFileName)
+    FileMetadata.create(fs, metaPath, sft, ParquetEncoding, scheme, conf)
+  }
+
   override def createNewFeatureType(sft: SimpleFeatureType, scheme: PartitionScheme): Unit = {
     val typeName = sft.getTypeName
 
     if (!typeNames.contains(typeName)) {
       MetadataCache.put((root, typeName), {
-          val typePath = new Path(root, typeName)
-          val scheme = PartitionScheme.extractFromSft(sft)
-          val metaPath = new Path(typePath, MetadataFileName)
-          val metadata = FileMetadata.create(fs, metaPath, sft, ParquetEncoding, scheme, conf)
+          val metadata = createFileMetadata(sft)
           typeNames += typeName
           metadata
       })
@@ -126,6 +132,7 @@ class ParquetFileSystemStorage(root: Path,
   override def getPartitionReader(sft: SimpleFeatureType, q: Query, partition: String): FileSystemPartitionIterator = {
 
     import org.locationtech.geomesa.index.conf.QueryHints._
+
     import scala.collection.JavaConversions._
 
     // parquetSft has all the fields needed for filtering and return, returnSft just has those needed for return
@@ -193,7 +200,7 @@ class ParquetFileSystemStorage(root: Path,
         c
       }
       private val leaf = meta.getPartitionScheme.isLeafStorage
-      private val dataPath = StorageUtils.nextFile(fs, root, typeName, partition, leaf, FileExtension)
+      private val dataPath = StorageUtils.nextFile(fs, root, typeName, partition, leaf, FileExtension, FileType.Written)
       private val writer = SimpleFeatureParquetWriter.builder(dataPath, sftConf).build()
       meta.addFile(partition, dataPath.getName)
 
@@ -222,15 +229,116 @@ class ParquetFileSystemStorage(root: Path,
 
   override def getMetadata(typeName: String): Metadata = metadata(typeName)
 
+  private def cleanBackups(typeName: String): Unit = {
+    val typePath = new Path(root, typeName)
+    val fileItr = fs.listFiles(typePath, false)
+    val backupFiles = mutable.ListBuffer.empty[Path]
+    while (fileItr.hasNext) {
+      val nextPath = fileItr.next().getPath
+      if (nextPath.getName.matches(s"\\.$MetadataFileName\\.old\\.\\d+.*")) {
+        backupFiles += nextPath
+      }
+    }
+
+    // Keep the 5 most recent metadata files and delete the old ones
+    backupFiles.sortBy(_.getName).dropRight(5).foreach { p =>
+      logger.debug(s"Removing old metadata backup $p")
+      fs.delete(p, false)
+    }
+  }
+
+  private def backupMetadata(typeName: String): Unit = {
+    val typePath = new Path(root, typeName)
+    val metaPath = new Path(typePath, MetadataFileName)
+    val backupFile = new Path(typePath, s".$MetadataFileName.old.${System.currentTimeMillis()}.${System.nanoTime()}")
+    fs.rename(metaPath, backupFile)
+
+    // Because of eventual consistency lets make sure they are there
+    var tryNum = 0
+    var backupComplete = false
+
+    def waitOnBackup: Boolean = {
+      backupComplete = fs.exists(backupFile) && !fs.exists(metaPath)
+      if (!backupComplete) {
+        val secs = 2 ^ tryNum
+        Thread.sleep(1000 * secs)
+      }
+      !backupComplete
+    }
+
+    do {
+      tryNum += 1
+    } while (waitOnBackup && tryNum <= 3)
+
+    if (!backupComplete) {
+      throw new IOException(s"Unable to properly backup metadata after $tryNum tries")
+    }
+  }
+
   override def updateMetadata(typeName: String): Unit = {
     val s = System.currentTimeMillis
     val scheme = metadata(typeName).getPartitionScheme
-    val parts = StorageUtils.partitionsAndFiles(root, fs, typeName, scheme, StorageUtils.SequenceLength, FileExtension)
+    val sft = metadata(typeName).getSimpleFeatureType
+    val parts = StorageUtils.partitionsAndFiles(root, fs, typeName, scheme, FileExtension)
+
+    // Save existing metadata
+    backupMetadata(typeName)
+    cleanBackups(typeName)
+
+    // Recreate a new metadata file
+    val newMetadata = createFileMetadata(sft)
+    MetadataCache.invalidate((root, typeName))
+    MetadataCache.put((root, typeName), newMetadata)
+
     metadata(typeName).addPartitions(parts)
     val e = System.currentTimeMillis
     logger.info(s"Metadata Update took in ${e-s}ms.")
   }
 
+  override def compact(typeName: String, partition: String): Unit = {
+    val existingFiles = getPaths(typeName, partition)
+
+    val meta = metadata(typeName)
+    val sft = meta.getSimpleFeatureType
+
+    val sftConf = {
+      val c = new Configuration(conf)
+      SimpleFeatureReadSupport.setSft(sft, c)
+      c
+    }
+    val leaf = meta.getPartitionScheme.isLeafStorage
+    val dataPath = StorageUtils.nextFile(fs, root, typeName, partition, leaf, FileExtension, FileType.Compacted)
+    val writer = SimpleFeatureParquetWriter.builder(dataPath, sftConf).build()
+
+    logger.debug(s"Compacting data files: [${existingFiles.map(_.toString).mkString(", ")}] to into file $dataPath")
+    val support = new SimpleFeatureReadSupport
+    val written: Long = existingFiles.map { f =>
+      logger.debug(s"Reading $f")
+      val reader = ParquetReader.builder[SimpleFeature](support, new Path(f)).withConf(sftConf).build()
+      var sf = reader.read()
+      var count = 0L
+      while (sf != null) {
+        writer.write(sf)
+        count += 1
+        sf = reader.read()
+      }
+      count
+    }.sum
+
+    writer.close()
+    logger.debug(s"Wrote compacted file $dataPath")
+
+    logger.debug(s"Deleting old files [${existingFiles.map(_.toString).mkString(", ")}]")
+    val deleteResult = existingFiles.forall(f => fs.delete(new Path(f), false))
+    if (!deleteResult) {
+      logger.warn(s"Failed to delete all files: [${existingFiles.map(_.toString).mkString(", ")}]")
+    }
+
+    logger.debug(s"Updating metadata for type $typeName")
+    updateMetadata(typeName)
+
+    logger.debug(s"Compacted $written records into file $dataPath")
+  }
 }
 
 object ParquetFileSystemStorage {

--- a/geomesa-fs/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/SimpleFeatureReadSupport.scala
+++ b/geomesa-fs/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/SimpleFeatureReadSupport.scala
@@ -43,7 +43,7 @@ object SimpleFeatureReadSupport {
 
   def setSft(sft: SimpleFeatureType, conf: Configuration): Unit = {
     // This must be serialized as conf due to the spec's inability to serialize user data completely
-    conf.set(SftConfKey, SimpleFeatureTypes.toConfigString(sft, includeUserData = true, concise = true, includePrefix = false))
+    conf.set(SftConfKey, SimpleFeatureTypes.toConfigString(sft, includeUserData = true, concise = true, includePrefix = false, json = true))
   }
 
   def getSft(conf: Configuration): SimpleFeatureType = {

--- a/geomesa-fs/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/CompactionTest.scala
+++ b/geomesa-fs/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/CompactionTest.scala
@@ -1,0 +1,97 @@
+/***********************************************************************
+ * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.parquet
+
+import java.nio.file.Files
+import java.text.SimpleDateFormat
+
+import com.vividsolutions.jts.geom.Coordinate
+import org.apache.commons.io.FileUtils
+import org.geotools.data.Query
+import org.geotools.factory.CommonFactoryFinder
+import org.geotools.geometry.jts.JTSFactoryFinder
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.fs.storage.common._
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.feature.simple.SimpleFeature
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.AllExpectations
+
+import scala.collection.JavaConversions._
+
+
+@RunWith(classOf[JUnitRunner])
+class CompactionTest extends Specification with AllExpectations {
+
+  sequential
+
+  "ParquetFileSystemStorage" should {
+    val gf = JTSFactoryFinder.getGeometryFactory
+    val sft = SimpleFeatureTypes.createType("test", "name:String,age:Int,dtg:Date,*geom:Point:srid=4326")
+    val ff = CommonFactoryFinder.getFilterFactory2
+    val tempDir = Files.createTempDirectory("geomesa")
+    println(tempDir)
+
+    "compact partitions" >> {
+      val parquetFactory = new ParquetFileSystemStorageFactory
+
+      val fsStorage = parquetFactory.build(Map(
+        "fs.path" -> tempDir.toFile.getPath,
+        "parquet.compression" -> "gzip"
+      ))
+
+      val scheme = CommonSchemeLoader.build("daily", sft)
+      PartitionScheme.addToSft(sft, scheme)
+      fsStorage.createNewFeatureType(sft, scheme)
+
+      fsStorage.listFeatureTypes().size mustEqual 1
+      fsStorage.listFeatureTypes().head.getTypeName mustEqual "test"
+
+      val sdf = new SimpleDateFormat("yyyy-MM-dd")
+      val dtg = sdf.parse("2017-01-01")
+      val sf1 = new ScalaSimpleFeature(sft, "1", Array("first", Integer.valueOf(100), dtg, gf.createPoint(new Coordinate(10, 10))))
+      val partition = scheme.getPartitionName(sf1)
+
+      def write(sf: SimpleFeature) = {
+        val writer = fsStorage.getWriter(sft.getTypeName, partition)
+        writer.write(sf)
+        writer.close()
+      }
+
+      // First simple feature goes in its own file
+      write(sf1)
+      fsStorage.getPaths(sft.getTypeName, partition) must haveSize(1)
+      fsStorage.getPartitionReader(sft, Query.ALL, partition).toList must haveSize(1)
+
+      // Second simple feature should be in a separate file
+      val sf2 = new ScalaSimpleFeature(sft, "2", Array("second", Integer.valueOf(200), dtg, gf.createPoint(new Coordinate(10, 10))))
+      write(sf2)
+      fsStorage.getPaths(sft.getTypeName, partition) must haveSize(2)
+      fsStorage.getPartitionReader(sft, Query.ALL, partition).toList must haveSize(2)
+
+      // Third feature in a third file
+      val sf3 = new ScalaSimpleFeature(sft, "3", Array("third", Integer.valueOf(300), dtg, gf.createPoint(new Coordinate(10, 10))))
+      write(sf3)
+      fsStorage.getPaths(sft.getTypeName, partition) must haveSize(3)
+      fsStorage.getPartitionReader(sft, Query.ALL, partition).toList must haveSize(3)
+
+      // Compact to create a single file
+      fsStorage.compact(sft.getTypeName, partition)
+      fsStorage.getPaths(sft.getTypeName, partition) must haveSize(1)
+      fsStorage.getPartitionReader(sft, Query.ALL, partition).toList must haveSize(3)
+
+    }
+
+    step {
+      FileUtils.deleteDirectory(tempDir.toFile)
+    }
+  }
+}

--- a/geomesa-fs/geomesa-fs-tools/bin/install-hadoop.sh
+++ b/geomesa-fs/geomesa-fs-tools/bin/install-hadoop.sh
@@ -177,6 +177,9 @@ else
       "${base_url}commons-cli/commons-cli/1.2/commons-cli-1.2.jar"
       "${base_url}com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar"
       "${base_url}commons-io/commons-io/2.5/commons-io-2.5.jar"
+      "${base_url}org/apache/httpcomponents/httpclient/4.3.4/httpclient-4.3.4.jar"
+      "${base_url}org/apache/httpcomponents/httpcore/4.3.3/httpcore-4.3.3.jar"
+      "${base_url}commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar"
     )
 
     # Download dependencies

--- a/geomesa-fs/geomesa-fs-tools/pom.xml
+++ b/geomesa-fs/geomesa-fs-tools/pom.xml
@@ -48,15 +48,36 @@
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-fs-storage-parquet_${scala.binary.version}</artifactId>
         </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+
 
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
             <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -83,6 +104,26 @@
                         <argument>--autocomplete-function</argument>
                         <argument>${project.build.directory}/autocomplete.sh,geomesa-fs</argument>
                     </arguments>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.1.13</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                    <dateFormat>yyyy-MM-dd HH:mm</dateFormat>
+                    <generateGitPropertiesFile>false</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>src/main/resources/org/locationtech/geomesa/tools/geomesaVersion.properties</generateGitPropertiesFilename>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
                 </configuration>
             </plugin>
         </plugins>

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/FsDataStoreCommand.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/FsDataStoreCommand.scala
@@ -10,6 +10,8 @@ package org.locationtech.geomesa.fs.tools
 
 import java.io.File
 import java.net.{MalformedURLException, URL}
+import java.util
+import java.util.concurrent.atomic.AtomicBoolean
 
 import com.beust.jcommander.{Parameter, ParameterException}
 import org.apache.hadoop.fs.FsUrlStreamHandlerFactory
@@ -24,7 +26,7 @@ trait FsDataStoreCommand extends DataStoreCommand[FileSystemDataStore] {
   override def params: FsParams
 
   override def connection: Map[String, String] = {
-    URL.setURLStreamHandlerFactory(new FsUrlStreamHandlerFactory())
+    FsDataStoreCommand.configureURLFactory()
     val url = if (params.path.matches("""\w+://.*""")) {
       try {
         new URL(params.path)
@@ -43,6 +45,17 @@ trait FsDataStoreCommand extends DataStoreCommand[FileSystemDataStore] {
   }
 }
 
+object FsDataStoreCommand {
+  private var urlStreamHandlerSet = false
+  def configureURLFactory(): Unit =
+    synchronized {
+      if (!urlStreamHandlerSet) {
+        URL.setURLStreamHandlerFactory(new FsUrlStreamHandlerFactory())
+        urlStreamHandlerSet = true
+      }
+    }
+}
+
 trait PathParam {
   @Parameter(names = Array("--path", "-p"), description = "Path to root of filesystem datastore", required = true)
   var path: String = _
@@ -52,6 +65,12 @@ trait PathParam {
 trait EncodingParam {
   @Parameter(names = Array("--encoding", "-e"), description = "Encoding (parquet, csv, etc)", required = true)
   var encoding: String = _
+}
+
+
+trait PartitionParam {
+  @Parameter(names = Array("--partitions"), description = "Partitions (if empty all partitions will be used)", required = false, variableArity = true)
+  var partitions: java.util.List[String] = new util.ArrayList[String]()
 }
 
 trait FsParams extends PathParam with EncodingParam

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/FsRunner.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/FsRunner.scala
@@ -9,9 +9,10 @@
 package org.locationtech.geomesa.fs.tools
 
 import com.beust.jcommander.JCommander
+import org.locationtech.geomesa.fs.tools.compact.CompactCommand
 import org.locationtech.geomesa.fs.tools.export.FsExportCommand
 import org.locationtech.geomesa.fs.tools.ingest.{FsIngestCommand, UpdateMetadataCommand}
-import org.locationtech.geomesa.fs.tools.status.{FsDescribeSchemaCommand, FsGetSftConfigCommand, FsGetTypeNamesCommand}
+import org.locationtech.geomesa.fs.tools.status._
 import org.locationtech.geomesa.tools.export.GenerateAvroSchemaCommand
 import org.locationtech.geomesa.tools.status._
 import org.locationtech.geomesa.tools.{Command, ConvertCommand, Runner}
@@ -33,6 +34,9 @@ object FsRunner extends Runner {
     new ConvertCommand,
     new UpdateMetadataCommand,
     new ClasspathCommand,
-    new ConfigureCommand
+    new ConfigureCommand,
+    new CompactCommand,
+    new FsGetPartitionsCommand,
+    new FSGetFilesCommand
   )
 }

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/compact/CompactCommand.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/compact/CompactCommand.scala
@@ -1,0 +1,96 @@
+/***********************************************************************
+ * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.tools.compact
+
+import java.io.File
+
+import com.beust.jcommander.{Parameter, ParameterException, Parameters}
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.hadoop.fs.Path
+import org.locationtech.geomesa.fs.FileSystemDataStore
+import org.locationtech.geomesa.fs.tools.ingest.TempDirParam
+import org.locationtech.geomesa.fs.tools.{FsDataStoreCommand, FsParams, PartitionParam}
+import org.locationtech.geomesa.tools.ingest.AbstractIngest
+import org.locationtech.geomesa.tools.ingest.AbstractIngest.PrintProgress
+import org.locationtech.geomesa.tools.{Command, RequiredTypeNameParam}
+import org.locationtech.geomesa.utils.classpath.ClassPathUtils
+import org.locationtech.geomesa.utils.text.TextTools
+
+import scala.collection.JavaConversions._
+
+class CompactCommand extends FsDataStoreCommand with LazyLogging {
+
+  override val name: String = "compact"
+  override val params = new CompactParams
+
+  override def execute(): Unit = {
+    if (!Seq(RunModes.Distributed, RunModes.Local).contains(params.runMode)) {
+      throw new ParameterException(s"Invalid run mode '${params.runMode}'")
+    }
+    withDataStore(compact)
+  }
+
+  val libjarsFile: String = "org/locationtech/geomesa/fs/tools/ingest-libjars.list"
+
+  def libjarsPaths: Iterator[() => Seq[File]] = Iterator(
+    () => ClassPathUtils.getJarsFromEnvironment("GEOMESA_FS_HOME"),
+    () => ClassPathUtils.getJarsFromClasspath(classOf[FileSystemDataStore])
+  )
+
+  def compact(ds: FileSystemDataStore): Unit = {
+    Command.user.info(s"Beginning Compaction Process...updating metadata")
+
+    ds.storage.updateMetadata(params.featureName)
+    Command.user.info(s"Metadata update complete")
+
+    val m = ds.storage.getMetadata(params.featureName)
+    val allPartitions = m.getPartitions
+    val toCompact: Seq[String] = if (params.partitions.nonEmpty) {
+      params.partitions.filterNot(allPartitions.contains).headOption.foreach { p =>
+        throw new ParameterException(s"Partition $p cannot be found in metadata")
+      }
+      params.partitions
+    } else {
+      allPartitions
+    }
+    Command.user.info(s"Compacting ${toCompact.size} partitions")
+
+    params.runMode match {
+      case RunModes.Local =>
+        toCompact.foreach { p =>
+          logger.info(s"Compacting ${params.featureName}:$p")
+          ds.storage.compact(params.featureName, p)
+          logger.info(s"Completed compaction of ${params.featureName}:$p")
+        }
+
+      case RunModes.Distributed =>
+        val tempDir = Option(params.tempDir).map(t => new Path(t))
+        val job = new ParquetCompactionJob(ds.getSchema(params.featureName), ds.root, tempDir)
+        val statusCallback = new PrintProgress(System.err, TextTools.buildString(' ', 60), '\u003d', '\u003e', '\u003e')
+
+        val start = System.currentTimeMillis()
+        val (success, failed) = job.run(connection, params.featureName, toCompact, libjarsFile, libjarsPaths, statusCallback)
+        Command.user.info(s"Distributed compaction complete in ${TextTools.getTime(start)}")
+        Command.user.info(AbstractIngest.getStatInfo(success, failed))
+    }
+
+    Command.user.info(s"Compaction completed")
+  }
+}
+
+@Parameters(commandDescription = "Compact partitions")
+class CompactParams extends FsParams with RequiredTypeNameParam with TempDirParam with PartitionParam {
+  @Parameter(names = Array("--mode"), description = "Run mode for compaction ('local' or 'distributed' via mapreduce)", required = false)
+  var runMode: String = "distributed"
+}
+
+object RunModes {
+  val Distributed = "distributed"
+  val Local = "local"
+}

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/compact/ParquetCompactionJob.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/compact/ParquetCompactionJob.scala
@@ -1,0 +1,298 @@
+/***********************************************************************
+ * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.tools.compact
+
+import java.io.{DataInput, DataOutput, File}
+import java.util
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io._
+import org.apache.hadoop.mapreduce._
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+import org.apache.parquet.hadoop.{ParquetInputFormat, ParquetOutputFormat}
+import org.geotools.data.{DataStoreFinder, Query}
+import org.geotools.factory.Hints
+import org.locationtech.geomesa.fs.{FileSystemDataStore, FileSystemDataStoreParams}
+import org.locationtech.geomesa.fs.storage.api.FileSystemPartitionIterator
+import org.locationtech.geomesa.fs.storage.common.{FileType, StorageUtils}
+import org.locationtech.geomesa.fs.tools.ingest.{ParquetJobUtils, SchemeOutputFormat}
+import org.locationtech.geomesa.jobs.JobUtils
+import org.locationtech.geomesa.jobs.mapreduce.GeoMesaOutputFormat
+import org.locationtech.geomesa.jobs.mapreduce.GeoMesaOutputFormat.{Counters => OutCounters}
+import org.locationtech.geomesa.parquet.{SimpleFeatureReadSupport, SimpleFeatureWriteSupport}
+import org.locationtech.geomesa.tools.Command
+import org.locationtech.geomesa.tools.ingest.AbstractIngest.StatusCallback
+import org.locationtech.geomesa.tools.ingest.AbstractIngestJob
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import org.opengis.filter.Filter
+
+import scala.collection.JavaConversions._
+
+class ParquetCompactionJob(sft: SimpleFeatureType,
+                           dsPath: Path,
+                           tempPath: Option[Path]) extends AbstractIngestJob with LazyLogging {
+
+  override def run(dsParams: Map[String, String],
+                   typeName: String,
+                   partitions: Seq[String],
+                   libjarsFile: String,
+                   libjarsPaths: Iterator[() => Seq[File]],
+                   statusCallback: StatusCallback): (Long, Long) = {
+
+    val ds = DataStoreFinder.getDataStore(dsParams).asInstanceOf[FileSystemDataStore]
+    val job = Job.getInstance(new Configuration, "GeoMesa Parquet Compaction")
+
+    JobUtils.setLibJars(job.getConfiguration, readLibJars(libjarsFile), defaultSearchPath ++ libjarsPaths)
+    job.setJarByClass(getClass)
+
+    // MapReduce options
+    job.getConfiguration.set("mapred.map.tasks.speculative.execution", "false")
+    job.getConfiguration.set("mapreduce.job.user.classpath.first", "true")
+
+    // InputFormat and Mappers
+    job.setMapperClass(classOf[CompactionMapper])
+    job.setInputFormatClass(classOf[PartitionInputFormat])
+    job.setMapOutputKeyClass(classOf[Void])
+    job.setMapOutputValueClass(classOf[SimpleFeature])
+    ParquetInputFormat.setReadSupportClass(job, classOf[SimpleFeatureReadSupport])
+    PartitionInputFormat.setFsPath(job.getConfiguration, FileSystemDataStoreParams.PathParam.lookUp(dsParams).asInstanceOf[String])
+    PartitionInputFormat.setFsEncoding(job.getConfiguration, FileSystemDataStoreParams.EncodingParam.lookUp(dsParams).asInstanceOf[String])
+    PartitionInputFormat.setPartitions(job.getConfiguration, partitions.toArray)
+
+    // No reducers - Mapper will read/write its own things
+    job.setNumReduceTasks(0)
+
+    // Output format
+    job.setOutputFormatClass(classOf[SchemeOutputFormat])
+    SchemeOutputFormat.setFileType(job.getConfiguration, FileType.Compacted)
+    job.setOutputKeyClass(classOf[Void])
+    job.setOutputValueClass(classOf[SimpleFeature])
+    FileOutputFormat.setOutputPath(job, tempPath.getOrElse(dsPath))
+
+    // Parquet Options
+    val summaryLevel = Option(sft.getUserData.get(ParquetOutputFormat.JOB_SUMMARY_LEVEL).asInstanceOf[String])
+      .getOrElse(ParquetOutputFormat.JobSummaryLevel.NONE.toString)
+    job.getConfiguration.set(ParquetOutputFormat.JOB_SUMMARY_LEVEL, summaryLevel)
+    Command.user.info(s"Parquet metadata summary level is $summaryLevel")
+
+    val compression = Option(sft.getUserData.get(ParquetOutputFormat.COMPRESSION).asInstanceOf[String])
+      .map(CompressionCodecName.valueOf)
+      .getOrElse(CompressionCodecName.SNAPPY)
+    ParquetOutputFormat.setCompression(job, compression)
+    Command.user.info(s"Parquet compression is $compression")
+
+    // More Parquet config
+    ParquetOutputFormat.setWriteSupportClass(job, classOf[SimpleFeatureWriteSupport])
+    ParquetJobUtils.setSimpleFeatureType(job.getConfiguration, sft)
+
+    // Save the existing files so we can delete them afterwards
+    // Be sure to filter this based on the input partitions
+    val existingDataFiles = ds.storage.listPartitions(typeName)
+      .intersect(partitions).flatMap(ds.storage.getPaths(typeName, _)).toList
+
+    Command.user.info("Submitting job - please wait...")
+    job.submit()
+    Command.user.info(s"Tracking available at ${job.getStatus.getTrackingUrl}")
+
+    def mapCounters = Seq(("mapped", written(job)), ("failed", failed(job)))
+
+    val stageCount = if (tempPath.isDefined) { 2 } else { 1 }
+
+    while (!job.isComplete) {
+      Thread.sleep(1000)
+      if (job.getStatus.getState != JobStatus.State.PREP) {
+        val mapProgress = job.mapProgress()
+        if (mapProgress < 1f) {
+          statusCallback(s"Map (stage 1/$stageCount): ", mapProgress, mapCounters, done = false)
+        } else {
+          statusCallback(s"Map (stage 1/$stageCount): ", mapProgress, mapCounters, done = true)
+          statusCallback.reset()
+        }
+      }
+    }
+
+    val counterResult = (written(job), failed(job))
+
+    val success = job.isSuccessful &&
+      tempPath.forall(tp => ParquetJobUtils.distCopy(tp, dsPath, sft, job.getConfiguration, statusCallback, 2, stageCount)) && {
+
+        Command.user.info("Removing old files")
+        val fs = ds.root.getFileSystem(job.getConfiguration)
+        existingDataFiles.foreach(o => fs.delete(new Path(o), false))
+        Command.user.info(s"Removed ${existingDataFiles.size} files")
+
+        Command.user.info("Updating metadata")
+        // TODO GEOMESA-2018 We sleep here to allow a chance for S3 to become "consistent" with its storage listings
+        Thread.sleep(5000)
+        ds.storage.updateMetadata(typeName)
+        Command.user.info("Metadata Updated")
+        true
+      }
+
+    if (!success) {
+      Command.user.error(s"Job failed with state ${job.getStatus.getState} due to: ${job.getStatus.getFailureInfo}")
+    }
+
+    counterResult
+  }
+
+  override def inputFormatClass: Class[_ <: FileInputFormat[_, SimpleFeature]] = null
+
+  override def written(job: Job): Long =
+    job.getCounters.findCounter(OutCounters.Group, OutCounters.Written).getValue
+
+  override def failed(job: Job): Long =
+    job.getCounters.findCounter(OutCounters.Group, OutCounters.Failed).getValue
+
+  override def configureJob(job: Job): Unit = {}
+}
+
+/**
+  * InputSplit corresponding to a single FileSystemDataStore PartitionScheme partition
+  */
+class PartitionInputSplit extends InputSplit with Writable {
+  private var name: String = _
+  private var length: Long = _
+
+  /**
+    * @return the name of this partition
+    */
+  def getName: String = name
+
+  override def getLength: Long = length
+
+  // TODO attempt to optimize the locations where this should run in the
+  // case of HDFS - With S3 this won't really matter
+  override def getLocations: Array[String] = Array.empty[String]
+
+  override def write(out: DataOutput): Unit = {
+    out.writeUTF(name)
+    out.writeLong(length)
+  }
+
+  override def readFields(in: DataInput): Unit = {
+    this.name = in.readUTF()
+    this.length = in.readLong()
+  }
+}
+
+object PartitionInputSplit{
+  def apply(name: String, length: Long): PartitionInputSplit = {
+    val split = new PartitionInputSplit
+    split.name = name
+    split.length = length
+    split
+  }
+}
+
+/**
+  * An Input format that creates splits based on FSDS Partitions
+  */
+class PartitionInputFormat extends InputFormat[Void, SimpleFeature] {
+
+  override def getSplits(context: JobContext): util.List[InputSplit] = {
+    val partitions = PartitionInputFormat.getPartitions(context.getConfiguration)
+    val rootPath = new Path(PartitionInputFormat.getFsPath(context.getConfiguration))
+    val fs = rootPath.getFileSystem(context.getConfiguration)
+    val typeName: String = ParquetJobUtils.getSimpleFeatureType(context.getConfiguration).getTypeName
+
+    val splits = partitions.map { p =>
+      val pp = StorageUtils.partitionPath(rootPath, typeName, p)
+      val size = StorageUtils.listFileStatuses(fs, pp, "parquet").map(_.getLen).sum
+      PartitionInputSplit(p, size)
+    }
+
+    splits.toList
+  }
+
+  override def createRecordReader(split: InputSplit, context: TaskAttemptContext): RecordReader[Void, SimpleFeature] = {
+
+    val partitionInputSplit = split.asInstanceOf[PartitionInputSplit]
+
+    new RecordReader[Void, SimpleFeature] {
+      private var sft: SimpleFeatureType = _
+      private var reader: FileSystemPartitionIterator = _
+
+      private var curValue: SimpleFeature = _
+
+      // TODO look at how the ParquetInputFormat provides progress and utilize something similar
+      override def getProgress: Float = 0.0f
+
+      override def nextKeyValue(): Boolean = {
+        curValue = if (reader.hasNext) reader.next() else null
+        curValue != null
+      }
+
+      override def getCurrentValue: SimpleFeature = curValue
+
+      override def initialize(split: InputSplit, context: TaskAttemptContext): Unit = {
+        sft = ParquetJobUtils.getSimpleFeatureType(context.getConfiguration)
+
+        val path = PartitionInputFormat.getFsPath(context.getConfiguration)
+        val encoding = PartitionInputFormat.getFsEncoding(context.getConfiguration)
+        val dsParams = Map(
+          FileSystemDataStoreParams.PathParam.getName -> path,
+          FileSystemDataStoreParams.EncodingParam.getName -> encoding
+        )
+        val ds: FileSystemDataStore = DataStoreFinder.getDataStore(dsParams).asInstanceOf[FileSystemDataStore]
+
+        reader = ds.storage.getPartitionReader(sft, new Query(sft.getTypeName, Filter.INCLUDE), partitionInputSplit.getName)
+      }
+
+      override def getCurrentKey: Void = null
+
+      override def close(): Unit = reader.close()
+    }
+  }
+}
+
+object PartitionInputFormat {
+  val FsPathParam     = s"geomesa.${FileSystemDataStoreParams.PathParam.getName}"
+  val FsEncodingParam = s"geomesa.${FileSystemDataStoreParams.EncodingParam.getName}"
+  val PartitionsParam = "geomesa.fs.compaction.partitions"
+
+  def setFsPath(conf: Configuration, path: String): Unit = conf.set(FsPathParam, path)
+  def getFsPath(conf: Configuration): String = conf.get(FsPathParam)
+
+  def setFsEncoding(conf: Configuration, encoding: String): Unit = conf.set(FsEncodingParam, encoding)
+  def getFsEncoding(conf: Configuration): String = conf.get(FsEncodingParam)
+
+  def setPartitions(conf: Configuration, partitions: Array[String]): Unit =
+    conf.setStrings(PartitionsParam, partitions: _*)
+  def getPartitions(conf: Configuration): Array[String] = conf.getStrings(PartitionsParam)
+}
+
+/**
+  * Mapper that simply reads the input format and writes the output to the sample node. This mapper
+  * is paired with the PartitionRecordReader which will feed all the features into a single map task
+  */
+class CompactionMapper extends Mapper[Void, SimpleFeature, Void, SimpleFeature] with LazyLogging {
+
+  type Context = Mapper[Void, SimpleFeature, Void, SimpleFeature]#Context
+
+  private var written: Counter = _
+  private var mapped: Counter = _
+
+  override def setup(context: Context): Unit = {
+    super.setup(context)
+    written = context.getCounter(GeoMesaOutputFormat.Counters.Group, GeoMesaOutputFormat.Counters.Written)
+    mapped = context.getCounter("org.locationtech.geomesa.fs.compaction", "mapped")
+  }
+
+  override def map(key: Void, sf: SimpleFeature, context: Context): Unit = {
+    sf.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+    mapped.increment(1)
+    context.write(null, sf)
+    written.increment(1)
+  }
+}

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/FsIngestCommand.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/FsIngestCommand.scala
@@ -89,11 +89,7 @@ class FsIngestCommand extends IngestCommand[FileSystemDataStore] with FsDataStor
 }
 
 @Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")
-class FsIngestParams extends IngestParams with FsParams {
-  @Parameter(names = Array("--temp-path"), description = "Path to temp dir for parquet ingest. " +
-    "Note that this may be useful when using s3 since its slow as a sink", required = false)
-  var tempDir: String = _
-
+class FsIngestParams extends IngestParams with FsParams with TempDirParam {
   @Parameter(names = Array("--num-reducers"), description = "Num reducers (required for distributed ingest)", required = false)
   var reducers: java.lang.Integer = _
 
@@ -105,4 +101,10 @@ class FsIngestParams extends IngestParams with FsParams {
 
   @Parameter(names = Array("--storage-opt"), variableArity = true, description = "Additional storage opts (k=v)", required = false)
   var storageOpts: java.util.List[java.lang.String] = new util.ArrayList[String]()
+}
+
+trait TempDirParam {
+  @Parameter(names = Array("--temp-path"), description = "Path to temp dir for parquet ingest. " +
+    "Note that this may be useful when using s3 since its slow as a sink", required = false)
+  var tempDir: String = _
 }

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/ParquetConverterJob.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/ParquetConverterJob.scala
@@ -8,40 +8,35 @@
 
 package org.locationtech.geomesa.fs.tools.ingest
 
-import java.io.{File, IOException}
+import java.io.File
 import java.lang.Iterable
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileUtil, Path}
+import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{BytesWritable, LongWritable, Text}
-import org.apache.hadoop.mapred.InvalidJobConfException
 import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
-import org.apache.hadoop.mapreduce.lib.output.{FileOutputCommitter, FileOutputFormat}
-import org.apache.hadoop.mapreduce.security.TokenCache
-import org.apache.hadoop.tools.{DistCp, DistCpOptions}
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
+import org.apache.parquet.hadoop.ParquetOutputFormat
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
-import org.apache.parquet.hadoop.util.ContextUtil
-import org.apache.parquet.hadoop.{ParquetOutputCommitter, ParquetOutputFormat}
 import org.geotools.data.{DataStoreFinder, DataUtilities}
 import org.geotools.factory.Hints
 import org.locationtech.geomesa.features.SerializationOption.SerializationOptions
 import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
 import org.locationtech.geomesa.fs.FileSystemDataStore
 import org.locationtech.geomesa.fs.storage.api.PartitionScheme
-import org.locationtech.geomesa.fs.storage.common.StorageUtils
+import org.locationtech.geomesa.fs.storage.common.FileType
 import org.locationtech.geomesa.jobs.JobUtils
 import org.locationtech.geomesa.jobs.mapreduce.GeoMesaOutputFormat
-import org.locationtech.geomesa.parquet.{SimpleFeatureReadSupport, SimpleFeatureWriteSupport}
+import org.locationtech.geomesa.parquet.SimpleFeatureWriteSupport
 import org.locationtech.geomesa.tools.Command
 import org.locationtech.geomesa.tools.ingest.AbstractIngest.StatusCallback
 import org.locationtech.geomesa.tools.ingest.ConverterIngestJob
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.JavaConversions._
-import scala.collection.mutable
 
 class ParquetConverterJob(sft: SimpleFeatureType,
                           converterConfig: Config,
@@ -79,6 +74,7 @@ class ParquetConverterJob(sft: SimpleFeatureType,
 
     // Output format
     job.setOutputFormatClass(classOf[SchemeOutputFormat])
+    SchemeOutputFormat.setFileType(job.getConfiguration, FileType.Written)
     job.setOutputKeyClass(classOf[Void])
     job.setOutputValueClass(classOf[SimpleFeature])
 
@@ -96,7 +92,7 @@ class ParquetConverterJob(sft: SimpleFeatureType,
 
     // More Parquet config
     ParquetOutputFormat.setWriteSupportClass(job, classOf[SimpleFeatureWriteSupport])
-    ParquetConverterJob.setSimpleFeatureType(job.getConfiguration, sft)
+    ParquetJobUtils.setSimpleFeatureType(job.getConfiguration, sft)
 
     FileOutputFormat.setOutputPath(job, tempPath.getOrElse(dsPath))
 
@@ -110,7 +106,7 @@ class ParquetConverterJob(sft: SimpleFeatureType,
     def mapCounters = Seq(("mapped", written(job)), ("failed", failed(job)))
     def reduceCounters = Seq(("ingested", reduced(job)))
 
-    val stageCount = if (tempPath.isDefined) { "3" } else { "2" }
+    val stageCount = if (tempPath.isDefined) { 3 } else { 2 }
 
     var mapping = true
     while (!job.isComplete) {
@@ -136,7 +132,7 @@ class ParquetConverterJob(sft: SimpleFeatureType,
     val res = (written(job), failed(job))
 
     val ret = job.isSuccessful &&
-        tempPath.forall(tp => distCopy(tp, dsPath, sft, job.getConfiguration, statusCallback)) && {
+        tempPath.forall(tp => ParquetJobUtils.distCopy(tp, dsPath, sft, job.getConfiguration, statusCallback, 3, stageCount)) && {
       Command.user.info("Attempting to update metadata")
       // We sleep here to allow a chance for S3 to become "consistent" with its storage listings
       Thread.sleep(5000)
@@ -152,103 +148,7 @@ class ParquetConverterJob(sft: SimpleFeatureType,
     res
   }
 
-  def distCopy(srcRoot: Path, dest: Path, sft: SimpleFeatureType, conf: Configuration, statusCallback: StatusCallback): Boolean = {
-    val typeName = sft.getTypeName
-    val typePath = new Path(srcRoot, typeName)
-    val destTypePath = new Path(dest, typeName)
-
-    statusCallback.reset()
-
-    Command.user.info("Submitting distcp job - please wait...")
-    val opts = new DistCpOptions(List(typePath), destTypePath)
-    opts.setAppend(false)
-    opts.setOverwrite(true)
-    opts.setCopyStrategy("dynamic")
-    val job = new DistCp(new Configuration, opts).execute()
-
-    Command.user.info(s"Tracking available at ${job.getStatus.getTrackingUrl}")
-
-    // distCp has no reduce phase
-    while (!job.isComplete) {
-      if (job.getStatus.getState != JobStatus.State.PREP) {
-          statusCallback("DistCp (stage 3/3): ", job.mapProgress(), Seq.empty, done = false)
-      }
-      Thread.sleep(1000)
-    }
-    statusCallback("DistCp (stage 3/3): ", job.mapProgress(), Seq.empty, done = true)
-
-    val success = job.isSuccessful
-    if (success) {
-      Command.user.info(s"Successfully copied data to $dest")
-    } else {
-      Command.user.error(s"failed to copy data to $dest")
-    }
-    success
-  }
-
-  // TODO probably make a better method for this and extract it to a static utility class
-  // TODO parallelize if the filesystems are not the same
-  def copyData(srcRoot: Path, destRoot: Path, sft: SimpleFeatureType, conf: Configuration): Boolean = {
-    val typeName = sft.getTypeName
-    Command.user.info(s"Job finished...copying data from $srcRoot to $destRoot for type $typeName")
-
-    val srcFS = srcRoot.getFileSystem(conf)
-    val destFS = destRoot.getFileSystem(conf)
-
-    val typePath = new Path(srcRoot, typeName)
-    val foundFiles = srcFS.listFiles(typePath, true)
-
-    val storageFiles = mutable.ListBuffer.empty[Path]
-    while (foundFiles.hasNext) {
-      val f = foundFiles.next()
-      if (!f.isDirectory) {
-        storageFiles += f.getPath
-      }
-    }
-
-    storageFiles.forall { f =>
-      val child = f.toString.replace(srcRoot.toString, "")
-      val target = new Path(destRoot, if (child.startsWith("/")) child.drop(1) else child)
-      logger.info(s"Moving $f to $target")
-      if (!destFS.exists(target.getParent)) {
-        destFS.mkdirs(target.getParent)
-      }
-      FileUtil.copy(srcFS, f, destFS, target, true, true, conf)
-    }
-  }
-
   def reduced(job: Job): Long = job.getCounters.findCounter(GeoMesaOutputFormat.Counters.Group, "reduced").getValue
-}
-
-object ParquetConverterJob {
-
-  def listFiles(path: Path, conf: Configuration, suffix: String): Seq[Path] = {
-    val fs = path.getFileSystem(conf)
-    val listing = fs.listFiles(path, true)
-
-    val result = mutable.ListBuffer.empty[Path]
-    while(listing.hasNext) {
-      val next = listing.next()
-      if (next.isFile) {
-        val p = next.getPath
-        if (p.getName.endsWith(suffix)) {
-          result += p
-        }
-      }
-    }
-
-    result
-  }
-
-  def setSimpleFeatureType(conf: Configuration, sft: SimpleFeatureType): Unit = {
-    // Validate that there is a partition scheme
-    org.locationtech.geomesa.fs.storage.common.PartitionScheme.extractFromSft(sft)
-    SimpleFeatureReadSupport.setSft(sft, conf)
-  }
-
-  def getSimpleFeatureType(conf: Configuration): SimpleFeatureType = {
-    SimpleFeatureReadSupport.getSft(conf)
-  }
 }
 
 class IngestMapper extends Mapper[LongWritable, SimpleFeature, Text, BytesWritable] with LazyLogging {
@@ -263,7 +163,7 @@ class IngestMapper extends Mapper[LongWritable, SimpleFeature, Text, BytesWritab
 
   override def setup(context: Context): Unit = {
     super.setup(context)
-    val sft = ParquetConverterJob.getSimpleFeatureType(context.getConfiguration)
+    val sft = ParquetJobUtils.getSimpleFeatureType(context.getConfiguration)
     serializer = KryoFeatureSerializer(sft, SerializationOptions.withUserData)
     partitionScheme = org.locationtech.geomesa.fs.storage.common.PartitionScheme.extractFromSft(sft)
 
@@ -297,7 +197,7 @@ class DummyReducer extends Reducer[Text, BytesWritable, Void, SimpleFeature] {
 
   override def setup(context: Context): Unit = {
     super.setup(context)
-    val sft = ParquetConverterJob.getSimpleFeatureType(context.getConfiguration)
+    val sft = ParquetJobUtils.getSimpleFeatureType(context.getConfiguration)
     serializer = KryoFeatureSerializer(sft, SerializationOptions.withUserData)
     reduced = context.getCounter(GeoMesaOutputFormat.Counters.Group, "reduced")
   }
@@ -309,86 +209,4 @@ class DummyReducer extends Reducer[Text, BytesWritable, Void, SimpleFeature] {
     }
   }
 
-}
-
-class SchemeOutputCommitter(extension: String,
-                            outputPath: Path,
-                            context: TaskAttemptContext)
-  extends FileOutputCommitter(outputPath, context) with LazyLogging {
-
-  @throws[IOException]
-  override def commitJob(jobContext: JobContext) {
-    super.commitJob(jobContext)
-    val conf = ContextUtil.getConfiguration(jobContext)
-    ParquetConverterJob.listFiles(outputPath, conf, extension).map(_.getParent).distinct.foreach { path =>
-      ParquetOutputCommitter.writeMetaDataFile(conf, path)
-      logger.info(s"Wrote metadata file for path $path")
-    }
-  }
-}
-
-class SchemeOutputFormat extends ParquetOutputFormat[SimpleFeature] {
-
-  val extension = ".parquet" // TODO this has to match the FS from the geomesa-fs abstraction need to do that
-  private var commiter: SchemeOutputCommitter = _
-
-  override def getOutputCommitter(context: TaskAttemptContext): OutputCommitter = {
-    if (commiter == null) {
-      val output = FileOutputFormat.getOutputPath(context)
-      commiter = new SchemeOutputCommitter(extension, output, context)
-    }
-    commiter
-  }
-
-  override def getRecordWriter(context: TaskAttemptContext): RecordWriter[Void, SimpleFeature] = {
-
-    val sft = ParquetConverterJob.getSimpleFeatureType(context.getConfiguration)
-    val name = sft.getTypeName
-    val conf = context.getConfiguration
-    new RecordWriter[Void, SimpleFeature] with LazyLogging {
-
-      private val partitionScheme = org.locationtech.geomesa.fs.storage.common.PartitionScheme.extractFromSft(sft)
-
-      var curPartition: String = _
-      var writer: RecordWriter[Void, SimpleFeature] = _
-      var sentToParquet: Counter = context.getCounter(GeoMesaOutputFormat.Counters.Group, "sentToParquet")
-
-      override def write(key: Void, value: SimpleFeature): Unit = {
-        val keyPartition = partitionScheme.getPartitionName(value)
-
-        def initWriter() = {
-          val committer = getOutputCommitter(context).asInstanceOf[FileOutputCommitter]
-          val root = committer.getWorkPath
-          val fs = root.getFileSystem(conf)
-          // TODO combine this with the same code in ParquetFileSystemStorage
-          val file = StorageUtils.nextFile(fs, root, name, keyPartition, partitionScheme.isLeafStorage, "parquet")
-          logger.info(s"Creating Date scheme record writer at path ${file.toString}")
-          curPartition = keyPartition
-          writer = getRecordWriter(context, file)
-        }
-
-        if (writer == null) {
-          initWriter()
-        } else if (keyPartition != curPartition) {
-          writer.close(context)
-          logger.info(s"Closing writer for $curPartition")
-          initWriter()
-        }
-        writer.write(key, value)
-        sentToParquet.increment(1)
-      }
-
-      override def close(context: TaskAttemptContext): Unit = {
-        if (writer != null) writer.close(context)
-      }
-    }
-  }
-
-  override def checkOutputSpecs(job: JobContext): Unit = {
-    // Ensure that the output directory is set and not already there
-    val outDir = FileOutputFormat.getOutputPath(job)
-    if (outDir == null) throw new InvalidJobConfException("Output directory not set.")
-    // get delegation token for outDir's file system
-    TokenCache.obtainTokensForNamenodes(job.getCredentials, Array[Path](outDir), job.getConfiguration)
-  }
 }

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/ParquetJobUtils.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/ParquetJobUtils.scala
@@ -1,0 +1,110 @@
+/***********************************************************************
+ * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.tools.ingest
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileUtil, Path}
+import org.apache.hadoop.mapreduce.JobStatus
+import org.apache.hadoop.tools.{DistCp, DistCpOptions}
+import org.locationtech.geomesa.parquet.SimpleFeatureReadSupport
+import org.locationtech.geomesa.tools.Command
+import org.locationtech.geomesa.tools.ingest.AbstractIngest.StatusCallback
+import org.opengis.feature.simple.SimpleFeatureType
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+object ParquetJobUtils extends LazyLogging {
+
+  def distCopy(srcRoot: Path,
+               dest: Path,
+               sft: SimpleFeatureType,
+               conf: Configuration,
+               statusCallback: StatusCallback,
+               stageId: Int,
+               numStages: Int): Boolean = {
+    val typeName = sft.getTypeName
+    val typePath = new Path(srcRoot, typeName)
+    val destTypePath = new Path(dest, typeName)
+
+    statusCallback.reset()
+
+    Command.user.info("Submitting DistCp job - please wait...")
+    val opts = new DistCpOptions(List(typePath), destTypePath)
+    opts.setAppend(false)
+    opts.setOverwrite(true)
+    opts.setCopyStrategy("dynamic")
+    val job = new DistCp(new Configuration, opts).execute()
+
+    Command.user.info(s"Tracking available at ${job.getStatus.getTrackingUrl}")
+
+    // distCp has no reduce phase
+    while (!job.isComplete) {
+      if (job.getStatus.getState != JobStatus.State.PREP) {
+        statusCallback(s"DistCp (stage $stageId/$numStages): ", job.mapProgress(), Seq.empty, done = false)
+      }
+      Thread.sleep(1000)
+    }
+    statusCallback(s"DistCp (stage $stageId/$numStages): ", job.mapProgress(), Seq.empty, done = true)
+
+    val success = job.isSuccessful
+    if (success) {
+      Command.user.info(s"Successfully copied data to $dest")
+    } else {
+      Command.user.error(s"Failed to copy data to $dest")
+    }
+    success
+  }
+
+  // TODO parallelize if the filesystems are not the same
+  def copyData(srcRoot: Path, destRoot: Path, sft: SimpleFeatureType, conf: Configuration): Boolean = {
+    val typeName = sft.getTypeName
+    Command.user.info(s"Job finished...copying data from $srcRoot to $destRoot for type $typeName")
+
+    val srcFS = srcRoot.getFileSystem(conf)
+    val destFS = destRoot.getFileSystem(conf)
+
+    val typePath = new Path(srcRoot, typeName)
+    val foundFiles = srcFS.listFiles(typePath, true)
+
+    val storageFiles = mutable.ListBuffer.empty[Path]
+    while (foundFiles.hasNext) {
+      val f = foundFiles.next()
+      if (!f.isDirectory) {
+        storageFiles += f.getPath
+      }
+    }
+
+    storageFiles.forall { f =>
+      val child = f.toString.replace(srcRoot.toString, "")
+      val target = new Path(destRoot, if (child.startsWith("/")) child.drop(1) else child)
+      logger.info(s"Moving $f to $target")
+      if (!destFS.exists(target.getParent)) {
+        destFS.mkdirs(target.getParent)
+      }
+      FileUtil.copy(srcFS, f, destFS, target, true, true, conf)
+    }
+  }
+
+  //
+  // Common configuration options
+  //
+
+  def setSimpleFeatureType(conf: Configuration, sft: SimpleFeatureType): Unit = {
+    // Validate that there is a partition scheme
+    org.locationtech.geomesa.fs.storage.common.PartitionScheme.extractFromSft(sft)
+    SimpleFeatureReadSupport.setSft(sft, conf)
+  }
+
+  def getSimpleFeatureType(conf: Configuration): SimpleFeatureType = {
+    SimpleFeatureReadSupport.getSft(conf)
+  }
+
+}

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/SchemeOutputFormat.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/SchemeOutputFormat.scala
@@ -1,0 +1,137 @@
+/***********************************************************************
+ * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.tools.ingest
+
+import java.io.IOException
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapred.InvalidJobConfException
+import org.apache.hadoop.mapreduce._
+import org.apache.hadoop.mapreduce.lib.output.{FileOutputCommitter, FileOutputFormat}
+import org.apache.hadoop.mapreduce.security.TokenCache
+import org.apache.parquet.hadoop.util.ContextUtil
+import org.apache.parquet.hadoop.{ParquetOutputCommitter, ParquetOutputFormat}
+import org.locationtech.geomesa.fs.storage.common.FileType.FileType
+import org.locationtech.geomesa.fs.storage.common.{FileType, StorageUtils}
+import org.locationtech.geomesa.jobs.mapreduce.GeoMesaOutputFormat
+import org.opengis.feature.simple.SimpleFeature
+
+import scala.collection.mutable
+
+class SchemeOutputFormat extends ParquetOutputFormat[SimpleFeature] {
+
+  val extension = ".parquet" // TODO read this from configuration
+  private var commiter: SchemeOutputCommitter = _
+
+  override def getOutputCommitter(context: TaskAttemptContext): OutputCommitter = {
+    if (commiter == null) {
+      val output = FileOutputFormat.getOutputPath(context)
+      commiter = new SchemeOutputCommitter(extension, output, context)
+    }
+    commiter
+  }
+
+  override def getRecordWriter(context: TaskAttemptContext): RecordWriter[Void, SimpleFeature] = {
+
+    val sft = ParquetJobUtils.getSimpleFeatureType(context.getConfiguration)
+    val name = sft.getTypeName
+    val conf = context.getConfiguration
+    val fileType: FileType = SchemeOutputFormat.getFileType(context.getConfiguration)
+
+    new RecordWriter[Void, SimpleFeature] with LazyLogging {
+
+      private val partitionScheme = org.locationtech.geomesa.fs.storage.common.PartitionScheme.extractFromSft(sft)
+
+      var curPartition: String = _
+      var writer: RecordWriter[Void, SimpleFeature] = _
+      var sentToParquet: Counter = context.getCounter(GeoMesaOutputFormat.Counters.Group, "sentToParquet")
+
+      override def write(key: Void, value: SimpleFeature): Unit = {
+        val keyPartition = partitionScheme.getPartitionName(value)
+
+        def initWriter() = {
+          val committer = getOutputCommitter(context).asInstanceOf[FileOutputCommitter]
+          val root = committer.getWorkPath
+          val fs = root.getFileSystem(conf)
+          // TODO combine this with the same code in ParquetFileSystemStorage
+          val file = StorageUtils.nextFile(fs, root, name, keyPartition, partitionScheme.isLeafStorage, "parquet", fileType)
+          logger.info(s"Creating Date scheme record writer at path ${file.toString}")
+          curPartition = keyPartition
+          writer = getRecordWriter(context, file)
+        }
+
+        if (writer == null) {
+          initWriter()
+        } else if (keyPartition != curPartition) {
+          writer.close(context)
+          logger.info(s"Closing writer for $curPartition")
+          initWriter()
+        }
+        writer.write(key, value)
+        sentToParquet.increment(1)
+      }
+
+      override def close(context: TaskAttemptContext): Unit = {
+        if (writer != null) writer.close(context)
+      }
+    }
+  }
+
+  override def checkOutputSpecs(job: JobContext): Unit = {
+    // Ensure that the output directory is set and not already there
+    val outDir = FileOutputFormat.getOutputPath(job)
+    if (outDir == null) throw new InvalidJobConfException("Output directory not set.")
+    // get delegation token for outDir's file system
+    TokenCache.obtainTokensForNamenodes(job.getCredentials, Array[Path](outDir), job.getConfiguration)
+  }
+}
+
+object SchemeOutputFormat {
+  val FileTypeParam = "geomesa.fs.mapreduce.output.filetype"
+  def getFileType(conf: Configuration): FileType = FileType.withName(conf.get(FileTypeParam))
+  def setFileType(conf: Configuration, fileType: FileType): Unit = conf.set(FileTypeParam, fileType.toString)
+}
+
+class SchemeOutputCommitter(extension: String,
+                            outputPath: Path,
+                            context: TaskAttemptContext)
+  extends FileOutputCommitter(outputPath, context) with LazyLogging {
+
+  @throws[IOException]
+  override def commitJob(jobContext: JobContext) {
+    super.commitJob(jobContext)
+    val conf = ContextUtil.getConfiguration(jobContext)
+    SchemeOutputCommitter.listFiles(outputPath, conf, extension).map(_.getParent).distinct.foreach { path =>
+      ParquetOutputCommitter.writeMetaDataFile(conf, path)
+      logger.info(s"Wrote metadata file for path $path")
+    }
+  }
+}
+
+object SchemeOutputCommitter {
+  def listFiles(path: Path, conf: Configuration, suffix: String): Seq[Path] = {
+    val fs = path.getFileSystem(conf)
+    val listing = fs.listFiles(path, true)
+
+    val result = mutable.ListBuffer.empty[Path]
+    while (listing.hasNext) {
+      val next = listing.next()
+      if (next.isFile) {
+        val p = next.getPath
+        if (p.getName.endsWith(suffix)) {
+          result += p
+        }
+      }
+    }
+
+    result
+  }
+}

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/status/FSGetFilesCommand.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/status/FSGetFilesCommand.scala
@@ -1,0 +1,43 @@
+/***********************************************************************
+ * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.tools.status
+
+import com.beust.jcommander.{ParameterException, Parameters}
+import org.locationtech.geomesa.fs.tools.{FsDataStoreCommand, FsParams, PartitionParam}
+import org.locationtech.geomesa.tools.{Command, RequiredTypeNameParam}
+
+import scala.collection.JavaConversions._
+
+class FSGetFilesCommand extends FsDataStoreCommand {
+  override val params = new FSGetFilesParams
+
+  override val name: String = "get-files"
+
+  override def execute(): Unit = withDataStore { ds =>
+    val existingPartitions = ds.storage.getMetadata(params.featureName).getPartitions
+    val toList = if (params.partitions.nonEmpty) {
+      params.partitions.filterNot(existingPartitions.contains).headOption.foreach { p =>
+        throw new ParameterException(s"Partition $p cannot be found in metadata")
+      }
+      params.partitions
+    } else {
+      existingPartitions
+    }
+
+    Command.user.info(s"Listing files for ${toList.size()} partitions")
+    toList.foreach { p =>
+      ds.storage.getMetadata(params.featureName).getFiles(p).foreach { f =>
+        Command.output.info(s"$p\t$f")
+      }
+    }
+  }
+}
+
+@Parameters(commandDescription = "List files for partitions")
+class FSGetFilesParams extends FsParams with RequiredTypeNameParam with PartitionParam

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/status/FsGetPartitionsCommand.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/status/FsGetPartitionsCommand.scala
@@ -1,0 +1,29 @@
+/***********************************************************************
+ * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.tools.status
+
+import com.beust.jcommander.Parameters
+import org.locationtech.geomesa.fs.tools.{FsDataStoreCommand, FsParams}
+import org.locationtech.geomesa.tools.{Command, RequiredTypeNameParam}
+
+import scala.collection.JavaConversions._
+
+class FsGetPartitionsCommand extends FsDataStoreCommand {
+  override val params = new FsGetPartitionsParams
+
+  override val name: String = "get-partitions"
+
+  override def execute(): Unit = withDataStore { ds =>
+    Command.user.info(s"Partitions for type ${params.featureName}")
+    ds.storage.getMetadata(params.featureName).getPartitions.foreach(Command.output.info)
+  }
+}
+
+@Parameters(commandDescription = "List GeoMesa feature type for a given Fs resource")
+class FsGetPartitionsParams extends FsParams with RequiredTypeNameParam

--- a/geomesa-fs/geomesa-fs-tools/src/test/scala/org/locationtech/geomesa/fs/tools/ingest/ParquetJobUtilsTest.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/test/scala/org/locationtech/geomesa/fs/tools/ingest/ParquetJobUtilsTest.scala
@@ -1,0 +1,37 @@
+/***********************************************************************
+ * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.tools.ingest
+
+import java.time.temporal.ChronoUnit
+
+import org.apache.hadoop.conf.Configuration
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.fs.storage.common.{DateTimeScheme, PartitionScheme}
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ParquetJobUtilsTest extends Specification {
+
+  "ParquetJobUtils" should {
+    "properly serialize sft with partition scheme user data" >> {
+      val sft = SimpleFeatureTypes.createType("test", "name:String,age:Int,dtg:Date,*geom:Point:srid=4326")
+      val partitionScheme = new DateTimeScheme(DateTimeScheme.Formats.Daily, ChronoUnit.DAYS, 1, "dtg", false)
+      val conf = new Configuration
+      PartitionScheme.addToSft(sft, partitionScheme)
+      ParquetJobUtils.setSimpleFeatureType(conf, sft)
+
+      val newSFT = ParquetJobUtils.getSimpleFeatureType(conf)
+      val extractedScheme = PartitionScheme.extractFromSft(newSFT)
+      extractedScheme.name mustEqual partitionScheme.name()
+    }
+  }
+
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureSpecConfig.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureSpecConfig.scala
@@ -108,11 +108,12 @@ object SimpleFeatureSpecConfig {
   def toConfigString(sft: SimpleFeatureType,
                      includeUserData: Boolean,
                      concise: Boolean,
-                     includePrefix: Boolean): String = {
+                     includePrefix: Boolean,
+                     json: Boolean): String = {
     val opts = if (concise) {
-      ConfigRenderOptions.concise
+      ConfigRenderOptions.concise.setJson(json)
     } else {
-      ConfigRenderOptions.defaults().setFormatted(true).setComments(false).setOriginComments(false).setJson(false)
+      ConfigRenderOptions.defaults().setFormatted(true).setComments(false).setOriginComments(false).setJson(json)
     }
     toConfig(sft, includeUserData, includePrefix).root().render(opts)
   }
@@ -139,8 +140,10 @@ object SimpleFeatureSpecConfig {
     }
   }
 
+  def normalizeKey(k: String): String = ConfigUtil.splitPath(k).mkString(".")
+
   private def getOptions(conf: Config): Map[String, String] = {
-    val asMap = conf.entrySet().map(e => e.getKey -> e.getValue.unwrapped()).toMap
+    val asMap = conf.entrySet().map(e => normalizeKey(e.getKey) -> e.getValue.unwrapped()).toMap
     asMap.filterKeys(!NonOptions.contains(_)).map {
       // Special case to handle adding keywords
       case (KEYWORDS_KEY, v: jList[String]) => KEYWORDS_KEY -> v.mkString(KEYWORDS_DELIMITER)

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
@@ -153,8 +153,9 @@ object SimpleFeatureTypes {
   def toConfigString(sft: SimpleFeatureType,
                      includeUserData: Boolean = true,
                      concise: Boolean = false,
-                     includePrefix: Boolean = true): String =
-    SimpleFeatureSpecConfig.toConfigString(sft, includeUserData, concise, includePrefix)
+                     includePrefix: Boolean = true,
+                     json: Boolean = false): String =
+    SimpleFeatureSpecConfig.toConfigString(sft, includeUserData, concise, includePrefix, json)
 
   /**
     * Renames a simple feature type. Preserves user data

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypesTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypesTest.scala
@@ -494,7 +494,7 @@ class SimpleFeatureTypesTest extends Specification {
           |    { name = "geom",     type = "Point" , srid = 4326, default = true }
           |  ]
           |  user-data = {
-          |    geomesa.one = "true"
+          |    "geomesa.one" = "true"
           |    geomesa.two = "two"
           |  }
           |}


### PR DESCRIPTION
* Distributed and Local compactions for Parquet FSDS
* Option to compact all or compact specific partitions
* Get-partitions and get-files commands for FSDS tools
* Rolling metadata file backups
* Parquet filenames are now include random UUID instead of sequence numbers
* Parquet filenames include a type character (e.g. C = compaction, W = written, etc)
* Fixed quoted user-data serialization for Typesafe config

Signed-off-by: Andrew Hulbert <ahulbert@ccri.com>