### PR TITLE
GEOMESA-2193 Fixing behavior for Query.NO_PROPERTIES

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTransformsTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTransformsTest.scala
@@ -67,13 +67,13 @@ class AccumuloDataStoreTransformsTest extends Specification with TestWithMultipl
 
         "with the correct schema" >> {
           val schema = SimpleFeatureTypes.encodeType(results.getSchema)
-          schema mustEqual "name:String,*geom:Point:srid=4326,derived:String"
+          schema mustEqual "name:String,derived:String,*geom:Point:srid=4326"
         }
         "with the correct results" >> {
           val features = results.features
           features.hasNext must beTrue
           val f = features.next()
-          DataUtilities.encodeFeature(f) mustEqual "fid-1=myname|POINT (45 49)|hellomyname"
+          DataUtilities.encodeFeature(f) mustEqual "fid-1=myname|hellomyname|POINT (45 49)"
         }
       }
 
@@ -133,13 +133,13 @@ class AccumuloDataStoreTransformsTest extends Specification with TestWithMultipl
         val results = ds.getFeatureSource(sftName).getFeatures(query)
 
         "with the correct schema" >> {
-          SimpleFeatureTypes.encodeType(results.getSchema) mustEqual "name:String,*geom:Point:srid=4326,derived:String"
+          SimpleFeatureTypes.encodeType(results.getSchema) mustEqual "name:String,derived:String,*geom:Point:srid=4326"
         }
         "with the correct results" >> {
           val features = results.features
           features.hasNext must beTrue
           val f = features.next()
-          DataUtilities.encodeFeature(f) mustEqual "fid-1=myname|POINT (45 49)|v1myname"
+          DataUtilities.encodeFeature(f) mustEqual "fid-1=myname|v1myname|POINT (45 49)"
         }
       }
 
@@ -174,6 +174,28 @@ class AccumuloDataStoreTransformsTest extends Specification with TestWithMultipl
           val f = features.next()
           DataUtilities.encodeFeature(f) mustEqual "fid-1=POINT (45 49)"
         }
+      }
+    }
+
+    "return no properties" in {
+      import scala.collection.JavaConverters._
+
+      val sft = createNewSchema("name:String:index=join,age:Int:index=full,dtg:Date,*geom:Point:srid=4326")
+      addFeature(sft, ScalaSimpleFeature.create(sft, "fid-1", "name1", "20", "2010-05-07T12:30:00.000Z", "POINT(45 49)"))
+      val filters = Seq(
+        "bbox(geom,40,40,60,60) AND dtg BETWEEN '2010-05-07T12:00:00.000Z' AND '2010-05-07T13:00:00.000Z'",
+        "bbox(geom,40,40,60,60)",
+        "name = 'name1'",
+        "age = 20",
+        "IN ('fid-1')"
+      )
+      foreach(filters) { filter =>
+        val query = new Query(sft.getTypeName, ECQL.toFilter(filter), Array.empty[String])
+        val features = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList
+        features must haveLength(1)
+        features.head.getID mustEqual "fid-1"
+        features.head.getAttributes.asScala must beEmpty
+        features.head.getType.getAttributeDescriptors.asScala must beEmpty
       }
     }
 
@@ -243,57 +265,6 @@ class AccumuloDataStoreTransformsTest extends Specification with TestWithMultipl
         }
         success
       }
