### PR TITLE
GEOMESA-2206 Kafka - don't index features during initial bulk load

### DIFF
--- a/docs/user/kafka/usage.rst
+++ b/docs/user/kafka/usage.rst
@@ -37,7 +37,9 @@ Parameter                            Type    Description
                                              format. See `Producer Configs <http://kafka.apache.org/documentation.html#producerconfigs>`_
 ``kafka.consumer.config``            String  Configuration options for kafka consumer, in Java properties
                                              format. See `New Consumer Configs <http://kafka.apache.org/documentation.html#newconsumerconfigs>`_
-``kafka.consumer.from-beginning``    Boolean Start reading from the beginning of the topic (vs ignore old messages)
+``kafka.consumer.from-beginning``    Boolean Start reading from the beginning of the topic (vs ignore existing messages). If enabled, features
+                                             will not be available for query until all existing messages are processed. However, feature
+                                             listeners will still be invoked as normal.
 ``kafka.consumer.count``             Integer Number of kafka consumers used per feature type. Set to 0
                                              to disable consuming (i.e. producer only)
 ``kafka.topic.partitions``           Integer Number of partitions to use in kafka topics

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaCacheLoader.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaCacheLoader.scala
@@ -10,18 +10,20 @@ package org.locationtech.geomesa.kafka.data
 
 import java.io.Closeable
 import java.util.Collections
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{ConcurrentHashMap, Executors}
 
+import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord}
 import org.geotools.data.simple.SimpleFeatureSource
 import org.geotools.data.{FeatureEvent, FeatureListener}
+import org.locationtech.geomesa.kafka.KafkaConsumerVersions
 import org.locationtech.geomesa.kafka.consumer.ThreadedConsumer
 import org.locationtech.geomesa.kafka.index.KafkaFeatureCache
 import org.locationtech.geomesa.kafka.utils.GeoMessage.{Change, Clear, Delete}
 import org.locationtech.geomesa.kafka.utils.{GeoMessageSerializer, KafkaFeatureEvent}
-import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
-import org.opengis.feature.simple.SimpleFeatureType
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.util.control.NonFatal
 
