### PR TITLE
GEOMESA-2191 System property to prevent full-table scans

### DIFF
--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -38,13 +38,6 @@ front, so estimates will cause problems. To force GeoMesa to calculate the exact
 set, you may set this property to ``true``. You may also override this behavior on a per-query basis
 by using the query hint ``org.locationtech.geomesa.accumulo.index.QueryHints.EXACT_COUNT``.
 
-geomesa.query.timeout
-+++++++++++++++++++++
-
-This property can be used to prevent long-running queries from overloading the system. When set,
-queries will be closed after the timeout, even if not all results have been returned yet. The
-timeout is specified as a duration, e.g. ``1 minute`` or ``30 seconds``.
-
 geomesa.scan.ranges.target
 ++++++++++++++++++++++++++
 
@@ -55,6 +48,25 @@ overwhelm clients, causing slowdowns. The optimal value depends on the environme
 queries against the Z3 or XZ3 index, the number of ranges will be multiplied by the number of time periods
 (e.g. weeks by default) being queried.
 
+geomesa.query.timeout
++++++++++++++++++++++
+
+This property can be used to prevent long-running queries from overloading the system. When set,
+queries will be closed after the timeout, even if not all results have been returned yet. The
+timeout is specified as a duration, e.g. ``1 minute`` or ``30 seconds``.
+
+geomesa.scan.block-full-table
++++++++++++++++++++++++++++++
+
+This property will prevent full-table scans from executing. A full-table scan is any query that can't be
+constrained down using a search index, and thus requires scanning the entire data set. With large data sets,
+such a scan can last a long time and be resource intensive. The property is specified as a Boolean, i.e.
+``true`` or ``false``.
+
+For more granularity, it is also possible to specify the full-table scan behavior for individual schemas
+(``SimpleFeatureTypes``). Use ``geomesa.scan.<type-name>.block-full-table``, where ``<type-name>`` is
+replaced with the schema name (e.g. "gdelt"). Properties set for an individual schema will take precedence
+over the globally-defined behavior.
 
 .. _stats_generate_config:
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/id/RecordQueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/id/RecordQueryableIndex.scala
@@ -17,12 +17,14 @@ import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloFeatur
 import org.locationtech.geomesa.accumulo.index._
 import org.locationtech.geomesa.accumulo.iterators._
 import org.locationtech.geomesa.filter._
+import org.locationtech.geomesa.index.conf.QueryProperties
 import org.locationtech.geomesa.index.iterators.StatsScan
 import org.locationtech.geomesa.index.strategies.IdFilterStrategy
 import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 import org.locationtech.geomesa.utils.index.VisibilityLevel
 import org.opengis.feature.simple.SimpleFeatureType
+import org.opengis.filter.Filter
 
 trait RecordQueryableIndex extends AccumuloFeatureIndex
     with IdFilterStrategy[AccumuloDataStore, AccumuloFeature, Mutation]
