### PR TITLE
GEOMESA-2033 Adding consistency checker for kafka feature cache

### DIFF
--- a/docs/user/kafka/usage.rst
+++ b/docs/user/kafka/usage.rst
@@ -46,6 +46,7 @@ Parameter                            Type    Description
 ``kafka.cache.cleanup``              String  Clean expired cache entries every so often, e.g.
                                              "60 seconds". If not specified, expired features will be
                                              cleaned incrementally during reads and writes
+``kafka.cache.consistency``          String  Check the feature cache for consistency at this interval, e.g. "1 hour"
 ``kafka.cache.cqengine``             Boolean Use CQEngine-based implementation of in-memory feature cache
 ``geomesa.query.loose-bounding-box`` Boolean Use loose bounding boxes, which offer improved performance but are not exact
 ``geomesa.query.audit``              Boolean Audit incoming queries. By default audits are written to a log file

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaDataStore.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaDataStore.scala
@@ -71,9 +71,9 @@ class KafkaDataStore(val config: KafkaDataStoreConfig)
       } else {
         val sft = getSchema(key)
         val cache = if (config.cqEngine) {
-          new FeatureCacheCqEngine(sft, config.cacheExpiry, config.cacheCleanup)(config.ticker)
+          new FeatureCacheCqEngine(sft, config.cacheExpiry, config.cacheCleanup, config.cacheConsistency)(config.ticker)
         } else {
-          new FeatureCacheGuava(sft, config.cacheExpiry, config.cacheCleanup)(config.ticker)
+          new FeatureCacheGuava(sft, config.cacheExpiry, config.cacheCleanup, config.cacheConsistency)(config.ticker)
         }
         val consumers = KafkaDataStore.consumers(config, KafkaDataStore.topic(sft))
         new KafkaCacheLoader.KafkaCacheLoaderImpl(sft, cache, consumers)
@@ -275,6 +275,7 @@ object KafkaDataStore extends LazyLogging {
                                   consumeFromBeginning: Boolean,
                                   cacheExpiry: Duration,
                                   cacheCleanup: Duration,
+                                  cacheConsistency: Duration,
                                   ticker: Ticker,
                                   cqEngine: Boolean,
                                   looseBBox: Boolean,

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/index/KafkaFeatureCache.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/index/KafkaFeatureCache.scala
@@ -33,7 +33,10 @@ object KafkaFeatureCache {
 
   def empty(): KafkaFeatureCache = EmptyFeatureCache
 
-  abstract class AbstractKafkaFeatureCache[T <: AnyRef](expiry: Duration, cleanup: Duration)(implicit ticker: Ticker)
+  abstract class AbstractKafkaFeatureCache[T <: AnyRef](expiry: Duration,
+                                                        cleanup: Duration,
+                                                        consistency: Duration)
+                                                       (implicit ticker: Ticker)
       extends KafkaFeatureCache with LazyLogging {
 
     protected val cache: Cache[String, T] = {
@@ -43,7 +46,7 @@ object KafkaFeatureCache {
           override def onRemoval(key: String, value: T, cause: RemovalCause): Unit = {
             if (cause != RemovalCause.REPLACED) {
               logger.debug(s"Removing feature $key due to ${cause.name()} after $expiry")
-              expired(value)
+              removeFromIndex(value)
             }
           }
         }
@@ -52,14 +55,71 @@ object KafkaFeatureCache {
       builder.build[String, T]()
     }
 
-    private val cleaner = if (expiry == Duration.Inf || cleanup == Duration.Inf) { None } else {
-      val executor = Executors.newSingleThreadScheduledExecutor()
-      val runnable = new Runnable() { override def run(): Unit = cache.cleanUp() }
-      executor.scheduleAtFixedRate(runnable, cleanup.toMillis, cleanup.toMillis, TimeUnit.MILLISECONDS)
-      Some(executor)
+    private val executor = {
+      val cleaner = if (expiry == Duration.Inf || cleanup == Duration.Inf) { None } else {
+        Some(new Runnable() { override def run(): Unit = cache.cleanUp() })
+      }
+      val checker = if (consistency == Duration.Inf) { None } else {
+        var lastRun = Set.empty[SimpleFeature]
+
+        Some(new Runnable() {
+          override def run(): Unit = {
+            // only remove features that have been found to be inconsistent on the last run just to make sure
+            lastRun = inconsistencies().filter { sf =>
+              if (lastRun.contains(sf)) {
+                cache.invalidate(sf.getID)
+                removeFromIndex(wrap(sf))
+                false
+              } else {
+                true // we'll check it again next time
+              }
+            }
+          }
+        })
+      }
+
+      val count = cleaner.map(_ => 1).getOrElse(0) + checker.map(_ => 1).getOrElse(0)
+      if (count == 0) { None } else {
+        val executor = Executors.newScheduledThreadPool(count)
+        cleaner.foreach(executor.scheduleAtFixedRate(_, cleanup.toMillis, cleanup.toMillis, TimeUnit.MILLISECONDS))
+        checker.foreach(executor.scheduleAtFixedRate(_, consistency.toMillis, consistency.toMillis, TimeUnit.MILLISECONDS))
+        Some(executor)
+      }
     }
 
-    protected def expired(value: T): Unit
+    /**
+      * WARNING: this method is not thread-safe
+      *
+      * TODO: https://geomesa.atlassian.net/browse/GEOMESA-1409
+      */
+    override def put(feature: SimpleFeature): Unit = {
+      val id = feature.getID
+      val old = cache.getIfPresent(id)
+      if (old != null) {
+        removeFromIndex(old)
+      }
+      val wrapped = wrap(feature)
+      cache.put(id, wrapped)
+      addToIndex(wrapped)
+    }
+
+    /**
+      * WARNING: this method is not thread-safe
+      *
+      * TODO: https://geomesa.atlassian.net/browse/GEOMESA-1409
+      */
+    override def remove(id: String): Unit = {
+      val old = cache.getIfPresent(id)
+      if (old != null) {
+        cache.invalidate(id)
+        removeFromIndex(old)
+      }
+    }
+
+    override def clear(): Unit = {
+      cache.invalidateAll()
+      clearIndex()
+    }
 
     override def size(): Int = cache.estimatedSize().toInt
 
@@ -72,7 +132,41 @@ object KafkaFeatureCache {
 
     override def cleanUp(): Unit = cache.cleanUp()
 
-    override def close(): Unit = cleaner.foreach(_.shutdown())
+    override def close(): Unit = executor.foreach(_.shutdown())
+
+    /**
+      * Create the cache value from a simple feature
+      *
+      * @param feature simple feature
+      * @return
+      */
+    protected def wrap(feature: SimpleFeature): T
+
+    /**
+      * Add a feature to any indices
+      *
+      * @param value value to add
+      */
+    protected def addToIndex(value: T): Unit
+
+    /**
+      * Remove a feature from any indices
+      *
+      * @param value value to remove
+      */
+    protected def removeFromIndex(value: T): Unit
+
+    /**
+      * Clear all features from any indices
+      */
+    protected def clearIndex(): Unit
+
+    /**
+      * Check for inconsistencies between the main cache and the spatial index
+      *
+      * @return any inconsistent features (i.e. in one but not both indices)
+      */
+    protected def inconsistencies(): Set[SimpleFeature]
   }
 
   object EmptyFeatureCache extends KafkaFeatureCache {


### PR DESCRIPTION
* Added 'kafka.cache.consistency' data store parameter to enable consistency checks

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>