### PR TITLE
GEOMESA-2117 Enable FAST_DIFF encoding on HBase tables

### DIFF
--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseAttributeIndex.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseAttributeIndex.scala
@@ -8,7 +8,9 @@
 
 package org.locationtech.geomesa.hbase.index
 
+import org.apache.hadoop.hbase._
 import org.apache.hadoop.hbase.client._
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding
 import org.locationtech.geomesa.hbase.data._
 import org.locationtech.geomesa.hbase.index.HBaseIndexAdapter.ScanConfig
 import org.locationtech.geomesa.index.index.AttributeIndex
@@ -18,4 +20,9 @@ case object HBaseAttributeIndex extends HBaseLikeAttributeIndex with HBasePlatfo
 trait HBaseLikeAttributeIndex extends HBaseFeatureIndex with HBaseIndexAdapter
     with AttributeIndex[HBaseDataStore, HBaseFeature, Mutation, Query, ScanConfig] {
   override val version: Int = 4
+
+  override def configureColumnFamilyDescriptor(desc: HColumnDescriptor): Unit = {
+    desc.setDataBlockEncoding(DataBlockEncoding.FAST_DIFF)
+  }
+
 }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseFeatureIndex.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseFeatureIndex.scala
@@ -63,6 +63,8 @@ object HBaseFeatureIndex extends HBaseIndexManagerType {
 
 trait HBaseFeatureIndex extends HBaseFeatureIndexType with ClientSideFiltering[Result] with LazyLogging {
 
+  def configureColumnFamilyDescriptor(desc: HColumnDescriptor): Unit = {}
+
   override def configure(sft: SimpleFeatureType, ds: HBaseDataStore): Unit = {
     super.configure(sft, ds)
 
@@ -90,6 +92,7 @@ trait HBaseFeatureIndex extends HBaseFeatureIndexType with ClientSideFiltering[R
         val descriptor = new HTableDescriptor(name)
         val dcfd = HBaseFeatureIndex.buildDataColumnFamilyDescriptor(sft)
         descriptor.addFamily(dcfd)
+        configureColumnFamilyDescriptor(dcfd)
         if (ds.config.remoteFilter) {
           import CoprocessorHost.USER_REGION_COPROCESSOR_CONF_KEY
           // if the coprocessors are installed site-wide don't register them in the table descriptor

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseXZ2Index.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseXZ2Index.scala
@@ -8,7 +8,9 @@
 
 package org.locationtech.geomesa.hbase.index
 
+import org.apache.hadoop.hbase._
 import org.apache.hadoop.hbase.client._
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding
 import org.locationtech.geomesa.hbase.data._
 import org.locationtech.geomesa.hbase.index.HBaseIndexAdapter.ScanConfig
 import org.locationtech.geomesa.index.index.z2.XZ2Index
@@ -20,4 +22,8 @@ trait HBaseLikeXZ2Index extends HBaseFeatureIndex with HBaseIndexAdapter
   override val version: Int = 1
 
   // TODO GEOMESA-1807 deal with non-points in a pushdown XZ filter
+  override def configureColumnFamilyDescriptor(desc: HColumnDescriptor): Unit = {
+    desc.setDataBlockEncoding(DataBlockEncoding.FAST_DIFF)
+  }
+
 }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseXZ3Index.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseXZ3Index.scala
@@ -8,7 +8,9 @@
 
 package org.locationtech.geomesa.hbase.index
 
+import org.apache.hadoop.hbase._
 import org.apache.hadoop.hbase.client._
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding
 import org.locationtech.geomesa.hbase.data._
 import org.locationtech.geomesa.hbase.index.HBaseIndexAdapter.ScanConfig
 import org.locationtech.geomesa.index.index.z3.XZ3Index
@@ -20,4 +22,8 @@ trait HBaseLikeXZ3Index extends HBaseFeatureIndex with HBaseIndexAdapter
   override val version: Int = 1
 
   // TODO GEOMESA-1807 deal with non-points in a pushdown XZ filter
+
+  override def configureColumnFamilyDescriptor(desc: HColumnDescriptor): Unit = {
+    desc.setDataBlockEncoding(DataBlockEncoding.FAST_DIFF)
+  }
 }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseZ2Index.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseZ2Index.scala
@@ -8,7 +8,9 @@
 
 package org.locationtech.geomesa.hbase.index
 
+import org.apache.hadoop.hbase._
 import org.apache.hadoop.hbase.client._
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding
 import org.locationtech.geomesa.hbase.data._
 import org.locationtech.geomesa.hbase.filters.Z2HBaseFilter
 import org.locationtech.geomesa.hbase.index.HBaseIndexAdapter.ScanConfig
@@ -21,6 +23,11 @@ case object HBaseZ2Index extends HBaseLikeZ2Index with HBasePlatform with HBaseZ
 trait HBaseLikeZ2Index extends HBaseFeatureIndex with HBaseIndexAdapter
     with Z2Index[HBaseDataStore, HBaseFeature, Mutation, Query, ScanConfig] {
   override val version: Int = 2
+
+  override def configureColumnFamilyDescriptor(desc: HColumnDescriptor): Unit = {
+    desc.setDataBlockEncoding(DataBlockEncoding.FAST_DIFF)
+  }
+
 }
 
 trait HBaseZ2PushDown extends Z2Index[HBaseDataStore, HBaseFeature, Mutation, Query, ScanConfig] {

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseZ3Index.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseZ3Index.scala
@@ -8,7 +8,9 @@
 
 package org.locationtech.geomesa.hbase.index
 
+import org.apache.hadoop.hbase._
 import org.apache.hadoop.hbase.client._
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding
 import org.locationtech.geomesa.hbase.data._
 import org.locationtech.geomesa.hbase.filters.Z3HBaseFilter
 import org.locationtech.geomesa.hbase.index.HBaseIndexAdapter.ScanConfig
@@ -21,6 +23,10 @@ case object HBaseZ3Index extends HBaseLikeZ3Index with HBasePlatform with HBaseZ
 trait HBaseLikeZ3Index extends HBaseFeatureIndex with HBaseIndexAdapter
     with Z3Index[HBaseDataStore, HBaseFeature, Mutation, Query, ScanConfig] {
   override val version: Int = 2
+
+  override def configureColumnFamilyDescriptor(desc: HColumnDescriptor): Unit = {
+    desc.setDataBlockEncoding(DataBlockEncoding.FAST_DIFF)
+  }
 }
 
 trait HBaseZ3PushDown extends Z3Index[HBaseDataStore, HBaseFeature, Mutation, Query, ScanConfig] {


### PR DESCRIPTION
* Enabled FAST_DIFF encoding on all but the id table

Signed-off-by: Anthony Fox <anthonyfox@ccri.com>