### PR TITLE
GEOMESA-860 Special encoding for UUID feature IDs

### DIFF
--- a/docs/user/datastores/analytic_queries.rst
+++ b/docs/user/datastores/analytic_queries.rst
@@ -242,6 +242,8 @@ following query hints:
 +-------------------------------------+--------------------+                      +
 | QueryHints.ARROW_INCLUDE_FID        | Boolean (optional) |                      |
 +-------------------------------------+--------------------+                      +
+| QueryHints.ARROW_PROXY_FID          | Boolean (optional) |                      |
++-------------------------------------+--------------------+                      +
 | QueryHints.ARROW_SORT_FIELD         | String (optional)  |                      |
 +-------------------------------------+--------------------+                      +
 | QueryHints.ARROW_SORT_REVERSE       | Boolean (optional) |                      |
@@ -277,6 +279,12 @@ ARROW_INCLUDE_FID
 ^^^^^^^^^^^^^^^^^
 
 This hint controls whether to include the feature ID as an Arrow vector or not. The default is to include it.
+
+ARROW_PROXY_FID
+^^^^^^^^^^^^^^^
+
+This hint controls whether to return the full feature ID, or a 4-byte proxy ID. Proxy IDs can be used
+for callbacks by using the ``proxyID()`` CQL filter function.
 
 ARROW_SORT_FIELD
 ^^^^^^^^^^^^^^^^

--- a/docs/user/datastores/index_config.rst
+++ b/docs/user/datastores/index_config.rst
@@ -147,6 +147,39 @@ you may instead call the ``withIndexes`` methods:
         .withIndexes(List("id", "z3", "attr"))
         .build("mySft")
 
+Configuring Feature ID Encoding
+-------------------------------
+
+While feature IDs can be any string, a common use case is to use UUIDs. A UUID is a globally unique, specially
+formatted string composed of hex characters in the format ``{8}-{4}-{4}-{4}-{12}``, for example
+``28a12c18-e5ae-4c04-ae7b-bf7cdbfaf234``. A UUID can also be considered as a 128 bit number, which can
+be serialized in a smaller size.
+
+You can indicate that feature IDs are UUIDs using the user data key ``geomesa.fid.uuid``. If set before
+calling ``createSchema``, then feature IDs will be serialized as 16 byte numbers instead of 36 byte strings,
+saving some overhead:
+
+.. code-block:: java
+
+    sft.getUserData().put("geomesa.fid.uuid", "true");
+    datastore.createSchema(sft);
+
+If the schema is already created, you may still retroactively indicate that feature IDs are UUIDs, but you
+**must also indicate** that they are not serialized that way using ``geomesa.fid.uuid-encoded``. This may still
+provide some benefit when exporting data in certain formats (e.g. Arrow):
+
+.. code-block:: java
+
+    SimpleFeatureType existing = datastore.getSchema("existing");
+    existing.getUserData().put("geomesa.fid.uuid", "true");
+    existing.getUserData().put("geomesa.fid.uuid-encoded", "false");
+    datastore.updateSchema("existing", existing);
+
+.. warning::
+
+    Ensure that you use valid UUIDs if you indicate that you are using them. Otherwise you will experience
+    exceptions writing and/or reading data.
+
 .. _configuring_z_shards:
 
 Configuring Z-Index Shards

--- a/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
@@ -134,20 +134,35 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.specs2</groupId>
             <artifactId>specs2_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+            <classifier>tests</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeature.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeature.scala
@@ -11,12 +11,13 @@ package org.locationtech.geomesa.accumulo.data
 import org.apache.accumulo.core.data.Value
 import org.apache.accumulo.core.security.ColumnVisibility
 import org.apache.hadoop.io.Text
+import org.locationtech.geomesa.accumulo.data.AccumuloFeature.RowValue
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
 import org.locationtech.geomesa.accumulo.index.encoders.{BinEncoder, IndexValueEncoder}
 import org.locationtech.geomesa.features.SerializationOption.SerializationOptions
 import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
 import org.locationtech.geomesa.features.{ScalaSimpleFeature, SimpleFeatureSerializer}
-import org.locationtech.geomesa.index.api.WrappedFeature
+import org.locationtech.geomesa.index.api.{GeoMesaFeatureIndex, WrappedFeature}
 import org.locationtech.geomesa.security.SecurityUtils._
 import org.locationtech.geomesa.utils.index.VisibilityLevel
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -52,10 +53,6 @@ trait AccumuloFeature extends WrappedFeature {
   def binValues: Seq[RowValue]
 }
 
-class RowValue(val cf: Text, val cq: Text, val vis: ColumnVisibility, toValue: => Value) {
-  lazy val value: Value = toValue
-}
-
 object AccumuloFeature {
 
   import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
@@ -63,6 +60,7 @@ object AccumuloFeature {
   def wrapper(sft: SimpleFeatureType, defaultVisibility: String): (SimpleFeature) => AccumuloFeature = {
     val serializer = KryoFeatureSerializer(sft, SerializationOptions.withoutId)
     val serializerWithId = KryoFeatureSerializer(sft)
+    val idSerializer = GeoMesaFeatureIndex.idToBytes(sft)
     val indexSerializer = IndexValueEncoder(sft)
     val indexSerializerWithId = IndexValueEncoder(sft, includeIds = true)
     val binEncoder = BinEncoder(sft)
@@ -70,112 +68,122 @@ object AccumuloFeature {
     sft.getVisibilityLevel match {
       case VisibilityLevel.Feature =>
         (sf) => new AccumuloFeatureLevelFeature(sf, defaultVisibility, serializer, serializerWithId,
-          indexSerializer, indexSerializerWithId, binEncoder)
+          idSerializer, indexSerializer, indexSerializerWithId, binEncoder)
       case VisibilityLevel.Attribute =>
         (sf) => new AccumuloAttributeLevelFeature(sf, sft, defaultVisibility, serializer, serializerWithId,
-          indexSerializer, indexSerializerWithId, binEncoder)
+          idSerializer, indexSerializer, indexSerializerWithId, binEncoder)
     }
   }
-}
 
