### PR TITLE
GEOMESA-2116 Allow users to configure compression on HBase tables

### DIFF
--- a/docs/user/datastores/index_config.rst
+++ b/docs/user/datastores/index_config.rst
@@ -1,3 +1,5 @@
+.. _index_config:
+
 Index Configuration
 ===================
 

--- a/docs/user/hbase/index.rst
+++ b/docs/user/hbase/index.rst
@@ -18,6 +18,7 @@ To get started with the HBase Data Store, try the :doc:`/tutorials/geomesa-quick
     usage
     geoserver
     commandline
+    index_config
     heatmaps
     visibilities
     kerberos

--- a/docs/user/hbase/index_config.rst
+++ b/docs/user/hbase/index_config.rst
@@ -1,0 +1,24 @@
+HBase Index Configuration
+=========================
+
+GeoMesa exposes a variety of configuration options that can be used to customize and optimize a given installation.
+This section contains HBase-specific options; general options can be found under :ref:`index_config`.
+
+Setting File Compression
+------------------------
+
+You can enable HBase file compression when creating a new ``SimpleFeatureType`` by setting the appropriate
+user data hints, or through the command line option. Valid compression types
+are ``snappy``, ``lzo``, ``gz``, ``bzip2``, ``lz4`` or ``zstd``.
+
+.. code-block:: java
+
+    SimpleFeatureType sft = ....;
+    sft.getUserData().put("geomesa.compression.enabled", "true");
+    sft.getUserData().put("geomesa.compression.type", "snappy");
+
+.. code-block:: shell
+
+    geomesa-hbase create-schema --compression snappy ...
+
+For more information on how to set schema options, see :ref:`set_sft_options`.

--- a/docs/user/hbase/usage.rst
+++ b/docs/user/hbase/usage.rst
@@ -46,3 +46,22 @@ Parameter                              Type    Description
 More information on using GeoTools can be found in the `GeoTools user guide
 <http://docs.geotools.org/stable/userguide/>`__.
 
+HBase Compression per SimpleFeatureType
+---------------------------------------
+
+You can enable compression on an HBase `SimpleFeatureType` by passing the appropriate
+userData hints in the SFT or by toggling the flag in the command line tool.
+
+.. code-block:: java
+
+    SimpleFeatureType sft = ....;
+    sft.getUserData().put("geomesa.compression.enabled", "true");
+    sft.getUserData().put("geomesa.compression.type", "snappy");
+.. _hbase_compression_java
+
+.. code-block:: shell
+
+    geomesa-hbase create-schema --compression snappy ...
+
+.. _hbase_compression_shell
+

--- a/docs/user/hbase/usage.rst
+++ b/docs/user/hbase/usage.rst
@@ -45,23 +45,3 @@ Parameter                              Type    Description
 
 More information on using GeoTools can be found in the `GeoTools user guide
 <http://docs.geotools.org/stable/userguide/>`__.
-
-HBase Compression per SimpleFeatureType
----------------------------------------
-
-You can enable compression on an HBase `SimpleFeatureType` by passing the appropriate
-userData hints in the SFT or by toggling the flag in the command line tool.
-
-.. code-block:: java
-
-    SimpleFeatureType sft = ....;
-    sft.getUserData().put("geomesa.compression.enabled", "true");
-    sft.getUserData().put("geomesa.compression.type", "snappy");
-.. _hbase_compression_java
-
-.. code-block:: shell
-
-    geomesa-hbase create-schema --compression snappy ...
-
-.. _hbase_compression_shell
-

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseFeatureIndex.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseFeatureIndex.scala
@@ -14,6 +14,7 @@ import org.apache.hadoop.hbase._
 import org.apache.hadoop.hbase.client._
 import org.apache.hadoop.hbase.coprocessor.CoprocessorHost
 import org.apache.hadoop.hbase.filter.KeyOnlyFilter
