### PR TITLE
GEOMESA-2195 Arrow - keep null dictionary values in the dictionary vector

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/ArrowBatchIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/ArrowBatchIteratorTest.scala
@@ -321,13 +321,13 @@ class ArrowBatchIteratorTest extends TestWithMultipleSfts {
         }
       }
     }
-    "return sorted, dictionary encoded projections for non-indexed attributes" in {
+    "return sorted, dictionary encoded projections for non-indexed attributes and nulls" in {
       foreach(sfts) { case (sft, features) =>
         foreach(filters) { filter =>
-          val transform = Array("team", "dtg", "geom")
+          val transform = Array("team", "weight", "dtg", "geom")
           val query = new Query(sft.getTypeName, filter, transform)
           query.getHints.put(QueryHints.ARROW_ENCODE, true)
-          query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "team")
+          query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "team,weight")
           query.getHints.put(QueryHints.ARROW_SORT_FIELD, "dtg")
           query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 100)
           val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
@@ -336,7 +336,8 @@ class ArrowBatchIteratorTest extends TestWithMultipleSfts {
           def in() = new ByteArrayInputStream(out.toByteArray)
           WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
             compare(reader.features(), features, transform.toSeq)
-            reader.dictionaries.keySet mustEqual Set("team")
+            reader.dictionaries.keySet mustEqual Set("team", "weight")
+            reader.dictionaries.apply("weight").iterator.toSeq must contain(null: AnyRef)
           }
         }
       }

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DictionaryBuildingWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DictionaryBuildingWriter.scala
@@ -96,9 +96,7 @@ class DictionaryBuildingWriter private (val sft: SimpleFeatureType,
 
       var i = 0
       w.dictionary.foreach { value =>
-        if (value != null) {
-          writer.apply(i, value)
-        }
+        writer.apply(i, value)
         i += 1
       }
       writer.setValueCount(w.size)

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeReader.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeReader.scala
@@ -174,6 +174,7 @@ object ArrowAttributeReader {
                                   val dictionaryType: TypeBindings) extends ArrowDictionaryReader {
     private val accessor = vector.getAccessor
     private val holder = new NullableTinyIntHolder
+
     override def apply(i: Int): AnyRef = {
       accessor.get(i, holder)
       if (holder.isSet == 0) { null } else {
@@ -196,6 +197,7 @@ object ArrowAttributeReader {
                                    val dictionaryType: TypeBindings) extends ArrowDictionaryReader {
     private val accessor = vector.getAccessor
     private val holder = new NullableSmallIntHolder
+
     override def apply(i: Int): AnyRef = {
       accessor.get(i, holder)
       if (holder.isSet == 0) { null } else {
@@ -218,6 +220,7 @@ object ArrowAttributeReader {
                                  val dictionaryType: TypeBindings) extends ArrowDictionaryReader {
     private val accessor = vector.getAccessor
     private val holder = new NullableIntHolder
+
     override def apply(i: Int): AnyRef = {
       accessor.get(i, holder)
       if (holder.isSet == 0) { null } else {

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeWriter.scala
@@ -239,12 +239,8 @@ object ArrowAttributeWriter {
 
     private val mutator = vector.getMutator
 
-    override def apply(i: Int, value: AnyRef): Unit =
-      if (value == null) {
-        mutator.setNull(i) // note: calls .setSafe internally
-      } else {
-        mutator.setSafe(i, dictionary.index(value).toByte)
-      }
+    // note: nulls get encoded in the dictionary
+    override def apply(i: Int, value: AnyRef): Unit = mutator.setSafe(i, dictionary.index(value).toByte)
   }
 
   /**
@@ -256,12 +252,8 @@ object ArrowAttributeWriter {
 
     private val mutator = vector.getMutator
 
-    override def apply(i: Int, value: AnyRef): Unit =
-      if (value == null) {
-        mutator.setNull(i) // note: calls .setSafe internally
-      } else {
-        mutator.setSafe(i, dictionary.index(value).toShort)
-      }
+    // note: nulls get encoded in the dictionary
+    override def apply(i: Int, value: AnyRef): Unit = mutator.setSafe(i, dictionary.index(value).toShort)
   }
 
   /**
@@ -273,12 +265,8 @@ object ArrowAttributeWriter {
 
     private val mutator = vector.getMutator
 
-    override def apply(i: Int, value: AnyRef): Unit =
-      if (value == null) {
-        mutator.setNull(i) // note: calls .setSafe internally
-      } else {
-        mutator.setSafe(i, dictionary.index(value))
-      }
+    // note: nulls get encoded in the dictionary
+    override def apply(i: Int, value: AnyRef): Unit = mutator.setSafe(i, dictionary.index(value))
   }
 
   /**

--- a/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/vector/SimpleFeatureVectorTest.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/vector/SimpleFeatureVectorTest.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.arrow.vector
 
 import java.util.Date
 
-import org.apache.arrow.memory.{BufferAllocator, RootAllocator}
+import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.DirtyRootAllocator
 import org.geotools.util.Converters
 import org.junit.runner.RunWith
@@ -122,7 +122,7 @@ class SimpleFeatureVectorTest extends Specification {
       }
     }
     "set and get null dictionary values" >> {
-      val dictionary = Map("name" -> ArrowDictionary.create(0, Array("name00", "name01")))
+      val dictionary = Map("name" -> ArrowDictionary.create(0, Array("name00", "name01", null)))
       WithClose(SimpleFeatureVector.create(sft, dictionary, SimpleFeatureEncoding.min(true))) { vector =>
         val nulls = features.map(ScalaSimpleFeature.copy)
         (0 until sft.getAttributeCount).foreach(i => nulls.foreach(_.setAttribute(i, null)))


### PR DESCRIPTION
* Previously the index vector held nulls and the dictionary vector never had nulls
* With this change, the dictionary vector holds nulls and the index vector will never have nulls

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>