@@ -41,7 +43,8 @@ trait RecordQueryableIndex extends AccumuloFeatureIndex
 
     val ranges = filter.primary match {
       case None =>
-        // allow for full table scans
+        // check that full table scans are allowed
+        QueryProperties.BlockFullTableScans.onFullTableScan(sft.getTypeName, filter.filter.getOrElse(Filter.INCLUDE))
         filter.secondary.foreach { f =>
           logger.warn(s"Running full table scan for schema ${sft.getTypeName} with filter ${filterToString(f)}")
         }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategyTest.scala
@@ -244,12 +244,12 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       forall(qps)(_.iterators.map(_.getIteratorClass) must contain(classOf[BinAggregatingIterator].getCanonicalName))
 
       // reduce our scan ranges so that we get fewer iterator instances and some aggregation
-      QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.set("1")
+      QueryProperties.ScanRangesTarget.threadLocalValue.set("1")
       val aggregates = try {
         // the same simple feature gets reused - so make sure you access in serial order
         runQuery(query).map(f => f.getAttribute(BIN_ATTRIBUTE_INDEX).asInstanceOf[Array[Byte]]).toSeq
       } finally {
-        QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.remove()
+        QueryProperties.ScanRangesTarget.threadLocalValue.remove()
       }
       aggregates.size must beLessThan(10) // ensure some aggregation was done
       val bin = aggregates.flatMap(a => a.grouped(16).map(BinaryOutputEncoder.decode))
@@ -273,12 +273,12 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       forall(qps)(_.iterators.map(_.getIteratorClass) must contain(classOf[BinAggregatingIterator].getCanonicalName))
 
       // reduce our scan ranges so that we get fewer iterator instances and some aggregation
-      QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.set("1")
+      QueryProperties.ScanRangesTarget.threadLocalValue.set("1")
       val aggregates = try {
         // the same simple feature gets reused - so make sure you access in serial order
         runQuery(query).map(f => f.getAttribute(BIN_ATTRIBUTE_INDEX).asInstanceOf[Array[Byte]]).toSeq
       } finally {
-        QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.remove()
+        QueryProperties.ScanRangesTarget.threadLocalValue.remove()
       }
       aggregates.size must beLessThan(10) // ensure some aggregation was done
       forall(aggregates) { a =>
@@ -306,12 +306,12 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       forall(qps)(_.iterators.map(_.getIteratorClass) must contain(classOf[BinAggregatingIterator].getCanonicalName))
 
       // reduce our scan ranges so that we get fewer iterator instances and some aggregation
-      QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.set("1")
+      QueryProperties.ScanRangesTarget.threadLocalValue.set("1")
       val aggregates = try {
         // the same simple feature gets reused - so make sure you access in serial order
         runQuery(query).map(f => f.getAttribute(BIN_ATTRIBUTE_INDEX).asInstanceOf[Array[Byte]]).toSeq
       } finally {
-        QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.remove()
+        QueryProperties.ScanRangesTarget.threadLocalValue.remove()
       }
       aggregates.size must beLessThan(10) // ensure some aggregation was done
       val bin = aggregates.flatMap(a => a.grouped(24).map(BinaryOutputEncoder.decode))
@@ -335,12 +335,12 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       forall(qps)(_.iterators.map(_.getIteratorClass) must contain(classOf[BinAggregatingIterator].getCanonicalName))
 
       // reduce our scan ranges so that we get fewer iterator instances and some aggregation
-      QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.set("1")
+      QueryProperties.ScanRangesTarget.threadLocalValue.set("1")
       val aggregates = try {
         // the same simple feature gets reused - so make sure you access in serial order
         runQuery(query).map(f => f.getAttribute(BIN_ATTRIBUTE_INDEX).asInstanceOf[Array[Byte]]).toSeq
       } finally {
-        QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.remove()
+        QueryProperties.ScanRangesTarget.threadLocalValue.remove()
       }
       aggregates.size must beLessThan(10) // ensure some aggregation was done
       val bin = aggregates.flatMap(a => a.grouped(16).map(BinaryOutputEncoder.decode))
@@ -361,9 +361,9 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       val query = new Query(sftName, ECQL.toFilter(filter))
       query.getHints.put(SAMPLING, new java.lang.Float(.2f))
       // reduce our scan ranges so that we get fewer iterator instances and some sampling
-      QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.set("1")
+      QueryProperties.ScanRangesTarget.threadLocalValue.set("1")
       val results = try { runQuery(query).toList } finally {
-        QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.remove()
+        QueryProperties.ScanRangesTarget.threadLocalValue.remove()
       }
       results.length must beLessThan(10)
     }
@@ -374,9 +374,9 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       val query = new Query(sftName, ECQL.toFilter(filter), Array("name", "geom"))
       query.getHints.put(SAMPLING, new java.lang.Float(.2f))
       // reduce our scan ranges so that we get fewer iterator instances and some sampling
-      QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.set("1")
+      QueryProperties.ScanRangesTarget.threadLocalValue.set("1")
       val results = try { runQuery(query).toList } finally {
-        QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.remove()
+        QueryProperties.ScanRangesTarget.threadLocalValue.remove()
       }
       results.length must beLessThan(10)
       forall(results)(_.getAttributeCount mustEqual 2)
@@ -389,9 +389,9 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       query.getHints.put(SAMPLING, new java.lang.Float(.2f))
       query.getHints.put(SAMPLE_BY, "track")
       // reduce our scan ranges so that we get fewer iterator instances and some sampling
-      QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.set("1")
+      QueryProperties.ScanRangesTarget.threadLocalValue.set("1")
       val results = try { runQuery(query).toList } finally {
-        QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.remove()
+        QueryProperties.ScanRangesTarget.threadLocalValue.remove()
       }
       results.length must beLessThan(10)
     }
@@ -407,12 +407,12 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       query.getHints.put(SAMPLE_BY, "track")
 
       // reduce our scan ranges so that we get fewer iterator instances and some sampling