+import org.apache.hadoop.hbase.io.compress.Compression
 import org.apache.hadoop.hbase.util.Bytes
 import org.locationtech.geomesa.hbase._
 import org.locationtech.geomesa.hbase.coprocessor.AllCoprocessors
@@ -21,12 +22,15 @@ import org.locationtech.geomesa.hbase.data._
 import org.locationtech.geomesa.hbase.index.legacy._
 import org.locationtech.geomesa.index.index.ClientSideFiltering
 import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.Configs
 import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
 import org.locationtech.geomesa.utils.io.WithClose
 import org.opengis.feature.simple.SimpleFeatureType
+import org.slf4j.LoggerFactory
 
 object HBaseFeatureIndex extends HBaseIndexManagerType {
 
+  private val log = LoggerFactory.getLogger(classOf[HBaseFeatureIndex])
   // note: keep in priority order for running full table scans
   override val AllIndices: Seq[HBaseFeatureIndex] =
     Seq(HBaseZ3Index, HBaseZ3IndexV1, HBaseXZ3Index, HBaseZ2Index, HBaseZ2IndexV1, HBaseXZ2Index,
@@ -41,7 +45,17 @@ object HBaseFeatureIndex extends HBaseIndexManagerType {
     super.index(identifier).asInstanceOf[HBaseFeatureIndex]
 
   val DataColumnFamily: Array[Byte] = Bytes.toBytes("d")
-  val DataColumnFamilyDescriptor = new HColumnDescriptor(DataColumnFamily)
+  def buildDataColumnFamilyDescriptor(sft: SimpleFeatureType): HColumnDescriptor = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType._
+    val dcfd = new HColumnDescriptor(DataColumnFamily)
+    if(sft.userData(Configs.COMPRESSION_ENABLED).isDefined) {
+      val compressionType =
+        sft.userData[String](Configs.COMPRESSION_TYPE).getOrElse("gz")
+      log.debug(s"Setting compression on index table for feature ${sft.getTypeName}")
+      dcfd.setCompressionType(Compression.getCompressionAlgorithmByName(compressionType))
+    }
+    dcfd
+  }
 
   val DataColumnQualifier: Array[Byte] = Bytes.toBytes("d")
   val DataColumnQualifierDescriptor = new HColumnDescriptor(DataColumnQualifier)
@@ -74,7 +88,8 @@ trait HBaseFeatureIndex extends HBaseFeatureIndexType with ClientSideFiltering[R
       if (!admin.tableExists(name)) {
         logger.debug(s"Creating table $name")
         val descriptor = new HTableDescriptor(name)
-        descriptor.addFamily(HBaseFeatureIndex.DataColumnFamilyDescriptor)
+        val dcfd = HBaseFeatureIndex.buildDataColumnFamilyDescriptor(sft)
+        descriptor.addFamily(dcfd)
         if (ds.config.remoteFilter) {
           import CoprocessorHost.USER_REGION_COPROCESSOR_CONF_KEY
           // if the coprocessors are installed site-wide don't register them in the table descriptor
@@ -91,6 +106,7 @@ trait HBaseFeatureIndex extends HBaseFeatureIndexType with ClientSideFiltering[R
 
   override def removeAll(sft: SimpleFeatureType, ds: HBaseDataStore): Unit = {
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
     import scala.collection.JavaConversions._
 
     val tableName = TableName.valueOf(getTableName(sft.getTypeName, ds))

--- a/geomesa-hbase/geomesa-hbase-tools/src/main/scala/org/locationtech/geomesa/hbase/tools/data/HBaseCreateSchemaCommand.scala
+++ b/geomesa-hbase/geomesa-hbase-tools/src/main/scala/org/locationtech/geomesa/hbase/tools/data/HBaseCreateSchemaCommand.scala
@@ -8,15 +8,34 @@
 
 package org.locationtech.geomesa.hbase.tools.data
 
-import com.beust.jcommander.Parameters
+import com.beust.jcommander.{IValueValidator, Parameter, ParameterException, Parameters}
 import org.locationtech.geomesa.hbase.data.HBaseDataStore
 import org.locationtech.geomesa.hbase.tools.HBaseDataStoreCommand
 import org.locationtech.geomesa.tools.CatalogParam
 import org.locationtech.geomesa.tools.data.{CreateSchemaCommand, CreateSchemaParams}
+import org.opengis.feature.simple.SimpleFeatureType
 
 class HBaseCreateSchemaCommand extends CreateSchemaCommand[HBaseDataStore] with HBaseDataStoreCommand {
   override val params = new HBaseCreateSchemaParams()
+
+  override protected def setBackendSpecificOptions(featureType: SimpleFeatureType): Unit = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType._
+    Option(params.compression).foreach { c => featureType.setCompression(c) }
+  }
 }
 
 @Parameters(commandDescription = "Create a GeoMesa feature type")
-class HBaseCreateSchemaParams extends CreateSchemaParams with CatalogParam
+class HBaseCreateSchemaParams extends CreateSchemaParams with CatalogParam {
+  @Parameter(names = Array("--compression"),
+    description = "Enable compression for a feature.  One of \"snappy\", \"lzo\", \"gz\", \"bzip2\", \"lz4\", \"zstd\"", required = false, validateValueWith = classOf[CompressionTypeValidator])
+  var compression: String = null
+}
+
+class CompressionTypeValidator extends IValueValidator[String] {
+  val VALID_COMPRESSION_TYPES = Seq("snappy", "lzo", "gz", "bzip2", "lz4", "zstd")
+  override def validate(name: String, value: String): Unit = {
+    if(!VALID_COMPRESSION_TYPES.contains(value)) {
+      throw new ParameterException(s"Invalid compression type.  Values types are ${VALID_COMPRESSION_TYPES.mkString(", ")}")
+    }
+  }
+}

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/data/CreateSchemaCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/data/CreateSchemaCommand.scala
@@ -26,8 +26,11 @@ trait CreateSchemaCommand[DS <: DataStore] extends DataStoreCommand[DS] {
     val sft = CLArgResolver.getSft(params.spec, params.featureName)
     Option(params.dtgField).foreach(sft.setDtgField)
     Option(params.useSharedTables).foreach(sft.setTableSharing)
+    setBackendSpecificOptions(sft)
     withDataStore(createSchema(_, sft))
   }
+
+  protected def setBackendSpecificOptions(featureType: SimpleFeatureType): Unit = {}
 
   protected def createSchema(ds: DS, sft: SimpleFeatureType): Unit = {
     lazy val sftString = SimpleFeatureTypes.encodeType(sft)

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -252,6 +252,11 @@ object RichSimpleFeatureType {
       Array.empty[Byte]
     }
 
+    def setCompression(c: String): Unit = {
+      sft.getUserData.put(COMPRESSION_ENABLED, "true")
+      sft.getUserData.put(COMPRESSION_TYPE, c)
+    }
+
     // gets (name, version, mode) of enabled indices
     def getIndices: Seq[(String, Int, IndexMode)] = {
       def toTuple(string: String): (String, Int, IndexMode) = {

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
@@ -45,6 +45,8 @@ object SimpleFeatureTypes {
     val Z_SPLITS_KEY        = "geomesa.z.splits"
     val ATTR_SPLITS_KEY     = "geomesa.attr.splits"
     val LOGICAL_TIME_KEY    = "geomesa.logical.time"
+    val COMPRESSION_ENABLED = "geomesa.table.compression.enabled"
+    val COMPRESSION_TYPE    = "geomesa.table.compression.type"  // valid: snappy, lzo, gz(default), bzip2, lz4, zstd
   }
 
   private [geomesa] object InternalConfigs {


### PR DESCRIPTION
* Users can enable compression either programmatically via
  SimpleFeatureType userData or via the command line

Signed-off-by: Anthony Fox <anthonyfox@ccri.com>