-    }
-
-    "always return a geometry if available" >> {
-      val sft = createNewSchema("name:String,dtg:Date,*geom:Point:srid=4326,geom2:Point:srid=4326")
-      val sftName = sft.getTypeName
-
-      val reference = (0 until 3).map { i =>
-        val sf = new ScalaSimpleFeature(sft, s"f$i")
-        sf.setAttribute(0, s"name$i")
-        sf.setAttribute(1, s"2014-01-01T0$i:00:00.000Z")
-        sf.setAttribute(2, s"POINT(5$i 50)")
-        sf.setAttribute(3, s"POINT(6$i 50)")
-        sf
-      }
-      addFeatures(sft, reference)
-
-      "if no geometry is specified" >> {
-        val query = new Query(sftName, Filter.INCLUDE, Array("name"))
-        val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toSeq
-        features must haveSize(3)
-        forall(features)(_.getAttributeCount mustEqual 2)
-        features.map(_.getAttribute("geom")) must containTheSameElementsAs(reference.map(_.getAttribute("geom")))
-        features.map(_.getAttribute("name")) must containTheSameElementsAs(reference.map(_.getAttribute("name")))
-      }
-
-      "if default geometry is specified" >> {
-        val query = new Query(sftName, Filter.INCLUDE, Array("name", "geom"))
-        val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toSeq
-        features must haveSize(3)
-        forall(features)(_.getAttributeCount mustEqual 2)
-        features.map(_.getAttribute("geom")) must containTheSameElementsAs(reference.map(_.getAttribute("geom")))
-        features.map(_.getAttribute("name")) must containTheSameElementsAs(reference.map(_.getAttribute("name")))
-      }
-
-      "if alternate geometry is specified" >> {
-        val query = new Query(sftName, Filter.INCLUDE, Array("name", "geom2"))
-        val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toSeq
-        features must haveSize(3)
-        forall(features)(_.getAttributeCount mustEqual 2)
-        features.map(_.getAttribute("geom2")) must containTheSameElementsAs(reference.map(_.getAttribute("geom2")))
-        features.map(_.getAttribute("name")) must containTheSameElementsAs(reference.map(_.getAttribute("name")))
-      }
-
-      "if geometry is renamed" >> {
-        val query = new Query(sftName, Filter.INCLUDE, Array("name", "geom3=geom"))
-        val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toSeq
-        features must haveSize(3)
-        forall(features)(_.getAttributeCount mustEqual 2)
-        features.map(_.getAttribute("geom3")) must containTheSameElementsAs(reference.map(_.getAttribute("geom")))
-        features.map(_.getAttribute("name")) must containTheSameElementsAs(reference.map(_.getAttribute("name")))
-      }.pendingUntilFixed("Can't detect transform types")
     }
 
     "do basic arithmetic" >> {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/IndexPackageObjectTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/IndexPackageObjectTest.scala
@@ -33,7 +33,7 @@ class IndexPackageObjectTest extends Specification {
 
       val transform = query.getHints.getTransformSchema
       transform must beSome
-      SimpleFeatureTypes.encodeType(transform.get) mustEqual "name:String,*geom:Point:srid=4326,helloName:String"
+      SimpleFeatureTypes.encodeType(transform.get) mustEqual "name:String,helloName:String,*geom:Point:srid=4326"
     }
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryPlannerTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryPlannerTest.scala
@@ -87,7 +87,7 @@ class QueryPlannerTest extends Specification with Mockito with TestWithDataStore
       val result = planner.runQuery(sft, query).toList
 
       result.map(_.getID) mustEqual Seq("id", "id2")
-      forall(result)(r => r.getAttributeCount mustEqual 2) // geom always gets included
+      forall(result)(r => r.getAttributeCount mustEqual 1)
       result.map(_.getAttribute("s")) must containTheSameElementsAs(Seq("string", "astring"))
 
     }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/XZ2IdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/XZ2IdxStrategyTest.scala
@@ -124,8 +124,7 @@ class XZ2IdxStrategyTest extends Specification with TestWithDataStore {
       val features = execute(filter, Some(Array("name"))).toList
       features must haveSize(4)
       features.map(_.getID.toInt) must containTheSameElementsAs(6 to 9)
-      forall(features)((f: SimpleFeature) => f.getAttributeCount mustEqual 2) // geom always gets added
-      forall(features)((f: SimpleFeature) => f.getAttribute("geom") must not(beNull))
+      forall(features)((f: SimpleFeature) => f.getAttributeCount mustEqual 1)
       forall(features)((f: SimpleFeature) => f.getAttribute("name") must not(beNull))
     }
 
@@ -134,8 +133,7 @@ class XZ2IdxStrategyTest extends Specification with TestWithDataStore {
       val features = execute(filter, Some(Array("name"))).toList
       features must haveSize(5)
       features.map(_.getID.toInt) must containTheSameElementsAs(10 to 14)
-      forall(features)((f: SimpleFeature) => f.getAttributeCount mustEqual 2) // geom always gets added
-      forall(features)((f: SimpleFeature) => f.getAttribute("geom") must not(beNull))
+      forall(features)((f: SimpleFeature) => f.getAttributeCount mustEqual 1)
       forall(features)((f: SimpleFeature) => f.getAttribute("name") must not(beNull))
     }
 