-      QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.set("1")
+      QueryProperties.ScanRangesTarget.threadLocalValue.set("1")
       val results = try {
         // have to evaluate attributes before pulling into collection, as the same sf is reused
         runQuery(query).map(_.getAttribute(BIN_ATTRIBUTE_INDEX)).toList
       } finally {
-        QueryProperties.SCAN_RANGES_TARGET.threadLocalValue.remove()
+        QueryProperties.ScanRangesTarget.threadLocalValue.remove()
       }
       forall(results)(_ must beAnInstanceOf[Array[Byte]])
       val bins = results.flatMap(_.asInstanceOf[Array[Byte]].grouped(16).map(BinaryOutputEncoder.decode))

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreTest.scala
@@ -17,6 +17,7 @@ import org.geotools.factory.Hints
 import org.geotools.filter.text.ecql.ECQL
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.hbase.data.HBaseDataStoreParams._
+import org.locationtech.geomesa.index.conf.QueryProperties
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.SimpleFeature
@@ -74,7 +75,8 @@ class HBaseDataStoreTest extends HBaseTest with LazyLogging {
           val settings = Map(LooseBBoxParam.getName -> loose, RemoteFilteringParam.getName -> remote)
           val ds = DataStoreFinder.getDataStore(params ++ settings).asInstanceOf[HBaseDataStore]
           foreach(transformsList) { transforms =>
-            testQuery(ds, typeName, "INCLUDE", transforms, toAdd)
+            // test that blocking full table scans doesn't interfere with regular queries
+            QueryProperties.BlockFullTableScans.threadLocalValue.set("true")
             testQuery(ds, typeName, "IN('0', '2')", transforms, Seq(toAdd(0), toAdd(2)))
             testQuery(ds, typeName, "bbox(geom,38,48,52,62) and dtg DURING 2014-01-01T00:00:00.000Z/2014-01-08T12:00:00.000Z", transforms, toAdd.dropRight(2))
             testQuery(ds, typeName, "bbox(geom,42,48,52,62) and dtg DURING 2013-12-15T00:00:00.000Z/2014-01-15T00:00:00.000Z", transforms, toAdd.drop(2))
@@ -83,6 +85,12 @@ class HBaseDataStoreTest extends HBaseTest with LazyLogging {
             testQuery(ds, typeName, "attr = 'name5' and bbox(geom,38,48,52,62) and dtg DURING 2014-01-01T00:00:00.000Z/2014-01-08T12:00:00.000Z", transforms, Seq(toAdd(5)))
             testQuery(ds, typeName, "name < 'name5'", transforms, toAdd.take(5))
             testQuery(ds, typeName, "name = 'name5'", transforms, Seq(toAdd(5)))
+
+            // this query should be blocked
+            testQuery(ds, typeName, "INCLUDE", transforms, toAdd) must throwA[RuntimeException]
+            QueryProperties.BlockFullTableScans.threadLocalValue.remove()
+            // now it should go through
+            testQuery(ds, typeName, "INCLUDE", transforms, toAdd)
           }
         }
       }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryHints.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryHints.scala
