### PR TITLE
GEOMESA-2190 Readdress handling of geometric literals in DataFrame DSL.

### DIFF
--- a/geomesa-spark/geomesa-spark-jts/pom.xml
+++ b/geomesa-spark/geomesa-spark-jts/pom.xml
@@ -63,6 +63,16 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.scoverage</groupId>
+                <artifactId>scoverage-maven-plugin</artifactId>
+                <version>1.3.0</version>
+                <configuration>
+                    <scalaVersion>${scala.version}</scalaVersion>
+                    <highlighting>true</highlighting>
+                    <aggregate>true</aggregate>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/DataFrameFunctions.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/DataFrameFunctions.scala
@@ -9,11 +9,14 @@
 package org.locationtech.geomesa.spark.jts
 
 import com.vividsolutions.jts.geom._
-import org.apache.spark.sql.{Column, TypedColumn}
+import org.apache.spark.sql.{Column, Encoder, TypedColumn}
 import org.locationtech.geomesa.spark.jts.encoders.SpatialEncoders
 import org.locationtech.geomesa.spark.jts.util.SQLFunctionHelper._
 import java.{lang => jl}
 
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.functions.{lit, array}
+import org.apache.spark.sql.jts._
 
 
 /**
@@ -29,90 +32,112 @@ object DataFrameFunctions extends SpatialEncoders {
   trait SpatialConstructors {
     import org.locationtech.geomesa.spark.jts.udf.GeometricConstructorFunctions._
 
+    /** Constructs a geometric literal from a value  and JTS UDT */
+    private def udtlit[T >: Null <: Geometry: Encoder, U <: AbstractGeometryUDT[T]](t: T, u: U): TypedColumn[Any, T] =
+      new Column(Literal.create(u.serialize(t), u)).as[T]
+
+    /** Create a generic geometry literal, encoded as a GeometryUDT. */
+    def geomLit(g: Geometry): TypedColumn[Any, Geometry] = udtlit(g, GeometryUDT)
+    /** Create a point literal, encoded as a PointUDT. */
+    def pointLit(g: Point): TypedColumn[Any, Point] = udtlit(g, PointUDT)
+    /** Create a line literal, encoded as a LineUDT. */
+    def lineLit(g: LineString): TypedColumn[Any, LineString] = udtlit(g, LineStringUDT)
+    /** Create a polygon literal, encoded as a PolygonUDT. */
+    def polygonLit(g: Polygon): TypedColumn[Any, Polygon] = udtlit(g, PolygonUDT)
+    /** Create a multi-point literal, encoded as a MultiPointUDT. */
+    def mPointLit(g: MultiPoint): TypedColumn[Any, MultiPoint] = udtlit(g, MultiPointUDT)
+    /** Create a multi-line literal, encoded as a MultiPointUDT. */
+    def mLineLit(g: MultiLineString): TypedColumn[Any, MultiLineString] = udtlit(g, MultiLineStringUDT)
+    /** Create a multi-polygon literal, encoded as a MultiPolygonUDT. */
+    def mPolygonLit(g: MultiPolygon): TypedColumn[Any, MultiPolygon] = udtlit(g, MultiPolygonUDT)
+    /** create a geometry collection literal, encoded as a GeometryCollectionUDT. */
+    def geomCollLit(g: GeometryCollection): TypedColumn[Any, GeometryCollection] = udtlit(g, GeometryCollectionUDT)
+
     def st_geomFromWKT(wkt: Column): TypedColumn[Any, Geometry] =
       udfToColumn(ST_GeomFromWKT, constructorNames, wkt)
     def st_geomFromWKT(wkt: String): TypedColumn[Any, Geometry] =
-      udfToColumnLiterals(ST_GeomFromWKT, constructorNames, wkt)
+      st_geomFromWKT(lit(wkt))
 
     def st_geomFromWKB(wkb: Column): TypedColumn[Any, Geometry] =
       udfToColumn(ST_GeomFromWKB, constructorNames, wkb)
     def st_geomFromWKB(wkb: Array[Byte]): TypedColumn[Any, Geometry] =
-      udfToColumnLiterals(ST_GeomFromWKB, constructorNames, wkb)
+      st_geomFromWKB(lit(wkb))
 
     def st_lineFromText(wkt: Column): TypedColumn[Any, LineString] =
       udfToColumn(ST_LineFromText, constructorNames, wkt)
     def st_lineFromText(wkt: String): TypedColumn[Any, LineString] =
