### PR TITLE
GEOMESA-2173 Fix return type of TypedColumn spatial functions.

### DIFF
--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/apache/spark/sql/jts/JTSTypes.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/apache/spark/sql/jts/JTSTypes.scala
@@ -66,6 +66,7 @@ object JTSTypes {
     SQLGeometricOutputFunctions.registerFunctions(sqlContext)
     SQLRules.registerOptimizations(sqlContext)
   }
+
 }
 
 abstract class AbstractGeometryUDT[T >: Null <: Geometry](override val simpleString: String)(implicit cm: ClassTag[T])

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/SQLFunctionHelper.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/SQLFunctionHelper.scala
@@ -8,13 +8,17 @@
 
 package org.locationtech.geomesa.spark
 
-import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference}
 import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.{Column, Encoder, TypedColumn}
+
 import scala.reflect.runtime.universe._
 
-object SQLFunctionHelper {
+// This should be some level of package private, but there's a dependency on it
+// from org.apache.spark.sql.SQLGeometricConstructorFunctions, which could/should be moved
+// into a org.locationtech.geomesa package eventually, and this access restriction reenabled
+/*private[geomesa]*/ object SQLFunctionHelper {
   def nullableUDF[A1, RT](f: A1 => RT): A1 => RT = {
     in1 => in1 match {
       case null => null.asInstanceOf[RT]
@@ -49,44 +53,45 @@ object SQLFunctionHelper {
     }
   }
 
-  def udfToColumn[A1: TypeTag, RT: TypeTag](f: A1 => RT, name: String, col: Column): Column = {
-    withAlias(name, col)(udf(f).apply(col))
-  }
-  def udfToColumn[A1: TypeTag, A2: TypeTag, RT: TypeTag](f: (A1, A2) => RT,
-                                                         name: String,
-                                                         colA: Column, colB: Column): Column = {
-    withAlias(name, colA, colB)(udf(f).apply(colA, colB))
-  }
-  def udfToColumn[A1: TypeTag, A2: TypeTag, A3: TypeTag, RT: TypeTag](f: (A1, A2, A3) => RT,
-                                                                      name: String,
-                                                                      colA: Column, colB: Column, colC: Column): Column = {
-    withAlias(name, colA, colB, colC)(udf(f).apply(colA, colB, colC))
-  }
-  def udfToColumn[A1: TypeTag, A2: TypeTag, A3: TypeTag, A4: TypeTag, RT: TypeTag](f: (A1, A2, A3, A4) => RT,
-                                                                                   name: String,
-                                                                                   colA: Column, colB: Column,
-                                                                                   colC: Column, colD: Column): Column = {
-    withAlias(name, colA, colB, colC)(udf(f).apply(colA, colB, colC, colD))
+  def udfToColumn[A1: TypeTag, RT: TypeTag: Encoder, N >: (A1 => RT)](
+    f: A1 => RT, namer: N => String, col: Column): TypedColumn[Any, RT] = {
+    withAlias(namer(f), col)(udf(f).apply(col)).as[RT]
   }
 
+  def udfToColumn[A1: TypeTag, A2: TypeTag, RT: TypeTag: Encoder, N >: (A1, A2) => RT](
+    f: (A1, A2) => RT, namer: N => String, colA: Column, colB: Column): TypedColumn[Any, RT] = {
+    withAlias(namer(f), colA, colB)(udf(f).apply(colA, colB)).as[RT]
+  }
 
-  def udfToColumnLiterals[A1: TypeTag, RT: TypeTag](f: A1 => RT, name: String, a1: A1): Column = {
-    udf(() => f(a1)).apply().as(name)
+  def udfToColumn[A1: TypeTag, A2: TypeTag, A3: TypeTag, RT: TypeTag: Encoder, N >: (A1, A2, A3) => RT](
+    f: (A1, A2, A3) => RT, namer: N => String, colA: Column, colB: Column, colC: Column): TypedColumn[Any, RT] = {
+    withAlias(namer(f), colA, colB, colC)(udf(f).apply(colA, colB, colC)).as[RT]
   }
-  def udfToColumnLiterals[A1: TypeTag, A2: TypeTag, RT: TypeTag](f: (A1, A2) => RT,
-                                                                 name: String,
-                                                                 a1: A1, a2: A2): Column = {
-    udf(() => f(a1, a2)).apply().as(name)
+
+  def udfToColumn[A1: TypeTag, A2: TypeTag, A3: TypeTag, A4: TypeTag, RT: TypeTag: Encoder, N >: (A1, A2, A3, A4) => RT](
+    f: (A1, A2, A3, A4) => RT, namer: N => String,
+    colA: Column, colB: Column, colC: Column, colD: Column): TypedColumn[Any, RT] = {
+    withAlias(namer(f), colA, colB, colC)(udf(f).apply(colA, colB, colC, colD)).as[RT]
   }
-  def udfToColumnLiterals[A1: TypeTag, A2: TypeTag, A3: TypeTag, RT: TypeTag](f: (A1, A2, A3) => RT,
-                                                                              name: String,
-                                                                              a1: A1, a2: A2, a3: A3): Column = {
-    udf(() => f(a1, a2, a3)).apply().as(name)
+
+  def udfToColumnLiterals[A1: TypeTag, RT: TypeTag: Encoder, N >: A1 => RT](
+    f: A1 => RT, namer: N => String, a1: A1): TypedColumn[Any, RT] = {
+    udf(() => f(a1)).apply().as(namer(f)).as[RT]
   }
-  def udfToColumnLiterals[A1: TypeTag, A2: TypeTag, A3: TypeTag, A4: TypeTag, RT: TypeTag](f: (A1, A2, A3, A4) => RT,
-                                                                                           name: String,
-                                                                                           a1: A1, a2: A2, a3: A3, a4: A4): Column = {
-    udf(() => f(a1, a2, a3, a4)).apply().as(name)
+
+  def udfToColumnLiterals[A1: TypeTag, A2: TypeTag, RT: TypeTag: Encoder, N >: (A1, A2) => RT](
+    f: (A1, A2) => RT, namer: N => String, a1: A1, a2: A2): TypedColumn[Any, RT] = {
+    udf(() => f(a1, a2)).apply().as(namer(f)).as[RT]
+  }
+
+  def udfToColumnLiterals[A1: TypeTag, A2: TypeTag, A3: TypeTag, RT: TypeTag: Encoder, N >: (A1, A2, A3) => RT](
+    f: (A1, A2, A3) => RT, namer: N => String, a1: A1, a2: A2, a3: A3): TypedColumn[Any, RT] = {
+    udf(() => f(a1, a2, a3)).apply().as(namer(f)).as[RT]
+  }
+
+  def udfToColumnLiterals[A1: TypeTag, A2: TypeTag, A3: TypeTag, A4: TypeTag, RT: TypeTag: Encoder, N >: (A1, A2, A3, A4) => RT](
+    f: (A1, A2, A3, A4) => RT, namer: N => String, a1: A1, a2: A2, a3: A3, a4: A4): TypedColumn[Any, RT] = {
+    udf(() => f(a1, a2, a3, a4)).apply().as(namer(f)).as[RT]
   }
 
   def columnName(column: Column): String = {

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/SQLGeometricCastFunctions.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/SQLGeometricCastFunctions.scala
@@ -12,8 +12,7 @@ import java.nio.charset.StandardCharsets
 
 import com.vividsolutions.jts.geom._
 import org.locationtech.geomesa.spark.SQLFunctionHelper._
-import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.Column
+import org.apache.spark.sql.{Column, SQLContext, TypedColumn}
 import org.locationtech.geomesa.spark.SpatialEncoders._
 import org.locationtech.geomesa.spark.SparkDefaultEncoders._
 
@@ -24,24 +23,38 @@ object SQLGeometricCastFunctions {
   val ST_ByteArray: (String) => Array[Byte] =
     nullableUDF((string) => string.getBytes(StandardCharsets.UTF_8))
 
-  def castToPoint(geom: Column) = udfToColumn(ST_CastToPoint, "castToPoint", geom).as[Point]
-  def castToPoint(geom: Geometry) = udfToColumnLiterals(ST_CastToPoint, "castToPoint", geom).as[Point]
+  private[geomesa] val namer = Map(
+    ST_CastToPoint -> "st_castToPoint",
+    ST_CastToPolygon -> "st_castToPolygon",
+    ST_CastToLineString -> "st_castToLineString",
+    ST_ByteArray -> "st_byteArray"
+  )
 
-  def castToPolygon(geom: Column) = udfToColumn(ST_CastToPoint, "castToPolygon", geom).as[Polygon]
-  def castToPolygon(geom: Geometry) = udfToColumnLiterals(ST_CastToPoint, "castToPolygon", geom).as[Polygon]
+  def st_castToPoint(geom: Column): TypedColumn[Any, Point] =
+    udfToColumn(ST_CastToPoint, namer, geom)
+  def st_castToPoint(geom: Geometry): TypedColumn[Any, Point] =
+    udfToColumnLiterals(ST_CastToPoint, namer, geom)
 
-  def castToLineString(geom: Column) = udfToColumn(ST_CastToLineString, "castToLineString", geom).as[LineString]
-  def castToLineString(geom: Geometry) = udfToColumnLiterals(ST_CastToLineString, "castToLineString", geom).as[LineString]
+  def st_castToPolygon(geom: Column): TypedColumn[Any, Polygon] =
+    udfToColumn(ST_CastToPolygon, namer, geom)
+  def st_castToPolygon(geom: Geometry): TypedColumn[Any, Polygon] =
+    udfToColumnLiterals(ST_CastToPolygon, namer, geom)
 
-  def byteArray(str: Column) = udfToColumn(ST_ByteArray, "byteArray", str).as[Array[Byte]]
-  def byteArray(str: String) = udfToColumnLiterals(ST_ByteArray, "byteArray", str).as[Array[Byte]]
+  def st_castToLineString(geom: Column): TypedColumn[Any, LineString] =
+    udfToColumn(ST_CastToLineString, namer, geom)
+  def st_castToLineString(geom: Geometry): TypedColumn[Any, LineString] =
+    udfToColumnLiterals(ST_CastToLineString, namer, geom)
 
+  def st_byteArray(str: Column): TypedColumn[Any, Array[Byte]] =
+    udfToColumn(ST_ByteArray, namer, str)
+  def st_byteArray(str: String): TypedColumn[Any, Array[Byte]] =
+    udfToColumnLiterals(ST_ByteArray, namer, str)
 
   def registerFunctions(sqlContext: SQLContext): Unit = {
     // Register type casting functions
-    sqlContext.udf.register("st_castToPoint", ST_CastToPoint)
-    sqlContext.udf.register("st_castToPolygon", ST_CastToPolygon)
-    sqlContext.udf.register("st_castToLineString", ST_CastToLineString)
-    sqlContext.udf.register("st_byteArray", ST_ByteArray)
+    sqlContext.udf.register(namer(ST_CastToPoint), ST_CastToPoint)
+    sqlContext.udf.register(namer(ST_CastToPolygon), ST_CastToPolygon)
+    sqlContext.udf.register(namer(ST_CastToLineString), ST_CastToLineString)
+    sqlContext.udf.register(namer(ST_ByteArray), ST_ByteArray)
   }
 }

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/SQLGeometricConstructorFunctions.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/SQLGeometricConstructorFunctions.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.spark
 
 import com.vividsolutions.jts.geom._
 import org.locationtech.geomesa.spark.SQLFunctionHelper._
-import org.apache.spark.sql.{Column, SQLContext}
+import org.apache.spark.sql.{Column, SQLContext, TypedColumn}
 import org.apache.spark.sql.jts.JTSTypes
 import org.geotools.geometry.jts.JTS
 import org.locationtech.geomesa.spark.SpatialEncoders._
@@ -41,82 +41,131 @@ object SQLGeometricConstructorFunctions {
   val ST_Polygon: LineString => Polygon = shell => ST_MakePolygon(shell)
   val ST_PolygonFromText: String => Polygon = nullableUDF(text => WKTUtils.read(text).asInstanceOf[Polygon])
 
-  def st_geomFromWKT(wkt: Column) = udfToColumn(ST_GeomFromWKT, "st_geomFromWKT", wkt).as[Geometry]
-  def st_geomFromWKT(wkt: String) = udfToColumnLiterals(ST_GeomFromWKT, "st_geomFromWKT", wkt).as[Geometry]
+  private[geomesa] val namer = Map(
+    ST_GeomFromWKT -> "st_geomFromWKT",
+    ST_GeomFromWKB -> "st_geomFromWKB",
+    ST_LineFromText -> "st_lineFromText",
+    ST_MakeBox2D -> "st_makeBox2D",
+    ST_MakeBBOX -> "st_makeBBOX",
+    ST_MakePolygon -> "st_makePolygon",
+    ST_MakePoint -> "st_makePoint",
+    ST_MakeLine -> "st_makeLine",
+    ST_MakePointM -> "st_makePointM",
+    ST_MLineFromText -> "st_mLineFromText",
+    ST_MPointFromText -> "st_mPointFromText",
+    ST_MPolyFromText -> "st_mPolyFromText",
+    ST_Point -> "st_point",
+    ST_PointFromText -> "st_pointFromText",
+    ST_PointFromWKB -> "st_pointFromWKB",
+    ST_Polygon -> "st_polygon",
+    ST_PolygonFromText  -> "st_polygonFromText"
+  )
 
+  def st_geomFromWKT(wkt: Column): TypedColumn[Any, Geometry] =
+    udfToColumn(ST_GeomFromWKT, namer, wkt)
+  def st_geomFromWKT(wkt: String): TypedColumn[Any, Geometry] =
+    udfToColumnLiterals(ST_GeomFromWKT, namer, wkt)
 
-  def st_geomFromWKB(wkb: Column) = udfToColumn(ST_GeomFromWKB, "st_geomFromWKB", wkb).as[Geometry]
-  def st_geomFromWKB(wkb: Array[Byte]) = udfToColumnLiterals(ST_GeomFromWKB, "st_geomFromWKB", wkb).as[Geometry]
+  def st_geomFromWKB(wkb: Column): TypedColumn[Any, Geometry] =
+    udfToColumn(ST_GeomFromWKB, namer, wkb)
+  def st_geomFromWKB(wkb: Array[Byte]): TypedColumn[Any, Geometry] =
+    udfToColumnLiterals(ST_GeomFromWKB, namer, wkb)
 
-  def st_lineFromText(wkt: Column) = udfToColumn(ST_LineFromText, "st_lineFromText", wkt).as[LineString]
-  def st_lineFromText(wkt: String) = udfToColumnLiterals(ST_LineFromText, "st_lineFromText", wkt).as[LineString]
+  def st_lineFromText(wkt: Column): TypedColumn[Any, LineString] =
+    udfToColumn(ST_LineFromText, namer, wkt)
+  def st_lineFromText(wkt: String): TypedColumn[Any, LineString] =
+    udfToColumnLiterals(ST_LineFromText, namer, wkt)
 
-  def st_makeBox2D(lowerLeft: Column, upperRight: Column) =
-    udfToColumn(ST_MakeBox2D, "st_makeBox2D", lowerLeft, upperRight).as[Geometry]
-  def st_makeBox2D(lowerLeft: Point, upperRight: Point) =
-    udfToColumnLiterals(ST_MakeBox2D, "st_makeBox2D", lowerLeft, upperRight).as[Geometry]
+  def st_makeBox2D(lowerLeft: Column, upperRight: Column): TypedColumn[Any, Geometry] =
+    udfToColumn(ST_MakeBox2D, namer, lowerLeft, upperRight)
+  def st_makeBox2D(lowerLeft: Point, upperRight: Point): TypedColumn[Any, Geometry] =
+    udfToColumnLiterals(ST_MakeBox2D, namer, lowerLeft, upperRight)
 
-  def st_makeBBOX(lowerX: Column, upperX: Column, lowerY: Column, upperY: Column) =
-    udfToColumn(ST_MakeBBOX, "st_makeBBOX", lowerX, upperX, lowerY, upperY).as[Geometry]
-  def st_makeBBOX(lowerX: Double, upperX: Double, lowerY: Double, upperY: Double) =
-    udfToColumnLiterals(ST_MakeBBOX, "st_makeBBOX", lowerX, upperX, lowerY, upperY).as[Geometry]
+  def st_makeBBOX(lowerX: Column, upperX: Column, lowerY: Column, upperY: Column): TypedColumn[Any, Geometry] =
+    udfToColumn(ST_MakeBBOX, namer, lowerX, upperX, lowerY, upperY)
+  def st_makeBBOX(lowerX: Double, upperX: Double, lowerY: Double, upperY: Double): TypedColumn[Any, Geometry] =
+    udfToColumnLiterals(ST_MakeBBOX, namer, lowerX, upperX, lowerY, upperY)
 
-  def st_makePolygon(lineString: Column) = udfToColumn(ST_MakePolygon, "st_makePolygon", lineString).as[Polygon]
-  def st_makePolygon(lineString: LineString) = udfToColumnLiterals(ST_MakePolygon, "st_makePolygon", lineString).as[Polygon]
+  def st_makePolygon(lineString: Column): TypedColumn[Any, Polygon] =
+    udfToColumn(ST_MakePolygon, namer, lineString)
+  def st_makePolygon(lineString: LineString): TypedColumn[Any, Polygon] =
+    udfToColumnLiterals(ST_MakePolygon, namer, lineString)
 
-  def st_makePoint(x: Column, y: Column) = udfToColumn(ST_MakePoint, "st_makePoint", x, y).as[Point]
-  def st_makePoint(x: Double, y: Double) = udfToColumnLiterals(ST_MakePoint, "st_makePoint", x, y).as[Point]
+  def st_makePoint(x: Column, y: Column): TypedColumn[Any, Point] =
+    udfToColumn(ST_MakePoint, namer, x, y)
+  def st_makePoint(x: Double, y: Double): TypedColumn[Any, Point] =
+    udfToColumnLiterals(ST_MakePoint, namer, x, y)
 
-  def st_makeLine(pointSeq: Column) = udfToColumn(ST_MakeLine, "st_makeLine", pointSeq).as[LineString]
-  def st_makeLine(pointSeq: Seq[Point]) = udfToColumnLiterals(ST_MakeLine, "st_makeLine", pointSeq).as[LineString]
+  def st_makeLine(pointSeq: Column): TypedColumn[Any, LineString] =
+    udfToColumn(ST_MakeLine, namer, pointSeq)
+  def st_makeLine(pointSeq: Seq[Point]): TypedColumn[Any, LineString] =
+    udfToColumnLiterals(ST_MakeLine, namer, pointSeq)
 
-  def st_makePointM(x: Column, y: Column, m: Column) = udfToColumn(ST_MakePointM, "st_makePointM", x, y, m).as[Point]
-  def st_makePointM(x: Double, y: Double, m: Double) = udfToColumnLiterals(ST_MakePointM, "st_makePointM", x, y, m).as[Point]
+  def st_makePointM(x: Column, y: Column, m: Column): TypedColumn[Any, Point] =
+    udfToColumn(ST_MakePointM, namer, x, y, m)
+  def st_makePointM(x: Double, y: Double, m: Double): TypedColumn[Any, Point] =
+    udfToColumnLiterals(ST_MakePointM, namer, x, y, m)
 
-  def st_mLineFromText(wkt: Column) = udfToColumn(ST_MLineFromText, "st_mLineFromText", wkt).as[MultiLineString]
-  def st_mLineFromText(wkt: String) = udfToColumnLiterals(ST_MLineFromText, "st_mLineFromText", wkt).as[MultiLineString]
+  def st_mLineFromText(wkt: Column): TypedColumn[Any, MultiLineString] =
+    udfToColumn(ST_MLineFromText, namer, wkt)
+  def st_mLineFromText(wkt: String): TypedColumn[Any, MultiLineString] =
+    udfToColumnLiterals(ST_MLineFromText, namer, wkt)
 
-  def st_mPointFromText(wkt: Column) = udfToColumn(ST_MPointFromText, "st_mPointFromText", wkt).as[MultiPoint]
-  def st_mPointFromText(wkt: String) = udfToColumnLiterals(ST_MPointFromText, "st_mPointFromText", wkt).as[MultiPoint]
+  def st_mPointFromText(wkt: Column): TypedColumn[Any, MultiPoint] =
+    udfToColumn(ST_MPointFromText, namer, wkt)
+  def st_mPointFromText(wkt: String): TypedColumn[Any, MultiPoint] =
+    udfToColumnLiterals(ST_MPointFromText, namer, wkt)
 
-  def st_mPolyFromText(wkt: Column) = udfToColumn(ST_MPolyFromText, "st_mPolyFromText", wkt).as[MultiPolygon]
-  def st_mPolyFromText(wkt: String) = udfToColumnLiterals(ST_MPolyFromText, "st_mPolyFromText", wkt).as[MultiPolygon]
+  def st_mPolyFromText(wkt: Column): TypedColumn[Any, MultiPolygon] =
+    udfToColumn(ST_MPolyFromText, namer, wkt)
+  def st_mPolyFromText(wkt: String): TypedColumn[Any, MultiPolygon] =
+    udfToColumnLiterals(ST_MPolyFromText, namer, wkt)
 
-  def st_point(x: Column, y: Column) = udfToColumn(ST_Point, "st_point", x, y).as[Point]
-  def st_point(x: Double, y: Double) = udfToColumnLiterals(ST_Point, "st_point", x, y).as[Point]
+  def st_point(x: Column, y: Column): TypedColumn[Any, Point] =
+    udfToColumn(ST_Point, namer, x, y)
+  def st_point(x: Double, y: Double): TypedColumn[Any, Point] =
+    udfToColumnLiterals(ST_Point, namer, x, y)
 
-  def st_pointFromText(wkt: Column) = udfToColumn(ST_PointFromText, "st_pointFromText", wkt).as[Point]
-  def st_pointFromText(wkt: String) = udfToColumnLiterals(ST_PointFromText, "st_pointFromText", wkt).as[Point]
+  def st_pointFromText(wkt: Column): TypedColumn[Any, Point] =
+    udfToColumn(ST_PointFromText, namer, wkt)
+  def st_pointFromText(wkt: String): TypedColumn[Any, Point] =
+    udfToColumnLiterals(ST_PointFromText, namer, wkt)
 
-  def st_pointFromWKB(wkb: Column) = udfToColumn(ST_PointFromWKB, "st_pointFromWKB", wkb).as[Point]
-  def st_pointFromWKB(wkb: Array[Byte]) = udfToColumnLiterals(ST_PointFromWKB, "st_pointFromWKB", wkb).as[Point]
+  def st_pointFromWKB(wkb: Column): TypedColumn[Any, Point] =
+    udfToColumn(ST_PointFromWKB, namer, wkb)
+  def st_pointFromWKB(wkb: Array[Byte]): TypedColumn[Any, Point] =
+    udfToColumnLiterals(ST_PointFromWKB, namer, wkb)
 
-  def st_polygon(lineString: Column) = udfToColumn(ST_Polygon, "st_polygon", lineString).as[Polygon]
-  def st_polygon(lineString: LineString) = udfToColumnLiterals(ST_Polygon, "st_polygon", lineString).as[Polygon]
+  def st_polygon(lineString: Column): TypedColumn[Any, Polygon] =
+    udfToColumn(ST_Polygon, namer, lineString)
+  def st_polygon(lineString: LineString): TypedColumn[Any, Polygon] =
+    udfToColumnLiterals(ST_Polygon, namer, lineString)
 
-  def st_polygonFromText(wkt: Column) = udfToColumn(ST_PolygonFromText, "st_polygonFromText", wkt).as[Polygon]
-  def st_polygonFromText(wkt: String) = udfToColumnLiterals(ST_PolygonFromText, "st_polygonFromText", wkt).as[Polygon]
+  def st_polygonFromText(wkt: Column): TypedColumn[Any, Polygon] =
+    udfToColumn(ST_PolygonFromText, namer, wkt)
+  def st_polygonFromText(wkt: String): TypedColumn[Any, Polygon] =
+    udfToColumnLiterals(ST_PolygonFromText, namer, wkt)
 
 
   def registerFunctions(sqlContext: SQLContext): Unit = {
-    sqlContext.udf.register("st_geomFromText"      , ST_GeomFromWKT)
-    sqlContext.udf.register("st_geomFromWKB"       , ST_GeomFromWKB)
-    sqlContext.udf.register("st_geomFromWKT"       , ST_GeomFromWKT)
-    sqlContext.udf.register("st_geometryFromText"  , ST_GeomFromWKT)
-    sqlContext.udf.register("st_lineFromText"      , ST_LineFromText)
-    sqlContext.udf.register("st_mLineFromText"     , ST_MLineFromText)
-    sqlContext.udf.register("st_mPointFromText"    , ST_MPointFromText)
-    sqlContext.udf.register("st_mPolyFromText"     , ST_MPolyFromText)
-    sqlContext.udf.register("st_makeBBOX"          , ST_MakeBBOX)
-    sqlContext.udf.register("st_makeBox2D"         , ST_MakeBox2D)
-    sqlContext.udf.register("st_makeLine"          , ST_MakeLine)
-    sqlContext.udf.register("st_makePoint"         , ST_MakePoint)
-    sqlContext.udf.register("st_makePointM"        , ST_MakePointM)
-    sqlContext.udf.register("st_makePolygon"       , ST_MakePolygon)
-    sqlContext.udf.register("st_point"             , ST_Point)
-    sqlContext.udf.register("st_pointFromText"     , ST_PointFromText)
-    sqlContext.udf.register("st_pointFromWKB"      , ST_PointFromWKB)
-    sqlContext.udf.register("st_polygon"           , ST_Polygon)
-    sqlContext.udf.register("st_polygonFromText"   , ST_PolygonFromText)
+    sqlContext.udf.register("st_geomFromText", ST_GeomFromWKT)
+    sqlContext.udf.register("st_geometryFromText", ST_GeomFromWKT)
+    sqlContext.udf.register(namer(ST_GeomFromWKT), ST_GeomFromWKT)
+    sqlContext.udf.register(namer(ST_GeomFromWKB), ST_GeomFromWKB)
+    sqlContext.udf.register(namer(ST_LineFromText), ST_LineFromText)
+    sqlContext.udf.register(namer(ST_MLineFromText), ST_MLineFromText)
+    sqlContext.udf.register(namer(ST_MPointFromText), ST_MPointFromText)
+    sqlContext.udf.register(namer(ST_MPolyFromText), ST_MPolyFromText)
+    sqlContext.udf.register(namer(ST_MakeBBOX), ST_MakeBBOX)
+    sqlContext.udf.register(namer(ST_MakeBox2D), ST_MakeBox2D)
+    sqlContext.udf.register(namer(ST_MakeLine), ST_MakeLine)
+    sqlContext.udf.register(namer(ST_MakePoint), ST_MakePoint)
+    sqlContext.udf.register(namer(ST_MakePointM), ST_MakePointM)
+    sqlContext.udf.register(namer(ST_MakePolygon), ST_MakePolygon)
+    sqlContext.udf.register(namer(ST_Point), ST_Point)
+    sqlContext.udf.register(namer(ST_PointFromText), ST_PointFromText)
+    sqlContext.udf.register(namer(ST_PointFromWKB), ST_PointFromWKB)
+    sqlContext.udf.register(namer(ST_Polygon), ST_Polygon)
+    sqlContext.udf.register(namer(ST_PolygonFromText), ST_PolygonFromText)
   }
 }

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/SQLGeometricOutputFunctions.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/SQLGeometricOutputFunctions.scala
@@ -11,7 +11,7 @@ package org.locationtech.geomesa.spark
 
 import com.vividsolutions.jts.geom.{Geometry, Point}
 import org.locationtech.geomesa.spark.SQLFunctionHelper._
-import org.apache.spark.sql.{Column, SQLContext}
+import org.apache.spark.sql.{Column, SQLContext, TypedColumn}
 import org.geotools.geojson.geom.GeometryJSON
 import org.locationtech.geomesa.spark.SparkDefaultEncoders._
 
@@ -25,21 +25,38 @@ object SQLGeometricOutputFunctions {
   val ST_AsLatLonText: Point => String = nullableUDF(point => toLatLonString(point))
   val ST_AsText: Geometry => String = nullableUDF(geom => geom.toText)
 
+  private[geomesa] val namer = Map(
+    ST_AsBinary -> "st_asBinary",
+    ST_AsGeoJSON -> "st_asGeoJSON",
+    ST_AsLatLonText -> "st_asLatLonText",
+    ST_AsText -> "st_asText"
+  )
 
-  def st_asBinary(geom: Column) = udfToColumn(ST_AsBinary, "st_asBinary", geom).as[Array[Byte]]
-  def st_asBinary(geom: Geometry) = udfToColumnLiterals(ST_AsBinary, "st_asBinary", geom).as[Array[Byte]]
-  def st_asGeoJSON(geom: Column) = udfToColumn(ST_AsGeoJSON, "st_asGeoJSON", geom).as[String]
-  def st_asGeoJSON(geom: Geometry) = udfToColumnLiterals(ST_AsGeoJSON, "st_asGeoJSON", geom).as[String]
-  def st_asLatLonText(point: Column) = udfToColumn(ST_AsLatLonText, "st_asLatLonText", point).as[String]
-  def st_asLatLonText(point: Point) = udfToColumnLiterals(ST_AsLatLonText, "st_asLatLonText", point).as[String]
-  def st_asText(geom: Column) = udfToColumn(ST_AsText, "st_asText", geom).as[String]
-  def st_asText(geom: Geometry) = udfToColumnLiterals(ST_AsText, "st_asText", geom).as[String]
+  def st_asBinary(geom: Column): TypedColumn[Any, Array[Byte]] =
+    udfToColumn(ST_AsBinary, namer, geom)
+  def st_asBinary(geom: Geometry): TypedColumn[Any, Array[Byte]] =
+    udfToColumnLiterals(ST_AsBinary, namer, geom)
+
+  def st_asGeoJSON(geom: Column): TypedColumn[Any, String] =
+    udfToColumn(ST_AsGeoJSON, namer, geom)
+  def st_asGeoJSON(geom: Geometry): TypedColumn[Any, String] =
+    udfToColumnLiterals(ST_AsGeoJSON, namer, geom)
+
+  def st_asLatLonText(point: Column): TypedColumn[Any, String] =
+    udfToColumn(ST_AsLatLonText, namer, point)
+  def st_asLatLonText(point: Point): TypedColumn[Any, String] =
+    udfToColumnLiterals(ST_AsLatLonText, namer, point)
+
+  def st_asText(geom: Column): TypedColumn[Any, String] =
+    udfToColumn(ST_AsText, namer, geom)
+  def st_asText(geom: Geometry): TypedColumn[Any, String] =
+    udfToColumnLiterals(ST_AsText, namer, geom).as[String]
 
   def registerFunctions(sqlContext: SQLContext): Unit = {
-    sqlContext.udf.register("st_asBinary", ST_AsBinary)
-    sqlContext.udf.register("st_asGeoJSON", ST_AsGeoJSON)
-    sqlContext.udf.register("st_asLatLonText", ST_AsLatLonText)
-    sqlContext.udf.register("st_asText", ST_AsText)
+    sqlContext.udf.register(namer(ST_AsBinary), ST_AsBinary)
+    sqlContext.udf.register(namer(ST_AsGeoJSON), ST_AsGeoJSON)
+    sqlContext.udf.register(namer(ST_AsLatLonText), ST_AsLatLonText)
+    sqlContext.udf.register(namer(ST_AsText), ST_AsText)
   }
 
   private def toLatLonString(point: Point): String = {

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/SQLSpatialAccessorFunctions.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/SQLSpatialAccessorFunctions.scala
@@ -12,7 +12,7 @@ import java.{lang => jl}
 
 import com.vividsolutions.jts.geom._
 import org.locationtech.geomesa.spark.SQLFunctionHelper._
-import org.apache.spark.sql.{Column, SQLContext}
+import org.apache.spark.sql.{Column, SQLContext, TypedColumn}
 import org.locationtech.geomesa.spark.SpatialEncoders._
 import org.locationtech.geomesa.spark.SparkDefaultEncoders._
 
@@ -77,83 +77,143 @@ object SQLSpatialAccessorFunctions {
     case _ => null
   }
 
-  def st_boundary(geom: Column) = udfToColumn(ST_Boundary, "st_boundary", geom).as[Geometry]
-  def st_boundary(geom: Geometry) = udfToColumnLiterals(ST_Boundary, "st_boundary", geom).as[Geometry]
+  private[geomesa] val namer = Map(
+    ST_Boundary -> "st_boundary",
+    ST_CoordDim -> "st_coordDim",
+    ST_Dimension -> "st_dimension",
+    ST_Envelope -> "st_envelope",
+    ST_ExteriorRing -> "st_exteriorRing",
+    ST_GeometryN -> "st_geometryN",
+    ST_GeometryType -> "st_geometryType",
+    ST_InteriorRingN -> "st_interiorRingN",
+    ST_IsClosed -> "st_isClosed",
+    ST_IsCollection -> "st_isCollection",
+    ST_IsEmpty -> "st_isEmpty",
+    ST_IsRing -> "st_isRing",
+    ST_IsSimple -> "st_isSimple",
+    ST_IsValid -> "st_isValid",
+    ST_NumGeometries -> "st_numGeometries",
+    ST_NumPoints -> "st_numPoints",
+    ST_PointN -> "st_pointN",
+    ST_X -> "st_x",
+    ST_Y -> "st_y"
+  )
 
-  def st_coordDim(geom: Column) = udfToColumn(ST_CoordDim, "st_coordDim", geom).as[Int]
-  def st_coordDim(geom: Geometry) = udfToColumnLiterals(ST_CoordDim, "st_coordDim", geom).as[Int]
+  def st_boundary(geom: Column): TypedColumn[Any, Geometry] =
+    udfToColumn(ST_Boundary, namer, geom)
+  def st_boundary(geom: Geometry): TypedColumn[Any, Geometry] =
+    udfToColumnLiterals(ST_Boundary, namer, geom)
 
-  def st_dimension(geom: Column) = udfToColumn(ST_Dimension, "st_dimension", geom).as[Int]
-  def st_dimension(geom: Geometry) = udfToColumnLiterals(ST_Dimension, "st_dimension", geom).as[Int]
+  def st_coordDim(geom: Column): TypedColumn[Any, Int] =
+    udfToColumn(ST_CoordDim, namer, geom)
+  def st_coordDim(geom: Geometry): TypedColumn[Any, Int] =
+    udfToColumnLiterals(ST_CoordDim, namer, geom)
 
-  def st_envelope(geom: Column) = udfToColumn(ST_Envelope, "st_envelope", geom).as[Geometry]
-  def st_envelope(geom: Geometry) = udfToColumnLiterals(ST_Envelope, "st_envelope", geom).as[Geometry]
+  def st_dimension(geom: Column): TypedColumn[Any, Int] =
+    udfToColumn(ST_Dimension, namer, geom)
+  def st_dimension(geom: Geometry): TypedColumn[Any, Int] =
+    udfToColumnLiterals(ST_Dimension, namer, geom)
 
-  def st_exteriorRing(geom: Column) = udfToColumn(ST_ExteriorRing, "st_exteriorRing", geom).as[LineString]
-  def st_exteriorRing(geom: Geometry) = udfToColumnLiterals(ST_ExteriorRing, "st_exteriorRing", geom).as[LineString]
+  def st_envelope(geom: Column): TypedColumn[Any, Geometry] =
+    udfToColumn(ST_Envelope, namer, geom)
+  def st_envelope(geom: Geometry): TypedColumn[Any, Geometry] =
+    udfToColumnLiterals(ST_Envelope, namer, geom)
 
-  def st_geometryN(geom: Column, n: Column) = udfToColumn(ST_GeometryN, "st_geometryN", geom, n).as[Geometry]
-  def st_geometryN(geom: Geometry, n: Int) = udfToColumnLiterals(ST_GeometryN, "st_geometryN", geom, n).as[Geometry]
+  def st_exteriorRing(geom: Column): TypedColumn[Any, LineString] =
+    udfToColumn(ST_ExteriorRing, namer, geom)
+  def st_exteriorRing(geom: Geometry): TypedColumn[Any, LineString] =
+    udfToColumnLiterals(ST_ExteriorRing, namer, geom)
 
-  def st_geometryType(geom: Column) = udfToColumn(ST_GeometryType, "st_geometryType", geom).as[String]
-  def st_geometryType(geom: Geometry) = udfToColumnLiterals(ST_GeometryType, "st_geometryType", geom).as[String]
+  def st_geometryN(geom: Column, n: Column): TypedColumn[Any, Geometry] =
+    udfToColumn(ST_GeometryN, namer, geom, n)
+  def st_geometryN(geom: Geometry, n: Int): TypedColumn[Any, Geometry] =
+    udfToColumnLiterals(ST_GeometryN, namer, geom, n)
 
-  def st_interiorRingN(geom: Column, n: Column) = udfToColumn(ST_InteriorRingN, "st_interiorRingN", geom, n).as[Geometry]
-  def st_interiorRingN(geom: Geometry, n: Int) = udfToColumnLiterals(ST_InteriorRingN, "st_interiorRingN", geom, n).as[Geometry]
+  def st_geometryType(geom: Column): TypedColumn[Any, String] =
+    udfToColumn(ST_GeometryType, namer, geom)
+  def st_geometryType(geom: Geometry): TypedColumn[Any, String] =
+    udfToColumnLiterals(ST_GeometryType, namer, geom)
 
-  def st_isClosed(geom: Column) = udfToColumn(ST_IsClosed, "st_isClosed", geom).as[Boolean]
-  def st_isClosed(geom: Geometry) = udfToColumnLiterals(ST_IsClosed, "st_isClosed", geom).as[Boolean]
+  def st_interiorRingN(geom: Column, n: Column): TypedColumn[Any, Geometry] =
+    udfToColumn(ST_InteriorRingN, namer, geom, n)
+  def st_interiorRingN(geom: Geometry, n: Int): TypedColumn[Any, Geometry] =
+    udfToColumnLiterals(ST_InteriorRingN, namer, geom, n)
 
-  def st_isCollection(geom: Column) = udfToColumn(ST_IsCollection, "st_isCollection", geom).as[Boolean]
-  def st_isCollection(geom: Geometry) = udfToColumnLiterals(ST_IsCollection, "st_isCollection", geom).as[Boolean]
+  def st_isClosed(geom: Column): TypedColumn[Any, jl.Boolean] =
+    udfToColumn(ST_IsClosed, namer, geom)
+  def st_isClosed(geom: Geometry): TypedColumn[Any, jl.Boolean] =
+    udfToColumnLiterals(ST_IsClosed, namer, geom)
 
-  def st_isEmpty(geom: Column) = udfToColumn(ST_IsEmpty, "st_isEmpty", geom).as[Boolean]
-  def st_isEmpty(geom: Geometry) = udfToColumnLiterals(ST_IsEmpty, "st_isEmpty", geom).as[Boolean]
+  def st_isCollection(geom: Column): TypedColumn[Any, jl.Boolean] =
+    udfToColumn(ST_IsCollection, namer, geom)
+  def st_isCollection(geom: Geometry): TypedColumn[Any, jl.Boolean] =
+    udfToColumnLiterals(ST_IsCollection, namer, geom)
 
-  def st_isRing(geom: Column) = udfToColumn(ST_IsRing, "st_isRing", geom).as[Boolean]
-  def st_isRing(geom: Geometry) = udfToColumnLiterals(ST_IsRing, "st_isRing", geom).as[Boolean]
+  def st_isEmpty(geom: Column): TypedColumn[Any, jl.Boolean] =
+    udfToColumn(ST_IsEmpty, namer, geom)
+  def st_isEmpty(geom: Geometry): TypedColumn[Any, jl.Boolean] =
+    udfToColumnLiterals(ST_IsEmpty, namer, geom)
 
-  def st_isSimple(geom: Column) = udfToColumn(ST_IsSimple, "st_isSimple", geom).as[Boolean]
-  def st_isSimple(geom: Geometry) = udfToColumnLiterals(ST_IsSimple, "st_isSimple", geom).as[Boolean]
+  def st_isRing(geom: Column): TypedColumn[Any, jl.Boolean] =
+    udfToColumn(ST_IsRing, namer, geom)
+  def st_isRing(geom: Geometry): TypedColumn[Any, jl.Boolean] =
+    udfToColumnLiterals(ST_IsRing, namer, geom)
 
-  def st_isValid(geom: Column) = udfToColumn(ST_IsValid, "st_isValid", geom).as[Boolean]
-  def st_isValid(geom: Geometry) = udfToColumnLiterals(ST_IsValid, "st_isValid", geom).as[Boolean]
+  def st_isSimple(geom: Column): TypedColumn[Any, jl.Boolean] =
+    udfToColumn(ST_IsSimple, namer, geom)
+  def st_isSimple(geom: Geometry): TypedColumn[Any, jl.Boolean] =
+    udfToColumnLiterals(ST_IsSimple, namer, geom)
 
-  def st_numGeometries(geom: Column) = udfToColumn(ST_NumGeometries, "st_numGeometries", geom).as[Int]
-  def st_numGeometries(geom: Geometry) = udfToColumnLiterals(ST_NumGeometries, "st_numGeometries", geom).as[Int]
+  def st_isValid(geom: Column): TypedColumn[Any, jl.Boolean] =
+    udfToColumn(ST_IsValid, namer, geom)
+  def st_isValid(geom: Geometry): TypedColumn[Any, jl.Boolean] =
+    udfToColumnLiterals(ST_IsValid, namer, geom)
 
-  def st_numPoints(geom: Column) = udfToColumn(ST_NumPoints, "st_numPoints", geom).as[Int]
-  def st_numPoints(geom: Geometry) = udfToColumnLiterals(ST_NumPoints, "st_numPoints", geom).as[Int]
+  def st_numGeometries(geom: Column): TypedColumn[Any, Int] =
+    udfToColumn(ST_NumGeometries, namer, geom)
+  def st_numGeometries(geom: Geometry): TypedColumn[Any, Int] =
+    udfToColumnLiterals(ST_NumGeometries, namer, geom)
 
-  def st_pointN(geom: Column, n: Column) = udfToColumn(ST_PointN, "st_pointN", geom, n).as[Point]
-  def st_pointN(geom: Geometry, n: Int) = udfToColumnLiterals(ST_PointN, "st_pointN", geom, n).as[Point]
+  def st_numPoints(geom: Column): TypedColumn[Any, Int] =
+    udfToColumn(ST_NumPoints, namer, geom)
+  def st_numPoints(geom: Geometry): TypedColumn[Any, Int] =
+    udfToColumnLiterals(ST_NumPoints, namer, geom)
 
-  def st_x(geom: Column) = udfToColumn(ST_X, "st_x", geom).as[Float]
-  def st_x(geom: Geometry) = udfToColumnLiterals(ST_X, "st_x", geom).as[Float]
+  def st_pointN(geom: Column, n: Column): TypedColumn[Any, Point] =
+    udfToColumn(ST_PointN, namer, geom, n)
+  def st_pointN(geom: Geometry, n: Int): TypedColumn[Any, Point] =
+    udfToColumnLiterals(ST_PointN, namer, geom, n)
 
-  def st_y(geom: Column) = udfToColumn(ST_Y, "st_y", geom).as[Float]
-  def st_y(geom: Geometry) = udfToColumnLiterals(ST_Y, "st_y", geom).as[Float]
+  def st_x(geom: Column): TypedColumn[Any, jl.Float] =
+    udfToColumn(ST_X, namer, geom)
+  def st_x(geom: Geometry): TypedColumn[Any, jl.Float] =
+    udfToColumnLiterals(ST_X, namer, geom)
+
+  def st_y(geom: Column): TypedColumn[Any, jl.Float] =
+    udfToColumn(ST_Y, namer, geom)
+  def st_y(geom: Geometry): TypedColumn[Any, jl.Float] =
+    udfToColumnLiterals(ST_Y, namer, geom)
 
 
   def registerFunctions(sqlContext: SQLContext): Unit = {
-    sqlContext.udf.register("st_boundary"      , ST_Boundary)
-    sqlContext.udf.register("st_coordDim"      , ST_CoordDim)
-    sqlContext.udf.register("st_dimension"     , ST_Dimension)
-    sqlContext.udf.register("st_envelope"      , ST_Envelope)
-    sqlContext.udf.register("st_exteriorRing"  , ST_ExteriorRing)
-    sqlContext.udf.register("st_geometryN"     , ST_GeometryN)
-    sqlContext.udf.register("st_geometryType"  , ST_GeometryType)
-    sqlContext.udf.register("st_interiorRingN" , ST_InteriorRingN)
-    sqlContext.udf.register("st_isClosed"      , ST_IsClosed)
-    sqlContext.udf.register("st_isCollection"  , ST_IsCollection)
-    sqlContext.udf.register("st_isEmpty"       , ST_IsEmpty)
-    sqlContext.udf.register("st_isRing"        , ST_IsRing)
-    sqlContext.udf.register("st_isSimple"      , ST_IsSimple)
-    sqlContext.udf.register("st_isValid"       , ST_IsValid)
-    sqlContext.udf.register("st_numGeometries" , ST_NumGeometries)
-    sqlContext.udf.register("st_numPoints"     , ST_NumPoints)
-    sqlContext.udf.register("st_pointN"        , ST_PointN)
-    sqlContext.udf.register("st_x"             , ST_X)
-    sqlContext.udf.register("st_y"             , ST_Y)
+    sqlContext.udf.register(namer(ST_Boundary), ST_Boundary)
+    sqlContext.udf.register(namer(ST_CoordDim), ST_CoordDim)
+    sqlContext.udf.register(namer(ST_Dimension), ST_Dimension)
+    sqlContext.udf.register(namer(ST_Envelope), ST_Envelope)
+    sqlContext.udf.register(namer(ST_ExteriorRing), ST_ExteriorRing)
+    sqlContext.udf.register(namer(ST_GeometryN), ST_GeometryN)
+    sqlContext.udf.register(namer(ST_GeometryType), ST_GeometryType)
+    sqlContext.udf.register(namer(ST_InteriorRingN), ST_InteriorRingN)
+    sqlContext.udf.register(namer(ST_IsClosed), ST_IsClosed)
+    sqlContext.udf.register(namer(ST_IsCollection), ST_IsCollection)
+    sqlContext.udf.register(namer(ST_IsEmpty), ST_IsEmpty)
+    sqlContext.udf.register(namer(ST_IsRing), ST_IsRing)
+    sqlContext.udf.register(namer(ST_IsSimple), ST_IsSimple)
+    sqlContext.udf.register(namer(ST_IsValid), ST_IsValid)
+    sqlContext.udf.register(namer(ST_NumGeometries), ST_NumGeometries)
+    sqlContext.udf.register(namer(ST_NumPoints), ST_NumPoints)
+    sqlContext.udf.register(namer(ST_PointN), ST_PointN)
+    sqlContext.udf.register(namer(ST_X), ST_X)
+    sqlContext.udf.register(namer(ST_Y), ST_Y)
   }
 }

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/SparkDefaultEncoders.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/SparkDefaultEncoders.scala
@@ -8,16 +8,22 @@
 
 package org.locationtech.geomesa.spark
 
+import java.lang
 
+import org.apache.spark.sql.{Encoder, Encoders}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+
 import scala.reflect.runtime.universe._
 
-trait SparkDefaultEncoders {
-  implicit def stringEncoder = ExpressionEncoder[String]()
-  implicit def floatEncoder = ExpressionEncoder[Float]()
-  implicit def intEncoder = ExpressionEncoder[Int]()
-  implicit def booleanEncoder = ExpressionEncoder[Boolean]()
-  implicit def arrayEncoder[T: TypeTag] = ExpressionEncoder[Array[T]]()
+private[geomesa] trait SparkDefaultEncoders {
+  implicit def stringEncoder: Encoder[String] = Encoders.STRING
+  implicit def jFloatEncoder: Encoder[lang.Float] = Encoders.FLOAT
+  implicit def doubleEncoder: Encoder[Double] = Encoders.scalaDouble
+  implicit def jDoubleEncoder: Encoder[lang.Double] = Encoders.DOUBLE
+  implicit def intEncoder: Encoder[Int] = Encoders.scalaInt
+  implicit def jBooleanEncoder: Encoder[lang.Boolean] = Encoders.BOOLEAN
+  implicit def booleanEncoder: Encoder[Boolean] = Encoders.scalaBoolean
+  implicit def arrayEncoder[T: TypeTag]: Encoder[Array[T]] = ExpressionEncoder()
 }
 
-object SparkDefaultEncoders extends SparkDefaultEncoders
+private[geomesa] object SparkDefaultEncoders extends SparkDefaultEncoders

--- a/geomesa-spark/geomesa-spark-jts/src/test/resources/log4j.xml
+++ b/geomesa-spark/geomesa-spark-jts/src/test/resources/log4j.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.EnhancedPatternLayout">
+            <param name="ConversionPattern" value="[%d{HH:mm:ss,SSS}] %5p %c: %m%n"/>
+        </layout>
+    </appender>
+
+    <category name="org.apache.zookeeper">
+        <priority value="warn"/>
+    </category>
+    <category name="org.apache.hadoop">
+        <priority value="error"/>
+    </category>
+    <category name="org.mortbay.log">
+        <priority value="warn"/>
+    </category>
+    <category name="BlockStateChange">
+        <priority value="warn"/>
+    </category>
+    <category name="SecurityLogger.org.apache.hadoop.hbase.Server">
+        <priority value="warn"/>
+    </category>
+    <category name="hsqldb">
+        <priority value="warn"/>
+    </category>
+
+    <category name="org.apache.spark">
+        <priority value="warn"/>
+    </category>
+
+    <category name="org.spark_project.jetty">
+        <priority value="error"/>
+    </category>
+
+    <!-- un-comment the following line to enable verbose log messages
+     from the Spark SQL query-planner; this can be helpful in debugging
+     Spark SQL query plans -->
+    <!--<category name="org.locationtech.geomesa.spark">-->
+        <!--<priority value="info"/>-->
+    <!--</category>-->
+
+    <!--<category name="org.apache.spark.sql.execution">-->
+        <!--<priority value="trace"/>-->
+    <!--</category>-->
+
+    <!--<category name="org.apache.spark.sql">-->
+        <!--<priority value="debug"/>-->
+    <!--</category>-->
+
+    <!-- un-comment the following line to enable verbose log messages
+         from the index query-planner; this can be helpful in debugging
+         query plans -->
+    <!--<category name="org.locationtech.geomesa.index.utils.Explainer">
+        <priority value="trace"/>
+    </category>-->
+
+    <root>
+        <priority value="info"/>
+        <appender-ref ref="CONSOLE" />
+    </root>
+</log4j:configuration>
+

--- a/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/BlankDataFrame.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/BlankDataFrame.scala
@@ -1,0 +1,25 @@
+
+/***********************************************************************
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.spark
+
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Mixin providing constructor for creating a DataFrame with a single row and no columns.
+ * Useful for testing the invocation of data constructing UDFs.
+ */
+trait BlankDataFrame {
+  def dfBlank(implicit spark: SparkSession): DataFrame = {
+    // This is to enable us to do a single row creation select operation in DataFrame
+    // world. Probably a better/easier way of doing this.
+    spark.createDataFrame(spark.sparkContext.makeRDD(Seq(Row())), StructType(Seq.empty))
+  }
+}

--- a/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/SparkSQLGeometricCastTest.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/SparkSQLGeometricCastTest.scala
@@ -9,21 +9,23 @@
 package org.locationtech.geomesa.spark
 
 
-import com.vividsolutions.jts.geom.{LineString, Point, Polygon}
-import org.apache.spark.sql.{SQLContext, SparkSession}
+import com.vividsolutions.jts.geom._
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.jts.JTSTypes
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-
+import SQLGeometricCastFunctions._
+import SQLGeometricConstructorFunctions._
 
 @RunWith(classOf[JUnitRunner])
-class SparkSQLGeometricCastTest extends Specification {
+class SparkSQLGeometricCastTest extends Specification with BlankDataFrame {
 
   "sql geometry accessors" should {
     sequential
 
-    var spark: SparkSession = null
+    implicit var spark: SparkSession = null
     var sc: SQLContext = null
 
     // before
@@ -39,47 +41,59 @@ class SparkSQLGeometricCastTest extends Specification {
     "st_castToPoint" >> {
       "null" >> {
         sc.sql("select st_castToPoint(null)").collect.head(0) must beNull
+        dfBlank.select(st_castToPoint(lit(null))).first must beNull
       }
 
       "point" >> {
-        val point = "st_geomFromWKT('POINT(1 1)')"
+        val pointTxt = "POINT(1 1)"
+        val point = s"st_geomFromWKT('$pointTxt')"
         val df = sc.sql(s"select st_castToPoint($point)")
         df.collect.head(0) must haveClass[Point]
+        dfBlank.select(st_castToPoint(st_geomFromWKT(pointTxt))).first must haveClass[Point]
       }
     }
 
     "st_castToPolygon" >> {
       "null" >> {
         sc.sql("select st_castToPolygon(null)").collect.head(0) must beNull
+        dfBlank.select(st_castToPolygon(null: Geometry)).first must beNull
       }
 
       "polygon" >> {
-        val polygon = "st_geomFromWKT('POLYGON((1 1, 1 2, 2 2, 2 1, 1 1))')"
+        val polygonTxt = "POLYGON((1 1, 1 2, 2 2, 2 1, 1 1))"
+        val polygon = s"st_geomFromWKT('$polygonTxt')"
         val df = sc.sql(s"select st_castToPolygon($polygon)")
         df.collect.head(0) must haveClass[Polygon]
+        dfBlank.select(st_castToPolygon(st_geomFromWKT(polygonTxt))).first must haveClass[Polygon]
       }
     }
 
     "st_castToLineString" >> {
       "null" >> {
         sc.sql("select st_castToLineString(null)").collect.head(0) must beNull
+        dfBlank.select(st_castToLineString(null: Geometry)).first must beNull
       }
 
       "linestring" >> {
-        val line = "st_geomFromWKT('LINESTRING(1 1, 2 2)')"
+        val lineTxt = "LINESTRING(1 1, 2 2)"
+        val line = s"st_geomFromWKT('$lineTxt')"
         val df = sc.sql(s"select st_castToLineString($line)")
         df.collect.head(0) must haveClass[LineString]
+        dfBlank.select(st_castToLineString(st_geomFromWKT(lineTxt))).first must haveClass[LineString]
       }
     }
 
     "st_bytearray" >> {
       "null" >> {
-        sc.sql("select st_bytearray(null)").collect.head(0) must beNull
+        sc.sql("select st_byteArray(null)").collect.head(0) must beNull
+        dfBlank.select(st_byteArray(null: String)).first must beNull
       }
 
       "bytearray" >> {
-        val df = sc.sql(s"select st_bytearray('foo')")
-        df.collect.head(0) mustEqual "foo".toArray.map(_.toByte)
+        val df = sc.sql(s"select st_byteArray('foo')")
+        val expected = "foo".toArray.map(_.toByte)
+        df.collect.head(0) mustEqual expected
+        dfBlank.select(st_byteArray("foo")).first mustEqual expected
       }
     }
 

--- a/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/SparkSQLGeometryAccessorsTest.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/SparkSQLGeometryAccessorsTest.scala
@@ -8,25 +8,23 @@
 
 package org.locationtech.geomesa.spark
 
-import java.util.{Map => JMap}
-
 import com.vividsolutions.jts.geom.Geometry
-import org.apache.spark.sql.{DataFrame, SQLContext, SparkSession}
+import org.apache.spark.sql.{SQLContext, SparkSession}
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.jts.JTSTypes
-import org.geotools.data.{DataStore, DataStoreFinder}
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-
-import scala.collection.JavaConversions._
+import SQLSpatialAccessorFunctions._
+import SQLGeometricConstructorFunctions._
 
 @RunWith(classOf[JUnitRunner])
-class SparkSQLGeometryAccessorsTest extends Specification {
+class SparkSQLGeometryAccessorsTest extends Specification with BlankDataFrame {
 
   "sql geometry accessors" should {
     sequential
 
-    var spark: SparkSession = null
+    implicit var spark: SparkSession = null
     var sc: SQLContext = null
 
     // before
@@ -42,17 +40,23 @@ class SparkSQLGeometryAccessorsTest extends Specification {
 
     "st_boundary" >> {
       sc.sql("select st_boundary(null)").collect.head(0) must beNull
+      dfBlank.select(st_boundary(lit(null))).first must beNull
 
+      val line = "LINESTRING(1 1, 0 0, -1 1)"
       val result = sc.sql(
-        """
-          |select st_boundary(st_geomFromWKT('LINESTRING(1 1, 0 0, -1 1)'))
+        s"""
+          |select st_boundary(st_geomFromWKT('$line'))
         """.stripMargin
       )
-      result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("MULTIPOINT(1 1, -1 1)")
+      val expected = WKTUtils.read("MULTIPOINT(1 1, -1 1)")
+      result.collect().head.getAs[Geometry](0) mustEqual expected
+      dfBlank.select(st_boundary(st_geomFromWKT(line))).first mustEqual expected
+
     }
 
     "st_coordDim" >> {
       sc.sql("select st_coordDim(null)").collect.head(0) must beNull
+      dfBlank.select(st_coordDim(lit(null))).first mustEqual 0
 
       val result = sc.sql(
         """
@@ -60,11 +64,14 @@ class SparkSQLGeometryAccessorsTest extends Specification {
         """.stripMargin
       )
       result.collect().head.getAs[Int](0) mustEqual 2
+
+      dfBlank.select(st_coordDim(st_geomFromWKT("POINT(0 0)"))).first mustEqual 2
     }
 
     "st_dimension" >> {
       "null" >> {
         sc.sql("select st_dimension(null)").collect.head(0) must beNull
+        dfBlank.select(st_dimension(lit(null))).first mustEqual 0
       }
 
       "point" >> {
@@ -74,39 +81,48 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[Int](0) mustEqual 0
+        dfBlank.select(st_dimension(st_geomFromWKT("POINT(0 0)"))).first mustEqual 0
       }
 
       "linestring" >> {
+        val line = "LINESTRING(1 1, 0 0, -1 1)"
         val result = sc.sql(
-          """
-            |select st_dimension(st_geomFromWKT('LINESTRING(1 1, 0 0, -1 1)'))
+          s"""
+            |select st_dimension(st_geomFromWKT('$line'))
           """.stripMargin
         )
         result.collect().head.getAs[Int](0) mustEqual 1
+
+        dfBlank.select(st_dimension(st_geomFromWKT(line))).first mustEqual 1
       }
 
       "polygon" >> {
+        val poly = "POLYGON((30 10, 40 40, 20 40, 10 20, 30 10))"
         val result = sc.sql(
-          """
-            |select st_dimension(st_geomFromWKT('POLYGON((30 10, 40 40, 20 40, 10 20, 30 10))'))
+          s"""
+            |select st_dimension(st_geomFromWKT('$poly'))
           """.stripMargin
         )
         result.collect().head.getAs[Int](0) mustEqual 2
+        dfBlank.select(st_dimension(st_geomFromWKT(poly))).first mustEqual 2
       }
 
       "geometrycollection" >> {
+        val geom = "GEOMETRYCOLLECTION(LINESTRING(1 1,0 0),POINT(0 0))"
         val result = sc.sql(
-          """
-            |select st_dimension(st_geomFromWKT('GEOMETRYCOLLECTION(LINESTRING(1 1,0 0),POINT(0 0))'))
+          s"""
+             |select st_dimension(st_geomFromWKT('$geom'))
           """.stripMargin
         )
         result.collect().head.getAs[Int](0) mustEqual 1
+        dfBlank.select(st_dimension(st_geomFromWKT(geom))).first mustEqual 1
       }
     }
 
     "st_envelope" >> {
       "null" >> {
         sc.sql("select st_envelope(null)").collect.head(0) must beNull
+        dfBlank.select(st_envelope(lit(null))).first must beNull
       }
 
       "point" >> {
@@ -115,7 +131,9 @@ class SparkSQLGeometryAccessorsTest extends Specification {
             |select st_envelope(st_geomFromWKT('POINT(0 0)'))
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("POINT(0 0)")
+        val expected = WKTUtils.read("POINT(0 0)")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_envelope(st_geomFromWKT("POINT(0 0)"))).first mustEqual expected
       }
 
       "linestring" >> {
@@ -124,22 +142,28 @@ class SparkSQLGeometryAccessorsTest extends Specification {
             |select st_envelope(st_geomFromWKT('LINESTRING(0 0, 1 3)'))
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("POLYGON((0 0,0 3,1 3,1 0,0 0))")
+        val expected = WKTUtils.read("POLYGON((0 0,0 3,1 3,1 0,0 0))")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_envelope(st_geomFromWKT("LINESTRING(0 0, 1 3)"))).first mustEqual expected
       }
 
       "polygon" >> {
+        val poly = "POLYGON((0 0, 0 1, 1.0000001 1, 1.0000001 0, 0 0))"
         val result = sc.sql(
-          """
-            |select st_envelope(st_geomFromWKT('POLYGON((0 0, 0 1, 1.0000001 1, 1.0000001 0, 0 0))'))
+          s"""
+            |select st_envelope(st_geomFromWKT('$poly'))
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("POLYGON((0 0, 0 1, 1.0000001 1, 1.0000001 0, 0 0))")
+        val expected = WKTUtils.read("POLYGON((0 0, 0 1, 1.0000001 1, 1.0000001 0, 0 0))")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_envelope(st_geomFromWKT(poly))).first mustEqual expected
       }
     }
 
     "st_exteriorRing" >> {
       "null" >> {
         sc.sql("select st_exteriorRing(null)").collect.head(0) must beNull
+        dfBlank.select(st_exteriorRing(lit(null))).first must beNull
       }
 
       "point" >> {
@@ -149,31 +173,38 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[Geometry](0) must beNull
+        dfBlank.select(st_exteriorRing(st_geomFromWKT("POINT(0 0)"))).first must beNull
       }
 
       "polygon without an interior ring" >> {
+        val poly = "POLYGON((30 10, 40 40, 20 40, 10 20, 30 10))"
         val result = sc.sql(
-          """
-            |select st_exteriorRing(st_geomFromWKT('POLYGON((30 10, 40 40, 20 40, 10 20, 30 10))'))
+          s"""
+             |select st_exteriorRing(st_geomFromWKT('$poly'))
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("LINESTRING(30 10, 40 40, 20 40, 10 20, 30 10)")
+        val expected = WKTUtils.read("LINESTRING(30 10, 40 40, 20 40, 10 20, 30 10)")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_exteriorRing(st_geomFromWKT(poly))).first mustEqual expected
       }
 
       "polygon with an interior ring" >> {
+        val poly = "POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))"
         val result = sc.sql(
-          """
-            |select st_exteriorRing(st_geomFromWKT('POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),
-            |(20 30, 35 35, 30 20, 20 30))'))
+          s"""
+            |select st_exteriorRing(st_geomFromWKT('$poly'))
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("LINESTRING(35 10, 45 45, 15 40, 10 20, 35 10)")
+        val expected = WKTUtils.read("LINESTRING(35 10, 45 45, 15 40, 10 20, 35 10)")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_exteriorRing(st_geomFromWKT(poly))).first mustEqual expected
       }
     }
 
     "st_geometryN" >> {
       "null" >> {
         sc.sql("select st_geometryN(null, null)").collect.head(0) must beNull
+        dfBlank.select(st_geometryN(lit(null), lit(null))).first must beNull
       }
 
       "point" >> {
@@ -182,31 +213,40 @@ class SparkSQLGeometryAccessorsTest extends Specification {
             |select st_geometryN(st_geomFromWKT('POINT(0 0)'), 1)
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("POINT(0 0)")
+        val expected = WKTUtils.read("POINT(0 0)")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_geometryN(st_geomFromWKT("POINT(0 0)"), lit(1))).first mustEqual expected
       }
 
       "multilinestring" >> {
+        val geom = "MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))"
         val result = sc.sql(
-          """
-            |select st_geometryN(st_geomFromWKT('MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))'), 1)
+          s"""
+             |select st_geometryN(st_geomFromWKT('$geom'), 1)
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("LINESTRING(10 10, 20 20, 10 40)")
+        val expected = WKTUtils.read("LINESTRING(10 10, 20 20, 10 40)")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_geometryN(st_geomFromWKT(geom), lit(1))).first mustEqual expected
       }
 
       "geometrycollection" >> {
+        val geom = "GEOMETRYCOLLECTION(LINESTRING(1 1,0 0),POINT(0 0))"
         val result = sc.sql(
-          """
-            |select st_geometryN(st_geomFromWKT('GEOMETRYCOLLECTION(LINESTRING(1 1,0 0),POINT(0 0))'), 1)
+          s"""
+            |select st_geometryN(st_geomFromWKT('$geom'), 1)
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("LINESTRING(1 1,0 0)")
+        val expected = WKTUtils.read("LINESTRING(1 1,0 0)")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_geometryN(st_geomFromWKT(geom), lit(1))).first mustEqual expected
       }
     }
 
     "st_geometryType" >> {
       "null" >> {
         sc.sql("select st_geometryType(null)").collect.head(0) must beNull
+        dfBlank.select(st_geomFromWKT(lit(null))).first must beNull
       }
 
       "point" >> {
@@ -216,6 +256,7 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[String](0) mustEqual "Point"
+        dfBlank.select(st_geometryType(st_geomFromWKT("POINT(0 0)"))).first mustEqual "Point"
       }
 
       "linestring" >> {
@@ -225,15 +266,18 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[String](0) mustEqual "LineString"
+        dfBlank.select(st_geometryType(st_geomFromWKT("LINESTRING(0 0, 1 3)"))).first mustEqual "LineString"
       }
 
       "geometrycollection" >> {
+        val geom = "GEOMETRYCOLLECTION(LINESTRING(1 1,0 0),POINT(0 0))"
         val result = sc.sql(
-          """
-            |select st_geometryType(st_geomFromWKT('GEOMETRYCOLLECTION(LINESTRING(1 1,0 0),POINT(0 0))'))
+          s"""
+            |select st_geometryType(st_geomFromWKT('$geom'))
           """.stripMargin
         )
         result.collect().head.getAs[String](0) mustEqual "GeometryCollection"
+        dfBlank.select(st_geometryType(st_geomFromWKT(geom))).first mustEqual "GeometryCollection"
       }
 
     }
@@ -241,6 +285,7 @@ class SparkSQLGeometryAccessorsTest extends Specification {
     "st_interiorRingN" >> {
       "null" >> {
         sc.sql("select st_interiorRingN(null, null)").collect.head(0) must beNull
+        dfBlank.select(st_interiorRingN(lit(null), lit(null))).first must beNull
       }
 
       "point" >> {
@@ -250,74 +295,88 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[Geometry](0) must beNull
+        dfBlank.select(st_interiorRingN(st_geomFromWKT("POINT(0 0)"), lit(1))).first must beNull
       }
 
       "polygon with a valid int" >> {
+        val poly = "POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))"
         val result = sc.sql(
-          """
-            |select st_interiorRingN(st_geomFromWKT('POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),
-            |(20 30, 35 35, 30 20, 20 30))'), 1)
+          s"""
+            |select st_interiorRingN(st_geomFromWKT('$poly'), 1)
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("LINESTRING(20 30, 35 35, 30 20, 20 30)")
+        val expected = WKTUtils.read("LINESTRING(20 30, 35 35, 30 20, 20 30)")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_interiorRingN(st_geomFromWKT(poly), lit(1))).first mustEqual expected
       }
 
       "polygon with an invalid int" >> {
+        val poly = "POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))"
         val result = sc.sql(
-          """
-            |select st_interiorRingN(st_geomFromWKT('POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),
-            |(20 30, 35 35, 30 20, 20 30))'), 5)
+          s"""
+            |select st_interiorRingN(st_geomFromWKT('$poly'), 5)
           """.stripMargin
         )
         result.collect().head.getAs[Geometry](0) must beNull
+        dfBlank.select(st_interiorRingN(st_geomFromWKT(poly), lit(5))).first must beNull
       }
     }
 
     "st_isClosed" >> {
       "null" >> {
         sc.sql("select st_isClosed(null)").collect.head(0) must beNull
+        dfBlank.select(st_isClosed(lit(null))).first must beNull
       }
 
       "open linestring" >> {
+        val line = "LINESTRING(0 0, 1 1)"
         val result = sc.sql(
-          """
-            |select st_isClosed(st_geomFromWKT('LINESTRING(0 0, 1 1)'))
+          s"""
+            |select st_isClosed(st_geomFromWKT('$line'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beFalse
+        dfBlank.select(st_isClosed(st_geomFromWKT(line))).first.booleanValue() must beFalse
       }
 
       "closed linestring" >> {
+        val line = "LINESTRING(0 0, 0 1, 1 1, 0 0)"
         val result = sc.sql(
-          """
-            |select st_isClosed(st_geomFromWKT('LINESTRING(0 0, 0 1, 1 1, 0 0)'))
+          s"""
+            |select st_isClosed(st_geomFromWKT('$line'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beTrue
+        dfBlank.select(st_isClosed(st_geomFromWKT(line))).first.booleanValue must beTrue
       }
 
       "open multilinestring" >> {
+        val line = "MULTILINESTRING((0 0, 0 1, 1 1, 0 0),(0 0, 1 1))"
         val result = sc.sql(
-          """
-            |select st_isClosed(st_geomFromWKT('MULTILINESTRING((0 0, 0 1, 1 1, 0 0),(0 0, 1 1))'))
+          s"""
+             |select st_isClosed(st_geomFromWKT('$line'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beFalse
+        dfBlank.select(st_isClosed(st_geomFromWKT(line))).first.booleanValue must beFalse
       }
 
       "closed multilinestring" >> {
+        val line = "MULTILINESTRING((0 0, 0 1, 1 1, 0 0),(0 0, 1 1, 0 0))"
         val result = sc.sql(
-          """
-            |select st_isClosed(st_geomFromWKT('MULTILINESTRING((0 0, 0 1, 1 1, 0 0),(0 0, 1 1, 0 0))'))
+          s"""
+             |select st_isClosed(st_geomFromWKT('$line'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beTrue
+        dfBlank.select(st_isClosed(st_geomFromWKT(line))).first.booleanValue() must beTrue
       }
     }
 
     "st_isCollection" >> {
       "null" >> {
         sc.sql("select st_isCollection(null)").collect.head(0) must beNull
+        dfBlank.select(st_isCollection(lit(null))).first must beNull
       }
 
       "point" >> {
@@ -327,24 +386,29 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beFalse
+        dfBlank.select(st_isCollection(st_geomFromWKT("POINT(0 0)"))).first.booleanValue() must beFalse
       }
 
       "multipoint" >> {
+        val point = "MULTIPOINT((0 0), (42 42))"
         val result = sc.sql(
-          """
-            |select st_isCollection(st_geomFromWKT('MULTIPOINT((0 0), (42 42))'))
+          s"""
+             |select st_isCollection(st_geomFromWKT('$point'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beTrue
+        dfBlank.select(st_isCollection(st_geomFromWKT(point))).first.booleanValue() must beTrue
       }
 
       "geometrycollection" >> {
+        val geom = "GEOMETRYCOLLECTION(POINT(0 0))"
         val result = sc.sql(
-          """
-            |select st_isCollection(st_geomFromWKT('GEOMETRYCOLLECTION(POINT(0 0))'))
+          s"""
+            |select st_isCollection(st_geomFromWKT('$geom'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beTrue
+        dfBlank.select(st_isCollection(st_geomFromWKT(geom))).first.booleanValue() must beTrue
       }
     }
 
@@ -360,6 +424,7 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beTrue
+        dfBlank.select(st_isEmpty(st_geomFromWKT("GEOMETRYCOLLECTION EMPTY"))).first.booleanValue() must beTrue
       }
 
       "non-empty point" >> {
@@ -369,36 +434,43 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beFalse
+        dfBlank.select(st_isEmpty(st_geomFromWKT("POINT(0 0)"))).first.booleanValue() must beFalse
       }
     }
 
     "st_isRing" >> {
       "null" >> {
         sc.sql("select st_isRing(null)").collect.head(0) must beNull
+        dfBlank.select(st_isRing(lit(null))).first must beNull
       }
 
       "closed and simple linestring" >> {
+        val line = "LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"
         val result = sc.sql(
-          """
-            |select st_isRing(st_geomFromWKT('LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)'))
+          s"""
+             |select st_isRing(st_geomFromWKT('$line'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beTrue
+        dfBlank.select(st_isRing(st_geomFromWKT(line))).first.booleanValue() must beTrue
       }
 
       "closed and non-simple linestring" >> {
+        val line = "LINESTRING(0 0, 0 1, 1 0, 1 1, 0 0)"
         val result = sc.sql(
-          """
-            |select st_isRing(st_geomFromWKT('LINESTRING(0 0, 0 1, 1 0, 1 1, 0 0)'))
+          s"""
+             |select st_isRing(st_geomFromWKT('$line'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beFalse
+        dfBlank.select(st_isRing(st_geomFromWKT(line))).first.booleanValue() must beFalse
       }
     }
 
     "st_isSimple" >> {
       "null" >> {
         sc.sql("select st_isSimple(null)").collect.head(0) must beNull
+        dfBlank.select(st_isSimple(lit(null))).first must beNull
       }
 
       "simple point" >> {
@@ -408,63 +480,76 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beTrue
+        dfBlank.select(st_isSimple(st_geomFromWKT("POINT(0 0)"))).first.booleanValue() must beTrue
       }
 
       "simple linestring" >> {
+        val line = "LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"
         val result = sc.sql(
-          """
-            |select st_isSimple(st_geomFromWKT('LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)'))
+          s"""
+             |select st_isSimple(st_geomFromWKT('$line'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beTrue
+        dfBlank.select(st_isSimple(st_geomFromWKT(line))).first.booleanValue() must beTrue
       }
 
       "non-simple linestring" >> {
+        val line = "LINESTRING(1 1,2 2,2 3.5,1 3,1 2,2 1)"
         val result = sc.sql(
-          """
-            |select st_isSimple(st_geomFromWKT('LINESTRING(1 1,2 2,2 3.5,1 3,1 2,2 1)'))
+          s"""
+             |select st_isSimple(st_geomFromWKT('$line'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beFalse
+        dfBlank.select(st_isSimple(st_geomFromWKT(line))).first.booleanValue() must beFalse
       }
 
       "non-simple polygon" >> {
+        val poly = "POLYGON((1 2, 3 4, 5 6, 1 2))"
         val result = sc.sql(
-          """
-            |select st_isSimple(st_geomFromWKT('POLYGON((1 2, 3 4, 5 6, 1 2))'))
+          s"""
+            |select st_isSimple(st_geomFromWKT('$poly'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beFalse
+        dfBlank.select(st_isSimple(st_geomFromWKT(poly))).first.booleanValue() must beFalse
       }
     }
 
     "st_isValid" >> {
       "null" >> {
         sc.sql("select st_isValid(null)").collect.head(0) must beNull
+        dfBlank.select(st_isValid(lit(null))).first must beNull
       }
 
       "valid linestring" >> {
+        val line = "LINESTRING(0 0, 1 1)"
         val result = sc.sql(
-          """
-            |select st_isValid(st_geomFromWKT('LINESTRING(0 0, 1 1)'))
+          s"""
+             |select st_isValid(st_geomFromWKT('$line'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beTrue
+        dfBlank.select(st_isValid(st_geomFromWKT(line))).first.booleanValue() must beTrue
       }
 
       "invalid polygon" >> {
+        val poly = "POLYGON((0 0, 1 1, 1 2, 1 1, 0 0))"
         val result = sc.sql(
-          """
-            |select st_isValid(st_geomFromWKT('POLYGON((0 0, 1 1, 1 2, 1 1, 0 0))'))
+          s"""
+            |select st_isValid(st_geomFromWKT('$poly'))
           """.stripMargin
         )
         result.collect().head.getAs[Boolean](0) must beFalse
+        dfBlank.select(st_isValid(st_geomFromWKT(poly))).first.booleanValue() must beFalse
       }
     }
 
     "st_numGeometries" >> {
       "null" >> {
         sc.sql("select st_numGeometries(null)").collect.head(0) must beNull
+        dfBlank.select(st_numGeometries(lit(null))).first mustEqual 0
       }
 
       "point" >> {
@@ -474,32 +559,36 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[Int](0) mustEqual 1
+        dfBlank.select(st_numGeometries(st_geomFromWKT("POINT(0 0)"))).first mustEqual 1
       }
 
       "linestring" >> {
+        val line = "LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"
         val result = sc.sql(
-          """
-            |select st_numGeometries(st_geomFromWKT('LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)'))
+          s"""
+             |select st_numGeometries(st_geomFromWKT('$line'))
           """.stripMargin
         )
         result.collect().head.getAs[Int](0) mustEqual 1
+        dfBlank.select(st_numGeometries(st_geomFromWKT(line))).first mustEqual 1
       }
 
       "geometrycollection" >> {
+        val geom = "GEOMETRYCOLLECTION(MULTIPOINT(-2 3,-2 2), LINESTRING(5 5,10 10), POLYGON((-7 4.2,-7.1 5,-7.1 4.3,-7 4.2)))"
         val result = sc.sql(
-          """
-            |select st_numGeometries(st_geomFromWKT('GEOMETRYCOLLECTION(MULTIPOINT(-2 3,-2 2),
-            |LINESTRING(5 5,10 10),
-            |POLYGON((-7 4.2,-7.1 5,-7.1 4.3,-7 4.2)))'))
+          s"""
+             |select st_numGeometries(st_geomFromWKT('$geom'))
           """.stripMargin
         )
         result.collect().head.getAs[Int](0) mustEqual 3
+        dfBlank.select(st_numGeometries(st_geomFromWKT(geom))).first mustEqual 3
       }
     }
 
     "st_numPoints" >> {
       "null" >> {
         sc.sql("select st_numPoints(null)").collect.head(0) must beNull
+        dfBlank.select(st_numPoints(lit(null))).first mustEqual 0
       }
 
       "point" >> {
@@ -512,69 +601,87 @@ class SparkSQLGeometryAccessorsTest extends Specification {
       }
 
       "multipoint" >> {
+        val point = "MULTIPOINT(-2 3,-2 2)"
         val result = sc.sql(
-          """
-            |select st_numPoints(st_geomFromWKT('MULTIPOINT(-2 3,-2 2)'))
+          s"""
+             |select st_numPoints(st_geomFromWKT('$point'))
           """.stripMargin
         )
         result.collect().head.getAs[Int](0) mustEqual 2
+        dfBlank.select(st_numPoints(st_geomFromWKT(point))).first mustEqual 2
       }
 
       "multipoint" >> {
+        val geom = "LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"
         val result = sc.sql(
-          """
-            |select st_numPoints(st_geomFromWKT('LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)'))
+          s"""
+             |select st_numPoints(st_geomFromWKT('$geom'))
           """.stripMargin
         )
         result.collect().head.getAs[Int](0) mustEqual 5
+        dfBlank.select(st_numPoints(st_geomFromWKT(geom))).first mustEqual 5
       }
     }
 
     "st_pointN" >> {
       "null" >> {
         sc.sql("select st_pointN(null, null)").collect.head(0) must beNull
+        dfBlank.select(st_pointN(lit(null), lit(null))).first must beNull
       }
 
       "first point" >> {
+        val line = "LINESTRING(0 0, 0 1, 1 1, 1 0, 0 2)"
         val result = sc.sql(
-          """
-            |select st_pointN(st_geomFromWKT('LINESTRING(0 0, 0 1, 1 1, 1 0, 0 2)'), 1)
+          s"""
+             |select st_pointN(st_geomFromWKT('$line'), 1)
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("POINT(0 0)")
+        val expected = WKTUtils.read("POINT(0 0)")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_pointN(st_geomFromWKT(line), lit(1))).first mustEqual expected
       }
 
       "last point" >> {
+        val line = "LINESTRING(0 0, 0 1, 1 1, 1 0, 0 2)"
         val result = sc.sql(
-          """
-            |select st_pointN(st_geomFromWKT('LINESTRING(0 0, 0 1, 1 1, 1 0, 0 2)'), 5)
+          s"""
+            |select st_pointN(st_geomFromWKT('$line'), 5)
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("POINT(0 2)")
+        val expected = WKTUtils.read("POINT(0 2)")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_pointN(st_geomFromWKT(line), lit(5))).first mustEqual expected
       }
 
       "first point using a negative index" >> {
+        val line = "LINESTRING(0 0, 0 1, 1 1, 1 0, 0 2)"
         val result = sc.sql(
-          """
-            |select st_pointN(st_geomFromWKT('LINESTRING(0 0, 0 1, 1 1, 1 0, 0 2)'), -5)
+          s"""
+            |select st_pointN(st_geomFromWKT('$line'), -5)
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("POINT(0 0)")
+        val expected = WKTUtils.read("POINT(0 0)")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_pointN(st_geomFromWKT(line), lit(-5))).first mustEqual expected
       }
 
       "last point using a negative index" >> {
+        val line = "LINESTRING(0 0, 0 1, 1 1, 1 0, 0 2)"
         val result = sc.sql(
-          """
-            |select st_pointN(st_geomFromWKT('LINESTRING(0 0, 0 1, 1 1, 1 0, 0 2)'), -1)
+          s"""
+             |select st_pointN(st_geomFromWKT('$line'), -1)
           """.stripMargin
         )
-        result.collect().head.getAs[Geometry](0) mustEqual WKTUtils.read("POINT(0 2)")
+        val expected = WKTUtils.read("POINT(0 2)")
+        result.collect().head.getAs[Geometry](0) mustEqual expected
+        dfBlank.select(st_pointN(st_geomFromWKT(line), lit(-1))).first mustEqual expected
       }
     }
 
     "st_x" >> {
       "null" >> {
         sc.sql("select st_x(null)").collect.head(0) must beNull
+        dfBlank.select(st_x(lit(null))).first must beNull
       }
 
       "point" >> {
@@ -584,6 +691,8 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[java.lang.Float](0) mustEqual 0f
+        dfBlank.select(st_x(st_geomFromWKT("POINT(0 1)"))).first mustEqual 0f
+
       }
 
       "non-point" >> {
@@ -593,12 +702,14 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[java.lang.Float](0) must beNull
+        dfBlank.select(st_x(st_geomFromWKT("LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"))).first must beNull
       }
     }
 
     "st_y" >> {
       "null" >> {
         sc.sql("select st_y(null)").collect.head(0) must beNull
+        dfBlank.select(st_y(lit(null))).first must beNull
       }
 
       "point" >> {
@@ -608,6 +719,8 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[java.lang.Float](0) mustEqual 1f
+        dfBlank.select(st_y(st_geomFromWKT("POINT(0 1)"))).first mustEqual 1f
+
       }
 
       "non-point" >> {
@@ -617,6 +730,8 @@ class SparkSQLGeometryAccessorsTest extends Specification {
           """.stripMargin
         )
         result.collect().head.getAs[java.lang.Float](0) must beNull
+        dfBlank.select(st_y(st_geomFromWKT("LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"))).first must beNull
+
       }
     }
 

--- a/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/SparkSQLSpatialRelationshipsTest.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/SparkSQLSpatialRelationshipsTest.scala
@@ -1,0 +1,504 @@
+/***********************************************************************
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.spark
+
+import java.{lang => jl}
+
+import com.vividsolutions.jts.geom.Point
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.jts.JTSTypes
+import org.apache.spark.sql.{Column, TypedColumn, _}
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.spark.SQLGeometricConstructorFunctions._
+import org.locationtech.geomesa.spark.SQLSpatialFunctions._
+import org.locationtech.geomesa.spark.SparkDefaultEncoders._
+import org.locationtech.geomesa.spark.SpatialEncoders._
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class SparkSQLSpatialRelationshipsTest extends Specification with BlankDataFrame {
+  type DFRelation = (Column, Column) => TypedColumn[Any, jl.Boolean]
+  sequential
+
+  "SQL spatial relationships" should {
+
+    implicit var spark: SparkSession = null
+    var sc: SQLContext = null
+
+    var dfPoints: DataFrame = null
+    var dfLines: DataFrame = null
+    var dfBoxes: DataFrame = null
+
+    val boxRef   = "POLYGON((0  0,  0 10, 10 10, 10  0,  0  0))"
+    val lineRef  = "LINESTRING(0 10, 0 -10)"
+
+    val points = Map(
+      "int"    -> "POINT(5 5)",
+      "edge"   -> "POINT(0 5)",
+      "corner" -> "POINT(0 0)",
+      "ext"    -> "POINT(-5 0)")
+
+    val lines = Map(
+      "touches" -> "LINESTRING(0 0, 1 0)",
+      "crosses" -> "LINESTRING(-1 0, 1 0)",
+      "disjoint" -> "LINESTRING(1 0, 2 0)")
+
+    val boxes = Map(
+      "int"     -> "POLYGON(( 1  1,  1  2,  2  2,  2  1,  1  1))",
+      "intEdge" -> "POLYGON(( 0  1,  0  2,  1  2,  1  1,  0  1))",
+      "overlap" -> "POLYGON((-1  1, -1  2,  1  2,  1  1, -1  1))",
+      "extEdge" -> "POLYGON((-1  1, -1  2,  0  2,  0  1, -1  1))",
+      "ext"     -> "POLYGON((-2  1, -2  2, -1  2, -1  1, -2  1))",
+      "corner"  -> "POLYGON((-1 -1, -1  0,  0  0,  0 -1, -1 -1))")
+
+    // before
+    step {
+      val session  = SparkSession.builder()
+        .appName("testSpark")
+        .master("local[*]")
+        .getOrCreate()
+
+      spark = session
+      sc = spark.sqlContext
+
+      JTSTypes.init(sc)
+
+      import session.implicits._
+
+      dfPoints = points.mapValues(WKTUtils.read).toSeq.toDF("name", "geom")
+      dfPoints.createOrReplaceTempView("points")
+
+      dfLines = lines.mapValues(WKTUtils.read).toSeq.toDF("name", "geom")
+      dfLines.createOrReplaceTempView("lines")
+
+      dfBoxes = boxes.mapValues(WKTUtils.read).toSeq.toDF("name", "geom")
+      dfBoxes.createOrReplaceTempView("boxes")
+    }
+
+    // DE-9IM comparisons
+    def testData(r: DataFrame, expectedNames: Seq[String]) = {
+      val d = r.collect()
+      val column = d.map(row => row.getAs[String]("name")).toSeq
+      column must containTheSameElementsAs(expectedNames)
+    }
+
+    def testDirect(relation: DFRelation, name: String, g1: String, g2: String, expected: Boolean) = {
+      dfBlank.select(relation(st_geomFromWKT(g1), st_geomFromWKT(g2)).as[Boolean]).first mustEqual expected
+      // NB: Hack to pull SQL-land name from columnar function.
+      val relationName = SQLFunctionHelper.columnName(relation(lit(null), lit(null))).split('(').head
+      val sql = s"select $relationName(st_geomFromWKT('$g1'), st_geomFromWKT('$g2'))"
+      sc.sql(sql).as[Boolean].first mustEqual expected
+    }
+
+    "st_contains" >> {
+      testData(
+        sc.sql(s"select * from points where st_contains(st_geomFromWKT('$boxRef'), geom)"),
+        Seq("int")
+      )
+      testData(
+        dfPoints.where(st_contains(st_geomFromWKT(boxRef), col("geom"))),
+        Seq("int")
+      )
+      testData(
+        sc.sql(s"select * from boxes where st_contains(st_geomFromWKT('$boxRef'), geom)"),
+        Seq("int", "intEdge")
+      )
+      testData(
+        dfBoxes.where(st_contains(st_geomFromWKT(boxRef), col("geom"))),
+        Seq("int", "intEdge")
+      )
+
+      testDirect(st_contains, "pt1", boxRef, points("int"),    true)
+      testDirect(st_contains, "pt2", boxRef, points("edge"),   false)
+      testDirect(st_contains, "pt3", boxRef, points("corner"), false)
+      testDirect(st_contains, "pt4", boxRef, points("ext"),    false)
+      testDirect(st_contains, "poly1", boxRef, boxes("int"),     true)
+      testDirect(st_contains, "poly2", boxRef, boxes("intEdge"), true)
+      testDirect(st_contains, "poly3", boxRef, boxes("overlap"), false)
+      testDirect(st_contains, "poly4", boxRef, boxes("extEdge"), false)
+      testDirect(st_contains, "poly5", boxRef, boxes("ext"),     false)
+      testDirect(st_contains, "poly6", boxRef, boxes("corner"),  false)
+
+      sc.sql("select st_contains(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_contains(lit(null), lit(null))).first must beNull
+    }
+
+    "st_covers" >> {
+      testData(
+        sc.sql(s"select * from points where st_covers(st_geomFromWKT('$boxRef'), geom)"),
+        Seq("int", "edge", "corner")
+      )
+      testData(
+        dfPoints.where(st_covers(st_geomFromWKT(boxRef), col("geom"))),
+        Seq("int", "edge", "corner")
+      )
+      testData(
+        sc.sql(s"select * from boxes where st_covers(st_geomFromWKT('$boxRef'), geom)"),
+        Seq("int", "intEdge")
+      )
+      testData(
+        dfBoxes.where(st_covers(st_geomFromWKT(boxRef), col("geom"))),
+        Seq("int", "intEdge")
+      )
+
+      testDirect(st_covers, "pt1", boxRef, points("int"),    true)
+      testDirect(st_covers, "pt2", boxRef, points("edge"),   true)
+      testDirect(st_covers, "pt3", boxRef, points("corner"), true)
+      testDirect(st_covers, "pt4", boxRef, points("ext"),    false)
+
+      testDirect(st_covers, "poly1", boxRef, boxes("int"),     true)
+      testDirect(st_covers, "poly2", boxRef, boxes("intEdge"), true)
+      testDirect(st_covers, "poly3", boxRef, boxes("overlap"), false)
+      testDirect(st_covers, "poly4", boxRef, boxes("extEdge"), false)
+      testDirect(st_covers, "poly5", boxRef, boxes("ext"),     false)
+      testDirect(st_covers, "poly6", boxRef, boxes("corner"),  false)
+
+      sc.sql("select st_covers(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_covers(lit(null), lit(null))).first must beNull
+    }
+
+    "st_crosses" >> {
+      testData(
+        sc.sql(s"select * from lines where st_crosses(st_geomFromWKT('$lineRef'), geom)"),
+        Seq("crosses")
+      )
+      testData(
+        dfLines.where(st_crosses(st_geomFromWKT(lineRef), col("geom"))),
+        Seq("crosses")
+      )
+      testDirect(st_crosses, "touches",  lineRef, lines("touches"),  false)
+      testDirect(st_crosses, "crosses",  lineRef, lines("crosses"),  true)
+      testDirect(st_crosses, "disjoint", lineRef, lines("disjoint"), false)
+
+      sc.sql("select st_crosses(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_crosses(lit(null), lit(null))).first must beNull
+    }
+
+    "st_disjoint" >> {
+      testData(
+        sc.sql(s"select * from points where st_disjoint(st_geomFromWKT('$boxRef'), geom)"),
+        Seq("ext")
+      )
+      testData(
+        dfPoints.where(st_disjoint(st_geomFromWKT(boxRef), col("geom"))),
+        Seq("ext")
+      )
+      testData(
+        sc.sql(s"select * from boxes where st_disjoint(st_geomFromWKT('$boxRef'), geom)"),
+        Seq("ext")
+      )
+      testData(
+        dfBoxes.where(st_disjoint(st_geomFromWKT(boxRef), col("geom"))),
+        Seq("ext")
+      )
+
+      testDirect(st_disjoint, "pt1", boxRef, points("int"),    false)
+      testDirect(st_disjoint, "pt2", boxRef, points("edge"),   false)
+      testDirect(st_disjoint, "pt3", boxRef, points("corner"), false)
+      testDirect(st_disjoint, "pt4", boxRef, points("ext"),    true)
+
+      testDirect(st_disjoint, "poly1", boxRef, boxes("int"),     false)
+      testDirect(st_disjoint, "poly2", boxRef, boxes("intEdge"), false)
+      testDirect(st_disjoint, "poly3", boxRef, boxes("overlap"), false)
+      testDirect(st_disjoint, "poly4", boxRef, boxes("extEdge"), false)
+      testDirect(st_disjoint, "poly5", boxRef, boxes("ext"),     true)
+      testDirect(st_disjoint, "poly6", boxRef, boxes("corner"),  false)
+
+      sc.sql("select st_disjoint(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_disjoint(lit(null), lit(null))).first must beNull
+    }
+
+    "st_equals" >> {
+      testData(
+        sc.sql(s"select * from points where st_equals(st_geomFromWKT('POINT(0 0)'), geom)"),
+        Seq("corner")
+      )
+      testData(
+        dfPoints.where(st_equals(st_geomFromWKT("POINT(0 0)"), col("geom"))),
+        Seq("corner")
+      )
+      testDirect(st_equals, "pt1", "POINT(0 0)", points("corner"), true)
+      testDirect(st_equals, "pt2", "POINT(0 0)", points("edge"), false)
+
+      testData(
+        sc.sql(s"select * from lines where st_equals(st_geomFromWKT('${lines("crosses")}'), geom)"),
+        Seq("crosses")
+      )
+      testData(
+        dfLines.where(st_equals(st_geomFromWKT(lines("crosses")), col("geom"))),
+        Seq("crosses")
+      )
+      testDirect(st_equals, "line", "LINESTRING(0 0, 1 1)", "LINESTRING(1 1, 0 0)", true)
+
+      testData(
+        sc.sql(s"select * from boxes where st_equals(st_geomFromWKT('${boxes("int")}'), geom)"),
+        Seq("int")
+      )
+      testData(
+        dfBoxes.where(st_equals(st_geomFromWKT(boxes("int")), col("geom"))),
+        Seq("int")
+      )
+      testDirect(st_equals, "polygon", boxRef, "POLYGON((10 0, 10 10, 0 10, 0 0, 10 0))", true)
+
+      sc.sql("select st_equals(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_equals(lit(null), lit(null))).first must beNull
+    }
+
+    "st_intersects" >> {
+      testData(
+        sc.sql(s"select * from points where st_intersects(st_geomFromWKT('$boxRef'), geom)"),
+        Seq("int", "edge", "corner")
+      )
+      testData(
+        dfPoints.where(st_intersects(st_geomFromWKT(boxRef), col("geom"))),
+        Seq("int", "edge", "corner")
+      )
+      testData(
+        sc.sql(s"select * from boxes where st_intersects(st_geomFromWKT('$boxRef'), geom)"),
+        Seq("int", "intEdge", "overlap", "extEdge", "corner")
+      )
+      testData(
+        dfBoxes.where(st_intersects(st_geomFromWKT(boxRef), col("geom"))),
+        Seq("int", "intEdge", "overlap", "extEdge", "corner")
+      )
+
+      testDirect(st_intersects, "pt1", boxRef, points("int"),    true)
+      testDirect(st_intersects, "pt2", boxRef, points("edge"),   true)
+      testDirect(st_intersects, "pt3", boxRef, points("corner"), true)
+      testDirect(st_intersects, "pt4", boxRef, points("ext"),    false)
+
+      testDirect(st_intersects, "poly1", boxRef, boxes("int"),     true)
+      testDirect(st_intersects, "poly2", boxRef, boxes("intEdge"), true)
+      testDirect(st_intersects, "poly3", boxRef, boxes("overlap"), true)
+      testDirect(st_intersects, "poly4", boxRef, boxes("extEdge"), true)
+      testDirect(st_intersects, "poly5", boxRef, boxes("ext"),     false)
+      testDirect(st_intersects, "poly6", boxRef, boxes("corner"),  true)
+
+      sc.sql("select st_intersects(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_intersects(lit(null), lit(null))).first must beNull
+    }
+
+    "st_overlaps" >> {
+      testData(
+        sc.sql(s"select * from points where st_overlaps(st_geomFromWKT('$boxRef'), geom)"),
+        Seq()
+      )
+      testData(
+        dfPoints.where(st_overlaps(st_geomFromWKT(boxRef), col("geom"))),
+        Seq()
+      )
+      testData(
+        sc.sql(s"select * from boxes where st_overlaps(st_geomFromWKT('$boxRef'), geom)"),
+        Seq("overlap")
+      )
+      testData(
+        dfBoxes.where(st_overlaps(st_geomFromWKT(boxRef), col("geom"))),
+        Seq("overlap")
+      )
+      testDirect(st_overlaps, "pt1", boxRef, points("int"),    false)
+      testDirect(st_overlaps, "pt2", boxRef, points("edge"),   false)
+      testDirect(st_overlaps, "pt3", boxRef, points("corner"), false)
+      testDirect(st_overlaps, "pt4", boxRef, points("ext"),    false)
+
+      testDirect(st_overlaps, "poly1", boxRef, boxes("int"),     false)
+      testDirect(st_overlaps, "poly2", boxRef, boxes("intEdge"), false)
+      testDirect(st_overlaps, "poly3", boxRef, boxes("overlap"), true)
+      testDirect(st_overlaps, "poly4", boxRef, boxes("extEdge"), false)
+      testDirect(st_overlaps, "poly5", boxRef, boxes("ext"),     false)
+      testDirect(st_overlaps, "poly6", boxRef, boxes("corner"),  false)
+
+      sc.sql("select st_overlaps(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_overlaps(lit(null), lit(null))).first must beNull
+    }
+
+    "st_touches" >> {
+      testData(
+        sc.sql(s"select * from points where st_touches(st_geomFromWKT('$boxRef'), geom)"),
+        Seq("edge", "corner")
+      )
+      testData(
+        dfPoints.where(st_touches(st_geomFromWKT(boxRef), col("geom"))),
+        Seq("edge", "corner")
+      )
+      testData(
+        sc.sql(s"select * from boxes where st_touches(st_geomFromWKT('$boxRef'), geom)"),
+        Seq("extEdge", "corner")
+      )
+      testData(
+        dfBoxes.where(st_touches(st_geomFromWKT(boxRef), col("geom"))),
+        Seq("extEdge", "corner")
+      )
+
+      testDirect(st_touches, "pt1", boxRef, points("int"),    false)
+      testDirect(st_touches, "pt2", boxRef, points("edge"),   true)
+      testDirect(st_touches, "pt3", boxRef, points("corner"), true)
+      testDirect(st_touches, "pt4", boxRef, points("ext"),    false)
+
+      testDirect(st_touches, "poly1", boxRef, boxes("int"),     false)
+      testDirect(st_touches, "poly2", boxRef, boxes("intEdge"), false)
+      testDirect(st_touches, "poly3", boxRef, boxes("overlap"), false)
+      testDirect(st_touches, "poly4", boxRef, boxes("extEdge"), true)
+      testDirect(st_touches, "poly5", boxRef, boxes("ext"),     false)
+      testDirect(st_touches, "poly6", boxRef, boxes("corner"),  true)
+
+      sc.sql("select st_touches(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_touches(lit(null), lit(null))).first must beNull
+    }
+
+    "st_within" >> {
+      // reversed expressions because st_contains(g1, g2) == st_within(g2, g1)
+      testData(
+        sc.sql(s"select * from points where st_within(geom, st_geomFromWKT('$boxRef'))"),
+        Seq("int")
+      )
+      testData(
+        dfPoints.where(st_within(col("geom"), st_geomFromWKT(boxRef))),
+        Seq("int")
+      )
+      testData(
+        sc.sql(s"select * from boxes where st_within(geom, st_geomFromWKT('$boxRef'))"),
+        Seq("int", "intEdge")
+      )
+      testData(
+        dfBoxes.where(st_within(col("geom"), st_geomFromWKT(boxRef))),
+        Seq("int", "intEdge")
+      )
+
+      testDirect(st_within, "pt1", points("int"),    boxRef, true)
+      testDirect(st_within, "pt2", points("edge"),   boxRef, false)
+      testDirect(st_within, "pt3", points("corner"), boxRef, false)
+      testDirect(st_within, "pt4", points("ext"),    boxRef, false)
+
+      testDirect(st_within, "poly1", boxes("int"),     boxRef, true)
+      testDirect(st_within, "poly2", boxes("intEdge"), boxRef, true)
+      testDirect(st_within, "poly3", boxes("overlap"), boxRef, false)
+      testDirect(st_within, "poly4", boxes("extEdge"), boxRef, false)
+      testDirect(st_within, "poly5", boxes("ext"),     boxRef, false)
+      testDirect(st_within, "poly6", boxes("corner"),  boxRef, false)
+
+      sc.sql("select st_within(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_within(lit(null), lit(null))).first must beNull
+    }
+
+    "st_relate" >> {
+      val ls1 = "LINESTRING(1 2, 3 4)"
+      val ls2 = "LINESTRING(5 6, 7 8)"
+      val l1 = s"st_geomFromWKT('$ls1')"
+      val l2 = s"st_geomFromWKT('$ls2')"
+
+      val expected = "FF1FF0102"
+      sc.sql(s"select st_relate($l1, $l2)").as[String].first mustEqual expected
+      dfBlank.select(st_relate(st_geomFromWKT(ls1), st_geomFromWKT(ls2))).first mustEqual expected
+
+      sc.sql(s"select st_relateBool($l1, $l2, 'FF*FF****')").as[Boolean].first mustEqual true
+      dfBlank.select(st_relateBool(st_geomFromWKT(ls1), st_geomFromWKT(ls2), lit("FF*FF****"))).first mustEqual true
+
+      sc.sql("select st_relate(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_relate(lit(null), lit(null))).first must beNull
+      sc.sql("select st_relateBool(null, null, null)").collect.head(0) must beNull
+      dfBlank.select(st_relateBool(lit(null), lit(null), lit(null))).first must beFalse
+    }
+
+    // other relationship functions
+    "st_area" >> {
+      /* units of deg^2, which may not be that useful to anyone */
+      val box1 = "POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))"
+      val box2 = "POLYGON((0 50, 0 60, 10 60, 10 50, 0 50))"
+
+      sc.sql(s"select st_area(st_geomFromWKT('$box1'))").as[Double].first mustEqual 100.0
+      dfBlank.select(st_area(st_geomFromWKT(box1))).first mustEqual 100.0
+
+      sc.sql(s"select st_area(st_geomFromWKT('$box2'))").as[Double].first mustEqual 100.0
+      dfBlank.select(st_area(st_geomFromWKT(box2))).first mustEqual 100.0
+
+      val r3 = sc.sql(s"select * from boxes where st_intersects(st_geomFromWKT('$box1'), geom) and st_area(geom) > 1")
+      r3.collect
+        .map(row => row.getAs[String]("name"))
+          .toSeq must containTheSameElementsAs(Seq("overlap"))
+
+      dfBoxes.select("name").as[String]
+        .where(st_intersects(st_geomFromWKT(box1), col("geom")) && st_area(col("geom")) > 1)
+        .collect.toSeq must containTheSameElementsAs(Seq("overlap"))
+
+      val r4 = sc.sql(s"select * from boxes where st_area(geom) > 1 and st_intersects(st_geomFromWKT('$box1'), geom)")
+      r4.collect
+        .map(row => row.getAs[String]("name"))
+          .toSeq must containTheSameElementsAs(Seq("overlap"))
+
+      dfBoxes.select("name").as[String]
+        .where(st_area(col("geom")) > 1 && st_intersects(st_geomFromWKT(box1), col("geom")))
+        .collect.toSeq must containTheSameElementsAs(Seq("overlap"))
+
+      sc.sql("select st_area(null)").collect.head(0) must beNull
+      dfBlank.select(st_area(lit(null))).first must beNull
+    }
+
+    "st_centroid" >> {
+      val expected = WKTUtils.read("POINT(5 5)").asInstanceOf[Point]
+      sc.sql(s"select st_centroid(st_geomFromWKT('$boxRef'))").as[Point].first mustEqual expected
+
+      dfBlank.select(st_centroid(st_geomFromWKT(boxRef))).first mustEqual expected
+
+      sc.sql("select st_centroid(null)").collect.head(0) must beNull
+      dfBlank.select(st_centroid(lit(null))).first must beNull
+    }
+
+    "st_closestpoint" >> {
+      val box1 = "POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))"
+      val pt1  = "POINT(15 5)"
+
+      val expected = WKTUtils.read("POINT(10 5)")
+
+      sc.sql(s"select st_closestPoint(st_geomFromWKT('$box1'), st_geomFromWKT('$pt1'))").as[Point].first mustEqual expected
+      dfBlank.select(st_closestPoint(st_geomFromWKT(box1), st_geomFromWKT(pt1))).first mustEqual expected
+
+      sc.sql("select st_closestPoint(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_closestPoint(lit(null), lit(null))).first must beNull
+    }
+
+    "st_distance" >> {
+      val pt1 = "POINT(0 0)"
+      val pt2 = "POINT(10 0)"
+
+      sc.sql(s"select st_distance(st_geomFromWKT('$pt1'), st_geomFromWKT('$pt2'))")
+        .as[Double].first mustEqual 10.0
+      dfBlank.select(st_distance(st_geomFromWKT(pt1), st_geomFromWKT(pt2))).first mustEqual 10.0
+
+      val expected = beCloseTo(1113194.0, 1.0)
+      sc.sql(s"select st_distanceSpheroid(st_geomFromWKT('$pt1'), st_geomFromWKT('$pt2'))")
+        .as[Double].first must expected
+      dfBlank.select(st_distanceSpheroid(st_geomFromWKT(pt1), st_geomFromWKT(pt2))).first.doubleValue() must expected
+
+      sc.sql("select st_distance(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_distance(lit(null), lit(null))).first must beNull
+
+      sc.sql("select st_distanceSpheroid(null, null)").collect.head(0) must beNull
+      dfBlank.select(st_distanceSpheroid(lit(null), lit(null))).first must beNull
+    }
+
+    "st_length" >> {
+      // length
+      sc.sql(s"select st_length(st_geomFromWKT('LINESTRING(0 0, 10 0)'))").as[Double].first mustEqual 10.0
+      dfBlank.select(st_length(st_geomFromWKT("LINESTRING(0 0, 10 0)"))).first mustEqual 10.0
+
+      // perimeter
+      sc.sql(s"select st_length(st_geomFromWKT('$boxRef'))").as[Double].first mustEqual 40.0
+      dfBlank.select(st_length(st_geomFromWKT(boxRef))).first mustEqual 40.0
+
+      sc.sql("select st_length(null)").collect.head(0) must beNull
+      dfBlank.select(st_length(lit(null))).first must beNull
+    }
+
+    // after
+    step {
+      spark.stop()
+    }
+  }
+}


### PR DESCRIPTION
Added testing parity between SQL and DataFrame tests of UDFs.
Also refactored mapping between string names and UDFs so we can
be more DRY and programmatically invoke DataFrame tests along with
SQL tests.

Signed-off-by: Simeon H.K. Fitch <fitch@astraea.io>