@@ -144,8 +142,7 @@ class XZ2IdxStrategyTest extends Specification with TestWithDataStore {
       val features = execute(filter, Some(Array("derived=strConcat('my', name)"))).toList
       features must haveSize(4)
       features.map(_.getID.toInt) must containTheSameElementsAs(6 to 9)
-      forall(features)((f: SimpleFeature) => f.getAttributeCount mustEqual 2) // geom always gets added
-      forall(features)((f: SimpleFeature) => f.getAttribute("geom") must not(beNull))
+      forall(features)((f: SimpleFeature) => f.getAttributeCount mustEqual 1)
       forall(features)((f: SimpleFeature) => f.getAttribute("derived").asInstanceOf[String] must beMatching("myname\\d"))
     }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z2IdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z2IdxStrategyTest.scala
@@ -53,7 +53,7 @@ class Z2IdxStrategyTest extends Specification with TestWithDataStore {
     }
   addFeatures(features)
 
-  implicit val ff = CommonFactoryFinder.getFilterFactory2
+  val ff = CommonFactoryFinder.getFilterFactory2
   val strategy = Z2Index
   val queryPlanner = ds.queryPlanner
   val output = ExplainNull
@@ -126,8 +126,7 @@ class Z2IdxStrategyTest extends Specification with TestWithDataStore {
       val features = execute(filter, Some(Array("name")))
       features must haveSize(4)
       features.map(_.getID.toInt) must containTheSameElementsAs(6 to 9)
-      forall(features)((f: SimpleFeature) => f.getAttributeCount mustEqual 2) // geom always gets added
-      forall(features)((f: SimpleFeature) => f.getAttribute("geom") must not(beNull))
+      forall(features)((f: SimpleFeature) => f.getAttributeCount mustEqual 1)
       forall(features)((f: SimpleFeature) => f.getAttribute("name") must not(beNull))
     }
 
@@ -137,8 +136,7 @@ class Z2IdxStrategyTest extends Specification with TestWithDataStore {
       val features = execute(filter, Some(Array("derived=strConcat('my', name)")))
       features must haveSize(4)
       features.map(_.getID.toInt) must containTheSameElementsAs(6 to 9)
-      forall(features)((f: SimpleFeature) => f.getAttributeCount mustEqual 2) // geom always gets added
-      forall(features)((f: SimpleFeature) => f.getAttribute("geom") must not(beNull))
+      forall(features)((f: SimpleFeature) => f.getAttributeCount mustEqual 1)
       forall(features)((f: SimpleFeature) => f.getAttribute("derived").asInstanceOf[String] must beMatching("myname\\d"))
     }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategyTest.scala
@@ -67,7 +67,7 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
     }
   addFeatures(features)
 
-  implicit val ff = CommonFactoryFinder.getFilterFactory2
+  val ff = CommonFactoryFinder.getFilterFactory2
 
   def runQuery(filter: String, transforms: Array[String] = null): Iterator[SimpleFeature] =
     runQuery(new Query(sftName, ECQL.toFilter(filter), transforms))
@@ -196,8 +196,7 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       features must haveSize(4)
       features.map(_.getID.toInt) must containTheSameElementsAs(6 to 9)
       forall(features) { f =>
-        f.getAttributeCount mustEqual 2 // geom always gets added
-        f.getAttribute("geom") must not(beNull)
+        f.getAttributeCount mustEqual 1
         f.getAttribute("name") must not(beNull)
       }
     }
@@ -209,8 +208,7 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       features must haveSize(4)
       features.map(_.getID.toInt) must containTheSameElementsAs(6 to 9)
       forall(features) { f =>
-        f.getAttributeCount mustEqual 2 // geom always gets added
-        f.getAttribute("geom") must not(beNull)
+        f.getAttributeCount mustEqual 1
         f.getAttribute("derived").asInstanceOf[String] must beMatching("myname\\d")
       }
     }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/AttributeIndexIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/AttributeIndexIteratorTest.scala
@@ -177,8 +177,7 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
         val results = query(filter, Array("dtg"))
 
         results must haveSize(4)
-        results.map(_.getAttributeCount) must contain(2).foreach // geom gets added back in
-        results.map(_.getAttribute("geom").toString) must contain("POINT (45 45)", "POINT (46 46)", "POINT (47 47)", "POINT (48 48)")
+        results.map(_.getAttributeCount) must contain(1).foreach
         results.map(_.getAttribute("dtg").asInstanceOf[Date]) must contain(dateToIndex).foreach
       }
 
@@ -196,9 +195,8 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
         val results = query(filter, Array("name"))
 
         results must haveSize(4)
-        results.map(_.getAttributeCount) must contain(2).foreach // geom gets added back in
+        results.map(_.getAttributeCount) must contain(1).foreach
         results.map(_.getAttribute("name").toString) must contain("b").foreach