@@ -96,7 +96,7 @@ object QueryHints {
     def getRequestedIndex: Option[String] = Option(hints.get(QUERY_INDEX).asInstanceOf[String])
     def getCostEvaluation: CostEvaluation = {
       Option(hints.get(COST_EVALUATION).asInstanceOf[CostEvaluation])
-          .orElse(QueryProperties.QUERY_COST_TYPE.option.flatMap(t => CostEvaluation.values.find(_.toString.equalsIgnoreCase(t))))
+          .orElse(QueryProperties.QueryCostType.option.flatMap(t => CostEvaluation.values.find(_.toString.equalsIgnoreCase(t))))
           .getOrElse(CostEvaluation.Stats)
     }
     def isSkipReduce: Boolean = Option(hints.get(Internal.SKIP_REDUCE).asInstanceOf[java.lang.Boolean]).exists(_.booleanValue())

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryProperties.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryProperties.scala
@@ -8,16 +8,32 @@
 
 package org.locationtech.geomesa.index.conf
 
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties
 import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
+import org.opengis.filter.Filter
 
 object QueryProperties {
-  val QUERY_EXACT_COUNT  = SystemProperty("geomesa.force.count", "false")
-  val QUERY_COST_TYPE    = SystemProperty("geomesa.query.cost.type")
-  val QUERY_TIMEOUT      = SystemProperty("geomesa.query.timeout") // default is no timeout
-  // rough upper limit on the number of ranges we will generate per query
-  val SCAN_RANGES_TARGET = SystemProperty("geomesa.scan.ranges.target", "2000")
-}
 
-object StatsProperties {
-  val GENERATE_STATS = SystemProperty("geomesa.stats.generate", null)
+  val QueryExactCount = SystemProperty("geomesa.force.count", "false")
+  val QueryCostType   = SystemProperty("geomesa.query.cost.type")
+  val QueryTimeout    = SystemProperty("geomesa.query.timeout") // default is no timeout
+
+  // rough upper limit on the number of ranges we will generate per query
+  val ScanRangesTarget = SystemProperty("geomesa.scan.ranges.target", "2000")
+
+  // noinspection TypeAnnotation
+  // allow for full table scans or preempt them due to size of data set
+  val BlockFullTableScans = new SystemProperty("geomesa.scan.block-full-table", "false") {
+    def onFullTableScan(typeName: String, filter: Filter): Unit = {
+      val block =
+        Option(GeoMesaSystemProperties.getProperty(s"geomesa.scan.$typeName.block-full-table"))
+          .map(java.lang.Boolean.parseBoolean)
+          .orElse(toBoolean)
+          .getOrElse(false)
+      if (block) {
+        throw new RuntimeException(s"Full-table scans are disabled. Query being stopped for $typeName: " +
+            org.locationtech.geomesa.filter.filterToString(filter))
+      }
+    }
+  }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/StatsProperties.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/StatsProperties.scala
@@ -1,0 +1,15 @@
+/***********************************************************************
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.conf
+
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
+
+object StatsProperties {
+  val GenerateStats = SystemProperty("geomesa.stats.generate", null)
+}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreFactory.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreFactory.scala
@@ -19,8 +19,8 @@ import scala.concurrent.duration.Duration
 
 object GeoMesaDataStoreFactory {
 
-  private val GenerateStatsSysParam = SystemPropertyBooleanParam(StatsProperties.GENERATE_STATS)
-  private val TimeoutSysParam = SystemPropertyDurationParam(QueryProperties.QUERY_TIMEOUT)
+  private val GenerateStatsSysParam = SystemPropertyBooleanParam(StatsProperties.GenerateStats)
+  private val TimeoutSysParam = SystemPropertyDurationParam(QueryProperties.QueryTimeout)
 
   private val DeprecatedTimeout = ConvertedParam[Duration, java.lang.Long]("queryTimeout", (v) => Duration(v, TimeUnit.SECONDS))
   private val DeprecatedAccumuloTimeout = ConvertedParam[Duration, java.lang.Long]("accumulo.queryTimeout", (v) => Duration(v, TimeUnit.SECONDS))

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureSource.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureSource.scala
@@ -60,9 +60,9 @@ class GeoMesaFeatureSource(val ds: DataStore with HasGeoMesaStats,
    */
   override def getCount(query: Query): Int = {
     import org.locationtech.geomesa.index.conf.QueryHints.RichHints
-    import org.locationtech.geomesa.index.conf.QueryProperties.QUERY_EXACT_COUNT
+    import org.locationtech.geomesa.index.conf.QueryProperties.QueryExactCount
 
-    val useExactCount = query.getHints.isExactCount.getOrElse(QUERY_EXACT_COUNT.get.toBoolean)
+    val useExactCount = query.getHints.isExactCount.getOrElse(QueryExactCount.get.toBoolean)
     lazy val exactCount = ds.stats.getCount(getSchema, query.getFilter, exact = true).getOrElse(-1L)
 
     val count = if (useExactCount) { exactCount } else {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/XZ2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/XZ2IndexKeySpace.scala
@@ -68,7 +68,7 @@ trait XZ2IndexKeySpace extends IndexKeySpace[XZ2IndexValues] {
 
   override def getRanges(sft: SimpleFeatureType, indexValues: XZ2IndexValues): Iterator[(Array[Byte], Array[Byte])] = {
     val XZ2IndexValues(sfc, _, xy) = indexValues
-    val zs = sfc.ranges(xy, QueryProperties.SCAN_RANGES_TARGET.option.map(_.toInt))
+    val zs = sfc.ranges(xy, QueryProperties.ScanRangesTarget.option.map(_.toInt))
     zs.iterator.map(r => (Longs.toByteArray(r.lower), ByteArrays.toBytesFollowingPrefix(r.upper)))
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/Z2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/Z2IndexKeySpace.scala
@@ -73,7 +73,7 @@ trait Z2IndexKeySpace extends IndexKeySpace[Z2IndexValues] {
     val Z2IndexValues(_, _, xy) = indexValues
 
     if (xy.isEmpty) { Iterator.empty } else {
-      val zs = sfc.ranges(xy, 64, QueryProperties.SCAN_RANGES_TARGET.option.map(_.toInt))
+      val zs = sfc.ranges(xy, 64, QueryProperties.ScanRangesTarget.option.map(_.toInt))
       zs.iterator.map(r => (Longs.toByteArray(r.lower), ByteArrays.toBytesFollowingPrefix(r.upper)))
     }
   }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3IndexKeySpace.scala
@@ -129,7 +129,7 @@ trait XZ3IndexKeySpace extends IndexKeySpace[XZ3IndexValues] {
 
     val XZ3IndexValues(sfc, _, xy, _, timesByBin) = indexValues
 
-    val rangeTarget = QueryProperties.SCAN_RANGES_TARGET.option.map(_.toInt)
+    val rangeTarget = QueryProperties.ScanRangesTarget.option.map(_.toInt)
 
     def toZRanges(t: (Double, Double)): Seq[IndexRange] =
       sfc.ranges(xy.map { case (xmin, ymin, xmax, ymax) => (xmin, ymin, t._1, xmax, ymax, t._2) }, rangeTarget)

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3IndexKeySpace.scala
@@ -122,7 +122,7 @@ trait Z3IndexKeySpace extends IndexKeySpace[Z3IndexValues] {
 
     val Z3IndexValues(z3, _, xy, _, timesByBin) = values
 
-    val rangeTarget = QueryProperties.SCAN_RANGES_TARGET.option.map(_.toInt)
+    val rangeTarget = QueryProperties.ScanRangesTarget.option.map(_.toInt)
 
     def toZRanges(t: Seq[(Long, Long)]): Seq[IndexRange] = z3.ranges(xy, t, 64, rangeTarget)
 

--- a/geomesa-utils/src/main/resources/org/locationtech/geomesa/geomesa-site.xml.template
+++ b/geomesa-utils/src/main/resources/org/locationtech/geomesa/geomesa-site.xml.template
@@ -196,6 +196,22 @@
     </property>
 
     <property>
+        <name>geomesa.scan.block-full-table</name>
+        <value></value>
+        <description>
+          This property will prevent full-table scans from executing. A full-table scan is any query that can't be
+          constrained down using a search index, and thus requires scanning the entire data set. With large data sets,
+          such a scan can last a long time and be resource intensive. The property is specified as a Boolean, i.e.
+          "true" or "false".
+          It is also possible to specify the full-table scan behavior for individual schemas. Use
+          "geomesa.scan.&lt;type-name&gt;.block-full-table", where "&lt;type-name&gt;" is replaced with the schema name
+          (e.g. "gdelt"). Properties set for an individual schema will take precedence over the globally-defined
+          behavior.
+        </description>
+        <final>false</final>
+    </property>
+
+    <property>
         <name>geomesa.scan.ranges.target</name>
         <value>2000</value>
         <description>This property provides a rough upper-limit for the

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/conf/GeoMesaSystemProperties.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/conf/GeoMesaSystemProperties.scala
@@ -45,12 +45,12 @@ object GeoMesaSystemProperties extends LazyLogging {
       }
     }
 
-    def toBoolean: Option[java.lang.Boolean] = option.flatMap { value =>
-      Try(Boolean.box(value.toBoolean)) match {
+    def toBoolean: Option[Boolean] = option.flatMap { value =>
+      Try(value.toBoolean) match {
         case Success(v) => Some(v)
         case Failure(e) =>
           logger.warn(s"Invalid Boolean for property $property: $value")
-          Option(default).map(java.lang.Boolean.valueOf)
+          Option(default).map(java.lang.Boolean.parseBoolean)
       }
     }
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeoMesaParam.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeoMesaParam.scala
@@ -168,7 +168,7 @@ object GeoMesaParam {
   }
 
   case class SystemPropertyBooleanParam(prop: SystemProperty) extends SystemPropertyParam[java.lang.Boolean] {
-    override def option: Option[java.lang.Boolean] = prop.toBoolean
+    override def option: Option[java.lang.Boolean] = prop.toBoolean.map(Boolean.box)
   }
 
   case class SystemPropertyIntegerParam(prop: SystemProperty) extends SystemPropertyParam[Integer] {


### PR DESCRIPTION
* Set 'geomesa.scan.block-full-table=true'
* Global behavior can be overridden for individual schemas with 'geomesa.scan.<type-name>.block-full-table'

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>