### PR TITLE
1.3 - GEOMESA-2195 Arrow - keep null dictionary values in the dictionary vector

### DIFF
--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DictionaryBuildingWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DictionaryBuildingWriter.scala
@@ -96,9 +96,7 @@ class DictionaryBuildingWriter private (val sft: SimpleFeatureType,
 
       var i = 0
       w.dictionary.foreach { value =>
-        if (value != null) {
-          writer.apply(i, value)
-        }
+        writer.apply(i, value)
         i += 1
       }
       writer.setValueCount(w.size)

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeReader.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeReader.scala
@@ -180,6 +180,7 @@ object ArrowAttributeReader {
                                   val dictionaryType: TypeBindings) extends ArrowDictionaryReader {
     private val accessor = vector.getAccessor
     private val holder = new NullableTinyIntHolder
+
     override def apply(i: Int): AnyRef = {
       accessor.get(i, holder)
       if (holder.isSet == 0) { null } else {
@@ -202,6 +203,7 @@ object ArrowAttributeReader {
                                    val dictionaryType: TypeBindings) extends ArrowDictionaryReader {
     private val accessor = vector.getAccessor
     private val holder = new NullableSmallIntHolder
+
     override def apply(i: Int): AnyRef = {
       accessor.get(i, holder)
       if (holder.isSet == 0) { null } else {
@@ -224,6 +226,7 @@ object ArrowAttributeReader {
                                  val dictionaryType: TypeBindings) extends ArrowDictionaryReader {
     private val accessor = vector.getAccessor
     private val holder = new NullableIntHolder
+
     override def apply(i: Int): AnyRef = {
       accessor.get(i, holder)
       if (holder.isSet == 0) { null } else {

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeWriter.scala
@@ -248,12 +248,8 @@ object ArrowAttributeWriter {
 
     private val mutator = vector.getMutator
 
-    override def apply(i: Int, value: AnyRef): Unit =
-      if (value == null) {
-        mutator.setNull(i) // note: calls .setSafe internally
-      } else {
-        mutator.setSafe(i, dictionary.index(value).toByte)
-      }
+    // note: nulls get encoded in the dictionary
+    override def apply(i: Int, value: AnyRef): Unit = mutator.setSafe(i, dictionary.index(value).toByte)
   }
 
   /**
@@ -265,12 +261,8 @@ object ArrowAttributeWriter {
 
     private val mutator = vector.getMutator
 
-    override def apply(i: Int, value: AnyRef): Unit =
-      if (value == null) {
-        mutator.setNull(i) // note: calls .setSafe internally
-      } else {
-        mutator.setSafe(i, dictionary.index(value).toShort)
-      }
+    // note: nulls get encoded in the dictionary
+    override def apply(i: Int, value: AnyRef): Unit = mutator.setSafe(i, dictionary.index(value).toShort)
   }
 
   /**
@@ -282,12 +274,8 @@ object ArrowAttributeWriter {
 
     private val mutator = vector.getMutator
 
-    override def apply(i: Int, value: AnyRef): Unit =
-      if (value == null) {
-        mutator.setNull(i) // note: calls .setSafe internally
-      } else {
-        mutator.setSafe(i, dictionary.index(value))
-      }
+    // note: nulls get encoded in the dictionary
+    override def apply(i: Int, value: AnyRef): Unit = mutator.setSafe(i, dictionary.index(value))
   }
 
   /**

--- a/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/vector/SimpleFeatureVectorTest.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/vector/SimpleFeatureVectorTest.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.arrow.vector
 
 import java.util.Date
 
-import org.apache.arrow.memory.{BufferAllocator, RootAllocator}
+import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.DirtyRootAllocator
 import org.geotools.util.Converters
 import org.junit.runner.RunWith
@@ -122,7 +122,7 @@ class SimpleFeatureVectorTest extends Specification {
       }
     }
     "set and get null dictionary values" >> {
-      val dictionary = Map("name" -> ArrowDictionary.create(0, Array("name00", "name01")))
+      val dictionary = Map("name" -> ArrowDictionary.create(0, Array("name00", "name01", null)))
       WithClose(SimpleFeatureVector.create(sft, dictionary, SimpleFeatureEncoding.min(true))) { vector =>
         val nulls = features.map(ScalaSimpleFeature.copy)
         (0 until sft.getAttributeCount).foreach(i => nulls.foreach(_.setAttribute(i, null)))


### PR DESCRIPTION
* Previously the index vector held nulls and the dictionary vector never had nulls
* With this change, the dictionary vector holds nulls and the index vector will never have nulls

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>