-class AccumuloFeatureLevelFeature(val feature: SimpleFeature,
-                                  defaultVisibility: String,
-                                  serializer: SimpleFeatureSerializer,
-                                  serializerWithId: SimpleFeatureSerializer,
-                                  indexSerializer: SimpleFeatureSerializer,
-                                  indexSerializerWithId: SimpleFeatureSerializer,
-                                  binEncoder: Option[BinEncoder]) extends AccumuloFeature {
-
-  import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.{BinColumnFamily, EmptyColumnQualifier, FullColumnFamily, IndexColumnFamily}
-  import org.locationtech.geomesa.utils.geotools.Conversions.RichSimpleFeature
-
-  private lazy val visibility =
-    new ColumnVisibility(feature.userData[String](FEATURE_VISIBILITY).getOrElse(defaultVisibility))
-
-  override lazy val fullValues: Seq[RowValue] =
-    Seq(new RowValue(FullColumnFamily, EmptyColumnQualifier, visibility, new Value(serializer.serialize(feature))))
-
-  override lazy val fullValuesWithId: Seq[RowValue] =
-    Seq(new RowValue(FullColumnFamily, EmptyColumnQualifier, visibility, new Value(serializerWithId.serialize(feature))))
-
-  override lazy val indexValues: Seq[RowValue] =
-    Seq(new RowValue(IndexColumnFamily, EmptyColumnQualifier, visibility, new Value(indexSerializer.serialize(feature))))
-
-  override lazy val indexValuesWithId: Seq[RowValue] =
-    Seq(new RowValue(IndexColumnFamily, EmptyColumnQualifier, visibility, new Value(indexSerializerWithId.serialize(feature))))
-
-  override lazy val binValues: Seq[RowValue] = binEncoder.toSeq.map { encoder =>
-    new RowValue(BinColumnFamily, EmptyColumnQualifier, visibility, new Value(encoder.encode(feature)))
+  class RowValue(val cf: Text, val cq: Text, val vis: ColumnVisibility, toValue: => Value) {
+    lazy val value: Value = toValue
   }
-}
 
-class AccumuloAttributeLevelFeature(val feature: SimpleFeature,
-                                    sft: SimpleFeatureType,
+  class AccumuloFeatureLevelFeature(val feature: SimpleFeature,
                                     defaultVisibility: String,
                                     serializer: SimpleFeatureSerializer,
                                     serializerWithId: SimpleFeatureSerializer,
+                                    idSerializer: (String) => Array[Byte],
                                     indexSerializer: SimpleFeatureSerializer,
                                     indexSerializerWithId: SimpleFeatureSerializer,
                                     binEncoder: Option[BinEncoder]) extends AccumuloFeature {
 
-  import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.AttributeColumnFamily
-
-  private lazy val visibilities: Array[String] = {
+    import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.{BinColumnFamily, EmptyColumnQualifier, FullColumnFamily, IndexColumnFamily}
     import org.locationtech.geomesa.utils.geotools.Conversions.RichSimpleFeature
-    val count = feature.getFeatureType.getAttributeCount
-    val userData = feature.userData[String](FEATURE_VISIBILITY)
-    val visibilities = userData.map(_.split(",")).getOrElse(Array.fill(count)(defaultVisibility))
-    require(visibilities.length == count,
-      s"Per-attribute visibilities do not match feature type ($count values expected): ${userData.getOrElse("")}")
-    visibilities
-  }
 
-  private lazy val indexGroups: Seq[(ColumnVisibility, Array[Byte])] =
-    visibilities.zipWithIndex.groupBy(_._1).map { case (vis, indices) =>
-      (new ColumnVisibility(vis), indices.map(_._2.toByte).sorted)
-    }.toSeq
+    private lazy val visibility =
+      new ColumnVisibility(feature.userData[String](FEATURE_VISIBILITY).getOrElse(defaultVisibility))
 
-  override lazy val fullValues: Seq[RowValue] = indexGroups.map { case (vis, indices) =>
-    val sf = new ScalaSimpleFeature(sft, "")
-    indices.foreach(i => sf.setAttribute(i, feature.getAttribute(i)))
-    new RowValue(AttributeColumnFamily, new Text(indices), vis, new Value(serializer.serialize(sf)))
-  }
+    override lazy val fullValues: Seq[RowValue] =
+      Seq(new RowValue(FullColumnFamily, EmptyColumnQualifier, visibility, new Value(serializer.serialize(feature))))
 
-  override lazy val fullValuesWithId: Seq[RowValue] = indexGroups.map { case (vis, indices) =>
-    val sf = new ScalaSimpleFeature(sft, "")
-    indices.foreach(i => sf.setAttribute(i, feature.getAttribute(i)))
-    new RowValue(AttributeColumnFamily, new Text(indices), vis, new Value(serializerWithId.serialize(sf)))
-  }
+    override lazy val fullValuesWithId: Seq[RowValue] =
+      Seq(new RowValue(FullColumnFamily, EmptyColumnQualifier, visibility, new Value(serializerWithId.serialize(feature))))
 
-  override lazy val indexValues: Seq[RowValue] = indexGroups.map { case (vis, indices) =>
-    val sf = new ScalaSimpleFeature(sft, "")
-    indices.foreach(i => sf.setAttribute(i, feature.getAttribute(i)))
-    new RowValue(AttributeColumnFamily, new Text(indices), vis, new Value(indexSerializer.serialize(sf)))
-  }
+    override lazy val indexValues: Seq[RowValue] =
+      Seq(new RowValue(IndexColumnFamily, EmptyColumnQualifier, visibility, new Value(indexSerializer.serialize(feature))))
 
-  override lazy val indexValuesWithId: Seq[RowValue] = indexGroups.map { case (vis, indices) =>
-    val sf = new ScalaSimpleFeature(sft, "")
-    indices.foreach(i => sf.setAttribute(i, feature.getAttribute(i)))
-    new RowValue(AttributeColumnFamily, new Text(indices), vis, new Value(indexSerializerWithId.serialize(sf)))
-  }
+    override lazy val indexValuesWithId: Seq[RowValue] =
+      Seq(new RowValue(IndexColumnFamily, EmptyColumnQualifier, visibility, new Value(indexSerializerWithId.serialize(feature))))
 
-  override lazy val binValues: Seq[RowValue] = {
-    import AccumuloFeatureIndex.{BinColumnFamily, EmptyColumnQualifier}
-    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-
-    val rowOpt = for {
-      encoder <- binEncoder
-      trackId <- sft.getBinTrackId
-      trackIndex = sft.indexOf(trackId)
-      if trackIndex != -1
-    } yield {
-      // merge the visibilities for the individual fields
-      val dateVis = sft.getDtgIndex.map(visibilities.apply)
-      val geomVis = visibilities(sft.getGeomIndex)
-      val trackVis = visibilities(trackIndex)
-      val vis = (Seq(geomVis, trackVis) ++ dateVis).flatMap(_.split("&")).distinct.mkString("&")
-      new RowValue(BinColumnFamily, EmptyColumnQualifier, new ColumnVisibility(vis), new Value(encoder.encode(feature)))
+    override lazy val binValues: Seq[RowValue] = binEncoder.toSeq.map { encoder =>
+      new RowValue(BinColumnFamily, EmptyColumnQualifier, visibility, new Value(encoder.encode(feature)))
     }
-    rowOpt.toSeq
+
+    override lazy val idBytes: Array[Byte] = idSerializer.apply(feature.getID)
+  }
+
+  class AccumuloAttributeLevelFeature(val feature: SimpleFeature,
+                                      sft: SimpleFeatureType,
+                                      defaultVisibility: String,
+                                      serializer: SimpleFeatureSerializer,
+                                      serializerWithId: SimpleFeatureSerializer,
+                                      idSerializer: (String) => Array[Byte],
+                                      indexSerializer: SimpleFeatureSerializer,
+                                      indexSerializerWithId: SimpleFeatureSerializer,
+                                      binEncoder: Option[BinEncoder]) extends AccumuloFeature {
+
+    import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex.AttributeColumnFamily
+
+    private lazy val visibilities: Array[String] = {
+      import org.locationtech.geomesa.utils.geotools.Conversions.RichSimpleFeature
+      val count = feature.getFeatureType.getAttributeCount
+      val userData = feature.userData[String](FEATURE_VISIBILITY)
+      val visibilities = userData.map(_.split(",")).getOrElse(Array.fill(count)(defaultVisibility))
+      require(visibilities.length == count,
+        s"Per-attribute visibilities do not match feature type ($count values expected): ${userData.getOrElse("")}")
+      visibilities
+    }
+
+    private lazy val indexGroups: Seq[(ColumnVisibility, Array[Byte])] =
+      visibilities.zipWithIndex.groupBy(_._1).map { case (vis, indices) =>
+        (new ColumnVisibility(vis), indices.map(_._2.toByte).sorted)
+      }.toSeq
+
+    override lazy val fullValues: Seq[RowValue] = indexGroups.map { case (vis, indices) =>
+      val sf = new ScalaSimpleFeature(sft, "")
+      indices.foreach(i => sf.setAttribute(i, feature.getAttribute(i)))
+      new RowValue(AttributeColumnFamily, new Text(indices), vis, new Value(serializer.serialize(sf)))
+    }
+
+    override lazy val fullValuesWithId: Seq[RowValue] = indexGroups.map { case (vis, indices) =>
+      val sf = new ScalaSimpleFeature(sft, "")
+      indices.foreach(i => sf.setAttribute(i, feature.getAttribute(i)))
+      new RowValue(AttributeColumnFamily, new Text(indices), vis, new Value(serializerWithId.serialize(sf)))
+    }
+
+    override lazy val indexValues: Seq[RowValue] = indexGroups.map { case (vis, indices) =>
+      val sf = new ScalaSimpleFeature(sft, "")
+      indices.foreach(i => sf.setAttribute(i, feature.getAttribute(i)))
+      new RowValue(AttributeColumnFamily, new Text(indices), vis, new Value(indexSerializer.serialize(sf)))
+    }
+
+    override lazy val indexValuesWithId: Seq[RowValue] = indexGroups.map { case (vis, indices) =>
+      val sf = new ScalaSimpleFeature(sft, "")
+      indices.foreach(i => sf.setAttribute(i, feature.getAttribute(i)))
+      new RowValue(AttributeColumnFamily, new Text(indices), vis, new Value(indexSerializerWithId.serialize(sf)))
+    }
+
+    override lazy val binValues: Seq[RowValue] = {
+      import AccumuloFeatureIndex.{BinColumnFamily, EmptyColumnQualifier}
+      import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
+      val rowOpt = for {
+        encoder <- binEncoder
+        trackId <- sft.getBinTrackId
+        trackIndex = sft.indexOf(trackId)
+        if trackIndex != -1
+      } yield {
+        // merge the visibilities for the individual fields
+        val dateVis = sft.getDtgIndex.map(visibilities.apply)
+        val geomVis = visibilities(sft.getGeomIndex)
+        val trackVis = visibilities(trackIndex)
+        val vis = (Seq(geomVis, trackVis) ++ dateVis).flatMap(_.split("&")).distinct.mkString("&")
+        new RowValue(BinColumnFamily, EmptyColumnQualifier, new ColumnVisibility(vis), new Value(encoder.encode(feature)))
+      }
+      rowOpt.toSeq
+    }
+
+    override lazy val idBytes: Array[Byte] = idSerializer.apply(feature.getID)
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloFeatureIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloFeatureIndex.scala
@@ -246,7 +246,7 @@ trait AccumuloFeatureIndex extends AccumuloFeatureIndexType {
       (kv: Entry[Key, Value]) => {
         val sf = deserializer.deserialize(kv.getValue.get)
         val row = kv.getKey.getRow
-        sf.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(row.getBytes, 0, row.getLength))
+        sf.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(row.getBytes, 0, row.getLength, sf))
         AccumuloFeatureIndex.applyVisibility(sf, kv.getKey)
         sf
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AttributeIndex.scala
@@ -381,11 +381,12 @@ trait AccumuloAttributeIndex extends AccumuloFeatureIndex with AccumuloIndexAdap
 
     // function to join the attribute index scan results to the record table
     // have to pull the feature id from the row
-    val prefix = sft.getTableSharingPrefix
+    val prefix = sft.getTableSharingBytes
     val getId = getIdFromRow(sft)
+    val getRowKey = RecordIndex.getRowKey(sft)
     val joinFunction: JoinFunction = (kv) => {
       val row = kv.getKey.getRow
-      new Range(RecordIndex.getRowKey(prefix, getId(row.getBytes, 0, row.getLength)))
+      new Range(new Text(getRowKey(prefix, getId(row.getBytes, 0, row.getLength, null))))
     }
 
     val recordRanges = Seq.empty // this will get overwritten in the join method

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/RecordIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/RecordIndex.scala
@@ -13,13 +13,18 @@ import org.apache.accumulo.core.data.{Mutation, Range}
 import org.apache.accumulo.core.file.keyfunctor.RowFunctor
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloFeature}
 import org.locationtech.geomesa.accumulo.index.AccumuloIndexAdapter.ScanConfig
+import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
 import org.locationtech.geomesa.index.index.IdIndex
+import org.locationtech.geomesa.utils.index.ByteArrays
 import org.opengis.feature.simple.SimpleFeatureType
 
 case object RecordIndex extends AccumuloFeatureIndex with AccumuloIndexAdapter
     with IdIndex[AccumuloDataStore, AccumuloFeature, Mutation, Range, ScanConfig] {
 
-  def getRowKey(rowIdPrefix: String, id: String): String = rowIdPrefix + id
+  def getRowKey(sft: SimpleFeatureType): (Array[Byte], String) => Array[Byte] = {
+    val idToBytes = GeoMesaFeatureIndex.idToBytes(sft)
+    (prefix, id) => ByteArrays.concat(prefix, idToBytes(id))
+  }
 
   override val version: Int = 3
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/attribute/AttributeQueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/attribute/AttributeQueryableIndex.scala
@@ -11,6 +11,7 @@ package org.locationtech.geomesa.accumulo.index.legacy.attribute
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.accumulo.core.client.IteratorSetting
 import org.apache.accumulo.core.data.{Range => AccRange}
+import org.apache.hadoop.io.Text
 import org.geotools.data.DataUtilities
 import org.geotools.factory.Hints
 import org.locationtech.geomesa.accumulo.AccumuloFilterStrategyType
@@ -258,11 +259,12 @@ trait AttributeQueryableIndex extends AccumuloFeatureIndex with LazyLogging {
 
     // function to join the attribute index scan results to the record table
     // have to pull the feature id from the row
-    val prefix = sft.getTableSharingPrefix
+    val prefix = sft.getTableSharingBytes
     val getId = getIdFromRow(sft)
+    val getRowKey = RecordIndex.getRowKey(sft)
     val joinFunction: JoinFunction = (kv) => {
       val row = kv.getKey.getRow
-      new AccRange(RecordIndex.getRowKey(prefix, getId(row.getBytes, 0, row.getLength)))
+      new AccRange(new Text(getRowKey(prefix, getId(row.getBytes, 0, row.getLength, null))))
     }
 
     val recordTable = recordIndex.getTableName(sft.getTypeName, ds)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/attribute/AttributeWritableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/attribute/AttributeWritableIndex.scala
@@ -31,7 +31,7 @@ import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleF
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.text.DateParsing
 import org.opengis.feature.`type`.AttributeDescriptor
-import org.opengis.feature.simple.SimpleFeatureType
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -56,11 +56,11 @@ trait AttributeWritableIndex extends AccumuloFeatureIndex
     }
   }
 
-  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int) => String = {
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int, SimpleFeature) => String = {
     // drop the encoded value and the date field (12 bytes) if it's present - the rest of the row is the ID
     val from = if (sft.isTableSharing) 3 else 2  // exclude feature byte and index bytes
     val prefix = if (sft.getDtgField.isDefined) 13 else 1
-    (row, offset, length) => {
+    (row, offset, length, feature) => {
       val start = row.indexOf(AttributeWritableIndex.NullByteArray.head, from + offset) + prefix
       new String(row, start, length + offset - start, StandardCharsets.UTF_8)
     }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/id/RecordIndexV1.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/id/RecordIndexV1.scala
@@ -8,13 +8,13 @@
 
 package org.locationtech.geomesa.accumulo.index.legacy.id
 
-import com.google.common.primitives.Bytes
 import org.apache.accumulo.core.data.Mutation
 import org.apache.hadoop.io.Text
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloFeature, EMPTY_COLQ}
-import org.locationtech.geomesa.accumulo.index.{AccumuloFeatureIndex, RecordIndex}
+import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
 import org.locationtech.geomesa.index.conf.TableSplitter
 import org.locationtech.geomesa.index.conf.splitter.DefaultSplitter
+import org.locationtech.geomesa.utils.index.ByteArrays
 import org.opengis.feature.simple.SimpleFeatureType
 
 case object RecordIndexV1 extends AccumuloFeatureIndex with RecordWritableIndex with RecordQueryableIndex {
@@ -38,31 +38,29 @@ case object RecordIndexV1 extends AccumuloFeatureIndex with RecordWritableIndex 
 
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
-    import scala.collection.JavaConversions._
-
     val sharing = sft.getTableSharingBytes
 
     val splitter = sft.getTableSplitter.getOrElse(classOf[DefaultSplitter]).newInstance().asInstanceOf[TableSplitter]
     val splits = nonEmpty(splitter.getSplits(sft, name, sft.getTableSplitterOptions))
 
     for (split <- splits) yield {
-      Bytes.concat(sharing, split)
+      ByteArrays.concat(sharing, split)
     }
   }
 
   override def writer(sft: SimpleFeatureType, ds: AccumuloDataStore): (AccumuloFeature) => Seq[Mutation] = {
-    val rowIdPrefix = sft.getTableSharingPrefix
+    val rowIdPrefix = sft.getTableSharingBytes
     (wf: AccumuloFeature) => {
-      val mutation = new Mutation(RecordIndex.getRowKey(rowIdPrefix, wf.feature.getID))
+      val mutation = new Mutation(ByteArrays.concat(rowIdPrefix, wf.idBytes))
       wf.fullValuesWithId.foreach(value => mutation.put(SFT_CF, EMPTY_COLQ, value.vis, value.value))
       Seq(mutation)
     }
   }
 
   override def remover(sft: SimpleFeatureType, ds: AccumuloDataStore): (AccumuloFeature) => Seq[Mutation] = {
-    val rowIdPrefix = sft.getTableSharingPrefix
+    val rowIdPrefix = sft.getTableSharingBytes
     (wf: AccumuloFeature) => {
-      val mutation = new Mutation(RecordIndex.getRowKey(rowIdPrefix, wf.feature.getID))
+      val mutation = new Mutation(ByteArrays.concat(rowIdPrefix, wf.idBytes))
       wf.fullValuesWithId.foreach(value => mutation.putDelete(SFT_CF, EMPTY_COLQ, value.vis))
       Seq(mutation)
     }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/id/RecordIndexV2.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/id/RecordIndexV2.scala
@@ -20,8 +20,6 @@ import org.opengis.feature.simple.SimpleFeatureType
 case object RecordIndexV2 extends AccumuloFeatureIndex with AccumuloIndexAdapter
     with IdIndex[AccumuloDataStore, AccumuloFeature, Mutation, Range, ScanConfig] {
 
-  def getRowKey(rowIdPrefix: String, id: String): String = rowIdPrefix + id
-
   override val name: String = "records"
 
   override val version: Int = 2

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/id/RecordQueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/id/RecordQueryableIndex.scala
@@ -39,7 +39,7 @@ trait RecordQueryableIndex extends AccumuloFeatureIndex
                             filter: AccumuloFilterStrategyType,
                             hints: Hints,
                             explain: Explainer): AccumuloQueryPlan = {
-    val prefix = sft.getTableSharingPrefix
+    val prefix = sft.getTableSharingBytes
 
     val ranges = filter.primary match {
       case None =>
@@ -56,7 +56,8 @@ trait RecordQueryableIndex extends AccumuloFeatureIndex
         // intersect together all groups of ID Filters, producing a set of IDs
         val identifiers = IdFilterStrategy.intersectIdFilters(primary)
         explain(s"Extracted ID filter: ${identifiers.mkString(", ")}")
-        identifiers.toSeq.map(id => aRange.exact(RecordIndex.getRowKey(prefix, id)))
+        val getRowKey = RecordIndex.getRowKey(sft)
+        identifiers.toSeq.map(id => aRange.exact(new Text(getRowKey(prefix, id))))
     }
 
     if (ranges.isEmpty) { EmptyPlan(filter) } else {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/id/RecordWritableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/id/RecordWritableIndex.scala
@@ -9,50 +9,47 @@
 package org.locationtech.geomesa.accumulo.index.legacy.id
 
 import java.nio.charset.StandardCharsets
+import java.util.Collections
 
-import com.google.common.collect.ImmutableSortedSet
 import org.apache.accumulo.core.conf.Property
 import org.apache.accumulo.core.file.keyfunctor.RowFunctor
 import org.apache.hadoop.io.Text
 import org.locationtech.geomesa.accumulo.AccumuloVersion
 import org.locationtech.geomesa.accumulo.data._
-import org.locationtech.geomesa.accumulo.index.{AccumuloFeatureIndex, RecordIndex}
+import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
 import org.locationtech.geomesa.index.conf.TableSplitter
 import org.locationtech.geomesa.index.conf.splitter.DefaultSplitter
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-import org.opengis.feature.simple.SimpleFeatureType
+import org.locationtech.geomesa.utils.index.ByteArrays
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 trait RecordWritableIndex extends AccumuloFeatureIndex {
 
-  import RecordIndex.getRowKey
-
-  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int) => String = {
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int, SimpleFeature) => String = {
     if (sft.isTableSharing) {
-      (row, offset, length) => new String(row, offset + 1, length - 1, StandardCharsets.UTF_8)
+      (row, offset, length, feature) => new String(row, offset + 1, length - 1, StandardCharsets.UTF_8)
     } else {
-      (row, offset, length) => new String(row, offset, length, StandardCharsets.UTF_8)
+      (row, offset, length, feature) => new String(row, offset, length, StandardCharsets.UTF_8)
     }
   }
 
   override def configure(sft: SimpleFeatureType, ds: AccumuloDataStore): Unit = {
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
-    import scala.collection.JavaConversions._
+    import scala.collection.JavaConverters._
 
     super.configure(sft, ds)
     val table = getTableName(sft.getTypeName, ds)
 
     AccumuloVersion.ensureTableExists(ds.connector, table)
 
-    val prefix = sft.getTableSharingPrefix
-    val prefixFn = getRowKey(prefix, _: String)
+    val prefix = sft.getTableSharingBytes
     val splitter = sft.getTableSplitter.getOrElse(classOf[DefaultSplitter]).newInstance().asInstanceOf[TableSplitter]
     val splits = splitter.getSplits(sft, name, sft.getTableSplitterOptions)
-    val sortedSplits = splits.map(new String(_, StandardCharsets.UTF_8)).map(prefixFn).map(new Text(_)).toSet
-    val splitsToAdd = sortedSplits -- ds.tableOps.listSplits(table).toSet
+    val sortedSplits = splits.map(s => new Text(ByteArrays.concat(prefix, s))).toSet
+    val splitsToAdd = sortedSplits -- ds.tableOps.listSplits(table).asScala.toSet
     if (splitsToAdd.nonEmpty) {
-      // noinspection RedundantCollectionConversion
-      ds.tableOps.addSplits(table, ImmutableSortedSet.copyOf(splitsToAdd.toIterable))
+      ds.tableOps.addSplits(table, Collections.unmodifiableSortedSet(new java.util.TreeSet(splitsToAdd.asJava)))
     }
 
     // enable the row functor as the feature ID is stored in the Row ID

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z2/Z2WritableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z2/Z2WritableIndex.scala
@@ -18,23 +18,19 @@ import org.apache.hadoop.io.Text
 import org.locationtech.geomesa.accumulo.AccumuloVersion
 import org.locationtech.geomesa.accumulo.data._
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
-import org.locationtech.geomesa.curve.NormalizedDimension.SemiNormalizedDimension
-import org.locationtech.geomesa.curve.{LegacyZ2SFC, NormalizedDimension}
+import org.locationtech.geomesa.curve.LegacyZ2SFC
 import org.locationtech.geomesa.index.utils.SplitArrays
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-import org.locationtech.sfcurve.zorder.Z2
-import org.opengis.feature.simple.SimpleFeatureType
-
-import scala.util.control.NonFatal
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 trait Z2WritableIndex extends AccumuloFeatureIndex {
 
   import AccumuloFeatureIndex.{BinColumnFamily, FullColumnFamily}
   import org.locationtech.geomesa.accumulo.index.legacy.z2.Z2IndexV1._
 
-  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int) => String = {
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int, SimpleFeature) => String = {
     val start = getIdRowOffset(sft)
-    (row, offset, length) => new String(row, offset + start, length - start, StandardCharsets.UTF_8)
+    (row, offset, length, feature) => new String(row, offset + start, length - start, StandardCharsets.UTF_8)
   }
 
   // split(1 byte), z value (8 bytes), id (n bytes)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3WritableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3WritableIndex.scala
@@ -26,7 +26,7 @@ import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
 import org.locationtech.geomesa.index.utils.SplitArrays
 import org.locationtech.geomesa.utils.geotools.Conversions._
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-import org.opengis.feature.simple.SimpleFeatureType
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.JavaConversions._
 
@@ -49,9 +49,9 @@ trait Z3WritableIndex extends AccumuloFeatureIndex {
     }
   }
 
-  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int) => String = {
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int, SimpleFeature) => String = {
     val start = getIdRowOffset(sft)
-    (row, offset, length) => new String(row, offset + start, length - start, StandardCharsets.UTF_8)
+    (row, offset, length, feature) => new String(row, offset + start, length - start, StandardCharsets.UTF_8)
   }
 
   // split(1 byte), week(2 bytes), z value (8 bytes), id (n bytes)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/AttributeIndexValueIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/AttributeIndexValueIterator.scala
@@ -88,7 +88,7 @@ class AttributeIndexValueIterator extends SortedKeyValueIterator[Key, Value] wit
     // noinspection ScalaDeprecation
     setId = if (index.serializedWithId || cql.isEmpty) { (_) => {} } else {
       val getFromRow = index.getIdFromRow(sft)
-      (row) => original.setId(getFromRow(row.getBytes, 0, row.getLength))
+      (row) => original.setId(getFromRow(row.getBytes, 0, row.getLength, original))
     }
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/BinAggregatingIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/BinAggregatingIterator.scala
@@ -97,7 +97,7 @@ class PrecomputedBinAggregatingIterator extends BinAggregatingIterator {
       }
       (_) => {
         val row = source.getTopKey.getRow
-        sf.setId(getId(row.getBytes, 0, row.getLength))
+        sf.setId(getId(row.getBytes, 0, row.getLength, sf))
         BinaryOutputEncoder.decode(source.getTopValue.get, callback)
         sf
       }
@@ -113,7 +113,7 @@ class PrecomputedBinAggregatingIterator extends BinAggregatingIterator {
       if (dedupe) {
         (_) => {
           val row = source.getTopKey.getRow
-          sf.setId(getId(row.getBytes, 0, row.getLength))
+          sf.setId(getId(row.getBytes, 0, row.getLength, sf))
           BinaryOutputEncoder.decode(source.getTopValue.get, callback)
           sf
         }
@@ -126,7 +126,7 @@ class PrecomputedBinAggregatingIterator extends BinAggregatingIterator {
     } else if (dedupe) {
       (_) => {
         val row = source.getTopKey.getRow
-        sf.setId(getId(row.getBytes, 0, row.getLength))
+        sf.setId(getId(row.getBytes, 0, row.getLength, sf))
         sf
       }
     } else {
@@ -279,7 +279,7 @@ object BinAggregatingIterator extends LazyLogging {
       (e: Entry[Key, Value]) => {
         val deserialized = deserializer.deserialize(e.getValue.get())
         val row = e.getKey.getRow
-        deserialized.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(row.getBytes, 0, row.getLength))
+        deserialized.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(row.getBytes, 0, row.getLength, deserialized))
         val values = Array[AnyRef](encoder.encode(deserialized), GeometryUtils.zeroPoint)
         new ScalaSimpleFeature(BinaryOutputEncoder.BinEncodedSft, deserialized.getID, values)
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoLazyFilterTransformIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoLazyFilterTransformIterator.scala
@@ -87,7 +87,7 @@ class KryoLazyFilterTransformIterator extends
       val getFromRow = index.getIdFromRow(sft)
       () => {
         val row = source.getTopKey.getRow()
-        reusableSf.setId(getFromRow(row.getBytes, 0, row.getLength))
+        reusableSf.setId(getFromRow(row.getBytes, 0, row.getLength, reusableSf))
       }
     }
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreUuidTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreUuidTest.scala
@@ -1,0 +1,141 @@
+/***********************************************************************
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.accumulo.data
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+
+import org.apache.accumulo.core.security.Authorizations
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.DirtyRootAllocator
+import org.geotools.data.{Query, Transaction}
+import org.geotools.factory.Hints
+import org.geotools.filter.text.ecql.ECQL
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.accumulo.TestWithDataStore
+import org.locationtech.geomesa.accumulo.index.RecordIndex
+import org.locationtech.geomesa.arrow.io.SimpleFeatureArrowFileReader
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.filter.function.ProxyIdFunction
+import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
+import org.locationtech.geomesa.index.conf.QueryHints
+import org.locationtech.geomesa.utils.collection.SelfClosingIterator
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.Configs
+import org.locationtech.geomesa.utils.index.ByteArrays
+import org.locationtech.geomesa.utils.io.WithClose
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class AccumuloDataStoreUuidTest extends Specification with TestWithDataStore {
+
+  import scala.collection.JavaConverters._
+
+  implicit val allocator: BufferAllocator = new DirtyRootAllocator(Long.MaxValue, 6.toByte)
+
+  override val spec =
+    s"name:String:index=true,age:Int:index=join,dtg:Date,*geom:Point:srid=4326;${Configs.FID_UUID_KEY}=true"
+
+  val features = (0 until 10).map { i =>
+    val id = s"28a12c18-e5ae-4c04-ae7b-bf7cdbfaf23$i"
+    val name = s"name$i"
+    val age = 20 + i / 2
+    ScalaSimpleFeature.create(sft, id, name, age, s"2017-02-03T00:0$i:01.000Z", s"POINT(40 6$i)")
+  }
+
+  val toBytes = GeoMesaFeatureIndex.idToBytes(sft)
+  val uuids = features.map(f => toBytes(f.getID))
+  val uuidStrings = uuids.map(ByteArrays.toHex)
+
+  step {
+    addFeatures(features)
+  }
+
+  "AccumuloDataStore" should {
+    "encode UUIDs as 16 bytes" in {
+      foreach(uuids)(_ must haveLength(16))
+      foreach(ds.getAllIndexTableNames(sftName)) { table =>
+        WithClose(connector.createScanner(table, new Authorizations)) { scanner =>
+          // compare the feature id serialized at the end of each row key
+          val bytes = scanner.asScala.map(_.getKey.getRow.getBytes.takeRight(16)).toList
+          // note: attribute table has each key twice, so can't use containTheSameElementsAs
+          bytes.map(ByteArrays.toHex) must containAllOf(uuidStrings)
+        }
+      }
+    }
+    "fail when writing non-uuids" in {
+      WithClose(ds.getFeatureWriterAppend(sftName, Transaction.AUTO_COMMIT)) { writer =>
+        val feature = writer.next()
+        feature.setAttributes(features.head.getAttributes)
+        feature.getUserData.put(Hints.PROVIDED_FID, "foo")
+        writer.write must throwAn[IllegalArgumentException]
+      }
+    }
+    "return correct ids" in {
+      val filters = Seq(
+        "IN ('28a12c18-e5ae-4c04-ae7b-bf7cdbfaf235')",
+        "bbox(geom,35,55,45,65)",
+        "bbox(geom,35,55,45,65) and dtg DURING 2017-02-03T00:00:00.000Z/2017-02-03T00:08:00.000Z",
+        "name IN ('name1', 'name2')",
+        "age = 24"
+      ).map(ECQL.toFilter)
+      val transforms = Seq(
+        null,
+        Array("age", "geom"),
+        Array("name", "geom"),
+        Array("dtg", "geom")
+      )
+      val ids = features.map(_.getID)
+      foreach(filters) { filter =>
+        foreach(transforms) { transform =>
+          val query = new Query(sftName, filter, transform)
+          val result = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList
+          result must not(beEmpty)
+          foreach(result)(f => ids.contains(f.getID) must beTrue)
+        }
+      }
+    }
+    "still query by feature id" in {
+      val query = new Query(sftName, ECQL.toFilter("IN ('28a12c18-e5ae-4c04-ae7b-bf7cdbfaf235')"))
+      foreach(ds.getQueryPlan(query)) { plan =>
+        plan.filter.index mustEqual RecordIndex
+      }
+      val result = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList
+      result mustEqual Seq(features(5))
+    }
+    "return minified arrow ids and use them for callbacks" in {
+      val filter = "bbox(geom,35,55,45,65) and dtg DURING 2017-02-03T00:00:00.000Z/2017-02-03T00:08:00.000Z"
+      val query = new Query(sftName, ECQL.toFilter(filter))
+      query.getHints.put(QueryHints.ARROW_ENCODE, true)
+      query.getHints.put(QueryHints.ARROW_PROXY_FID, true)
+      query.getHints.put(QueryHints.ARROW_SORT_FIELD, "dtg")
+      query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "name,age")
+      query.getHints.put(QueryHints.ARROW_DICTIONARY_CACHED, false)
+      query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 100)
+
+      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
+      val out = new ByteArrayOutputStream
+      results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
+      def in() = new ByteArrayInputStream(out.toByteArray)
+      val ids = WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
+        WithClose(reader.features())(_.map(_.getID).toList)
+      }
+      val proxy = new ProxyIdFunction()
+      features.map(proxy.evaluate(_).toString) must containAllOf(ids)
+
+      val callback = new Query(sftName, ECQL.toFilter(s"$filter AND proxyId() = '${ids.head}'"))
+      val callbackResults = SelfClosingIterator(ds.getFeatureReader(callback, Transaction.AUTO_COMMIT)).toList
+      callbackResults must haveLength(1)
+      proxy.evaluate(callbackResults.head).toString mustEqual ids.head
+    }
+  }
+
+  step {
+    allocator.close()
+  }
+}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
@@ -451,7 +451,7 @@ class AccumuloFeatureWriterTest extends Specification with TestWithDataStore wit
       // ensure that the second part of the UUID is random
       rowKeys.map(_.substring(19)).toSet must haveLength(5)
 
-      val ids = rows.map(e => RecordIndex.getIdFromRow(sft)(e.getKey.getRow.getBytes, 0, e.getKey.getRow.getLength))
+      val ids = rows.map(e => RecordIndex.getIdFromRow(sft)(e.getKey.getRow.getBytes, 0, e.getKey.getRow.getLength, null))
       ids must haveLength(5)
       forall(ids)(_ must not(beMatching("fid\\d")))
       // ensure they share a common prefix, since they have the same dtg/geom

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/ArrowBatchIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/ArrowBatchIteratorTest.scala
@@ -11,7 +11,8 @@ package org.locationtech.geomesa.accumulo.iterators
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, Closeable}
 
 import com.vividsolutions.jts.geom.LineString
-import org.apache.arrow.memory.{BufferAllocator, RootAllocator}
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.DirtyRootAllocator
 import org.geotools.data.{Query, Transaction}
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.geotools.filter.text.ecql.ECQL
@@ -38,7 +39,7 @@ class ArrowBatchIteratorTest extends TestWithMultipleSfts {
   lazy val pointSft = createNewSchema("name:String:index=join,team:String:index-value=true,age:Int,weight:Int,dtg:Date,*geom:Point:srid=4326")
   lazy val lineSft = createNewSchema("name:String:index=join,team:String:index-value=true,age:Int,weight:Int,dtg:Date,*geom:LineString:srid=4326")
 
-  implicit val allocator: BufferAllocator = new RootAllocator(Long.MaxValue)
+  implicit val allocator: BufferAllocator = new DirtyRootAllocator(Long.MaxValue, 6.toByte)
 
   val pointFeatures = (0 until 10).map { i =>
     val name = s"name${i % 2}"

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/process/transform/ArrowConversionProcessTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/process/transform/ArrowConversionProcessTest.scala
@@ -43,7 +43,7 @@ class ArrowConversionProcessTest extends TestWithDataStore {
 
   "ArrowConversionProcess" should {
     "encode an empty feature collection" in {
-      val bytes = process.execute(new ListFeatureCollection(sft), null, null, null, null, null, null, null).reduce(_ ++ _)
+      val bytes = process.execute(new ListFeatureCollection(sft), null, null, null, null, null, null, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()) must beEmpty
@@ -51,7 +51,7 @@ class ArrowConversionProcessTest extends TestWithDataStore {
     }
 
     "encode an empty accumulo feature collection" in {
-      val bytes = process.execute(fs.getFeatures(ECQL.toFilter("bbox(geom,20,20,30,30)")), null, null, null, null, null, null, null).reduce(_ ++ _)
+      val bytes = process.execute(fs.getFeatures(ECQL.toFilter("bbox(geom,20,20,30,30)")), null, null, null, null, null, null, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()) must beEmpty
@@ -59,7 +59,7 @@ class ArrowConversionProcessTest extends TestWithDataStore {
     }
 
     "encode an accumulo feature collection in distributed fashion" in {
-      val bytes = process.execute(fs.getFeatures(Filter.INCLUDE), null, null, null, null, null, null, null).reduce(_ ++ _)
+      val bytes = process.execute(fs.getFeatures(Filter.INCLUDE), null, null, null, null, null, null, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
@@ -69,7 +69,7 @@ class ArrowConversionProcessTest extends TestWithDataStore {
 
     "encode an accumulo feature collection in distributed fashion with cached dictionary values" in {
       val filter = ECQL.toFilter("name = 'name0'")
-      val bytes = process.execute(fs.getFeatures(filter), null, Seq("name"), null, null, null, null, null).reduce(_ ++ _)
+      val bytes = process.execute(fs.getFeatures(filter), null, null, Seq("name"), null, null, null, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
@@ -81,7 +81,7 @@ class ArrowConversionProcessTest extends TestWithDataStore {
 
     "encode an accumulo feature collection in distributed fashion with calculated dictionary values" in {
       val filter = ECQL.toFilter("name = 'name0'")
-      val bytes = process.execute(fs.getFeatures(filter), null, Seq("name"), false, null, null, null, null).reduce(_ ++ _)
+      val bytes = process.execute(fs.getFeatures(filter), null, null, Seq("name"), false, null, null, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
@@ -92,7 +92,7 @@ class ArrowConversionProcessTest extends TestWithDataStore {
     }
 
     "sort and encode an accumulo feature collection in distributed fashion" in {
-      val bytes = process.execute(fs.getFeatures(Filter.INCLUDE), null, null, null, "dtg", null, null, null).reduce(_ ++ _)
+      val bytes = process.execute(fs.getFeatures(Filter.INCLUDE), null, null, null, null, "dtg", null, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toList mustEqual features
@@ -100,7 +100,7 @@ class ArrowConversionProcessTest extends TestWithDataStore {
     }
 
     "reverse sort and encode an accumulo feature collection in distributed fashion" in {
-      val bytes = process.execute(fs.getFeatures(Filter.INCLUDE), null, null, null, "dtg", Boolean.box(true), null, null).reduce(_ ++ _)
+      val bytes = process.execute(fs.getFeatures(Filter.INCLUDE), null, null, null, null, "dtg", Boolean.box(true), null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toList mustEqual features.reverse

--- a/geomesa-arrow/geomesa-arrow-datastore/src/main/scala/org/locationtech/geomesa/arrow/data/ArrowFeatureStore.scala
+++ b/geomesa-arrow/geomesa-arrow-datastore/src/main/scala/org/locationtech/geomesa/arrow/data/ArrowFeatureStore.scala
@@ -64,7 +64,7 @@ class ArrowFeatureStore(entry: ContentEntry, reader: SimpleFeatureArrowFileReade
     val sft = delegate.getSchema
     val os = entry.getDataStore.asInstanceOf[ArrowDataStore].createOutputStream(true)
 
-    val writer = SimpleFeatureArrowFileWriter(sft, os, encoding = SimpleFeatureEncoding.max(true))
+    val writer = SimpleFeatureArrowFileWriter(sft, os, encoding = SimpleFeatureEncoding.Max)
     val flushCount = ArrowProperties.BatchSize.get.toLong
 
     new FeatureWriter[SimpleFeatureType, SimpleFeature] {

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DeltaWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DeltaWriter.scala
@@ -69,7 +69,7 @@ class DeltaWriter(val sft: SimpleFeatureType,
     if (reverse) { o.reverse } else { o }
   }
 
-  private val idWriter = ArrowAttributeWriter.id(Some(vector), encoding)
+  private val idWriter = ArrowAttributeWriter.id(sft, Some(vector), encoding)
   private val writers = sft.getAttributeDescriptors.map { descriptor =>
     val name = descriptor.getLocalName
     val isDictionary = dictionaryFields.contains(name)
@@ -161,10 +161,10 @@ class DeltaWriter(val sft: SimpleFeatureType,
     }
 
     // set feature ids in the vector
-    if (encoding.fids) {
+    if (encoding.fids.isDefined) {
       var i = 0
       while (i < count) {
-        idWriter.apply(i, features(i).getID)
+        idWriter.apply(i, features(i))
         i += 1
       }
       idWriter.setValueCount(count)

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DictionaryBuildingWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DictionaryBuildingWriter.scala
@@ -45,7 +45,7 @@ class DictionaryBuildingWriter private (val sft: SimpleFeatureType,
 
   private val arrowWriter = underlying.getWriter
 
-  private val idWriter = ArrowAttributeWriter.id(Some(underlying), encoding)
+  private val idWriter = ArrowAttributeWriter.id(sft, Some(underlying), encoding)
   private val attributeWriters =
     DictionaryBuildingWriter.attribute(sft, underlying, dictionaries, encoding, maxSize).toArray
 
@@ -56,7 +56,7 @@ class DictionaryBuildingWriter private (val sft: SimpleFeatureType,
   def add(feature: SimpleFeature): Unit = {
     arrowWriter.setPosition(index)
     arrowWriter.start()
-    idWriter.apply(index, feature.getID)
+    idWriter.apply(index, feature)
     var i = 0
     while (i < attributeWriters.length) {
       attributeWriters(i).apply(index, feature.getAttribute(i))
@@ -133,7 +133,7 @@ object DictionaryBuildingWriter {
     */
   def create(sft: SimpleFeatureType,
              dictionaries: Seq[String],
-             encoding: SimpleFeatureEncoding = SimpleFeatureEncoding.min(false),
+             encoding: SimpleFeatureEncoding = SimpleFeatureEncoding.Min,
              maxSize: Int = Short.MaxValue)
             (implicit allocator: BufferAllocator): DictionaryBuildingWriter = {
     val underlying = NullableMapVector.empty(sft.getTypeName, allocator)

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/SimpleFeatureArrowFileWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/SimpleFeatureArrowFileWriter.scala
@@ -104,7 +104,7 @@ object SimpleFeatureArrowFileWriter {
   def apply(sft: SimpleFeatureType,
             os: OutputStream,
             dictionaries: Map[String, ArrowDictionary] = Map.empty,
-            encoding: SimpleFeatureEncoding = SimpleFeatureEncoding.min(false),
+            encoding: SimpleFeatureEncoding = SimpleFeatureEncoding.Min,
             sort: Option[(String, Boolean)] = None)
            (implicit allocator: BufferAllocator): SimpleFeatureArrowFileWriter = {
     apply(SimpleFeatureVector.create(sft, dictionaries, encoding), os, sort)

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeReader.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeReader.scala
@@ -30,8 +30,9 @@ import org.locationtech.geomesa.arrow.vector.PointFloatVector.PointFloatReader
 import org.locationtech.geomesa.arrow.vector.PointVector.PointDoubleReader
 import org.locationtech.geomesa.arrow.vector.PolygonFloatVector.PolygonFloatReader
 import org.locationtech.geomesa.arrow.vector.PolygonVector.PolygonDoubleReader
-import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.EncodingPrecision.EncodingPrecision
-import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.{EncodingPrecision, SimpleFeatureEncoding}
+import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding
+import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding.Encoding
+import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding.Encoding.Encoding
 import org.locationtech.geomesa.arrow.vector.impl.{AbstractLineStringVector, AbstractPointVector}
 import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
@@ -81,16 +82,23 @@ object ArrowAttributeReader {
   /**
     * Reads an ID
     *
-    * @param vector simple feature vector
-    * @param includeFids whether ids are included in the vector or not. If not, will return an incrementing ID value.
+    * @param sft simple feature type
+    * @param vector simple feature vector to read from
+    * @param encoding encoding options
     * @return
     */
-  def id(vector: NullableMapVector, includeFids: Boolean): ArrowAttributeReader = {
-    if (includeFids) {
-      val child = vector.getChild(SimpleFeatureVector.FeatureIdField)
-      ArrowAttributeReader(Seq(ObjectType.STRING), child, None, null)
-    } else {
-      ArrowAttributeReader.ArrowIncrementingFeatureIdReader
+  def id(sft: SimpleFeatureType,
+         vector: NullableMapVector,
+         encoding: SimpleFeatureEncoding = SimpleFeatureEncoding.Min): ArrowAttributeReader = {
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
+    def child = vector.getChild(SimpleFeatureVector.FeatureIdField)
+
+    encoding.fids match {
+      case None                             => ArrowAttributeReader.ArrowFeatureIdIncrementingReader
+      case Some(Encoding.Min)               => new ArrowFeatureIdMinimalReader(child.asInstanceOf[NullableIntVector])
+      case Some(Encoding.Max) if sft.isUuid => new ArrowFeatureIdUuidReader(child.asInstanceOf[FixedSizeListVector])
+      case Some(Encoding.Max)               => new ArrowStringReader(child.asInstanceOf[NullableVarCharVector])
     }
   }
 
@@ -107,7 +115,7 @@ object ArrowAttributeReader {
   def apply(sft: SimpleFeatureType,
             vector: NullableMapVector,
             dictionaries: Map[String, ArrowDictionary],
-            encoding: SimpleFeatureEncoding = SimpleFeatureEncoding.min(false)): Seq[ArrowAttributeReader] = {
+            encoding: SimpleFeatureEncoding = SimpleFeatureEncoding.Min): Seq[ArrowAttributeReader] = {
     import scala.collection.JavaConversions._
     sft.getAttributeDescriptors.map { descriptor =>
       val name = descriptor.getLocalName
@@ -151,7 +159,7 @@ object ArrowAttributeReader {
           case ObjectType.MAP      => new ArrowMapReader(vector.asInstanceOf[NullableMapVector], bindings(1), bindings(2), encoding)
           case ObjectType.BYTES    => new ArrowByteReader(vector.asInstanceOf[NullableVarBinaryVector])
           case ObjectType.JSON     => new ArrowStringReader(vector.asInstanceOf[NullableVarCharVector])
-          case ObjectType.UUID     => new ArrowUuidReader(vector.asInstanceOf[NullableVarCharVector])
+          case ObjectType.UUID     => new ArrowUuidReader(vector.asInstanceOf[FixedSizeListVector])
           case _ => throw new IllegalArgumentException(s"Unexpected object type ${bindings.head}")
         }
 
@@ -235,39 +243,39 @@ object ArrowAttributeReader {
   }
 
   object ArrowGeometryReader {
-    def apply(vector: FieldVector, binding: ObjectType, precision: EncodingPrecision): ArrowAttributeReader = {
+    def apply(vector: FieldVector, binding: ObjectType, encoding: Encoding): ArrowAttributeReader = {
       if (binding == ObjectType.POINT) {
-        val delegate = precision match {
-          case EncodingPrecision.Min => new PointFloatReader(vector.asInstanceOf[FixedSizeListVector])
-          case EncodingPrecision.Max => new PointDoubleReader(vector.asInstanceOf[FixedSizeListVector])
+        val delegate = encoding match {
+          case Encoding.Min => new PointFloatReader(vector.asInstanceOf[FixedSizeListVector])
+          case Encoding.Max => new PointDoubleReader(vector.asInstanceOf[FixedSizeListVector])
         }
         new ArrowPointReader(vector, delegate.asInstanceOf[AbstractPointVector.PointReader])
       } else if (binding == ObjectType.LINESTRING) {
-        val delegate = precision match {
-          case EncodingPrecision.Min => new LineStringFloatReader(vector.asInstanceOf[ListVector])
-          case EncodingPrecision.Max => new LineStringDoubleReader(vector.asInstanceOf[ListVector])
+        val delegate = encoding match {
+          case Encoding.Min => new LineStringFloatReader(vector.asInstanceOf[ListVector])
+          case Encoding.Max => new LineStringDoubleReader(vector.asInstanceOf[ListVector])
         }
         new ArrowLineStringReader(vector, delegate.asInstanceOf[AbstractLineStringVector.LineStringReader])
       } else {
         val delegate: GeometryReader[_ <: Geometry] = if (binding == ObjectType.POLYGON) {
-          precision match {
-            case EncodingPrecision.Min => new PolygonFloatReader(vector.asInstanceOf[ListVector])
-            case EncodingPrecision.Max => new PolygonDoubleReader(vector.asInstanceOf[ListVector])
+          encoding match {
+            case Encoding.Min => new PolygonFloatReader(vector.asInstanceOf[ListVector])
+            case Encoding.Max => new PolygonDoubleReader(vector.asInstanceOf[ListVector])
           }
         } else if (binding == ObjectType.MULTILINESTRING) {
-          precision match {
-            case EncodingPrecision.Min => new MultiLineStringFloatReader(vector.asInstanceOf[ListVector])
-            case EncodingPrecision.Max => new MultiLineStringDoubleReader(vector.asInstanceOf[ListVector])
+          encoding match {
+            case Encoding.Min => new MultiLineStringFloatReader(vector.asInstanceOf[ListVector])
+            case Encoding.Max => new MultiLineStringDoubleReader(vector.asInstanceOf[ListVector])
           }
         } else if (binding == ObjectType.MULTIPOLYGON) {
-          precision match {
-            case EncodingPrecision.Min => new MultiPolygonFloatReader(vector.asInstanceOf[ListVector])
-            case EncodingPrecision.Max => new MultiPolygonDoubleReader(vector.asInstanceOf[ListVector])
+          encoding match {
+            case Encoding.Min => new MultiPolygonFloatReader(vector.asInstanceOf[ListVector])
+            case Encoding.Max => new MultiPolygonDoubleReader(vector.asInstanceOf[ListVector])
           }
         } else if (binding == ObjectType.MULTIPOINT) {
-          precision match {
-            case EncodingPrecision.Min => new MultiPointFloatReader(vector.asInstanceOf[ListVector])
-            case EncodingPrecision.Max => new MultiPointDoubleReader(vector.asInstanceOf[ListVector])
+          encoding match {
+            case Encoding.Min => new MultiPointFloatReader(vector.asInstanceOf[ListVector])
+            case Encoding.Max => new MultiPointDoubleReader(vector.asInstanceOf[ListVector])
           }
         } else if (binding == ObjectType.GEOMETRY_COLLECTION) {
           throw new NotImplementedError(s"Geometry type $binding is not supported")
@@ -348,11 +356,19 @@ object ArrowAttributeReader {
   /**
     * Returns an incrementing Long to use as a feature id
     */
-  object ArrowIncrementingFeatureIdReader extends ArrowAttributeReader {
+  object ArrowFeatureIdIncrementingReader extends ArrowAttributeReader {
     private val ids = new AtomicLong(0)
     override val vector: FieldVector = null
     override def apply(i: Int): AnyRef = ids.getAndIncrement.toString
     override def getValueCount: Int = 0
+  }
+
+  class ArrowFeatureIdUuidReader(vector: FixedSizeListVector) extends ArrowUuidReader(vector) {
+    override def apply(i: Int): AnyRef = String.valueOf(super.apply(i))
+  }
+
+  class ArrowFeatureIdMinimalReader(vector: NullableIntVector) extends ArrowIntReader(vector) {
+    override def apply(i: Int): AnyRef = String.valueOf(super.apply(i))
   }
 
   class ArrowStringReader(override val vector: NullableVarCharVector) extends ArrowAttributeReader {
@@ -402,10 +418,10 @@ object ArrowAttributeReader {
   }
 
   object ArrowDateReader {
-    def apply(vector: FieldVector, precision: EncodingPrecision): ArrowDateReader = {
-      precision match {
-        case EncodingPrecision.Min => new ArrowDateSecondsReader(vector.asInstanceOf[NullableIntVector])
-        case EncodingPrecision.Max => new ArrowDateMillisReader(vector.asInstanceOf[NullableBigIntVector])
+    def apply(vector: FieldVector, encoding: Encoding): ArrowDateReader = {
+      encoding match {
+        case Encoding.Min => new ArrowDateSecondsReader(vector.asInstanceOf[NullableIntVector])
+        case Encoding.Max => new ArrowDateMillisReader(vector.asInstanceOf[NullableBigIntVector])
       }
     }
   }
@@ -449,12 +465,14 @@ object ArrowAttributeReader {
     override def apply(i: Int): AnyRef = accessor.getObject(i)
   }
 
-  class ArrowUuidReader(override val vector: NullableVarCharVector) extends ArrowStringReader(vector) {
+  class ArrowUuidReader(override val vector: FixedSizeListVector) extends ArrowAttributeReader {
     private val accessor = vector.getAccessor
+    private val bitsAccessor = vector.getChildrenFromFields.get(0).getAccessor.asInstanceOf[NullableBigIntVector#Accessor]
     override def apply(i: Int): AnyRef = {
-      val string = super.apply(i).asInstanceOf[String]
-      if (string == null) { null } else {
-        UUID.fromString(string)
+      if (accessor.isNull(i)) { null } else {
+        val msb = bitsAccessor.get(i * 2)
+        val lsb = bitsAccessor.get(i * 2 + 1)
+        new UUID(msb, lsb)
       }
     }
   }

--- a/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/io/DeltaWriterTest.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/io/DeltaWriterTest.scala
@@ -47,7 +47,7 @@ class DeltaWriterTest extends Specification {
   "DeltaWriter" should {
     "dynamically encode dictionary values without sorting" >> {
       val dictionaries = Seq("name", "age")
-      val encoding = SimpleFeatureEncoding.min(true)
+      val encoding = SimpleFeatureEncoding.min(includeFids = true)
       val result = ArrayBuffer.empty[Array[Byte]]
 
       WithClose(new DeltaWriter(sft, dictionaries, encoding, None, 10)) { writer =>
@@ -76,7 +76,7 @@ class DeltaWriterTest extends Specification {
     }
     "dynamically encode dictionary values with sorting" >> {
       val dictionaries = Seq("name", "age")
-      val encoding = SimpleFeatureEncoding.min(true)
+      val encoding = SimpleFeatureEncoding.min(includeFids = true)
       val sort = Some(("dtg", false))
       val result = ArrayBuffer.empty[Array[Byte]]
 
@@ -105,7 +105,7 @@ class DeltaWriterTest extends Specification {
       }
     }
     "work with line strings" >> {
-      val encoding = SimpleFeatureEncoding.min(true)
+      val encoding = SimpleFeatureEncoding.min(includeFids = true)
       val result = ArrayBuffer.empty[Array[Byte]]
 
       WithClose(new DeltaWriter(lineSft, Seq.empty, encoding, None, 10)) { writer =>
@@ -124,7 +124,7 @@ class DeltaWriterTest extends Specification {
       }
     }
     "work with sorted line strings" >> {
-      val encoding = SimpleFeatureEncoding.min(true)
+      val encoding = SimpleFeatureEncoding.min(includeFids = true)
       val result = ArrayBuffer.empty[Array[Byte]]
       val sort = Some(("dtg", false))
 

--- a/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/io/DictionaryBuildingWriterTest.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/io/DictionaryBuildingWriterTest.scala
@@ -33,7 +33,7 @@ class DictionaryBuildingWriterTest extends Specification {
   "SimpleFeatureVector" should {
     "dynamically encode dictionary values" >> {
       val out = new ByteArrayOutputStream()
-      WithClose(DictionaryBuildingWriter.create(sft, Seq("name"), SimpleFeatureEncoding.max(true))) { writer =>
+      WithClose(DictionaryBuildingWriter.create(sft, Seq("name"), SimpleFeatureEncoding.Max)) { writer =>
         features.foreach(writer.add)
         writer.encode(out)
       }

--- a/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/io/SimpleFeatureArrowFileTest.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/io/SimpleFeatureArrowFileTest.scala
@@ -57,7 +57,7 @@ class SimpleFeatureArrowFileTest extends Specification {
   "SimpleFeatureArrowFiles" should {
     "write and read just a schema" >> {
       withTestFile("empty") { file =>
-        SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), encoding = SimpleFeatureEncoding.max(true)).close()
+        SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), encoding = SimpleFeatureEncoding.Max).close()
         WithClose(SimpleFeatureArrowFileReader.streaming(() => new FileInputStream(file))) { reader =>
           reader.sft mustEqual sft
           reader.features().toSeq must beEmpty
@@ -70,7 +70,7 @@ class SimpleFeatureArrowFileTest extends Specification {
     }
     "write and read and filter values" >> {
       withTestFile("simple") { file =>
-        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), encoding = SimpleFeatureEncoding.max(true))) { writer =>
+        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), encoding = SimpleFeatureEncoding.Max)) { writer =>
           features0.foreach(writer.add)
           writer.flush()
           features1.foreach(writer.add)
@@ -93,7 +93,7 @@ class SimpleFeatureArrowFileTest extends Specification {
     }
     "optimize queries for sorted files" >> {
       withTestFile("sorted") { file =>
-        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), encoding = SimpleFeatureEncoding.max(true), sort = Some(("dtg", false)))) { writer =>
+        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), encoding = SimpleFeatureEncoding.Max, sort = Some(("dtg", false)))) { writer =>
           features0.foreach(writer.add)
           writer.flush()
           features1.foreach(writer.add)
@@ -116,10 +116,10 @@ class SimpleFeatureArrowFileTest extends Specification {
     }
     "write and read multiple logical files in one" >> {
       withTestFile("multi-files") { file =>
-        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), encoding = SimpleFeatureEncoding.max(true))) { writer =>
+        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), encoding = SimpleFeatureEncoding.Max)) { writer =>
           features0.foreach(writer.add)
         }
-        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file, true), encoding = SimpleFeatureEncoding.max(true))) { writer =>
+        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file, true), encoding = SimpleFeatureEncoding.Max)) { writer =>
           features1.foreach(writer.add)
         }
         WithClose(SimpleFeatureArrowFileReader.streaming(() => new FileInputStream(file))) { reader =>
@@ -142,7 +142,7 @@ class SimpleFeatureArrowFileTest extends Specification {
     "write and read dictionary encoded values" >> {
       val dictionaries = Map("foo:String" -> ArrowDictionary.create(0, Array("foo0", "foo1", "foo2")))
       withTestFile("dictionary") { file =>
-        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), dictionaries, SimpleFeatureEncoding.max(true))) { writer =>
+        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), dictionaries, SimpleFeatureEncoding.Max)) { writer =>
           features0.foreach(writer.add)
           writer.flush()
           features1.foreach(writer.add)
@@ -158,7 +158,7 @@ class SimpleFeatureArrowFileTest extends Specification {
     "write and read dictionary encoded ints" >> {
       val dictionaries = Map("age" -> ArrowDictionary.create(0, Array(0, 1, 2, 3, 4, 5).map(Int.box)))
       withTestFile("dictionary-int") { file =>
-        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), dictionaries, SimpleFeatureEncoding.max(true))) { writer =>
+        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), dictionaries, SimpleFeatureEncoding.Max)) { writer =>
           features0.foreach(writer.add)
           writer.flush()
           features1.foreach(writer.add)
@@ -174,7 +174,7 @@ class SimpleFeatureArrowFileTest extends Specification {
     "write and read dictionary encoded values with defaults" >> {
       val dictionaries = Map("foo" -> ArrowDictionary.create(0, Array("foo0", "foo1")))
       withTestFile("dictionary-defaults") { file =>
-        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), dictionaries, SimpleFeatureEncoding.max(true))) { writer =>
+        WithClose(SimpleFeatureArrowFileWriter(sft, new FileOutputStream(file), dictionaries, SimpleFeatureEncoding.Max)) { writer =>
           features0.foreach(writer.add)
           writer.flush()
           features1.foreach(writer.add)
@@ -196,7 +196,7 @@ class SimpleFeatureArrowFileTest extends Specification {
     }
     "write and read linestrings" >> {
       withTestFile("lines") { file =>
-        val encoding = SimpleFeatureEncoding.min(true)
+        val encoding = SimpleFeatureEncoding.min(includeFids = true)
         WithClose(SimpleFeatureArrowFileWriter(lineSft, new FileOutputStream(file), Map.empty, encoding)) { writer =>
           lineFeatures.foreach(writer.add)
         }

--- a/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/io/SimpleFeatureArrowIOTest.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/io/SimpleFeatureArrowIOTest.scala
@@ -15,7 +15,7 @@ import org.apache.arrow.vector.DirtyRootAllocator
 import org.apache.arrow.vector.complex.NullableMapVector
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.arrow.io.records.{RecordBatchLoader, RecordBatchUnloader}
-import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.{EncodingPrecision, SimpleFeatureEncoding}
+import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding
 import org.locationtech.geomesa.arrow.vector.{ArrowDictionary, SimpleFeatureVector}
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
@@ -42,7 +42,7 @@ class SimpleFeatureArrowIOTest extends Specification {
 
   "SimpleFeatureArrowIO" should {
     "merge sort arrow batches" >> {
-      val encoding = SimpleFeatureEncoding(fids = true, EncodingPrecision.Min, EncodingPrecision.Min)
+      val encoding = SimpleFeatureEncoding.min(includeFids = true)
       val dictionaries = Map.empty[String, ArrowDictionary]
       val (field, batches) = WithClose(SimpleFeatureVector.create(sft, dictionaries, encoding)) { vector =>
         val unloader = new RecordBatchUnloader(vector)

--- a/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/vector/SimpleFeatureVectorTest.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/vector/SimpleFeatureVectorTest.scala
@@ -11,12 +11,15 @@ package org.locationtech.geomesa.arrow.vector
 import java.util.Date
 
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.DirtyRootAllocator
+import org.apache.arrow.vector.{DirtyRootAllocator, NullableBigIntVector, NullableIntVector}
+import org.apache.arrow.vector.complex.FixedSizeListVector
 import org.geotools.util.Converters
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding
 import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.filter.function.ProxyIdFunction
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.Configs
 import org.locationtech.geomesa.utils.io.WithClose
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -28,12 +31,16 @@ class SimpleFeatureVectorTest extends Specification {
 
   val sft = SimpleFeatureTypes.createType("test", "name:String,age:Int,dtg:Date,*geom:Point:srid=4326")
   val features = (0 until 10).map { i =>
-    ScalaSimpleFeature.create(sft, s"0$i", s"name0${i % 2}", s"${i % 5}", s"2017-03-15T00:0$i:00.000Z", s"POINT (4$i 5$i)")
+    ScalaSimpleFeature.create(sft, s"28a12c18-e5ae-4c04-ae7b-bf7cdbfaf23$i", s"name0${i % 2}",
+      s"${i % 5}", s"2017-03-15T00:0$i:00.000Z", s"POINT (4$i 5$i)")
   }
+
+  val uuidSft = SimpleFeatureTypes.createType(sft.getTypeName,
+    SimpleFeatureTypes.encodeType(sft) + s";${Configs.FID_UUID_KEY}=true")
 
   "SimpleFeatureVector" should {
     "set and get values" >> {
-      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.max(true))) { vector =>
+      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.Max)) { vector =>
         features.zipWithIndex.foreach { case (f, i) => vector.writer.set(i, f) }
         vector.writer.setValueCount(features.length)
         vector.reader.getValueCount mustEqual features.length
@@ -47,7 +54,7 @@ class SimpleFeatureVectorTest extends Specification {
     }
     "expand capacity" >> {
       val total = 128
-      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.max(true), capacity = total / 2)) { vector =>
+      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.Max, capacity = total / 2)) { vector =>
         var i = 0
         while (i < total) {
           vector.writer.set(i, features(i % features.length))
@@ -59,7 +66,7 @@ class SimpleFeatureVectorTest extends Specification {
       }
     }
     "set and get float precision values" >> {
-      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.min(true))) { vector =>
+      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.min(includeFids = true))) { vector =>
         features.zipWithIndex.foreach { case (f, i) => vector.writer.set(i, f) }
         vector.writer.setValueCount(features.length)
         vector.reader.getValueCount mustEqual features.length
@@ -71,8 +78,55 @@ class SimpleFeatureVectorTest extends Specification {
         }
       }
     }
+    "set and get feature uuids" >> {
+      WithClose(SimpleFeatureVector.create(uuidSft, Map.empty, SimpleFeatureEncoding.Max)) { vector =>
+        features.zipWithIndex.foreach { case (f, i) => vector.writer.set(i, f) }
+        vector.writer.setValueCount(features.length)
+        vector.reader.getValueCount mustEqual features.length
+        forall(0 until 10)(i => vector.reader.get(i) mustEqual features(i))
+        // verify that id is encoded as 2 longs
+        val idVector = vector.underlying.getChild(SimpleFeatureVector.FeatureIdField)
+        idVector must beAnInstanceOf[FixedSizeListVector]
+        idVector.asInstanceOf[FixedSizeListVector].getDataVector must beAnInstanceOf[NullableBigIntVector]
+        // check wrapping
+        WithClose(SimpleFeatureVector.wrap(vector.underlying, Map.empty)) { wrapped =>
+          wrapped.reader.getValueCount mustEqual features.length
+          forall(0 until 10)(i => wrapped.reader.get(i) mustEqual features(i))
+        }
+      }
+    }
+    "proxy feature ids" >> {
+      val encoding = SimpleFeatureEncoding.min(includeFids = true, proxyFids = true)
+      val proxy = new ProxyIdFunction()
+      foreach(Seq(sft, uuidSft)) { sft =>
+        WithClose(SimpleFeatureVector.create(sft, Map.empty, encoding)) { vector =>
+          features.zipWithIndex.foreach { case (f, i) => vector.writer.set(i, f) }
+          vector.writer.setValueCount(features.length)
+          vector.reader.getValueCount mustEqual features.length
+          forall(0 until 10) { i =>
+            val read = vector.reader.get(i)
+            read.getAttributes mustEqual features(i).getAttributes
+            // note: copy the test feature so that the uuid hint is in the feature sft
+            read.getID.toInt mustEqual proxy.evaluate(ScalaSimpleFeature.copy(sft, features(i)))
+          }
+          // verify that id is encoded as an int
+          val idVector = vector.underlying.getChild(SimpleFeatureVector.FeatureIdField)
+          idVector must beAnInstanceOf[NullableIntVector]
+          // check wrapping
+          WithClose(SimpleFeatureVector.wrap(vector.underlying, Map.empty)) { wrapped =>
+            wrapped.reader.getValueCount mustEqual features.length
+            forall(0 until 10) { i =>
+              val read = vector.reader.get(i)
+              read.getAttributes mustEqual features(i).getAttributes
+              // note: copy the test feature so that the uuid hint is in the feature sft
+              read.getID.toInt mustEqual proxy.evaluate(ScalaSimpleFeature.copy(sft, features(i)))
+            }
+          }
+        }
+      }
+    }
     "set and get null values" >> {
-      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.min(true))) { vector =>
+      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.min(includeFids = true))) { vector =>
         val nulls = features.map(ScalaSimpleFeature.copy)
         (0 until sft.getAttributeCount).foreach(i => nulls.foreach(_.setAttribute(i, null)))
         nulls.zipWithIndex.foreach { case (f, i) => vector.writer.set(i, f) }
@@ -87,7 +141,7 @@ class SimpleFeatureVectorTest extends Specification {
       }
     }
     "exclude feature ids" >> {
-      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.min(false))) { vector =>
+      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.min(includeFids = false))) { vector =>
         features.zipWithIndex.foreach { case (f, i) => vector.writer.set(i, f) }
         vector.writer.setValueCount(features.length)
         vector.reader.getValueCount mustEqual features.length
@@ -109,7 +163,7 @@ class SimpleFeatureVectorTest extends Specification {
     }
     "set and get dictionary encoded values" >> {
       val dictionary = Map("name" -> ArrowDictionary.create(0, Array("name00", "name01")))
-      WithClose(SimpleFeatureVector.create(sft, dictionary, SimpleFeatureEncoding.max(true))) { vector =>
+      WithClose(SimpleFeatureVector.create(sft, dictionary, SimpleFeatureEncoding.Max)) { vector =>
         features.zipWithIndex.foreach { case (f, i) => vector.writer.set(i, f) }
         vector.writer.setValueCount(features.length)
         vector.reader.getValueCount mustEqual features.length
@@ -123,7 +177,7 @@ class SimpleFeatureVectorTest extends Specification {
     }
     "set and get null dictionary values" >> {
       val dictionary = Map("name" -> ArrowDictionary.create(0, Array("name00", "name01", null)))
-      WithClose(SimpleFeatureVector.create(sft, dictionary, SimpleFeatureEncoding.min(true))) { vector =>
+      WithClose(SimpleFeatureVector.create(sft, dictionary, SimpleFeatureEncoding.min(includeFids = true))) { vector =>
         val nulls = features.map(ScalaSimpleFeature.copy)
         (0 until sft.getAttributeCount).foreach(i => nulls.foreach(_.setAttribute(i, null)))
         nulls.zipWithIndex.foreach { case (f, i) => vector.writer.set(i, f) }
@@ -139,7 +193,7 @@ class SimpleFeatureVectorTest extends Specification {
     }
     "set and get dictionary encoded ints" >> {
       val dictionary = Map("age" -> ArrowDictionary.create(0, Array(0, 1, 2, 3, 4, 5).map(Int.box)))
-      WithClose(SimpleFeatureVector.create(sft, dictionary, SimpleFeatureEncoding.max(true))) { vector =>
+      WithClose(SimpleFeatureVector.create(sft, dictionary, SimpleFeatureEncoding.Max)) { vector =>
         features.zipWithIndex.foreach { case (f, i) => vector.writer.set(i, f) }
         vector.writer.setValueCount(features.length)
         vector.reader.getValueCount mustEqual features.length
@@ -161,7 +215,7 @@ class SimpleFeatureVectorTest extends Specification {
         val tags = Map(s"a$i" -> s"av$i", s"b$i" -> s"bv$i").asJava
         ScalaSimpleFeature.create(sft, s"0$i", s"name0${i % 2}", tags, dates, s"POINT (4$i 5$i)")
       }
-      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.max(true))) { vector =>
+      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.Max)) { vector =>
         features.zipWithIndex.foreach { case (f, i) => vector.writer.set(i, f) }
         vector.writer.setValueCount(features.length)
         vector.reader.getValueCount mustEqual features.length
@@ -180,7 +234,7 @@ class SimpleFeatureVectorTest extends Specification {
         ScalaSimpleFeature.create(sft, s"$i", s"LINESTRING (30 10, 1$i 30, 40 40)",
           s"POLYGON ((30 10, 4$i 40, 20 40, 10 20, 30 10))", s"POINT (4$i 5$i)")
       }
-      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.max(true))) { vector =>
+      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.Max)) { vector =>
         features.zipWithIndex.foreach { case (f, i) => vector.writer.set(i, f) }
         vector.writer.setValueCount(features.length)
         vector.reader.getValueCount mustEqual features.length
@@ -197,7 +251,7 @@ class SimpleFeatureVectorTest extends Specification {
       }
     }
     "clear" >> {
-      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.min(true))) { vector =>
+      WithClose(SimpleFeatureVector.create(sft, Map.empty, SimpleFeatureEncoding.min(includeFids = true))) { vector =>
         features.zipWithIndex.foreach { case (f, i) => vector.writer.set(i, f) }
         vector.writer.setValueCount(features.length)
         vector.reader.getValueCount mustEqual features.length

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraFeature.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraFeature.scala
@@ -1,5 +1,6 @@
 /***********************************************************************
- * Copyright (c) 2017 IBM
+ * Copyright (c) 2017-2018 IBM
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at
@@ -8,11 +9,25 @@
 
 package org.locationtech.geomesa.cassandra.data
 
+import org.locationtech.geomesa.features.SerializationOption.SerializationOptions
 import org.locationtech.geomesa.features.SimpleFeatureSerializer
-import org.locationtech.geomesa.cassandra.index.CassandraFeatureIndex
-import org.locationtech.geomesa.index.api.WrappedFeature
-import org.opengis.feature.simple.SimpleFeature
+import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
+import org.locationtech.geomesa.index.api.{GeoMesaFeatureIndex, WrappedFeature}
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
-class CassandraFeature(val feature: SimpleFeature, serializer: SimpleFeatureSerializer) extends WrappedFeature {
-  lazy val fullValue = serializer.serialize(feature)
+class CassandraFeature(val feature: SimpleFeature,
+                       serializer: SimpleFeatureSerializer,
+                       idSerializer: (String) => Array[Byte]) extends WrappedFeature {
+  lazy val fullValue: Array[Byte] = serializer.serialize(feature)
+
+  override lazy val idBytes: Array[Byte] = idSerializer.apply(feature.getID)
+}
+
+object CassandraFeature {
+
+  def wrapper(sft: SimpleFeatureType): (SimpleFeature) => CassandraFeature = {
+    val serializer = KryoFeatureSerializer(sft, SerializationOptions.withoutId)
+    val idSerializer = GeoMesaFeatureIndex.idToBytes(sft)
+    (feature) => new CassandraFeature(feature, serializer, idSerializer)
+  }
 }

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraFeatureWriter.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraFeatureWriter.scala
@@ -11,8 +11,6 @@ package org.locationtech.geomesa.cassandra.data
 
 import com.datastax.driver.core.querybuilder._
 import org.locationtech.geomesa.cassandra._
-import org.locationtech.geomesa.features.SerializationOption.SerializationOptions
-import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 
@@ -28,7 +26,8 @@ class CassandraModifyFeatureWriter(sft: SimpleFeatureType,
     extends CassandraFeatureWriterType(sft, ds, indices) with CassandraModifyFeatureWriterType with CassandraFeatureWriter
 
 trait CassandraFeatureWriter extends CassandraFeatureWriterType {
-  private val serializer = KryoFeatureSerializer(sft, SerializationOptions.withoutId)
+
+  private val wrapper = CassandraFeature.wrapper(sft)
 
   override protected def createMutators(tables: IndexedSeq[String]): IndexedSeq[String] = tables
 
@@ -52,5 +51,5 @@ trait CassandraFeatureWriter extends CassandraFeatureWriterType {
     }
   }
 
-  override def wrapFeature(feature: SimpleFeature): CassandraFeature = new CassandraFeature(feature, serializer)
+  override def wrapFeature(feature: SimpleFeature): CassandraFeature = wrapper(feature)
 }

--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/function/ProxyIdFunctionTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/function/ProxyIdFunctionTest.scala
@@ -33,7 +33,7 @@ class ProxyIdFunctionTest extends Specification {
       fn.evaluate(sf2) must not(beEqualTo(result))
     }
     "consistently and uniquely evaluate uuids" >> {
-      val sft = SimpleFeatureTypes.createType("foo", s"name:String,dtg:Date,*geom:Point:srid=4326;${Configs.UUID_KEY}=true")
+      val sft = SimpleFeatureTypes.createType("foo", s"name:String,dtg:Date,*geom:Point:srid=4326;${Configs.FID_UUID_KEY}=true")
       val sf1 = ScalaSimpleFeature.create(sft, "28a12c18-e5ae-4c04-ae7b-bf7cdbfaf234", "foo", "2017-01-01T00:00:00.000Z", "POINT (45 50)")
       val sf2 = ScalaSimpleFeature.create(sft, "28a12c18-e5ae-4c04-ae7b-bf7cdbfaf235", "foo", "2017-01-01T00:00:00.000Z", "POINT (45 50)")
       val fn = new ProxyIdFunction()
@@ -43,7 +43,7 @@ class ProxyIdFunctionTest extends Specification {
       fn.evaluate(sf2) must not(beEqualTo(result))
     }
     "fail for invalid uuids" >> {
-      val sft = SimpleFeatureTypes.createType("foo", s"name:String,dtg:Date,*geom:Point:srid=4326;${Configs.UUID_KEY}=true")
+      val sft = SimpleFeatureTypes.createType("foo", s"name:String,dtg:Date,*geom:Point:srid=4326;${Configs.FID_UUID_KEY}=true")
       val sf1 = ScalaSimpleFeature.create(sft, "not a uuid", "foo", "2017-01-01T00:00:00.000Z", "POINT (45 50)")
       val fn = new ProxyIdFunction()
       fn.setParameters(Collections.emptyList())

--- a/geomesa-hbase/geomesa-hbase-jobs/src/main/scala/org/locationtech/geomesa/hbase/jobs/GeoMesaHBaseInputFormat.scala
+++ b/geomesa-hbase/geomesa-hbase-jobs/src/main/scala/org/locationtech/geomesa/hbase/jobs/GeoMesaHBaseInputFormat.scala
@@ -19,7 +19,7 @@ import org.apache.hadoop.mapreduce._
 import org.geotools.filter.identity.FeatureIdImpl
 import org.geotools.filter.text.ecql.ECQL
 import org.geotools.process.vector.TransformProcess
-import org.locationtech.geomesa.hbase.data.{HBaseConnectionPool, HBaseDataStoreFactory}
+import org.locationtech.geomesa.hbase.data.HBaseConnectionPool
 import org.locationtech.geomesa.hbase.index.HBaseFeatureIndex
 import org.locationtech.geomesa.jobs.GeoMesaConfigurator
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -123,7 +123,7 @@ class HBaseGeoMesaRecordReader(sft: SimpleFeatureType,
       val row = reader.getCurrentKey
       val offset = row.getOffset
       val length = row.getLength
-      staged.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(row.get(), offset, length))
+      staged.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(row.get(), offset, length, staged))
       true
     } else {
       false

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/WrappedFeature.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/WrappedFeature.scala
@@ -9,7 +9,9 @@
 package org.locationtech.geomesa.index.api
 
 import java.nio.charset.StandardCharsets
+import java.util.UUID
 
+import org.locationtech.geomesa.utils.index.ByteArrays
 import org.opengis.feature.simple.SimpleFeature
 
 import scala.util.hashing.MurmurHash3
@@ -28,12 +30,14 @@ trait WrappedFeature {
   def feature: SimpleFeature
 
   /**
-    * Hash of the simple feature ID - can be used for sharding
-    */
-  lazy val idHash: Int = Math.abs(MurmurHash3.stringHash(feature.getID))
-
-  /**
     * Feature ID bytes
     */
-  lazy val idBytes: Array[Byte] = feature.getID.getBytes(StandardCharsets.UTF_8)
+  def idBytes: Array[Byte]
+
+  /**
+    * Hash of the simple feature ID - can be used for sharding.
+    *
+    * Note: we could use the idBytes here, but for back compatibility of deletes we don't want to change it
+    */
+  lazy val idHash: Int = Math.abs(MurmurHash3.stringHash(feature.getID))
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryHints.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryHints.scala
@@ -47,6 +47,7 @@ object QueryHints {
 
   val ARROW_ENCODE             = new ClassKey(classOf[java.lang.Boolean])
   val ARROW_INCLUDE_FID        = new ClassKey(classOf[java.lang.Boolean])
+  val ARROW_PROXY_FID          = new ClassKey(classOf[java.lang.Boolean])
   val ARROW_BATCH_SIZE         = new ClassKey(classOf[java.lang.Integer])
   val ARROW_SORT_FIELD         = new ClassKey(classOf[java.lang.String])
   val ARROW_SORT_REVERSE       = new ClassKey(classOf[java.lang.Boolean])
@@ -122,6 +123,7 @@ object QueryHints {
     def isArrowMultiFile: Boolean = Option(hints.get(ARROW_MULTI_FILE).asInstanceOf[java.lang.Boolean]).exists(Boolean.unbox)
     def isArrowDoublePass: Boolean = Option(hints.get(ARROW_DOUBLE_PASS).asInstanceOf[java.lang.Boolean]).exists(Boolean.unbox)
     def isArrowIncludeFid: Boolean = Option(hints.get(ARROW_INCLUDE_FID).asInstanceOf[java.lang.Boolean]).forall(Boolean.unbox)
+    def isArrowProxyFid: Boolean = Option(hints.get(ARROW_PROXY_FID).asInstanceOf[java.lang.Boolean]).exists(Boolean.unbox)
     def getArrowDictionaryFields: Seq[String] =
       Option(hints.get(ARROW_DICTIONARY_FIELDS).asInstanceOf[String]).toSeq.flatMap(_.split(",")).map(_.trim).filter(_.nonEmpty)
     def isArrowCachedDictionaries: Boolean =

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/BaseFeatureIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/BaseFeatureIndex.scala
@@ -8,9 +8,6 @@
 
 package org.locationtech.geomesa.index.index
 
-import java.nio.charset.StandardCharsets
-
-import com.google.common.primitives.Bytes
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.factory.Hints
 import org.locationtech.geomesa.filter._
@@ -19,6 +16,7 @@ import org.locationtech.geomesa.index.conf.splitter.DefaultSplitter
 import org.locationtech.geomesa.index.conf.{QueryProperties, TableSplitter}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.utils.{Explainer, SplitArrays}
+import org.locationtech.geomesa.utils.index.ByteArrays
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 
@@ -55,12 +53,13 @@ trait BaseFeatureIndex[DS <: GeoMesaDataStore[DS, F, W], F <: WrappedFeature, W,
                         wrapper: F): Array[Byte] = {
     val split = shards(wrapper.idHash % shards.length)
     val indexKey = toIndexKey(wrapper.feature)
-    Bytes.concat(sharing, split, indexKey, wrapper.idBytes)
+    ByteArrays.concat(sharing, split, indexKey, wrapper.idBytes)
   }
 
-  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int) => String = {
+  override def getIdFromRow(sft: SimpleFeatureType): (Array[Byte], Int, Int, SimpleFeature) => String = {
+    val idFromBytes = GeoMesaFeatureIndex.idFromBytes(sft)
     val start = keySpace.indexKeyLength + (if (sft.isTableSharing) { 2 } else { 1 }) // key + table sharing + shard
-    (row, offset, length) => new String(row, offset + start, length - start, StandardCharsets.UTF_8)
+    (row, offset, length, feature) => idFromBytes(row, offset + start, length - start, feature)
   }
 
   override def getSplits(sft: SimpleFeatureType): Seq[Array[Byte]] = {
@@ -75,7 +74,7 @@ trait BaseFeatureIndex[DS <: GeoMesaDataStore[DS, F, W], F <: WrappedFeature, W,
     val splits = nonEmpty(splitter.getSplits(sft, name, sft.getTableSplitterOptions))
 
     val result = for (shard <- shards; split <- splits) yield {
-      Bytes.concat(sharing, shard, split)
+      ByteArrays.concat(sharing, shard, split)
     }
 
     // if not sharing, or the first feature in the table, drop the first split, which will otherwise be empty
@@ -106,9 +105,9 @@ trait BaseFeatureIndex[DS <: GeoMesaDataStore[DS, F, W], F <: WrappedFeature, W,
 
       case Some(values) =>
         val splits = SplitArrays(sft)
-        val prefixes = if (sharing.length == 0) { splits } else { splits.map(Bytes.concat(sharing, _)) }
+        val prefixes = if (sharing.length == 0) { splits } else { splits.map(ByteArrays.concat(sharing, _)) }
         keySpace.getRanges(sft, values).flatMap { case (s, e) =>
-          prefixes.map(p => range(Bytes.concat(p, s), Bytes.concat(p, e)))
+          prefixes.map(p => range(ByteArrays.concat(p, s), ByteArrays.concat(p, e)))
         }.toSeq
     }
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/ClientSideFiltering.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/ClientSideFiltering.scala
@@ -94,8 +94,7 @@ trait ClientSideFiltering[R] {
     (result) => {
       val RowAndValue(row, rowOffset, rowLength, value, valueOffset, valueLength) = rowAndValue(result)
       val sf = deserializer.deserialize(value, valueOffset, valueLength)
-      val id = getId(row, rowOffset, rowLength)
-      sf.getIdentifier.asInstanceOf[FeatureIdImpl].setID(id)
+      sf.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(row, rowOffset, rowLength, sf))
       sf
     }
   }
@@ -113,8 +112,7 @@ trait ClientSideFiltering[R] {
     (result) => {
       val RowAndValue(row, rowOffset, rowLength, value, valueOffset, valueLength) = rowAndValue(result)
       val sf = deserializer.deserialize(value, valueOffset, valueLength)
-      val id = getId(row, rowOffset, rowLength)
-      sf.getIdentifier.asInstanceOf[FeatureIdImpl].setID(id)
+      sf.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(row, rowOffset, rowLength, sf))
       Some(sf).filter(ecql.evaluate)
     }
   }
@@ -138,8 +136,8 @@ trait ClientSideFiltering[R] {
       val reusableSf = KryoFeatureSerializer(sft, SerializationOptions.withoutId).getReusableFeature
       (result) => {
         val RowAndValue(row, rowOffset, rowLength, value, valueOffset, valueLength) = rowAndValue(result)
-        val id = getId(row, rowOffset, rowLength)
         reusableSf.setBuffer(value, valueOffset, valueLength)
+        val id = getId(row, rowOffset, rowLength, reusableSf)
         reusableSf.setId(id)
         val values = transforms.map(_.expression.evaluate(reusableSf))
         new ScalaSimpleFeature(transformSft, id, values)
@@ -150,8 +148,7 @@ trait ClientSideFiltering[R] {
       (result) => {
         val RowAndValue(row, rowOffset, rowLength, value, valueOffset, valueLength) = rowAndValue(result)
         val sf = deserializer.deserialize(value, valueOffset, valueLength)
-        val id = getId(row, rowOffset, rowLength)
-        sf.getIdentifier.asInstanceOf[FeatureIdImpl].setID(id)
+        sf.getIdentifier.asInstanceOf[FeatureIdImpl].setID(getId(row, rowOffset, rowLength, sf))
         sf
       }
     }
@@ -168,10 +165,10 @@ trait ClientSideFiltering[R] {
     * @return
     */
   def toFeaturesWithFilterTransform(sft: SimpleFeatureType,
-                                            ecql: Filter,
-                                            transforms: Array[Definition],
-                                            indices: Array[Int],
-                                            transformSft: SimpleFeatureType): EVALFEATUREOPTION = {
+                                    ecql: Filter,
+                                    transforms: Array[Definition],
+                                    indices: Array[Int],
+                                    transformSft: SimpleFeatureType): EVALFEATUREOPTION = {
     val getId = getIdFromRow(sft)
     if (indices.contains(-1)) {
       // need to evaluate the expressions against the original feature
@@ -180,7 +177,7 @@ trait ClientSideFiltering[R] {
       (result) => {
         val RowAndValue(row, rowOffset, rowLength, value, valueOffset, valueLength) = rowAndValue(result)
         val sf = deserializer.deserialize(value, valueOffset, valueLength)
-        val id = getId(row, rowOffset, rowLength)
+        val id = getId(row, rowOffset, rowLength, sf)
         sf.getIdentifier.asInstanceOf[FeatureIdImpl].setID(id)
         if (ecql.evaluate(sf)) {
           val values = transforms.map(_.expression.evaluate(sf))
@@ -194,8 +191,8 @@ trait ClientSideFiltering[R] {
       val reusableSf = KryoFeatureSerializer(sft, SerializationOptions.withoutId).getReusableFeature
       (result) => {
         val RowAndValue(row, rowOffset, rowLength, value, valueOffset, valueLength) = rowAndValue(result)
-        val id = getId(row, rowOffset, rowLength)
         reusableSf.setBuffer(value, valueOffset, valueLength)
+        val id = getId(row, rowOffset, rowLength, reusableSf)
         reusableSf.setId(id)
         if (ecql.evaluate(reusableSf)) {
           val values = indices.map(reusableSf.getAttribute)

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/IndexAdapter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/IndexAdapter.scala
@@ -17,7 +17,7 @@ import com.typesafe.scalalogging.{LazyLogging, Logger}
 import org.geotools.factory.Hints
 import org.locationtech.geomesa.index.api.{FilterStrategy, QueryPlan, WrappedFeature}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
-import org.locationtech.geomesa.index.utils.ByteArrays
+import org.locationtech.geomesa.utils.index.ByteArrays
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/XZ2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/XZ2IndexKeySpace.scala
@@ -14,8 +14,9 @@ import org.locationtech.geomesa.curve.XZ2SFC
 import org.locationtech.geomesa.filter.FilterValues
 import org.locationtech.geomesa.index.conf.QueryProperties
 import org.locationtech.geomesa.index.index.IndexKeySpace
-import org.locationtech.geomesa.index.utils.{ByteArrays, Explainer}
+import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.utils.geotools.{GeometryUtils, WholeWorldPolygon}
+import org.locationtech.geomesa.utils.index.ByteArrays
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/Z2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/Z2IndexKeySpace.scala
@@ -14,8 +14,9 @@ import org.locationtech.geomesa.curve.Z2SFC
 import org.locationtech.geomesa.filter.FilterValues
 import org.locationtech.geomesa.index.conf.QueryProperties
 import org.locationtech.geomesa.index.index.IndexKeySpace
-import org.locationtech.geomesa.index.utils.{ByteArrays, Explainer}
+import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.utils.geotools.{GeometryUtils, WholeWorldPolygon}
+import org.locationtech.geomesa.utils.index.ByteArrays
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3IndexKeySpace.scala
@@ -16,8 +16,9 @@ import org.locationtech.geomesa.curve.{BinnedTime, XZ3SFC}
 import org.locationtech.geomesa.filter.FilterValues
 import org.locationtech.geomesa.index.conf.QueryProperties
 import org.locationtech.geomesa.index.index.IndexKeySpace
-import org.locationtech.geomesa.index.utils.{ByteArrays, Explainer}
+import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.utils.geotools.{GeometryUtils, WholeWorldPolygon}
+import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.sfcurve.IndexRange
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3IndexKeySpace.scala
@@ -17,8 +17,9 @@ import org.locationtech.geomesa.curve.{BinnedTime, Z3SFC}
 import org.locationtech.geomesa.filter.FilterValues
 import org.locationtech.geomesa.index.conf.QueryProperties
 import org.locationtech.geomesa.index.index.IndexKeySpace
-import org.locationtech.geomesa.index.utils.{ByteArrays, Explainer}
+import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.utils.geotools.{GeometryUtils, WholeWorldPolygon}
+import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.sfcurve.IndexRange
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/InMemoryQueryRunner.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/InMemoryQueryRunner.scala
@@ -150,7 +150,7 @@ abstract class InMemoryQueryRunner(stats: GeoMesaStats, authProvider: Option[Aut
 
     val sort = hints.getArrowSort
     val batchSize = ArrowScan.getBatchSize(hints)
-    val encoding = SimpleFeatureEncoding.min(hints.isArrowIncludeFid)
+    val encoding = SimpleFeatureEncoding.min(hints.isArrowIncludeFid, hints.isArrowProxyFid)
 
     val (features, arrowSft) = hints.getTransform match {
       case None =>

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/TestGeoMesaDataStore.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/TestGeoMesaDataStore.scala
@@ -8,6 +8,7 @@
 
 package org.locationtech.geomesa.index
 
+import java.nio.charset.StandardCharsets
 import java.util.Comparator
 
 import org.geotools.data.{Query, Transaction}
@@ -77,7 +78,9 @@ object TestGeoMesaDataStore {
     }
   }
 
-  case class TestWrappedFeature(feature: SimpleFeature) extends WrappedFeature
+  case class TestWrappedFeature(feature: SimpleFeature) extends WrappedFeature {
+    override lazy val idBytes: Array[Byte] = feature.getID.getBytes(StandardCharsets.UTF_8)
+  }
 
   case class TestWrite(row: Array[Byte], feature: SimpleFeature, delete: Boolean = false)
 

--- a/geomesa-lambda/geomesa-lambda-datastore/src/main/scala/org/locationtech/geomesa/lambda/data/LambdaQueryRunner.scala
+++ b/geomesa-lambda/geomesa-lambda-datastore/src/main/scala/org/locationtech/geomesa/lambda/data/LambdaQueryRunner.scala
@@ -78,7 +78,7 @@ class LambdaQueryRunner(persistence: DataStore, transients: LoadingCache[String,
 
       val sort = hints.getArrowSort
       val batchSize = ArrowScan.getBatchSize(hints)
-      val encoding = SimpleFeatureEncoding.min(hints.isArrowIncludeFid)
+      val encoding = SimpleFeatureEncoding.min(hints.isArrowIncludeFid, hints.isArrowProxyFid)
 
       val dictionaryFields = hints.getArrowDictionaryFields
       val providedDictionaries = hints.getArrowDictionaryEncodedValues(sft)

--- a/geomesa-process/geomesa-process-vector/src/test/scala/org/locationtech/geomesa/process/transform/ArrowConversionProcessTest.scala
+++ b/geomesa-process/geomesa-process-vector/src/test/scala/org/locationtech/geomesa/process/transform/ArrowConversionProcessTest.scala
@@ -42,7 +42,7 @@ class ArrowConversionProcessTest extends Specification {
 
   "ArrowConversionProcess" should {
     "encode an empty feature collection" in {
-      val bytes = process.execute(new ListFeatureCollection(sft), null, null, null, null, null, null, null).reduce(_ ++ _)
+      val bytes = process.execute(new ListFeatureCollection(sft), null, null, null, null, null, null, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()) must beEmpty
@@ -50,7 +50,7 @@ class ArrowConversionProcessTest extends Specification {
     }
 
     "encode a generic feature collection" in {
-      val bytes = process.execute(collection, null, null, null, null, null, null, null).reduce(_ ++ _)
+      val bytes = process.execute(collection, null, null, null, null, null, null, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
@@ -59,7 +59,7 @@ class ArrowConversionProcessTest extends Specification {
     }
 
     "encode a generic feature collection with dictionary values" in {
-      val bytes = process.execute(collection, null, Seq("name"), null, null, null, null, null).reduce(_ ++ _)
+      val bytes = process.execute(collection, null, null, Seq("name"), null, null, null, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
@@ -69,12 +69,12 @@ class ArrowConversionProcessTest extends Specification {
     }
 
     "encode a generic feature collection with sorting" in {
-      val ascending = process.execute(collection, null, null, null, "dtg", null, null, null).reduce(_ ++ _)
+      val ascending = process.execute(collection, null, null, null, null, "dtg", null, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(ascending))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq mustEqual features
       }
-      val descending = process.execute(collection, null, null, null, "dtg", true, null, null).reduce(_ ++ _)
+      val descending = process.execute(collection, null, null, null, null, "dtg", true, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(descending))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq mustEqual features.reverse
@@ -82,13 +82,13 @@ class ArrowConversionProcessTest extends Specification {
     }
 
     "encode a generic feature collection with sorting and dictionary values" in {
-      val ascending = process.execute(collection, null, Seq("name"), null, "dtg", null, null, null).reduce(_ ++ _)
+      val ascending = process.execute(collection, null, null, Seq("name"), null, "dtg", null, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(ascending))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq mustEqual features
         reader.dictionaries.get("name") must beSome
       }
-      val descending = process.execute(collection, null, Seq("name"), null, "dtg", true, null, null).reduce(_ ++ _)
+      val descending = process.execute(collection, null, null, Seq("name"), null, "dtg", true, null, null).reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(descending))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq mustEqual features.reverse

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/ArrowExporter.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/formats/ArrowExporter.scala
@@ -43,7 +43,7 @@ class ArrowExporter(hints: Hints, os: OutputStream, queryDictionaries: => Map[St
     if (sft == org.locationtech.geomesa.arrow.ArrowEncodedSft) {
       doExport = exportEncoded
     } else {
-      val encoding = SimpleFeatureEncoding.min(hints.isArrowIncludeFid)
+      val encoding = SimpleFeatureEncoding.min(hints.isArrowIncludeFid, hints.isArrowProxyFid)
       val sort = hints.getArrowSort
       val batchSize = hints.getArrowBatchSize.getOrElse(ArrowProperties.BatchSize.get.toInt)
       val dictionaryFields = hints.getArrowDictionaryFields

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -295,8 +295,9 @@ object RichSimpleFeatureType {
     def setAttributeShards(splits: Int): Unit = sft.getUserData.put(ATTR_SPLITS_KEY, splits.toString)
     def getAttributeShards: Int = userData[String](ATTR_SPLITS_KEY).map(_.toInt).getOrElse(4)
 
-    def setUuid(uuid: Boolean): Unit = sft.getUserData.put(UUID_KEY, String.valueOf(uuid))
-    def isUuid: Boolean = userData[String](UUID_KEY).exists(java.lang.Boolean.parseBoolean)
+    def setUuid(uuid: Boolean): Unit = sft.getUserData.put(FID_UUID_KEY, String.valueOf(uuid))
+    def isUuid: Boolean = userData[String](FID_UUID_KEY).exists(java.lang.Boolean.parseBoolean)
+    def isUuidEncoded: Boolean = isUuid && userData[String](FID_UUID_ENCODED_KEY).forall(java.lang.Boolean.parseBoolean)
 
     def getKeywords: Set[String] =
       userData[String](KEYWORDS_KEY).map(_.split(KEYWORDS_DELIMITER).toSet).getOrElse(Set.empty)

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
@@ -26,28 +26,29 @@ object SimpleFeatureTypes {
   import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors._
 
   object Configs {
-    val TABLE_SHARING_KEY   = "geomesa.table.sharing"
-    val DEFAULT_DATE_KEY    = "geomesa.index.dtg"
-    val IGNORE_INDEX_DTG    = "geomesa.ignore.dtg"
-    val VIS_LEVEL_KEY       = "geomesa.visibility.level"
-    val Z3_INTERVAL_KEY     = "geomesa.z3.interval"
-    val XZ_PRECISION_KEY    = "geomesa.xz.precision"
-    val TABLE_SPLITTER      = "table.splitter.class"
-    val TABLE_SPLITTER_OPTS = "table.splitter.options"
-    val MIXED_GEOMETRIES    = "geomesa.mixed.geometries"
-    val RESERVED_WORDS      = "override.reserved.words" // note: doesn't start with geomesa so we don't persist it
-    val DEFAULT_DTG_JOIN    = "override.index.dtg.join"
-    val KEYWORDS_KEY        = "geomesa.keywords"
-    val ENABLED_INDICES     = "geomesa.indices.enabled"
+    val TABLE_SHARING_KEY    = "geomesa.table.sharing"
+    val DEFAULT_DATE_KEY     = "geomesa.index.dtg"
+    val IGNORE_INDEX_DTG     = "geomesa.ignore.dtg"
+    val VIS_LEVEL_KEY        = "geomesa.visibility.level"
+    val Z3_INTERVAL_KEY      = "geomesa.z3.interval"
+    val XZ_PRECISION_KEY     = "geomesa.xz.precision"
+    val TABLE_SPLITTER       = "table.splitter.class"
+    val TABLE_SPLITTER_OPTS  = "table.splitter.options"
+    val MIXED_GEOMETRIES     = "geomesa.mixed.geometries"
+    val RESERVED_WORDS       = "override.reserved.words" // note: doesn't start with geomesa so we don't persist it
+    val DEFAULT_DTG_JOIN     = "override.index.dtg.join"
+    val KEYWORDS_KEY         = "geomesa.keywords"
+    val ENABLED_INDICES      = "geomesa.indices.enabled"
     // keep around old values for back compatibility
-    val ENABLED_INDEX_OPTS  = Seq(ENABLED_INDICES, "geomesa.indexes.enabled", "table.indexes.enabled")
-    val ST_INDEX_SCHEMA_KEY = "geomesa.index.st.schema"
-    val Z_SPLITS_KEY        = "geomesa.z.splits"
-    val ATTR_SPLITS_KEY     = "geomesa.attr.splits"
-    val LOGICAL_TIME_KEY    = "geomesa.logical.time"
-    val COMPRESSION_ENABLED = "geomesa.table.compression.enabled"
-    val COMPRESSION_TYPE    = "geomesa.table.compression.type"  // valid: snappy, lzo, gz(default), bzip2, lz4, zstd
-    val UUID_KEY            = "geomesa.fid.uuid"
+    val ENABLED_INDEX_OPTS   = Seq(ENABLED_INDICES, "geomesa.indexes.enabled", "table.indexes.enabled")
+    val ST_INDEX_SCHEMA_KEY  = "geomesa.index.st.schema"
+    val Z_SPLITS_KEY         = "geomesa.z.splits"
+    val ATTR_SPLITS_KEY      = "geomesa.attr.splits"
+    val LOGICAL_TIME_KEY     = "geomesa.logical.time"
+    val COMPRESSION_ENABLED  = "geomesa.table.compression.enabled"
+    val COMPRESSION_TYPE     = "geomesa.table.compression.type"  // valid: snappy, lzo, gz(default), bzip2, lz4, zstd
+    val FID_UUID_KEY         = "geomesa.fid.uuid"
+    val FID_UUID_ENCODED_KEY = "geomesa.fid.uuid-encoded"
   }
 
   private [geomesa] object InternalConfigs {


### PR DESCRIPTION
* Feature IDs encoded as UUIDs can be specified by 'geomesa.fid.uuid=true'
  * If back-porting to existing data, also need to set 'geomesa.fid.uuid-encoded=false'
* UUIDs will be serialized as a 16-byte number instead of a 36-byte string
* Arrow results will encode UUIDs as pairs of longs
* Arrow results can specify proxy IDs encoded as ints

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>