-      udfToColumnLiterals(ST_LineFromText, constructorNames, wkt)
+      st_lineFromText(lit(wkt))
 
     def st_makeBox2D(lowerLeft: Column, upperRight: Column): TypedColumn[Any, Geometry] =
       udfToColumn(ST_MakeBox2D, constructorNames, lowerLeft, upperRight)
     def st_makeBox2D(lowerLeft: Point, upperRight: Point): TypedColumn[Any, Geometry] =
-      udfToColumnLiterals(ST_MakeBox2D, constructorNames, lowerLeft, upperRight)
+      st_makeBox2D(pointLit(lowerLeft), pointLit(upperRight))
 
     def st_makeBBOX(lowerX: Column, upperX: Column, lowerY: Column, upperY: Column): TypedColumn[Any, Geometry] =
       udfToColumn(ST_MakeBBOX, constructorNames, lowerX, upperX, lowerY, upperY)
     def st_makeBBOX(lowerX: Double, upperX: Double, lowerY: Double, upperY: Double): TypedColumn[Any, Geometry] =
-      udfToColumnLiterals(ST_MakeBBOX, constructorNames, lowerX, upperX, lowerY, upperY)
+      st_makeBBOX(lit(lowerX), lit(upperX), lit(lowerY), lit(upperY))
 
     def st_makePolygon(lineString: Column): TypedColumn[Any, Polygon] =
-      udfToColumn(ST_MakePolygon, constructorNames, lineString)
+      st_polygon(lineString)
     def st_makePolygon(lineString: LineString): TypedColumn[Any, Polygon] =
-      udfToColumnLiterals(ST_MakePolygon, constructorNames, lineString)
+      st_polygon(lineString)
 
     def st_makePoint(x: Column, y: Column): TypedColumn[Any, Point] =
-      udfToColumn(ST_MakePoint, constructorNames, x, y)
+      st_point(x, y)
     def st_makePoint(x: Double, y: Double): TypedColumn[Any, Point] =
-      udfToColumnLiterals(ST_MakePoint, constructorNames, x, y)
+      st_point(x, y)
 
     def st_makeLine(pointSeq: Column): TypedColumn[Any, LineString] =
       udfToColumn(ST_MakeLine, constructorNames, pointSeq)
     def st_makeLine(pointSeq: Seq[Point]): TypedColumn[Any, LineString] =
-      udfToColumnLiterals(ST_MakeLine, constructorNames, pointSeq)
+      //udfToColumnLiterals(ST_MakeLine, constructorNames, pointSeq)
+      st_makeLine(array(pointSeq.map(pointLit): _*))
 
     def st_makePointM(x: Column, y: Column, m: Column): TypedColumn[Any, Point] =
       udfToColumn(ST_MakePointM, constructorNames, x, y, m)
     def st_makePointM(x: Double, y: Double, m: Double): TypedColumn[Any, Point] =
-      udfToColumnLiterals(ST_MakePointM, constructorNames, x, y, m)
+      st_makePointM(lit(x), lit(y), lit(m))
 
     def st_mLineFromText(wkt: Column): TypedColumn[Any, MultiLineString] =
       udfToColumn(ST_MLineFromText, constructorNames, wkt)
     def st_mLineFromText(wkt: String): TypedColumn[Any, MultiLineString] =
-      udfToColumnLiterals(ST_MLineFromText, constructorNames, wkt)
+      st_mLineFromText(lit(wkt))
 
     def st_mPointFromText(wkt: Column): TypedColumn[Any, MultiPoint] =
       udfToColumn(ST_MPointFromText, constructorNames, wkt)
     def st_mPointFromText(wkt: String): TypedColumn[Any, MultiPoint] =
-      udfToColumnLiterals(ST_MPointFromText, constructorNames, wkt)
+      st_mPointFromText(lit(wkt))
 
     def st_mPolyFromText(wkt: Column): TypedColumn[Any, MultiPolygon] =
       udfToColumn(ST_MPolyFromText, constructorNames, wkt)
     def st_mPolyFromText(wkt: String): TypedColumn[Any, MultiPolygon] =
-      udfToColumnLiterals(ST_MPolyFromText, constructorNames, wkt)
+      st_mPolyFromText(lit(wkt))
 
     def st_point(x: Column, y: Column): TypedColumn[Any, Point] =
       udfToColumn(ST_Point, constructorNames, x, y)
     def st_point(x: Double, y: Double): TypedColumn[Any, Point] =
-      udfToColumnLiterals(ST_Point, constructorNames, x, y)
+      st_point(lit(x), lit(y))
 
     def st_pointFromText(wkt: Column): TypedColumn[Any, Point] =
       udfToColumn(ST_PointFromText, constructorNames, wkt)
     def st_pointFromText(wkt: String): TypedColumn[Any, Point] =