@@ -43,20 +45,20 @@ trait KafkaCacheLoader extends Closeable with LazyLogging {
   def removeListener(source: SimpleFeatureSource, listener: FeatureListener): Unit =
     listeners.remove((source, listener))
 
-  protected def fireEvent(message: Change): Unit = {
+  protected [KafkaCacheLoader] def fireEvent(message: Change): Unit = {
     if (!listeners.isEmpty) {
       fireEvent(KafkaFeatureEvent.changed(_, message.feature, message.timestamp.toEpochMilli))
     }
   }
 
-  protected def fireEvent(message: Delete): Unit = {
+  protected [KafkaCacheLoader] def fireEvent(message: Delete): Unit = {
     if (!listeners.isEmpty) {
       val removed = cache.query(message.id).orNull
       fireEvent(KafkaFeatureEvent.removed(_, message.id, removed, message.timestamp.toEpochMilli))
     }
   }
 
-  protected def fireEvent(message: Clear): Unit = {
+  protected [KafkaCacheLoader] def fireEvent(message: Clear): Unit = {
     if (!listeners.isEmpty) {
       fireEvent(KafkaFeatureEvent.cleared(_, message.timestamp.toEpochMilli))
     }
@@ -84,15 +86,23 @@ object KafkaCacheLoader {
   }
 
   class KafkaCacheLoaderImpl(sft: SimpleFeatureType,
-                             val cache: KafkaFeatureCache,
-                             override protected val consumers: Seq[Consumer[Array[Byte], Array[Byte]]])
-      extends ThreadedConsumer with KafkaCacheLoader {
-
-    override protected val topic: String = KafkaDataStore.topic(sft)
-    override protected val frequency: Long =
-      SystemProperty("geomesa.kafka.load.interval").toDuration.map(_.toMillis).getOrElse(100L)
+                             override val cache: KafkaFeatureCache,
+                             override protected val consumers: Seq[Consumer[Array[Byte], Array[Byte]]],
+                             override protected val topic: String,
+                             override protected val frequency: Long,
+                             private var doInitialLoad: Boolean) extends ThreadedConsumer with KafkaCacheLoader {
 
     private val serializer = new GeoMessageSerializer(sft)
+
+    if (doInitialLoad) {
+      doInitialLoad = false
+      // for the initial load, don't bother indexing in the feature cache until we have the final state
+      val executor = Executors.newSingleThreadExecutor()
+      executor.submit(new InitialLoader(consumers, topic, frequency, serializer, this))
+      executor.shutdown()
+    } else {
+      startConsumers()
+    }
 
     override def close(): Unit = {
       try {
@@ -102,7 +112,7 @@ object KafkaCacheLoader {
       }
     }
 
-    override protected def consume(record: ConsumerRecord[Array[Byte], Array[Byte]]): Unit = {
+    override protected [KafkaCacheLoader] def consume(record: ConsumerRecord[Array[Byte], Array[Byte]]): Unit = {
       val message = serializer.deserialize(record.key, record.value)
       logger.trace(s"Consumed message [$topic:${record.partition}:${record.offset}] $message")
       message match {
@@ -111,6 +121,91 @@ object KafkaCacheLoader {
         case m: Clear  => fireEvent(m); cache.clear()
         case m => throw new IllegalArgumentException(s"Unknown message: $m")
       }
+    }
+  }
+
+  /**
+    * Handles initial loaded 'from-beginning' without indexing features in the spatial index. Will still
+    * trigger message events.
+    *
+    * @param consumers consumers, won't be closed even on call to 'close()'
+    * @param topic kafka topic
+    * @param frequency polling frequency in milliseconds
+    * @param serializer message serializer
+    * @param toLoad main cache loader, used for callback when bulk loading is done
+    */
+  private class InitialLoader(override protected val consumers: Seq[Consumer[Array[Byte], Array[Byte]]],
+                              override protected val topic: String,
+                              override protected val frequency: Long,
+                              serializer: GeoMessageSerializer,
+                              toLoad: KafkaCacheLoaderImpl) extends ThreadedConsumer with Runnable {
+
+    private val loadCache: Cache[String, SimpleFeature] = Caffeine.newBuilder().build()
+
+    // track the offsets that we want to read to
+    private val offsets = new ConcurrentHashMap[Int, Long]()
+    private val done = new AtomicBoolean(false)
+
+    override protected def closeConsumers: Boolean = false
+
+    override protected def consume(record: ConsumerRecord[Array[Byte], Array[Byte]]): Unit = {
+      if (done.get) { toLoad.consume(record) } else {
+        val message = serializer.deserialize(record.key, record.value)
+        logger.trace(s"Consumed message [$topic:${record.partition}:${record.offset}] $message")
+        message match {
+          case m: Change => toLoad.fireEvent(m); loadCache.put(m.feature.getID, m.feature)
+          case m: Delete => toLoad.fireEvent(m); loadCache.invalidate(m.id)
+          case m: Clear  => toLoad.fireEvent(m); loadCache.invalidateAll()
+          case m => throw new IllegalArgumentException(s"Unknown message: $m")
+        }
+        // once we've hit the max offset for the partition, remove from the offset map to indicate we're done
+        if (offsets.getOrDefault(record.partition, Long.MaxValue) <= record.offset) {
+          offsets.remove(record.partition)
+        }
+      }
+    }
+
+    override def run(): Unit = {
+      import scala.collection.JavaConverters._
+
+      val partitions = consumers.head.partitionsFor(topic).asScala.map(_.partition)
+      try {
+        // note: these methods are not available in kafka 0.9, which will cause it to fall back to normal loading
+        val beginningOffsets = KafkaConsumerVersions.beginningOffsets(consumers.head, topic, partitions)
+        val endOffsets = KafkaConsumerVersions.endOffsets(consumers.head, topic, partitions)
+        partitions.foreach { p =>
+          // end offsets are the *next* offset that will be returned, so subtract one to track the last offset
+          // we will actually consume
+          val endOffset = endOffsets.getOrElse(p, 0L) - 1L
+          // note: not sure if start offsets are also off by one, but at the worst we would skip bulk loading
+          // for the last message per topic
+          val beginningOffset = beginningOffsets.getOrElse(p, 0L)
+          if (beginningOffset < endOffset) {
+            offsets.put(p, endOffset)
+          }
+        }
+      } catch {
+        case e: NoSuchMethodException => logger.warn(s"Can't support initial bulk loading for current Kafka version: $e")
+      }
+      // don't bother spinning up the consumer threads if we don't need to actually bulk load anything
+      if (!offsets.isEmpty) {
+        startConsumers() // kick off the asynchronous consumer threads
+        try {
+          // offsets will get removed from the map in `consume`, so we're done when the map is empty
+          while (!offsets.isEmpty) {
+            Thread.sleep(1000)
+          }
+        } finally {
+          // stop the consumer threads, but won't close the consumers due to `closeConsumers`
+          close()
+        }
+        // set a flag just in case the consumer threads haven't finished spinning down, so that we will
+        // pass any additional messages back to the main loader
+        done.set(true)
+        loadCache.asMap().asScala.foreach { case (_, v) => toLoad.cache.put(v) }
+      }
+      // start the normal loading
+      toLoad.startConsumers()
     }
   }
 }

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreFactory.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreFactory.scala
@@ -22,6 +22,7 @@ import org.locationtech.geomesa.kafka.data.KafkaDataStoreFactory.KafkaDataStoreF
 import org.locationtech.geomesa.security
 import org.locationtech.geomesa.security.AuthorizationsProvider
 import org.locationtech.geomesa.utils.audit.{AuditLogger, AuditProvider, NoOpAuditProvider}
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
 import org.locationtech.geomesa.utils.geotools.GeoMesaParam
 import org.locationtech.geomesa.utils.geotools.GeoMesaParam.{ConvertedParam, DeprecatedParam}
 

--- a/geomesa-kafka/geomesa-kafka-utils/src/main/scala/org/locationtech/geomesa/kafka/consumer/ThreadedConsumer.scala
+++ b/geomesa-kafka/geomesa-kafka-utils/src/main/scala/org/locationtech/geomesa/kafka/consumer/ThreadedConsumer.scala
@@ -49,7 +49,10 @@ trait ThreadedConsumer extends Closeable with LazyLogging {
   def startConsumers(): Unit = {
     val format = if (consumers.lengthCompare(10) > 0) { "%02d" } else { "%d" }
     var i = 0
-    consumers.foreach { c => executor.execute(new ConsumerRunnable(c, frequency, String.format(format, i))); i += 1 }
+    consumers.foreach { c =>
+      executor.execute(new ConsumerRunnable(c, frequency, String.format(format, Int.box(i))))
+      i += 1
+    }
     logger.debug(s"Started $i consumer(s) on topic $topic")
   }
 

--- a/geomesa-kafka/geomesa-kafka-utils/src/main/scala/org/locationtech/geomesa/kafka/consumer/ThreadedConsumer.scala
+++ b/geomesa-kafka/geomesa-kafka-utils/src/main/scala/org/locationtech/geomesa/kafka/consumer/ThreadedConsumer.scala
@@ -10,29 +10,48 @@ package org.locationtech.geomesa.kafka.consumer
 
 import java.io.Closeable
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.{Executors, TimeUnit}
+import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
 
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord}
+import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord, OffsetAndMetadata, OffsetCommitCallback}
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.WakeupException
 
 import scala.util.control.NonFatal
 
 trait ThreadedConsumer extends Closeable with LazyLogging {
 
+  import scala.collection.JavaConverters._
+
   protected val consumers: Seq[Consumer[Array[Byte], Array[Byte]]]
   protected val topic: String
   protected val frequency: Long
 
+  protected def closeConsumers: Boolean = true
+
   protected def consume(record: ConsumerRecord[Array[Byte], Array[Byte]]): Unit
+
+  private val executor: ExecutorService = Executors.newFixedThreadPool(consumers.length)
 
   private val closed = new AtomicBoolean(false)
 
-  private val executor = Executors.newFixedThreadPool(consumers.length)
+  private val commitCallback = new OffsetCommitCallback() {
+    override def onComplete(offsets: java.util.Map[TopicPartition, OffsetAndMetadata], exception: Exception): Unit = {
+      lazy val o = offsets.asScala.map { case (tp, om) => s"[${tp.topic}:${tp.partition}:${om.offset}]"}.mkString(",")
+      if (exception == null) {
+        logger.trace(s"Consumer committed offsets: $o")
+      } else {
+        logger.error(s"Consumer error committing offsets: $o : ${exception.getMessage}", exception)
+      }
+    }
+  }
 
-  consumers.foreach(c => executor.execute(new ConsumerRunnable(c, frequency)))
-
-  logger.debug(s"Started ${consumers.length} consumer(s) on topic $topic")
+  def startConsumers(): Unit = {
+    val format = if (consumers.lengthCompare(10) > 0) { "%02d" } else { "%d" }
+    var i = 0
+    consumers.foreach { c => executor.execute(new ConsumerRunnable(c, frequency, String.format(format, i))); i += 1 }
+    logger.debug(s"Started $i consumer(s) on topic $topic")
+  }
 
   override def close(): Unit = {
     closed.set(true)
@@ -41,7 +60,7 @@ trait ThreadedConsumer extends Closeable with LazyLogging {
     executor.awaitTermination(1, TimeUnit.SECONDS)
   }
 
-  class ConsumerRunnable(val consumer: Consumer[Array[Byte], Array[Byte]], frequency: Long) extends Runnable {
+  class ConsumerRunnable(consumer: Consumer[Array[Byte], Array[Byte]], frequency: Long, id: String) extends Runnable {
 
     private var errorCount = 0
 
@@ -50,33 +69,38 @@ trait ThreadedConsumer extends Closeable with LazyLogging {
         while (!closed.get()) {
           try {
             val result = consumer.poll(frequency)
-            logger.debug(s"Consumer poll received ${result.count()} records from topic $topic")
+            lazy val topics = result.partitions.asScala.map(tp => s"[${tp.topic}:${tp.partition}]").mkString(",")
+            logger.debug(s"Consumer [$id] poll received ${result.count()} records for $topics")
             if (!result.isEmpty) {
               val records = result.iterator()
               while (records.hasNext) {
                 consume(records.next())
               }
+              logger.trace(s"Consumer [$id] finished processing ${result.count()} records from topic $topics")
               // we commit the offsets so that the next poll doesn't return the same records
-              consumer.commitAsync()
-              logger.trace(s"Consumer finished processing ${result.count()} records from topic $topic")
+              consumer.commitAsync(commitCallback)
               errorCount = 0 // reset error count
             }
           } catch {
             case e: WakeupException => throw e
             case e: InterruptedException => throw e
             case NonFatal(e) =>
-              logger.warn(s"Error receiving message from topic $topic:", e)
-              errorCount += 1
-              if (errorCount < 300) { Thread.sleep(1000) } else {
-                logger.error("Shutting down due to too many errors")
-                throw new InterruptedException("Too many errors")
+              if (errorCount < 300) {
+                errorCount += 1
+                logger.warn(s"Consumer [$id] error receiving message from topic $topic:", e)
+                Thread.sleep(1000)
+              } else {
+                logger.error(s"Consumer [$id] shutting down due to too many errors from topic $topic:", e)
+                throw e
               }
           }
         }
       } catch {
         case _: WakeupException | _: InterruptedException => // return
       } finally {
-        consumer.close()
+        if (closeConsumers) {
+          consumer.close()
+        }
       }
     }
   }

--- a/geomesa-lambda/geomesa-lambda-datastore/src/main/scala/org/locationtech/geomesa/lambda/stream/kafka/KafkaCacheLoader.scala
+++ b/geomesa-lambda/geomesa-lambda-datastore/src/main/scala/org/locationtech/geomesa/lambda/stream/kafka/KafkaCacheLoader.scala
@@ -13,7 +13,6 @@ import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
 import org.locationtech.geomesa.kafka.consumer.ThreadedConsumer
 import org.locationtech.geomesa.lambda.stream.kafka.KafkaFeatureCache.WritableFeatureCache
 import org.locationtech.geomesa.lambda.stream.kafka.KafkaStore.MessageTypes
-import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
 
 /**
   * Consumes from kakfa and populates the local cache
@@ -23,16 +22,17 @@ import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemPropert
   *
   * @param consumers consumers
   * @param topic kafka topic
+  * @param frequency kafka poll delay, in milliseconds
   * @param serializer feature serializer
   * @param cache shared state
   */
 class KafkaCacheLoader(override protected val consumers: Seq[Consumer[Array[Byte], Array[Byte]]],
                        override protected val topic: String,
+                       override protected val frequency: Long,
                        serializer: KryoFeatureSerializer,
                        cache: WritableFeatureCache) extends ThreadedConsumer {
 
-  override protected val frequency: Long =
-    SystemProperty("geomesa.lambda.load.interval").toDuration.map(_.toMillis).getOrElse(100L)
+  startConsumers()
 
   override protected def consume(record: ConsumerRecord[Array[Byte], Array[Byte]]): Unit = {
     val (time, action) = KafkaStore.deserializeKey(record.key)

--- a/geomesa-lambda/geomesa-lambda-datastore/src/main/scala/org/locationtech/geomesa/lambda/stream/kafka/KafkaStore.scala
+++ b/geomesa-lambda/geomesa-lambda-datastore/src/main/scala/org/locationtech/geomesa/lambda/stream/kafka/KafkaStore.scala
@@ -66,7 +66,8 @@ class KafkaStore(ds: DataStore,
 
   private val loader = {
     val consumers = KafkaStore.consumers(consumerConfig, topic, offsetManager, config.consumers, cache.partitionAssigned)
-    new KafkaCacheLoader(consumers, topic, serializer, cache)
+    val frequency = KafkaStore.LoadIntervalProperty.toDuration.get.toMillis
+    new KafkaCacheLoader(consumers, topic, frequency, serializer, cache)
   }
 
   private val persistence = if (config.expiry == Duration.Inf) { None } else {
@@ -163,6 +164,8 @@ class KafkaStore(ds: DataStore,
 }
 
 object KafkaStore {
+
+  val LoadIntervalProperty = SystemProperty("geomesa.lambda.load.interval", "100ms")
 
   object MessageTypes {
     val Write:  Byte = 0


### PR DESCRIPTION
* If 'kafka.consumer.from-beginning', features will not be available
  to query until consumers have caught up, although listeners will be
  called as normal

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>