-        results.map(_.getAttribute("geom").toString) must contain("POINT (45 45)", "POINT (46 46)", "POINT (47 47)", "POINT (48 48)")
       }
 
       "with additional filter applied" >> {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/IteratorTriggerTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/IteratorTriggerTest.scala
@@ -23,6 +23,7 @@ import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class IteratorTriggerTest extends Specification {
+
   sequential
 
   object TestTable {
@@ -239,7 +240,7 @@ class IteratorTriggerTest extends Specification {
 
   "IteratorTrigger" should {
     "accept INCLUDE as a pass through filter" in {
-      IteratorTrigger.passThroughFilter(Filter.INCLUDE) mustEqual(true)
+      IteratorTrigger.passThroughFilter(Filter.INCLUDE) must beTrue
     }
 
     "determine overlap between transforms and filters" >> {
@@ -278,11 +279,10 @@ class IteratorTriggerTest extends Specification {
       }
 
       "for non-included geoms" >> {
-        // geom will always get added to the transforms
         val filter = "BBOX(geom, -180, -90, 180, 90) AND dtg = 2010-08-08T23:59:59Z"
         val attributes = Array("dtg")
         val result = testOverlap(filter, attributes)
-        result must beTrue
+        result must beFalse
       }
     }
   }

--- a/geomesa-accumulo/geomesa-accumulo-tools/src/test/scala/org/locationtech/geomesa/accumulo/tools/export/FeatureExporterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/test/scala/org/locationtech/geomesa/accumulo/tools/export/FeatureExporterTest.scala
@@ -109,12 +109,12 @@ class FeatureExporterTest extends Specification {
       val result = writer.toString.split("\r\n")
       val (header, data) = (result(0), result(1))
 
-      header mustEqual "id,*geom:Point:srid=4326,dtg:Date,derived:String"
-      data mustEqual "fid-1,POINT (45 49),1970-01-01T00:00:00.000Z,myname-test"
+      header mustEqual "id,derived:String,*geom:Point:srid=4326,dtg:Date"
+      data mustEqual "fid-1,myname-test,POINT (45 49),1970-01-01T00:00:00.000Z"
     }
 
     "should handle escapes" >> {
-      val query = new Query(sftName, Filter.INCLUDE, Array("derived=strConcat(name, ',test')", "geom", "dtg"))
+      val query = new Query(sftName, Filter.INCLUDE, Array("geom", "dtg", "derived=strConcat(name, ',test')"))
       val features = ds.getFeatureSource(sftName).getFeatures(query)
 
       val writer = new StringWriter()
@@ -136,7 +136,7 @@ class FeatureExporterTest extends Specification {
     val (ds, sft) = getDataStoreAndSft(sftName, 10)
 
     "should handle transforms" >> {
-      val query = new Query(sftName, Filter.INCLUDE, Array("derived=strConcat(name, '-test')", "geom", "dtg"))
+      val query = new Query(sftName, Filter.INCLUDE, Array("geom", "dtg", "derived=strConcat(name, '-test')"))
       val featureCollection = ds.getFeatureSource(sftName).getFeatures(query)
 
       val os = new ByteArrayOutputStream()

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
@@ -111,7 +111,7 @@ class CassandraDataStoreTest extends Specification {
           val fr = ds.getFeatureReader(new Query(typeName, ECQL.toFilter(filter), transforms), Transaction.AUTO_COMMIT)
           val features = SelfClosingIterator(fr).toList
           features.headOption.map(f => SimpleFeatureTypes.encodeType(f.getFeatureType)) must
-              beSome("*geom:Point:srid=4326,derived:String")
+              beSome("derived:String,*geom:Point:srid=4326")
           features.map(_.getID) must containTheSameElementsAs(results.map(_.getID))
           forall(features) { feature =>
             feature.getAttribute("derived") mustEqual s"helloname${feature.getID}"

--- a/geomesa-fs/geomesa-fs-datastore/src/test/scala/org/locationtech/geomesa/fs/FileSystemDataStoreTest.scala
+++ b/geomesa-fs/geomesa-fs-datastore/src/test/scala/org/locationtech/geomesa/fs/FileSystemDataStoreTest.scala
@@ -119,7 +119,7 @@ class FileSystemDataStoreTest extends Specification {
         "dtg > '2017-06-05T04:03:00.0000Z' AND dtg < '2017-06-05T04:04:00.0000Z'",
         "dtg DURING 2017-06-05T04:03:00.0000Z/2017-06-05T04:04:00.0000Z and bbox(geom, 5, 5, 15, 15)"
       ).map(ECQL.toFilter)
-      val transforms = Seq(null, Array("name"), Array("dtg", "geom")) // note: geom is always returned
+      val transforms = Seq(null, Array("name"), Array("dtg", "geom"))
 
       foreach(filters) { filter =>
         foreach(transforms) { transform =>
@@ -130,13 +130,9 @@ class FileSystemDataStoreTest extends Specification {
           if (transform == null) {
             feature.getAttributeCount mustEqual 4
             feature.getAttributes mustEqual sf.getAttributes
-          } else if (transform.contains("geom")) {
+          } else {
             feature.getAttributeCount mustEqual transform.length
             foreach(transform)(t => feature.getAttribute(t) mustEqual sf.getAttribute(t))
-          } else {
-            feature.getAttributeCount mustEqual transform.length + 1
-            foreach(transform)(t => feature.getAttribute(t) mustEqual sf.getAttribute(t))
-            feature.getAttribute("geom") mustEqual sf.getAttribute("geom")
           }
         }
       }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreTest.scala
@@ -93,7 +93,7 @@ class HBaseDataStoreTest extends HBaseTest with LazyLogging {
           val fr = ds.getFeatureReader(new Query(typeName, ECQL.toFilter(filter), transforms), Transaction.AUTO_COMMIT)
           val features = SelfClosingIterator(fr).toList
           features.headOption.map(f => SimpleFeatureTypes.encodeType(f.getFeatureType)) must
-            beSome("*geom:Point:srid=4326,derived:String")
+            beSome("derived:String,*geom:Point:srid=4326")
           features.map(_.getID) must containTheSameElementsAs(results.map(_.getID))
           forall(features) { feature =>
             feature.getAttribute("derived") mustEqual s"helloname${feature.getID}"

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureSpecParser.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureSpecParser.scala
@@ -49,7 +49,7 @@ object SimpleFeatureSpecParser {
         if (matchers.isEmpty) {
           s"Invalid spec string at index ${e.getStartIndex}."
         } else {
-          val expected = if (matchers.length > 1) { s"one of: ${matchers.mkString(", ")}" } else { matchers.head }
+          val expected = if (matchers.lengthCompare(1) > 0) { s"one of: ${matchers.mkString(", ")}" } else { matchers.head }
           s"Invalid spec string at index ${e.getStartIndex}. Expected $expected."
         }
       }.getOrElse(fallback)
@@ -98,7 +98,7 @@ private class SimpleFeatureSpecParser extends BasicParser {
 
   // full simple feature spec
   def spec: Rule1[SimpleFeatureSpec] = rule("Specification") {
-    (oneOrMore(attribute, ",") ~ sftOptions) ~ EOI ~~> {
+    (zeroOrMore(attribute, ",") ~ sftOptions) ~ EOI ~~> {
       (attributes, sftOpts) => SimpleFeatureSpec(attributes, sftOpts)
     }
   }

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypesTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypesTest.scala
@@ -76,6 +76,19 @@ class SimpleFeatureTypesTest extends Specification {
       }
     }
 
+    "create an empty type" >> {
+      val sft = SimpleFeatureTypes.createType("test", "")
+      sft.getTypeName mustEqual "test"
+      sft.getAttributeDescriptors must beEmpty
+    }
+
+    "create an empty type with user data" >> {
+      val sft = SimpleFeatureTypes.createType("test", ";geomesa.table.sharing='true'")
+      sft.getTypeName mustEqual "test"
+      sft.getAttributeDescriptors must beEmpty
+      sft.getUserData.get("geomesa.table.sharing") mustEqual "true"
+    }
+
     "handle namespaces" >> {
       "simple ones" >> {
         val sft = SimpleFeatureTypes.createType("ns:testing", "dtg:Date,*geom:Point:srid=4326")
@@ -322,7 +335,6 @@ class SimpleFeatureTypesTest extends Specification {
       Try(SimpleFeatureTypes.createType("test", null)) must
           beAFailedTry.withThrowable[IllegalArgumentException](Pattern.quote("Invalid spec string: null"))
       val failures = Seq(
-        ("", "0. Expected one of: attribute name, '*'"),
         ("foo:Strong", "7. Expected attribute type binding"),
         ("foo:String,*bar:String", "16. Expected geometry type binding"),
         ("foo:String,bar:String;;", "22. Expected one of: feature type option, end of spec"),


### PR DESCRIPTION
* Will return all properties for null array
* Will return no properties for empty array
* No longer always add default geometry as a return property
* Returns property in the order they are passed in

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>