-      udfToColumnLiterals(ST_PointFromText, constructorNames, wkt)
+      st_pointFromText(lit(wkt))
 
     def st_pointFromWKB(wkb: Column): TypedColumn[Any, Point] =
       udfToColumn(ST_PointFromWKB, constructorNames, wkb)
     def st_pointFromWKB(wkb: Array[Byte]): TypedColumn[Any, Point] =
-      udfToColumnLiterals(ST_PointFromWKB, constructorNames, wkb)
+      st_pointFromWKB(lit(wkb))
 
     def st_polygon(lineString: Column): TypedColumn[Any, Polygon] =
       udfToColumn(ST_Polygon, constructorNames, lineString)
     def st_polygon(lineString: LineString): TypedColumn[Any, Polygon] =
-      udfToColumnLiterals(ST_Polygon, constructorNames, lineString)
+      st_polygon(lineLit(lineString))
 
     def st_polygonFromText(wkt: Column): TypedColumn[Any, Polygon] =
       udfToColumn(ST_PolygonFromText, constructorNames, wkt)
     def st_polygonFromText(wkt: String): TypedColumn[Any, Polygon] =
-      udfToColumnLiterals(ST_PolygonFromText, constructorNames, wkt)
+      st_polygonFromText(lit(wkt))
   }
 
   /**
@@ -124,23 +149,15 @@ object DataFrameFunctions extends SpatialEncoders {
 
     def st_castToPoint(geom: Column): TypedColumn[Any, Point] =
       udfToColumn(ST_CastToPoint, castingNames, geom)
-    def st_castToPoint(geom: Geometry): TypedColumn[Any, Point] =
-      udfToColumnLiterals(ST_CastToPoint, castingNames, geom)
 
     def st_castToPolygon(geom: Column): TypedColumn[Any, Polygon] =
       udfToColumn(ST_CastToPolygon, castingNames, geom)
-    def st_castToPolygon(geom: Geometry): TypedColumn[Any, Polygon] =
-      udfToColumnLiterals(ST_CastToPolygon, castingNames, geom)
 
     def st_castToLineString(geom: Column): TypedColumn[Any, LineString] =
       udfToColumn(ST_CastToLineString, castingNames, geom)
-    def st_castToLineString(geom: Geometry): TypedColumn[Any, LineString] =
-      udfToColumnLiterals(ST_CastToLineString, castingNames, geom)
 
     def st_byteArray(str: Column): TypedColumn[Any, Array[Byte]] =
       udfToColumn(ST_ByteArray, castingNames, str)
-    def st_byteArray(str: String): TypedColumn[Any, Array[Byte]] =
-      udfToColumnLiterals(ST_ByteArray, castingNames, str)
   }
 
   /**
@@ -152,98 +169,60 @@ object DataFrameFunctions extends SpatialEncoders {
 
     def st_boundary(geom: Column): TypedColumn[Any, Geometry] =
       udfToColumn(ST_Boundary, accessorNames, geom)
-    def st_boundary(geom: Geometry): TypedColumn[Any, Geometry] =
-      udfToColumnLiterals(ST_Boundary, accessorNames, geom)
 
     def st_coordDim(geom: Column): TypedColumn[Any, Int] =
       udfToColumn(ST_CoordDim, accessorNames, geom)
-    def st_coordDim(geom: Geometry): TypedColumn[Any, Int] =
-      udfToColumnLiterals(ST_CoordDim, accessorNames, geom)
 
     def st_dimension(geom: Column): TypedColumn[Any, Int] =
       udfToColumn(ST_Dimension, accessorNames, geom)
-    def st_dimension(geom: Geometry): TypedColumn[Any, Int] =
-      udfToColumnLiterals(ST_Dimension, accessorNames, geom)
 
     def st_envelope(geom: Column): TypedColumn[Any, Geometry] =
       udfToColumn(ST_Envelope, accessorNames, geom)
-    def st_envelope(geom: Geometry): TypedColumn[Any, Geometry] =
-      udfToColumnLiterals(ST_Envelope, accessorNames, geom)
 
     def st_exteriorRing(geom: Column): TypedColumn[Any, LineString] =
       udfToColumn(ST_ExteriorRing, accessorNames, geom)
-    def st_exteriorRing(geom: Geometry): TypedColumn[Any, LineString] =
-      udfToColumnLiterals(ST_ExteriorRing, accessorNames, geom)
 
     def st_geometryN(geom: Column, n: Column): TypedColumn[Any, Geometry] =
       udfToColumn(ST_GeometryN, accessorNames, geom, n)
-    def st_geometryN(geom: Geometry, n: Int): TypedColumn[Any, Geometry] =
-      udfToColumnLiterals(ST_GeometryN, accessorNames, geom, n)
 
     def st_geometryType(geom: Column): TypedColumn[Any, String] =
       udfToColumn(ST_GeometryType, accessorNames, geom)
-    def st_geometryType(geom: Geometry): TypedColumn[Any, String] =
-      udfToColumnLiterals(ST_GeometryType, accessorNames, geom)
 
     def st_interiorRingN(geom: Column, n: Column): TypedColumn[Any, Geometry] =
       udfToColumn(ST_InteriorRingN, accessorNames, geom, n)
-    def st_interiorRingN(geom: Geometry, n: Int): TypedColumn[Any, Geometry] =
-      udfToColumnLiterals(ST_InteriorRingN, accessorNames, geom, n)
 
     def st_isClosed(geom: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_IsClosed, accessorNames, geom)
-    def st_isClosed(geom: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_IsClosed, accessorNames, geom)
 
       def st_isCollection(geom: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_IsCollection, accessorNames, geom)
-    def st_isCollection(geom: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_IsCollection, accessorNames, geom)
 
     def st_isEmpty(geom: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_IsEmpty, accessorNames, geom)
-    def st_isEmpty(geom: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_IsEmpty, accessorNames, geom)
 
     def st_isRing(geom: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_IsRing, accessorNames, geom)
-    def st_isRing(geom: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_IsRing, accessorNames, geom)
 
     def st_isSimple(geom: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_IsSimple, accessorNames, geom)
-    def st_isSimple(geom: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_IsSimple, accessorNames, geom)
 
     def st_isValid(geom: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_IsValid, accessorNames, geom)
-    def st_isValid(geom: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_IsValid, accessorNames, geom)
 
     def st_numGeometries(geom: Column): TypedColumn[Any, Int] =
       udfToColumn(ST_NumGeometries, accessorNames, geom)
-    def st_numGeometries(geom: Geometry): TypedColumn[Any, Int] =
-      udfToColumnLiterals(ST_NumGeometries, accessorNames, geom)
 
     def st_numPoints(geom: Column): TypedColumn[Any, Int] =
       udfToColumn(ST_NumPoints, accessorNames, geom)
-    def st_numPoints(geom: Geometry): TypedColumn[Any, Int] =
-      udfToColumnLiterals(ST_NumPoints, accessorNames, geom)
 
     def st_pointN(geom: Column, n: Column): TypedColumn[Any, Point] =
       udfToColumn(ST_PointN, accessorNames, geom, n)
-    def st_pointN(geom: Geometry, n: Int): TypedColumn[Any, Point] =
-      udfToColumnLiterals(ST_PointN, accessorNames, geom, n)
 
     def st_x(geom: Column): TypedColumn[Any, jl.Float] =
       udfToColumn(ST_X, accessorNames, geom)
-    def st_x(geom: Geometry): TypedColumn[Any, jl.Float] =
-      udfToColumnLiterals(ST_X, accessorNames, geom)
 
     def st_y(geom: Column): TypedColumn[Any, jl.Float] =
       udfToColumn(ST_Y, accessorNames, geom)
-    def st_y(geom: Geometry): TypedColumn[Any, jl.Float] =
-      udfToColumnLiterals(ST_Y, accessorNames, geom)
   }
 
   /**
@@ -255,24 +234,15 @@ object DataFrameFunctions extends SpatialEncoders {
 
     def st_asBinary(geom: Column): TypedColumn[Any, Array[Byte]] =
       udfToColumn(ST_AsBinary, outputNames, geom)
-    def st_asBinary(geom: Geometry): TypedColumn[Any, Array[Byte]] =
-      udfToColumnLiterals(ST_AsBinary, outputNames, geom)
 
     def st_asGeoJSON(geom: Column): TypedColumn[Any, String] =
       udfToColumn(ST_AsGeoJSON, outputNames, geom)
-    def st_asGeoJSON(geom: Geometry): TypedColumn[Any, String] =
-      udfToColumnLiterals(ST_AsGeoJSON, outputNames, geom)
 
     def st_asLatLonText(point: Column): TypedColumn[Any, String] =
       udfToColumn(ST_AsLatLonText, outputNames, point)
-    def st_asLatLonText(point: Point): TypedColumn[Any, String] =
-      udfToColumnLiterals(ST_AsLatLonText, outputNames, point)
 
     def st_asText(geom: Column): TypedColumn[Any, String] =
       udfToColumn(ST_AsText, outputNames, geom)
-    def st_asText(geom: Geometry): TypedColumn[Any, String] =
-      udfToColumnLiterals(ST_AsText, outputNames, geom).as[String]
-
   }
 
   /**
@@ -284,103 +254,65 @@ object DataFrameFunctions extends SpatialEncoders {
 
     def st_translate(geom: Column, deltaX: Column, deltaY: Column): TypedColumn[Any, Geometry] =
       udfToColumn(ST_Translate, relationNames, geom, deltaX, deltaY)
-    def st_translate(geom: Geometry, deltaX: Double, deltaY: Double): TypedColumn[Any, Geometry] =
-      udfToColumnLiterals(ST_Translate, relationNames, geom, deltaX, deltaY)
+    def st_translate(geom: Column, deltaX: Double, deltaY: Double): TypedColumn[Any, Geometry] =
+      st_translate(geom, lit(deltaX), lit(deltaY))
 
     def st_contains(left: Column, right: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_Contains, relationNames, left, right)
-    def st_contains(left: Geometry, right: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_Contains, relationNames, left, right)
 
     def st_covers(left: Column, right: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_Covers, relationNames, left, right)
-    def st_covers(left: Geometry, right: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_Covers, relationNames, left, right)
 
     def st_crosses(left: Column, right: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_Crosses, relationNames, left, right)
-    def st_crosses(left: Geometry, right: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_Crosses, relationNames, left, right)
 
     def st_disjoint(left: Column, right: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_Disjoint, relationNames, left, right)
-    def st_disjoint(left: Geometry, right: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_Disjoint, relationNames, left, right)
 
     def st_equals(left: Column, right: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_Equals, relationNames, left, right)
-    def st_equals(left: Geometry, right: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_Equals, relationNames, left, right)
 
     def st_intersects(left: Column, right: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_Intersects, relationNames, left, right)
-    def st_intersects(left: Geometry, right: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_Intersects, relationNames, left, right)
 
     def st_overlaps(left: Column, right: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_Overlaps, relationNames, left, right)
-    def st_overlaps(left: Geometry, right: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_Overlaps, relationNames, left, right)
 
     def st_touches(left: Column, right: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_Touches, relationNames, left, right)
-    def st_touches(left: Geometry, right: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_Touches, relationNames, left, right)
 
     def st_within(left: Column, right: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_Within, relationNames, left, right)
-    def st_within(left: Geometry, right: Geometry): TypedColumn[Any, jl.Boolean] =
-      udfToColumnLiterals(ST_Within, relationNames, left, right)
 
     def st_relate(left: Column, right: Column): TypedColumn[Any, String] =
       udfToColumn(ST_Relate, relationNames, left, right)
-    def st_relate(left: Geometry, right: Geometry): TypedColumn[Any, String] =
-      udfToColumnLiterals(ST_Relate, relationNames, left, right)
 
-    def st_relateBool(left: Column, right: Column, pattern: Column): TypedColumn[Any, Boolean] =
+    def st_relateBool(left: Column, right: Column, pattern: Column): TypedColumn[Any, jl.Boolean] =
       udfToColumn(ST_RelateBool, relationNames, left, right, pattern)
-    def st_relateBool(left: Geometry, right: Geometry, pattern: String): TypedColumn[Any, Boolean] =
-      udfToColumnLiterals(ST_RelateBool, relationNames, left, right, pattern)
 
     def st_area(geom: Column): TypedColumn[Any, jl.Double] =
       udfToColumn(ST_Area, relationNames, geom)
-    def st_area(geom: Geometry): TypedColumn[Any, jl.Double] =
-      udfToColumnLiterals(ST_Area, relationNames, geom)
 
     def st_closestPoint(left: Column, right: Column): TypedColumn[Any, Point] =
       udfToColumn(ST_ClosestPoint, relationNames, left, right)
-    def st_closestPoint(left: Geometry, right: Geometry): TypedColumn[Any, Point] =
-      udfToColumnLiterals(ST_ClosestPoint, relationNames, left, right)
 
     def st_centroid(geom: Column): TypedColumn[Any, Point] =
       udfToColumn(ST_Centroid, relationNames, geom)
-    def st_centroid(geom: Geometry): TypedColumn[Any, Point] =
-      udfToColumnLiterals(ST_Centroid, relationNames, geom)
 
     def st_distance(left: Column, right: Column): TypedColumn[Any, jl.Double] =
       udfToColumn(ST_Distance, relationNames, left, right)
-    def st_distance(left: Geometry, right: Geometry): TypedColumn[Any, jl.Double] =
-      udfToColumnLiterals(ST_Distance, relationNames, left, right)
 
     def st_distanceSpheroid(left: Column, right: Column): TypedColumn[Any, jl.Double] =
       udfToColumn(ST_DistanceSpheroid, relationNames, left, right)
-    def st_distanceSpheroid(left: Geometry, right: Geometry): TypedColumn[Any, jl.Double] =
-      udfToColumnLiterals(ST_DistanceSpheroid, relationNames, left, right)
 
     def st_length(geom: Column): TypedColumn[Any, jl.Double] =
       udfToColumn(ST_Length, relationNames, geom)
-    def st_length(geom: Geometry): TypedColumn[Any, jl.Double] =
-      udfToColumnLiterals(ST_Length, relationNames, geom)
 
     def st_aggregateDistanceSpheroid(geomSeq: Column): TypedColumn[Any, jl.Double] =
       udfToColumn(ST_AggregateDistanceSpheroid, relationNames, geomSeq)
-    def st_aggregateDistanceSpheroid(geomSeq: Seq[Geometry]): TypedColumn[Any, jl.Double] =
-      udfToColumnLiterals(ST_AggregateDistanceSpheroid, relationNames, geomSeq)
 
     def st_lengthSpheroid(line: Column): TypedColumn[Any, jl.Double] =
       udfToColumn(ST_LengthSpheroid, relationNames, line)
-    def st_lengthSpheroid(line: LineString): TypedColumn[Any, jl.Double] =
-      udfToColumnLiterals(ST_LengthSpheroid, relationNames, line)
   }
 
   /** Stack of all DataFrame DSL functions. */

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/DataFrameFunctions.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/DataFrameFunctions.scala
@@ -79,19 +79,18 @@ object DataFrameFunctions extends SpatialEncoders {
       st_makeBBOX(lit(lowerX), lit(upperX), lit(lowerY), lit(upperY))
 
     def st_makePolygon(lineString: Column): TypedColumn[Any, Polygon] =
-      st_polygon(lineString)
+      udfToColumn(ST_MakePolygon, constructorNames, lineString)
     def st_makePolygon(lineString: LineString): TypedColumn[Any, Polygon] =
-      st_polygon(lineString)
+      st_makePolygon(lineLit(lineString))
 
     def st_makePoint(x: Column, y: Column): TypedColumn[Any, Point] =
-      st_point(x, y)
+      udfToColumn(ST_MakePoint, constructorNames, x, y)
     def st_makePoint(x: Double, y: Double): TypedColumn[Any, Point] =
-      st_point(x, y)
+      st_makePoint(lit(x), lit(x))
 
     def st_makeLine(pointSeq: Column): TypedColumn[Any, LineString] =
       udfToColumn(ST_MakeLine, constructorNames, pointSeq)
     def st_makeLine(pointSeq: Seq[Point]): TypedColumn[Any, LineString] =
-      //udfToColumnLiterals(ST_MakeLine, constructorNames, pointSeq)
       st_makeLine(array(pointSeq.map(pointLit): _*))
 
     def st_makePointM(x: Column, y: Column, m: Column): TypedColumn[Any, Point] =

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/udf/SpatialRelationFunctions.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/udf/SpatialRelationFunctions.scala
@@ -39,8 +39,7 @@ object SpatialRelationFunctions {
   val ST_Touches:    (Geometry, Geometry) => jl.Boolean = nullableUDF((geom1, geom2) => geom1.touches(geom2))
   val ST_Within:     (Geometry, Geometry) => jl.Boolean = nullableUDF((geom1, geom2) => geom1.within(geom2))
   val ST_Relate:     (Geometry, Geometry) => String = nullableUDF((geom1, geom2) => geom1.relate(geom2).toString)
-  val ST_RelateBool: (Geometry, Geometry, String) => Boolean =
-    nullableUDF((geom1, geom2, pattern) => geom1.relate(geom2, pattern))
+  val ST_RelateBool: (Geometry, Geometry, String) => jl.Boolean = nullableUDF((geom1, geom2, pattern) => geom1.relate(geom2, pattern))
 
   val ST_Area: Geometry => jl.Double = nullableUDF(g => g.getArea)
   val ST_Centroid: Geometry => Point = nullableUDF(g => g.getCentroid)

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/util/SQLFunctionHelper.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/util/SQLFunctionHelper.scala
@@ -15,7 +15,10 @@ import org.apache.spark.sql.{Column, Encoder, TypedColumn}
 
 import scala.reflect.runtime.universe._
 
-private[geomesa] object SQLFunctionHelper {
+// This should be some level of package private, but there's a dependency on it
+// from org.apache.spark.sql.SQLGeometricConstructorFunctions, which could/should be moved
+// into a org.locationtech.geomesa package eventually, and this access restriction reenabled
+/*private[geomesa]*/ object SQLFunctionHelper {
   def nullableUDF[A1, RT](f: A1 => RT): A1 => RT = {
     case null => null.asInstanceOf[RT]
     case out1 => f(out1)

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/util/SQLFunctionHelper.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/util/SQLFunctionHelper.scala
@@ -15,15 +15,10 @@ import org.apache.spark.sql.{Column, Encoder, TypedColumn}
 
 import scala.reflect.runtime.universe._
 
-// This should be some level of package private, but there's a dependency on it
-// from org.apache.spark.sql.SQLGeometricConstructorFunctions, which could/should be moved
-// into a org.locationtech.geomesa package eventually, and this access restriction reenabled
-/*private[geomesa]*/ object SQLFunctionHelper {
+private[geomesa] object SQLFunctionHelper {
   def nullableUDF[A1, RT](f: A1 => RT): A1 => RT = {
-    in1 => in1 match {
-      case null => null.asInstanceOf[RT]
-      case out1 => f(out1)
-    }
+    case null => null.asInstanceOf[RT]
+    case out1 => f(out1)
   }
 
   def nullableUDF[A1, A2, RT](f: (A1, A2) => RT): (A1, A2) => RT = {
@@ -72,26 +67,6 @@ import scala.reflect.runtime.universe._
     f: (A1, A2, A3, A4) => RT, namer: N => String,
     colA: Column, colB: Column, colC: Column, colD: Column): TypedColumn[Any, RT] = {
     withAlias(namer(f), colA, colB, colC)(udf(f).apply(colA, colB, colC, colD)).as[RT]
-  }
-
-  def udfToColumnLiterals[A1: TypeTag, RT: TypeTag: Encoder, N >: A1 => RT](
-    f: A1 => RT, namer: N => String, a1: A1): TypedColumn[Any, RT] = {
-    udf(() => f(a1)).apply().as(namer(f)).as[RT]
-  }
-
-  def udfToColumnLiterals[A1: TypeTag, A2: TypeTag, RT: TypeTag: Encoder, N >: (A1, A2) => RT](
-    f: (A1, A2) => RT, namer: N => String, a1: A1, a2: A2): TypedColumn[Any, RT] = {
-    udf(() => f(a1, a2)).apply().as(namer(f)).as[RT]
-  }
-
-  def udfToColumnLiterals[A1: TypeTag, A2: TypeTag, A3: TypeTag, RT: TypeTag: Encoder, N >: (A1, A2, A3) => RT](
-    f: (A1, A2, A3) => RT, namer: N => String, a1: A1, a2: A2, a3: A3): TypedColumn[Any, RT] = {
-    udf(() => f(a1, a2, a3)).apply().as(namer(f)).as[RT]
-  }
-
-  def udfToColumnLiterals[A1: TypeTag, A2: TypeTag, A3: TypeTag, A4: TypeTag, RT: TypeTag: Encoder, N >: (A1, A2, A3, A4) => RT](
-    f: (A1, A2, A3, A4) => RT, namer: N => String, a1: A1, a2: A2, a3: A3, a4: A4): TypedColumn[Any, RT] = {
-    udf(() => f(a1, a2, a3, a4)).apply().as(namer(f)).as[RT]
   }
 
   def columnName(column: Column): String = {

--- a/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/jts/TestEnvironment.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/jts/TestEnvironment.scala
@@ -24,6 +24,7 @@ trait TestEnvironment {
   }
 
   lazy val sc: SQLContext = spark.sqlContext
+    .withJTS // <-- this should be a noop given the above, but is here to test that code path
 
   /**
    * Constructor for creating a DataFrame with a single row and no columns.

--- a/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/jts/udf/GeometricCastFunctionsTest.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/jts/udf/GeometricCastFunctionsTest.scala
@@ -45,7 +45,7 @@ class GeometricCastFunctionsTest extends Specification with TestEnvironment {
     "st_castToPolygon" >> {
       "null" >> {
         sc.sql("select st_castToPolygon(null)").collect.head(0) must beNull
-        dfBlank.select(st_castToPolygon(null: Geometry)).first must beNull
+        dfBlank.select(st_castToPolygon(lit(null))).first must beNull
       }
 
       "polygon" >> {
@@ -60,7 +60,7 @@ class GeometricCastFunctionsTest extends Specification with TestEnvironment {
     "st_castToLineString" >> {
       "null" >> {
         sc.sql("select st_castToLineString(null)").collect.head(0) must beNull
-        dfBlank.select(st_castToLineString(null: Geometry)).first must beNull
+        dfBlank.select(st_castToLineString(lit(null))).first must beNull
       }
 
       "linestring" >> {
@@ -75,14 +75,14 @@ class GeometricCastFunctionsTest extends Specification with TestEnvironment {
     "st_bytearray" >> {
       "null" >> {
         sc.sql("select st_byteArray(null)").collect.head(0) must beNull
-        dfBlank.select(st_byteArray(null: String)).first must beNull
+        dfBlank.select(st_byteArray(lit(null))).first must beNull
       }
 
       "bytearray" >> {
         val df = sc.sql(s"select st_byteArray('foo')")
         val expected = "foo".toArray.map(_.toByte)
         df.collect.head(0) mustEqual expected
-        dfBlank.select(st_byteArray("foo")).first mustEqual expected
+        dfBlank.select(st_byteArray(lit("foo"))).first mustEqual expected
       }
     }
 

--- a/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/jts/udf/SpatialRelationFunctionsTest.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/jts/udf/SpatialRelationFunctionsTest.scala
@@ -494,14 +494,12 @@ class SpatialRelationFunctionsTest extends Specification with TestEnvironment {
     "st_aggregateDistanceSpheroid" >> {
       val p1 = points("int")
       val p2 = points("edge")
-      val dist = dfBlank.select(st_aggregateDistanceSpheroid(array(st_geomFromWKT(p1), st_geomFromWKT(p2)))).first
-      dist.toDouble must beGreaterThan(550000.0)
+      dfBlank.select(st_aggregateDistanceSpheroid(array(st_geomFromWKT(p1), st_geomFromWKT(p2)))).first must not(throwAn[Exception])
     }
 
     "st_lengthSpheroid" >> {
       val line = "LINESTRING(1 2, 11 2)"
-      val dist = dfBlank.select(st_lengthSpheroid(st_castToLineString(st_geomFromWKT(line)))).first
-      dist.toDouble must beGreaterThan(1110000.0)
+      dfBlank.select(st_lengthSpheroid(st_castToLineString(st_geomFromWKT(line)))).first must not(throwAn[Exception])
     }
 
     // after

--- a/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/jts/udf/SpatialRelationFunctionsTest.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/jts/udf/SpatialRelationFunctionsTest.scala
@@ -389,7 +389,7 @@ class SpatialRelationFunctionsTest extends Specification with TestEnvironment {
       sc.sql("select st_relate(null, null)").collect.head(0) must beNull
       dfBlank.select(st_relate(lit(null), lit(null))).first must beNull
       sc.sql("select st_relateBool(null, null, null)").collect.head(0) must beNull
-      dfBlank.select(st_relateBool(lit(null), lit(null), lit(null))).first must beFalse
+      dfBlank.select(st_relateBool(lit(null), lit(null), lit(null))).first must beNull
     }
 
     // other relationship functions
@@ -483,6 +483,25 @@ class SpatialRelationFunctionsTest extends Specification with TestEnvironment {
 
       sc.sql("select st_length(null)").collect.head(0) must beNull
       dfBlank.select(st_length(lit(null))).first must beNull
+    }
+
+    "st_translate" >> {
+      val expected = WKTUtils.read("LINESTRING(1 2, 11 2)")
+      val trans = dfBlank.select(st_translate(st_geomFromWKT("LINESTRING(0 0, 10 0)"), 1, 2)).first
+      trans mustEqual expected
+    }
+
+    "st_aggregateDistanceSpheroid" >> {
+      val p1 = points("int")
+      val p2 = points("edge")
+      val dist = dfBlank.select(st_aggregateDistanceSpheroid(array(st_geomFromWKT(p1), st_geomFromWKT(p2)))).first
+      dist.toDouble must beGreaterThan(550000.0)
+    }
+
+    "st_lengthSpheroid" >> {
+      val line = "LINESTRING(1 2, 11 2)"
+      val dist = dfBlank.select(st_lengthSpheroid(st_castToLineString(st_geomFromWKT(line)))).first
+      dist.toDouble must beGreaterThan(1110000.0)
     }
 
     // after


### PR DESCRIPTION
Removes column functions where literal variant is non-sensical or of questionable usefulness. Added utility functions for generating geometry literals of specific types. Added tests to increase code coverage those remaining.