### PR TITLE
GEOMESA-2058 Fixing serialization of HBase z-filter

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Z2Index.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Z2Index.scala
@@ -19,6 +19,8 @@ import org.opengis.feature.simple.SimpleFeatureType
 case object Z2Index extends AccumuloFeatureIndex with AccumuloIndexAdapter
     with Z2Index[AccumuloDataStore, AccumuloFeature, Mutation, Range, ScanConfig] {
 
+  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
   val Z2IterPriority = 23
 
   override val version: Int = 4
@@ -32,8 +34,8 @@ case object Z2Index extends AccumuloFeatureIndex with AccumuloIndexAdapter
                                           indexValues: Option[Z2IndexValues]): ScanConfig = {
     indexValues match {
       case None => config
-      case Some(Z2IndexValues(sfc, _, xy)) =>
-        val zIter = Z2Iterator.configure(sft, sfc, xy, Z2IterPriority)
+      case Some(values) =>
+        val zIter = Z2Iterator.configure(values, sft.isTableSharing, Z2IterPriority)
         config.copy(iterators = config.iterators :+ zIter)
     }
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Z3Index.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/Z3Index.scala
@@ -34,12 +34,8 @@ case object Z3Index extends AccumuloFeatureIndex with AccumuloIndexAdapter
                                           indexValues: Option[Z3IndexValues]): ScanConfig = {
     indexValues match {
       case None => config
-      case Some(Z3IndexValues(sfc, _, xy, _, times)) =>
-        // we know we're only going to scan appropriate periods, so leave out whole ones
-        val wholePeriod = Seq((sfc.time.min.toLong, sfc.time.max.toLong))
-        val filteredTimes = times.filter(_._2 != wholePeriod)
-        val sharing = sft.isTableSharing
-        val zIter = Z3Iterator.configure(sfc, xy, filteredTimes, isPoints = true, hasSplits = true, sharing, Z3IterPriority)
+      case Some(values) =>
+        val zIter = Z3Iterator.configure(values, hasSplits = true, sft.isTableSharing, Z3IterPriority)
         config.copy(iterators = config.iterators :+ zIter)
     }
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z2/Z2IndexV3.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z2/Z2IndexV3.scala
@@ -21,6 +21,8 @@ import org.opengis.feature.simple.SimpleFeatureType
 case object Z2IndexV3 extends AccumuloFeatureIndex with AccumuloIndexAdapter
     with Z2LegacyIndex[AccumuloDataStore, AccumuloFeature, Mutation, Range, ScanConfig] {
 
+  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
   val Z2IterPriority = 23
 
   override val version: Int = 3
@@ -34,8 +36,8 @@ case object Z2IndexV3 extends AccumuloFeatureIndex with AccumuloIndexAdapter
                                           indexValues: Option[Z2IndexValues]): ScanConfig = {
     indexValues match {
       case None => config
-      case Some(Z2IndexValues(sfc, _, xy)) =>
-        val zIter = Z2Iterator.configure(sft, sfc, xy, Z2IterPriority)
+      case Some(values) =>
+        val zIter = Z2Iterator.configure(values, sft.isTableSharing, Z2IterPriority)
         config.copy(iterators = config.iterators :+ zIter)
     }
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3IndexV4.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3IndexV4.scala
@@ -36,12 +36,8 @@ case object Z3IndexV4 extends AccumuloFeatureIndex with AccumuloIndexAdapter
                                           indexValues: Option[Z3IndexValues]): ScanConfig = {
     indexValues match {
       case None => config
-      case Some(Z3IndexValues(sfc, _, xy, _, times)) =>
-        // we know we're only going to scan appropriate periods, so leave out whole ones
-        val wholePeriod = Seq((sfc.time.min.toLong, sfc.time.max.toLong))
-        val filteredTimes = times.filter(_._2 != wholePeriod)
-        val sharing = sft.isTableSharing
-        val zIter = Z3Iterator.configure(sfc, xy, filteredTimes, isPoints = true, hasSplits = true, sharing, Z3IterPriority)
+      case Some(values) =>
+        val zIter = Z3Iterator.configure(values, hasSplits = true, sft.isTableSharing, Z3IterPriority)
         config.copy(iterators = config.iterators :+ zIter)
     }
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3Iterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3Iterator.scala
@@ -12,11 +12,8 @@ import org.apache.accumulo.core.client.IteratorSetting
 import org.apache.accumulo.core.data.{ByteSequence, Key, Value, Range => AccRange}
 import org.apache.accumulo.core.iterators.{IteratorEnvironment, SortedKeyValueIterator}
 import org.apache.hadoop.io.Text
-import org.locationtech.geomesa.accumulo.index.legacy.z3.Z3IndexV2
-import org.locationtech.geomesa.curve.Z3SFC
 import org.locationtech.geomesa.index.filters.Z3Filter
-import org.locationtech.sfcurve.zorder.Z3
-
+import org.locationtech.geomesa.index.index.z3.Z3IndexValues
 
 class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
 
@@ -24,46 +21,22 @@ class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
 
   private var source: SortedKeyValueIterator[Key, Value] = _
 
-  private var keyXY: String = _
-  private var keyT: String = _
   private var filter: Z3Filter = _
   private var zOffset: Int = -1
 
   private var topKey: Key = _
   private var topValue: Value = _
-
   private val row = new Text()
 
   override def init(source: SortedKeyValueIterator[Key, Value],
                     options: java.util.Map[String, String],
                     env: IteratorEnvironment): Unit = {
+    import scala.collection.JavaConverters._
+
     this.source = source
 
-    var minEpoch: Short = Short.MaxValue
-    var maxEpoch: Short = Short.MinValue
-    keyT = options.get(ZKeyT)
-    val epochsAndTimes = keyT.split(EpochSeparator).filterNot(_.isEmpty).map { times =>
-      val parts = times.split(TermSeparator)
-      val epoch = parts(0).toShort
-      // set min/max epochs - note: side effect in map
-      if (epoch < minEpoch) {
-        minEpoch = epoch
-      }
-      if (epoch > maxEpoch) {
-        maxEpoch = epoch
-      }
-      (epoch, parts.drop(1).map(_.split(RangeSeparator).map(_.toInt)))
-    }
-
-    val tvals: Array[Array[Array[Int]]] =
-      if (minEpoch == Short.MaxValue && maxEpoch == Short.MinValue) Array.empty else Array.ofDim(maxEpoch - minEpoch + 1)
-    epochsAndTimes.foreach { case (w, times) => tvals(w - minEpoch) = times }
-
-    keyXY = options.get(ZKeyXY)
-    val xyvals = keyXY.split(TermSeparator).map(_.split(RangeSeparator).map(_.toInt))
-    val zLength = options.get(ZLengthKey).toInt
-    zOffset = options.get(ZOffsetKey).toInt
-    filter = new Z3Filter(xyvals, tvals, minEpoch, maxEpoch, zLength)
+    zOffset = options.get(Config.ZOffsetKey).toInt
+    filter = Z3Filter.deserializeFromStrings(options.asScala)
   }
 
   override def next(): Unit = {
@@ -97,13 +70,8 @@ class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
 
   override def deepCopy(env: IteratorEnvironment): SortedKeyValueIterator[Key, Value] = {
     import scala.collection.JavaConversions._
-    val opts = Map(
-      ZKeyXY     -> keyXY,
-      ZKeyT      -> keyT,
-      ZOffsetKey -> zOffset.toString,
-      ZLengthKey -> filter.zLength.toString
-    )
     val iter = new Z3Iterator
+    val opts = Z3Filter.serializeToStrings(filter) + (Config.ZOffsetKey -> zOffset.toString)
     iter.init(source.deepCopy(env), opts, env)
     iter
   }
@@ -111,64 +79,21 @@ class Z3Iterator extends SortedKeyValueIterator[Key, Value] {
 
 object Z3Iterator {
 
-  val ZKeyXY = "zxy"
-  val ZKeyT  = "zt"
+  object Config {
+    val ZOffsetKey = "zo"
+  }
 
-  val ZOffsetKey = "zo"
-  val ZLengthKey = "zl"
-
-  val RangeSeparator = ":"
-  val TermSeparator  = ";"
-  val EpochSeparator  = ","
-
-  def configure(sfc: Z3SFC,
-                bounds: Seq[(Double, Double, Double, Double)],
-                timesByBin: Map[Short, Seq[(Long, Long)]],
-                isPoints: Boolean,
+  def configure(values: Z3IndexValues,
                 hasSplits: Boolean,
                 isSharing: Boolean,
                 priority: Int): IteratorSetting = {
 
+    val offset = if (isSharing && hasSplits) { "2" } else if (isSharing || hasSplits) { "1" } else { "0" }
+
     val is = new IteratorSetting(priority, "z3", classOf[Z3Iterator])
-
+    is.addOption(Config.ZOffsetKey, offset)
     // index space values for comparing in the iterator
-    val (xyOpts, tOpts) = if (isPoints) {
-      val xyOpts = bounds.map { case (xmin, ymin, xmax, ymax) =>
-        s"${sfc.lon.normalize(xmin)}$RangeSeparator${sfc.lat.normalize(ymin)}$RangeSeparator" +
-            s"${sfc.lon.normalize(xmax)}$RangeSeparator${sfc.lat.normalize(ymax)}"
-      }
-      val tOpts = timesByBin.toSeq.sortBy(_._1).map { case (bin, times) =>
-        val time = times.map { case (t1, t2) =>
-          s"${sfc.time.normalize(t1)}$RangeSeparator${sfc.time.normalize(t2)}"
-        }
-        s"$bin$TermSeparator${time.mkString(TermSeparator)}"
-      }
-      (xyOpts, tOpts)
-    } else {
-      val normalized = bounds.map { case (xmin, ymin, xmax, ymax) =>
-        val (lx, ly, _) = decodeNonPoints(sfc, xmin, ymin, 0) // note: time is not used
-        val (ux, uy, _) = decodeNonPoints(sfc, xmax, ymax, 0) // note: time is not used
-        s"$lx$RangeSeparator$ly$RangeSeparator$ux$RangeSeparator$uy"
-      }
-      val tOpts = timesByBin.toSeq.sortBy(_._1).map { case (bin, times) =>
-        val time = times.map { case (t1, t2) =>
-          s"${decodeNonPoints(sfc, 0, 0, t1)._3}$RangeSeparator${decodeNonPoints(sfc, 0, 0, t2)._3}"
-        }
-        s"$bin$TermSeparator${time.mkString(TermSeparator)}"
-      }
-      (normalized, tOpts)
-    }
-
-    is.addOption(ZKeyXY, xyOpts.mkString(TermSeparator))
-    is.addOption(ZKeyT, tOpts.mkString(EpochSeparator))
-    is.addOption(ZOffsetKey, if (isSharing && hasSplits) { "2" } else if (isSharing || hasSplits) { "1" } else { "0" })
-    is.addOption(ZLengthKey, if (isPoints) { "8" } else { Z3IndexV2.GEOM_Z_NUM_BYTES.toString })
-
+    Z3Filter.serializeToStrings(Z3Filter(values)).foreach { case (k, v) => is.addOption(k, v) }
     is
   }
-
-  private def decodeNonPoints(sfc: Z3SFC, x: Double, y: Double, t: Long): (Int, Int, Int) =
-    Z3(sfc.index(x, y, t).z & Z3IndexV2.GEOM_Z_MASK).decode
-
-
 }

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterValues.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterValues.scala
@@ -20,7 +20,7 @@ import scala.collection.GenTraversableOnce
   * @param disjoint mutually exclusive values were extracted, e.g. 'a < 1 && a > 2'
   * @tparam T type parameter
   */
-case class FilterValues[T](values: Seq[T], precise: Boolean = true, disjoint: Boolean = false) {
+case class FilterValues[+T](values: Seq[T], precise: Boolean = true, disjoint: Boolean = false) {
   def map[U](f: T => U): FilterValues[U] = FilterValues(values.map(f), precise, disjoint)
   def flatMap[U](f: T => GenTraversableOnce[U]): FilterValues[U] = FilterValues(values.flatMap(f), precise, disjoint)
   def foreach[U](f: T => U): Unit = values.foreach(f)

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseQueryPlan.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseQueryPlan.scala
@@ -17,10 +17,8 @@ import org.apache.hadoop.hbase.filter.MultiRowRangeFilter.RowRange
 import org.apache.hadoop.hbase.filter.{FilterList, MultiRowRangeFilter, Filter => HFilter}
 import org.locationtech.geomesa.hbase.coprocessor.utils.CoprocessorConfig
 import org.locationtech.geomesa.hbase.data.HBaseQueryPlan.filterToString
-import org.locationtech.geomesa.hbase.filters.{Z2HBaseFilter, Z3HBaseFilter}
 import org.locationtech.geomesa.hbase.utils.HBaseBatchScan
 import org.locationtech.geomesa.hbase.{HBaseFilterStrategyType, HBaseQueryPlanType}
-import org.locationtech.geomesa.index.filters.{Z2Filter, Z3Filter}
 import org.locationtech.geomesa.index.index.IndexAdapter
 import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.utils.collection.{CloseableIterator, SelfClosingIterator}
@@ -63,10 +61,8 @@ object HBaseQueryPlan {
   private [data] def filterToString(filter: HFilter): String = {
     import scala.collection.JavaConversions._
     filter match {
-      case f: FilterList    => f.getFilters.map(filterToString).mkString(", ")
-      case f: Z3HBaseFilter => s"Z3HBaseFilter[${Z3Filter.serializeToStrings(f.filter).mkString(",")}]"
-      case f: Z2HBaseFilter => s"Z2HBaseFilter[${Z2Filter.serializeToStrings(f.filter).mkString(",")}]"
-      case f                => f.toString
+      case f: FilterList => f.getFilters.map(filterToString).mkString(", ")
+      case f             => f.toString
     }
   }
 }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseQueryPlan.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseQueryPlan.scala
@@ -20,6 +20,7 @@ import org.locationtech.geomesa.hbase.data.HBaseQueryPlan.filterToString
 import org.locationtech.geomesa.hbase.filters.{Z2HBaseFilter, Z3HBaseFilter}
 import org.locationtech.geomesa.hbase.utils.HBaseBatchScan
 import org.locationtech.geomesa.hbase.{HBaseFilterStrategyType, HBaseQueryPlanType}
+import org.locationtech.geomesa.index.filters.{Z2Filter, Z3Filter}
 import org.locationtech.geomesa.index.index.IndexAdapter
 import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.utils.collection.{CloseableIterator, SelfClosingIterator}
@@ -63,8 +64,8 @@ object HBaseQueryPlan {
     import scala.collection.JavaConversions._
     filter match {
       case f: FilterList    => f.getFilters.map(filterToString).mkString(", ")
-      case f: Z3HBaseFilter => s"Z3HBaseFilter[xy: (${f.filter.xyvals.map(_.mkString(",")).mkString(")(")}), times ${f.filter.minEpoch} to ${f.filter.maxEpoch}: (${f.filter.tvals.map(_.map(_.mkString(",")).mkString(" ")).mkString(")(")})]"
-      case f: Z2HBaseFilter => s"Z2HBaseFilter[xy: (${f.filter.xyvals.map(_.mkString(",")).mkString(")(")})]"
+      case f: Z3HBaseFilter => s"Z3HBaseFilter[${Z3Filter.serializeToStrings(f.filter).mkString(",")}]"
+      case f: Z2HBaseFilter => s"Z2HBaseFilter[${Z2Filter.serializeToStrings(f.filter).mkString(",")}]"
       case f                => f.toString
     }
   }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/filters/HBaseZFilters.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/filters/HBaseZFilters.scala
@@ -30,6 +30,8 @@ class Z3HBaseFilter(val filter: Z3Filter, offset: Int) extends FilterBase with L
     logger.trace("Serializing Z3HBaseFilter")
     Bytes.concat(Z3Filter.serializeToBytes(filter), Ints.toByteArray(offset))
   }
+
+  override def toString: String = s"Z3HBaseFilter[$filter]"
 }
 
 object Z3HBaseFilter extends LazyLogging {
@@ -37,7 +39,7 @@ object Z3HBaseFilter extends LazyLogging {
 
   @throws[DeserializationException]
   def parseFrom(pbBytes: Array[Byte]): Filter = {
-    logger.debug("Deserializing Z3HBaseFilter")
+    logger.trace("Deserializing Z3HBaseFilter")
     val offset = Ints.fromBytes(pbBytes(pbBytes.length - 4), pbBytes(pbBytes.length - 3),
       pbBytes(pbBytes.length - 2), pbBytes(pbBytes.length - 1))
     new Z3HBaseFilter(Z3Filter.deserializeFromBytes(pbBytes), offset)
@@ -59,6 +61,8 @@ class Z2HBaseFilter(val filter: Z2Filter, offset: Int) extends FilterBase with L
     logger.trace("Serializing Z2HBaseFilter")
     Bytes.concat(Z2Filter.serializeToBytes(filter), Ints.toByteArray(offset))
   }
+
+  override def toString: String = s"Z2HBaseFilter[$filter]"
 }
 
 object Z2HBaseFilter extends LazyLogging {
@@ -66,7 +70,7 @@ object Z2HBaseFilter extends LazyLogging {
 
   @throws[DeserializationException]
   def parseFrom(pbBytes: Array[Byte]): Filter = {
-    logger.debug("Deserializing Z2HBaseFilter")
+    logger.trace("Deserializing Z2HBaseFilter")
     val offset = Ints.fromBytes(pbBytes(pbBytes.length - 4), pbBytes(pbBytes.length - 3),
       pbBytes(pbBytes.length - 2), pbBytes(pbBytes.length - 1))
     new Z2HBaseFilter(Z2Filter.deserializeFromBytes(pbBytes), offset)

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/filters/HBaseZFilters.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/filters/HBaseZFilters.scala
@@ -28,7 +28,7 @@ class Z3HBaseFilter(val filter: Z3Filter, offset: Int) extends FilterBase with L
 
   override def toByteArray: Array[Byte] = {
     logger.trace("Serializing Z3HBaseFilter")
-    Bytes.concat(Z3Filter.toByteArray(filter), Ints.toByteArray(offset))
+    Bytes.concat(Z3Filter.serializeToBytes(filter), Ints.toByteArray(offset))
   }
 }
 
@@ -40,10 +40,9 @@ object Z3HBaseFilter extends LazyLogging {
     logger.debug("Deserializing Z3HBaseFilter")
     val offset = Ints.fromBytes(pbBytes(pbBytes.length - 4), pbBytes(pbBytes.length - 3),
       pbBytes(pbBytes.length - 2), pbBytes(pbBytes.length - 1))
-    new Z3HBaseFilter(Z3Filter.fromByteArray(pbBytes), offset)
+    new Z3HBaseFilter(Z3Filter.deserializeFromBytes(pbBytes), offset)
   }
 }
-
 
 class Z2HBaseFilter(val filter: Z2Filter, offset: Int) extends FilterBase with LazyLogging {
 
@@ -58,7 +57,7 @@ class Z2HBaseFilter(val filter: Z2Filter, offset: Int) extends FilterBase with L
 
   override def toByteArray: Array[Byte] = {
     logger.trace("Serializing Z2HBaseFilter")
-    Bytes.concat(Z2Filter.toByteArray(filter), Ints.toByteArray(offset))
+    Bytes.concat(Z2Filter.serializeToBytes(filter), Ints.toByteArray(offset))
   }
 }
 
@@ -70,6 +69,6 @@ object Z2HBaseFilter extends LazyLogging {
     logger.debug("Deserializing Z2HBaseFilter")
     val offset = Ints.fromBytes(pbBytes(pbBytes.length - 4), pbBytes(pbBytes.length - 3),
       pbBytes(pbBytes.length - 2), pbBytes(pbBytes.length - 1))
-    new Z2HBaseFilter(Z2Filter.fromByteArray(pbBytes), offset)
+    new Z2HBaseFilter(Z2Filter.deserializeFromBytes(pbBytes), offset)
   }
 }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseZ3Index.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseZ3Index.scala
@@ -9,8 +9,6 @@
 package org.locationtech.geomesa.hbase.index
 
 import org.apache.hadoop.hbase.client._
-import org.apache.hadoop.hbase.filter.{Filter => HFilter}
-import org.locationtech.geomesa.curve.Z3SFC
 import org.locationtech.geomesa.hbase.data._
 import org.locationtech.geomesa.hbase.filters.Z3HBaseFilter
 import org.locationtech.geomesa.hbase.index.HBaseIndexAdapter.ScanConfig
@@ -31,42 +29,10 @@ trait HBaseZ3PushDown extends Z3Index[HBaseDataStore, HBaseFeature, Mutation, Qu
                                           config: ScanConfig,
                                           indexValues: Option[Z3IndexValues]): ScanConfig = {
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-    val z3Filter = indexValues.map { case Z3IndexValues(sfc, _, xy, _, times) =>
+    val z3Filter = indexValues.map { values =>
       val offset = if (sft.isTableSharing) { 2 } else { 1 } // sharing + shard - note: currently sharing is always false
-      configureZ3PushDown(sfc, xy, times, offset)
+      (Z3HBaseFilter.Priority, new Z3HBaseFilter(Z3Filter(values), offset))
     }
     config.copy(filters = config.filters ++ z3Filter)
-  }
-
-  private def configureZ3PushDown(sfc: Z3SFC,
-                                  xy: Seq[(Double, Double, Double, Double)],
-                                  timeMap: Map[Short, Seq[(Long, Long)]],
-                                  offset: Int): (Int, HFilter) = {
-    var minEpoch = Short.MaxValue
-    var maxEpoch = Short.MinValue
-    // we know we're only going to scan appropriate periods, so leave out whole ones
-    val wholePeriod = Seq((sfc.time.min.toLong, sfc.time.max.toLong))
-    val filteredTimes = timeMap.filter(_._2 != wholePeriod)
-    val epochsAndTimes = filteredTimes.toSeq.sortBy(_._1).map { case (epoch, times) =>
-      // set min/max epochs - note: side effect in map
-      if (epoch < minEpoch) {
-        minEpoch = epoch
-      }
-      if (epoch > maxEpoch) {
-        maxEpoch = epoch
-      }
-      (epoch, times.map { case (t1, t2) => Array(sfc.time.normalize(t1), sfc.time.normalize(t2)) }.toArray)
-    }
-
-    val tvals: Array[Array[Array[Int]]] =
-      if (minEpoch == Short.MaxValue && maxEpoch == Short.MinValue) Array.empty else Array.ofDim(maxEpoch - minEpoch + 1)
-    epochsAndTimes.foreach { case (w, times) => tvals(w - minEpoch) = times }
-
-    val normalizedXY = xy.map { case (xmin, ymin, xmax, ymax) =>
-      Array(sfc.lon.normalize(xmin), sfc.lat.normalize(ymin), sfc.lon.normalize(xmax), sfc.lat.normalize(ymax))
-    }.toArray
-
-    val filter = new Z3HBaseFilter(new Z3Filter(normalizedXY, tvals, minEpoch, maxEpoch, 8), offset)
-    (Z3HBaseFilter.Priority, filter)
   }
 }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreTest.scala
@@ -76,6 +76,7 @@ class HBaseDataStoreTest extends HBaseTest with LazyLogging {
             testQuery(ds, typeName, "INCLUDE", transforms, toAdd)
             testQuery(ds, typeName, "IN('0', '2')", transforms, Seq(toAdd(0), toAdd(2)))
             testQuery(ds, typeName, "bbox(geom,38,48,52,62) and dtg DURING 2014-01-01T00:00:00.000Z/2014-01-08T12:00:00.000Z", transforms, toAdd.dropRight(2))
+            testQuery(ds, typeName, "bbox(geom,42,48,52,62) and dtg DURING 2013-12-15T00:00:00.000Z/2014-01-15T00:00:00.000Z", transforms, toAdd.drop(2))
             testQuery(ds, typeName, "bbox(geom,42,48,52,62)", transforms, toAdd.drop(2))
             testQuery(ds, typeName, "dtg DURING 2014-01-01T00:00:00.000Z/2014-01-08T12:00:00.000Z", transforms, toAdd.dropRight(2))
             testQuery(ds, typeName, "attr = 'name5' and bbox(geom,38,48,52,62) and dtg DURING 2014-01-01T00:00:00.000Z/2014-01-08T12:00:00.000Z", transforms, Seq(toAdd(5)))

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z2Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z2Filter.scala
@@ -10,15 +10,15 @@ package org.locationtech.geomesa.index.filters
 
 import java.nio.ByteBuffer
 
-import com.google.common.primitives.{Bytes, Ints, Longs}
+import com.google.common.primitives.Longs
+import org.locationtech.geomesa.index.filters.Z3Filter._
+import org.locationtech.geomesa.index.index.z2.Z2IndexValues
 import org.locationtech.sfcurve.zorder.Z2
 
-class Z2Filter(val xyvals: Array[Array[Int]], val zLength: Int) extends java.io.Serializable {
-
-  val rowToZ: (Array[Byte], Int) => Long = Z2Filter.getRowToZ(zLength)
+class Z2Filter(val xy: Array[Array[Int]]) extends java.io.Serializable {
 
   def inBounds(buf: Array[Byte], offset: Int): Boolean = {
-    val keyZ = rowToZ(buf, offset)
+    val keyZ = Z2Filter.rowToZ(buf, offset)
     pointInBounds(keyZ)
   }
 
@@ -26,60 +26,67 @@ class Z2Filter(val xyvals: Array[Array[Int]], val zLength: Int) extends java.io.
     val x = Z2(z).d0
     val y = Z2(z).d1
     var i = 0
-    while (i < xyvals.length) {
-      val xy = xyvals(i)
-      if (x >= xy(0) && x <= xy(2) && y >= xy(1) && y <= xy(3)) {
+    while (i < xy.length) {
+      val xyi = xy(i)
+      if (x >= xyi(0) && x <= xyi(2) && y >= xyi(1) && y <= xyi(3)) {
         return true
       }
       i += 1
     }
     false
   }
+
+  override def equals(other: Any): Boolean = other match {
+    case that: Z2Filter => java.util.Arrays.deepEquals(equalityArray, that.equalityArray)
+    case _ => false
+  }
+
+  override def hashCode(): Int = java.util.Arrays.deepHashCode(equalityArray)
+
+  private def equalityArray: Array[AnyRef] = xy.asInstanceOf[Array[AnyRef]]
 }
 
 object Z2Filter {
-  def getRowToZ(length: Int): (Array[Byte], Int) => Long = {
-    if (length == 8) {
-      zToRow8
-    } else if (length == 4) {
-      zToRow4
-    } else if (length == 3) {
-      zToRow3
-    } else {
-      throw new IllegalArgumentException(s"Unhandled number of bytes for z value: $length")
-    }
-  }
 
-  private def zToRow8(b: Array[Byte], i: Int): Long =
-    Longs.fromBytes(b(i), b(i + 1), b(i + 2), b(i + 3), b(i + 4), b(i + 5), b(i + 6), b(i + 7))
+  private val RangeSeparator = ":"
+  private val TermSeparator  = ";"
 
-  private def zToRow4(b: Array[Byte], i: Int): Long =
-    Longs.fromBytes(b(i), b(i + 1), b(i + 2), b(i + 3), 0, 0, 0, 0)
-
-  private def zToRow3(b: Array[Byte], i: Int): Long =
-    Longs.fromBytes(b(i), b(i + 1), b(i + 2), 0, 0, 0, 0, 0)
-
-  def toByteArray(f: Z2Filter): Array[Byte] = {
-    val boundsLength = f.xyvals.length
-    val boundsSer =
-      f.xyvals.map { bounds =>
-        val length = bounds.length
-        val ser = Bytes.concat(bounds.map { v => Ints.toByteArray(v) }: _*)
-        Bytes.concat(Ints.toByteArray(length), ser)
-      }
-    Bytes.concat(Ints.toByteArray(boundsLength), Bytes.concat(boundsSer: _*), Ints.toByteArray(f.zLength))
-  }
-
-  def fromByteArray(a: Array[Byte]): Z2Filter = {
-    val buf = ByteBuffer.wrap(a)
-    val boundsLength = buf.getInt()
-    val bounds = (0 until boundsLength).map { i =>
-      val length = buf.getInt()
-      (0 until length).map { j =>
-        buf.getInt()
-      }.toArray
+  def apply(values: Z2IndexValues): Z2Filter = {
+    val sfc = values.sfc
+    val xy: Array[Array[Int]] = values.bounds.map { case (xmin, ymin, xmax, ymax) =>
+      Array(sfc.lon.normalize(xmin), sfc.lat.normalize(ymin), sfc.lon.normalize(xmax), sfc.lat.normalize(ymax))
     }.toArray
-    val zLength = buf.getInt
-    new Z2Filter(bounds, zLength)
+
+    new Z2Filter(xy)
   }
+
+  def serializeToBytes(filter: Z2Filter): Array[Byte] = {
+    // 4 bytes for length plus 16 bytes for each xy val (4 ints)
+    val xyLength = 4 + filter.xy.length * 16
+    val buffer = ByteBuffer.allocate(xyLength)
+
+    buffer.putInt(filter.xy.length)
+    filter.xy.foreach(bounds => bounds.foreach(buffer.putInt))
+
+    buffer.array()
+  }
+
+  def deserializeFromBytes(serialized: Array[Byte]): Z2Filter = {
+    val buffer = ByteBuffer.wrap(serialized)
+    val xy = Array.fill(buffer.getInt())(Array.fill(4)(buffer.getInt))
+    new Z2Filter(xy)
+  }
+
+  def serializeToStrings(filter: Z2Filter): Map[String, String] = {
+    val xy = filter.xy.map(bounds => bounds.mkString(RangeSeparator)).mkString(TermSeparator)
+    Map(XYKey -> xy)
+  }
+
+  def deserializeFromStrings(serialized: scala.collection.Map[String, String]): Z2Filter = {
+    val xy = serialized(XYKey).split(TermSeparator).map(_.split(RangeSeparator).map(_.toInt))
+    new Z2Filter(xy)
+  }
+
+  private def rowToZ(b: Array[Byte], i: Int): Long =
+    Longs.fromBytes(b(i), b(i + 1), b(i + 2), b(i + 3), b(i + 4), b(i + 5), b(i + 6), b(i + 7))
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z2Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z2Filter.scala
@@ -36,14 +36,7 @@ class Z2Filter(val xy: Array[Array[Int]]) extends java.io.Serializable {
     false
   }
 
-  override def equals(other: Any): Boolean = other match {
-    case that: Z2Filter => java.util.Arrays.deepEquals(equalityArray, that.equalityArray)
-    case _ => false
-  }
-
-  override def hashCode(): Int = java.util.Arrays.deepHashCode(equalityArray)
-
-  private def equalityArray: Array[AnyRef] = xy.asInstanceOf[Array[AnyRef]]
+  override def toString: String = Z2Filter.serializeToStrings(this).toSeq.sortBy(_._1).mkString(",")
 }
 
 object Z2Filter {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
@@ -10,20 +10,17 @@ package org.locationtech.geomesa.index.filters
 
 import java.nio.ByteBuffer
 
-import com.google.common.primitives.{Bytes, Ints, Longs, Shorts}
+import com.google.common.primitives.{Longs, Shorts}
+import org.locationtech.geomesa.index.index.z3.Z3IndexValues
 import org.locationtech.sfcurve.zorder.Z3
 
-
-class Z3Filter(val xyvals: Array[Array[Int]],
-               val tvals: Array[Array[Array[Int]]],
+class Z3Filter(val xy: Array[Array[Int]],
+               val t: Array[Array[Array[Int]]],
                val minEpoch: Short,
-               val maxEpoch: Short,
-               val zLength: Int) extends java.io.Serializable {
-
-  val rowToZ: (Array[Byte], Int) => Long = Z3Filter.getRowToZ(zLength)
+               val maxEpoch: Short) extends java.io.Serializable {
 
   def inBounds(buf: Array[Byte], offset: Int): Boolean = {
-    val keyZ = rowToZ(buf, offset)
+    val keyZ = Z3Filter.rowToZ(buf, offset)
     pointInBounds(keyZ) && timeInBounds(Z3Filter.rowToEpoch(buf, offset), keyZ)
   }
 
@@ -31,9 +28,9 @@ class Z3Filter(val xyvals: Array[Array[Int]],
     val x = Z3(z).d0
     val y = Z3(z).d1
     var i = 0
-    while (i < xyvals.length) {
-      val xy = xyvals(i)
-      if (x >= xy(0) && x <= xy(2) && y >= xy(1) && y <= xy(3)) {
+    while (i < xy.length) {
+      val xyi = xy(i)
+      if (x >= xyi(0) && x <= xyi(2) && y >= xyi(1) && y <= xyi(3)) {
         return true
       }
       i += 1
@@ -44,13 +41,13 @@ class Z3Filter(val xyvals: Array[Array[Int]],
   def timeInBounds(epoch: Short, z: Long): Boolean = {
     // we know we're only going to scan appropriate epochs, so leave out whole epochs
     if (epoch > maxEpoch || epoch < minEpoch) { true } else {
-      val times = tvals(epoch - minEpoch)
-      if (times == null) { true } else {
-        val t = Z3(z).d2
+      val tEpoch = t(epoch - minEpoch)
+      if (tEpoch == null) { true } else {
+        val time = Z3(z).d2
         var i = 0
-        while (i < times.length) {
-          val time = times(i)
-          if (t >= time(0) && t <= time(1)) {
+        while (i < tEpoch.length) {
+          val ti = tEpoch(i)
+          if (time >= ti(0) && time <= ti(1)) {
             return true
           }
           i += 1
@@ -59,89 +56,136 @@ class Z3Filter(val xyvals: Array[Array[Int]],
       }
     }
   }
+
+  override def equals(other: Any): Boolean = other match {
+    case that: Z3Filter => java.util.Arrays.deepEquals(equalityArray, that.equalityArray)
+    case _ => false
+  }
+
+  override def hashCode(): Int = java.util.Arrays.deepHashCode(equalityArray)
+
+  private def equalityArray: Array[AnyRef] = Array[AnyRef](xy, t, Short.box(minEpoch), Short.box(maxEpoch))
 }
 
 object Z3Filter {
 
-  def getRowToZ(zLength: Int): (Array[Byte], Int) => Long = {
-    if (zLength == 8) {
-      zToRow8
-    } else if (zLength == 4) {
-      zToRow4
-    } else if (zLength == 3) {
-      zToRow3
-    } else {
-      throw new IllegalArgumentException(s"Unhandled number of bytes for z value: $zLength")
+  private val RangeSeparator = ":"
+  private val TermSeparator  = ";"
+  private val EpochSeparator = ","
+
+  val XYKey     = "zxy"
+  val TKey      = "zt"
+  val EpochKey  = "epoch"
+
+  def apply(values: Z3IndexValues): Z3Filter = {
+    val Z3IndexValues(sfc, _, spatialBounds, _, temporalBounds) = values
+
+    val xy: Array[Array[Int]] = spatialBounds.map { case (xmin, ymin, xmax, ymax) =>
+      Array(sfc.lon.normalize(xmin), sfc.lat.normalize(ymin), sfc.lon.normalize(xmax), sfc.lat.normalize(ymax))
+    }.toArray
+
+    // we know we're only going to scan appropriate periods, so leave out whole ones
+    val wholePeriod = Seq((sfc.time.min.toLong, sfc.time.max.toLong))
+    var minEpoch: Short = Short.MaxValue
+    var maxEpoch: Short = Short.MinValue
+    val epochsAndTimes = temporalBounds.toSeq.filter(_._2 != wholePeriod).sortBy(_._1).map { case (epoch, times) =>
+      // set min/max epochs - note: side effect in map
+      if (epoch < minEpoch) {
+        minEpoch = epoch
+      }
+      if (epoch > maxEpoch) {
+        maxEpoch = epoch
+      }
+      (epoch, times.map { case (t1, t2) => Array(sfc.time.normalize(t1), sfc.time.normalize(t2)) }.toArray)
     }
+
+    val t: Array[Array[Array[Int]]] =
+      if (minEpoch == Short.MaxValue && maxEpoch == Short.MinValue) {
+        Array.empty
+      } else {
+        Array.ofDim(maxEpoch - minEpoch + 1)
+      }
+
+    epochsAndTimes.foreach { case (w, times) => t(w - minEpoch) = times }
+
+    new Z3Filter(xy, t, minEpoch, maxEpoch)
+  }
+
+  def serializeToBytes(filter: Z3Filter): Array[Byte] = {
+    // 4 bytes for length plus 16 bytes for each xy val (4 ints)
+    val xyLength = 4 + filter.xy.length * 16
+    // 4 bytes for length, then per-epoch 4 bytes for length plus 8 bytes for each t val (2 ints)
+    val tLength = 4 + filter.t.map(bounds => if (bounds == null) { 4 } else { 4 + bounds.length * 8 } ).sum
+    // additional 4 bytes for min/max epoch
+    val buffer = ByteBuffer.allocate(xyLength + tLength + 4)
+
+    buffer.putInt(filter.xy.length)
+    filter.xy.foreach(bounds => bounds.foreach(buffer.putInt))
+
+    buffer.putInt(filter.t.length)
+    filter.t.foreach { bounds =>
+      if (bounds == null) {
+        buffer.putInt(-1)
+      } else {
+        buffer.putInt(bounds.length)
+        bounds.foreach(inner => inner.foreach(buffer.putInt))
+      }
+    }
+
+    buffer.putShort(filter.minEpoch)
+    buffer.putShort(filter.maxEpoch)
+
+    buffer.array()
+  }
+
+  def deserializeFromBytes(serialized: Array[Byte]): Z3Filter = {
+    val buffer = ByteBuffer.wrap(serialized)
+
+    val xy = Array.fill(buffer.getInt())(Array.fill(4)(buffer.getInt))
+    val t = Array.fill(buffer.getInt) {
+      val length = buffer.getInt
+      if (length == -1) { null } else {
+        Array.fill(length)(Array.fill(2)(buffer.getInt))
+      }
+    }
+    val minEpoch = buffer.getShort
+    val maxEpoch = buffer.getShort
+
+    new Z3Filter(xy, t, minEpoch, maxEpoch)
+  }
+
+  def serializeToStrings(filter: Z3Filter): Map[String, String] = {
+    val xy = filter.xy.map(bounds => bounds.mkString(RangeSeparator)).mkString(TermSeparator)
+    val t = filter.t.map { bounds =>
+      if (bounds == null) { "" } else {
+        bounds.map(_.mkString(RangeSeparator)).mkString(TermSeparator)
+      }
+    }.mkString(EpochSeparator)
+    val epoch = s"${filter.minEpoch}$RangeSeparator${filter.maxEpoch}"
+
+    Map(
+      XYKey    -> xy,
+      TKey     -> t,
+      EpochKey -> epoch
+    )
+  }
+
+  def deserializeFromStrings(serialized: scala.collection.Map[String, String]): Z3Filter = {
+    val xy = serialized(XYKey).split(TermSeparator).map(_.split(RangeSeparator).map(_.toInt))
+    val t = serialized(TKey).split(EpochSeparator).map { bounds =>
+      if (bounds.isEmpty) { null } else {
+        bounds.split(TermSeparator).map(_.split(RangeSeparator).map(_.toInt))
+      }
+    }
+    val Array(minEpoch, maxEpoch) = serialized(EpochKey).split(RangeSeparator).map(_.toShort)
+
+    new Z3Filter(xy, t, minEpoch, maxEpoch)
   }
 
   // account for epoch - first 2 bytes
-  private def zToRow8(b: Array[Byte], i: Int): Long =
+  private def rowToZ(b: Array[Byte], i: Int): Long =
     Longs.fromBytes(b(i + 2), b(i + 3), b(i + 4), b(i + 5), b(i + 6), b(i + 7), b(i + 8), b(i + 9))
 
-  // account for epoch - first 2 bytes
-  private def zToRow4(b: Array[Byte], i: Int): Long =
-    Longs.fromBytes(b(i + 2), b(i + 3), b(i + 4), b(i + 5), 0, 0, 0, 0)
-
-  // account for epoch - first 2 bytes
-  private def zToRow3(b: Array[Byte], i: Int): Long =
-    Longs.fromBytes(b(i + 2), b(i + 3), b(i + 4), 0, 0, 0, 0, 0)
-
-  def rowToEpoch(bytes: Array[Byte], offset: Int): Short =
+  private def rowToEpoch(bytes: Array[Byte], offset: Int): Short =
     Shorts.fromBytes(bytes(offset), bytes(offset + 1))
-
-  def toByteArray(f: Z3Filter): Array[Byte] = {
-    val boundsLength = f.xyvals.length
-    val boundsSer =
-      f.xyvals.map { bounds =>
-        val length = bounds.length
-        val ser = Bytes.concat(bounds.map { v => Ints.toByteArray(v) }: _*)
-        Bytes.concat(Ints.toByteArray(length), ser)
-      }
-    val xyz = Bytes.concat(Ints.toByteArray(boundsLength), Bytes.concat(boundsSer: _*), Ints.toByteArray(f.zLength))
-
-
-    val tlength = f.tvals.length
-    val tSer =
-      f.tvals.map { bounds =>
-        val length = bounds.length
-        val innerSer = bounds.map { b =>
-          val innerLength = b.length
-          val ser = Bytes.concat(b.map { v => Ints.toByteArray(v) }: _*)
-          Bytes.concat(Ints.toByteArray(innerLength), ser)
-        }
-        Bytes.concat(Ints.toByteArray(length), Bytes.concat(innerSer: _*))
-      }
-
-    val t = Bytes.concat(Ints.toByteArray(tlength), Bytes.concat(tSer: _*))
-
-    Bytes.concat(xyz, t, Shorts.toByteArray(f.minEpoch), Shorts.toByteArray(f.maxEpoch))
-  }
-
-  def fromByteArray(a: Array[Byte]): Z3Filter = {
-    val buf = ByteBuffer.wrap(a)
-    val boundsLength = buf.getInt()
-    val bounds = (0 until boundsLength).map { _ =>
-      val length = buf.getInt()
-      (0 until length).map { _ =>
-        buf.getInt()
-      }.toArray
-    }.toArray
-    val zLength = buf.getInt
-
-    val tLength = buf.getInt
-    val tvals = (0 until tLength).map { _ =>
-      val length = buf.getInt()
-      (0 until length).map { _ =>
-        val innerLength = buf.getInt()
-        (0 until innerLength).map { _ =>
-          buf.getInt
-        }.toArray
-      }.toArray
-    }.toArray
-
-    val minEpoch = buf.getShort
-    val maxEpoch = buf.getShort
-    new Z3Filter(bounds, tvals, minEpoch, maxEpoch, zLength)
-  }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
@@ -57,14 +57,7 @@ class Z3Filter(val xy: Array[Array[Int]],
     }
   }
 
-  override def equals(other: Any): Boolean = other match {
-    case that: Z3Filter => java.util.Arrays.deepEquals(equalityArray, that.equalityArray)
-    case _ => false
-  }
-
-  override def hashCode(): Int = java.util.Arrays.deepHashCode(equalityArray)
-
-  private def equalityArray: Array[AnyRef] = Array[AnyRef](xy, t, Short.box(minEpoch), Short.box(maxEpoch))
+  override def toString: String = Z3Filter.serializeToStrings(this).toSeq.sortBy(_._1).mkString(",")
 }
 
 object Z3Filter {

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/filters/Z2FilterTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/filters/Z2FilterTest.scala
@@ -1,0 +1,46 @@
+/***********************************************************************
+ * Copyright (c) 2013-2017 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.filters
+
+import org.geotools.filter.text.ecql.ECQL
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.index.index.z2.Z2IndexKeySpace
+import org.locationtech.geomesa.index.utils.ExplainNull
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class Z2FilterTest extends Specification {
+
+  val sft = SimpleFeatureTypes.createType("z2FilterTest", "dtg:Date,*geom:Point:srid=4326")
+
+  val filters = Seq(
+    "bbox(geom,38,48,52,62)"
+  ).map(ECQL.toFilter)
+
+  val values = filters.map(Z2IndexKeySpace.getIndexValues(sft, _, ExplainNull))
+
+  "Z2Filter" should {
+    "serialize to and from bytes" in {
+      forall(values) { value =>
+        val filter = Z2Filter(value)
+        val result = Z2Filter.deserializeFromBytes(Z2Filter.serializeToBytes(filter))
+        result mustEqual filter
+      }
+    }
+    "serialize to and from strings" in {
+      forall(values) { value =>
+        val filter = Z2Filter(value)
+        val result = Z2Filter.deserializeFromStrings(Z2Filter.serializeToStrings(filter))
+        result mustEqual filter
+      }
+    }
+  }
+}

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/filters/Z2FilterTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/filters/Z2FilterTest.scala
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.index.index.z2.Z2IndexKeySpace
 import org.locationtech.geomesa.index.utils.ExplainNull
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -27,19 +28,25 @@ class Z2FilterTest extends Specification {
 
   val values = filters.map(Z2IndexKeySpace.getIndexValues(sft, _, ExplainNull))
 
+  def compare(actual: Z2Filter, expected: Z2Filter): MatchResult[Boolean] = {
+    val left = actual.xy.asInstanceOf[Array[AnyRef]]
+    val right = expected.xy.asInstanceOf[Array[AnyRef]]
+    java.util.Arrays.deepEquals(left, right) must beTrue
+  }
+
   "Z2Filter" should {
     "serialize to and from bytes" in {
       forall(values) { value =>
         val filter = Z2Filter(value)
         val result = Z2Filter.deserializeFromBytes(Z2Filter.serializeToBytes(filter))
-        result mustEqual filter
+        compare(result, filter)
       }
     }
     "serialize to and from strings" in {
       forall(values) { value =>
         val filter = Z2Filter(value)
         val result = Z2Filter.deserializeFromStrings(Z2Filter.serializeToStrings(filter))
-        result mustEqual filter
+        compare(result, filter)
       }
     }
   }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/filters/Z3FilterTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/filters/Z3FilterTest.scala
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.index.index.z3.Z3IndexKeySpace
 import org.locationtech.geomesa.index.utils.ExplainNull
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -29,19 +30,25 @@ class Z3FilterTest extends Specification {
 
   val values = filters.map(Z3IndexKeySpace.getIndexValues(sft, _, ExplainNull))
 
+  def compare(actual: Z3Filter, expected: Z3Filter): MatchResult[Boolean] = {
+    val left = Array[AnyRef](actual.xy, actual.t, Short.box(actual.minEpoch), Short.box(actual.maxEpoch))
+    val right = Array[AnyRef](expected.xy, expected.t, Short.box(expected.minEpoch), Short.box(expected.maxEpoch))
+    java.util.Arrays.deepEquals(left, right) must beTrue
+  }
+
   "Z3Filter" should {
     "serialize to and from bytes" in {
       forall(values) { value =>
         val filter = Z3Filter(value)
         val result = Z3Filter.deserializeFromBytes(Z3Filter.serializeToBytes(filter))
-        result mustEqual filter
+        compare(result, filter)
       }
     }
     "serialize to and from strings" in {
       forall(values) { value =>
         val filter = Z3Filter(value)
         val result = Z3Filter.deserializeFromStrings(Z3Filter.serializeToStrings(filter))
-        result mustEqual filter
+        compare(result, filter)
       }
     }
   }


### PR DESCRIPTION
* Moves z filters configuration into index-api
* Includes a breaking change in the Accumulo z-iterator config
* Removes z-iterator from deprecated non-point z2/z3 indices

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>