### PR TITLE
GEOMESA-2224 Updating default kafka version to 1.0.1

### DIFF
--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -232,7 +232,7 @@ org.tukaani:xz	1.0	compile
 picocontainer:picocontainer	1.2	compile
 redis.clients:jedis	2.9.0	compile
 
-com.101tec:zkclient	0.7	provided
+com.101tec:zkclient	0.10	provided
 com.datastax.cassandra:cassandra-driver-core	3.0.0	provided
 com.datastax.cassandra:cassandra-driver-mapping	3.0.0	provided
 javax.media:jai_codec	1.1.3	provided
@@ -244,8 +244,8 @@ org.apache.hadoop:hadoop-distcp	2.6.4	provided
 org.apache.hadoop:hadoop-mapreduce-client-core	2.6.4	provided
 org.apache.hadoop:hadoop-yarn-api	2.6.4	provided
 org.apache.hadoop:hadoop-yarn-common	2.6.4	provided
-org.apache.kafka:kafka_2.11	0.9.0.1	provided
-org.apache.kafka:kafka-clients	0.9.0.1	provided
+org.apache.kafka:kafka_2.11	1.0.1	provided
+org.apache.kafka:kafka-clients	1.0.1	provided
 org.apache.spark:spark-catalyst_2.11	2.2.0	provided
 org.apache.spark:spark-core_2.11	2.2.0	provided
 org.apache.spark:spark-sql_2.11	2.2.0	provided
@@ -262,8 +262,8 @@ org.apache.camel:camel-netty4	2.15.1	test
 org.apache.cassandra:cassandra-all	3.0.0	test
 org.apache.curator:curator-test	2.7.1	test
 org.apache.hbase:hbase-testing-util	1.3.1	test
-org.apache.kafka:kafka_2.11	test:0.9.0.1	test
-org.apache.kafka:kafka-clients	test:0.9.0.1	test
+org.apache.kafka:kafka_2.11	test:1.0.1	test
+org.apache.kafka:kafka-clients	test:1.0.1	test
 org.cassandraunit:cassandra-unit	2.2.2.1	test
 org.codehaus.groovy:groovy-jsr223	2.4.5	test
 org.geotools:gt-geometry	18.0	test

--- a/docs/user/kafka/install.rst
+++ b/docs/user/kafka/install.rst
@@ -193,19 +193,28 @@ your GeoServer ``WEB-INF/lib`` directory:
 
 .. tabs::
 
-    .. tab:: Kafka 0.9
+    .. tab:: Kafka 1.0.1
 
-        * kafka-clients-0.9.0.1.jar
-        * kafka_2.11-0.9.0.1.jar
-        * zkclient-0.7.jar
+        * kafka-clients-1.0.1.jar
+        * kafka_2.11-1.0.1.jar
+        * zkclient-0.10.jar
         * zookeeper-3.4.6.jar
         * metrics-core-2.2.0.jar
+        * jopt-simple-5.0.4.jar
 
     .. tab:: Kafka 0.10
 
         * kafka-clients-0.10.2.1.jar
         * kafka-2.11-0.10.2.1.jar
         * zkclient-0.10.jar
+        * zookeeper-3.4.6.jar
+        * metrics-core-2.2.0.jar
+
+    .. tab:: Kafka 0.9
+
+        * kafka-clients-0.9.0.1.jar
+        * kafka_2.11-0.9.0.1.jar
+        * zkclient-0.7.jar
         * zookeeper-3.4.6.jar
         * metrics-core-2.2.0.jar
 

--- a/geomesa-kafka/geomesa-kafka-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/pom.xml
@@ -86,6 +86,10 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${scala.binary.version}</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
 
         <!-- test -->
         <dependency>

--- a/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/EmbeddedKafka.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/EmbeddedKafka.scala
@@ -13,6 +13,7 @@ import java.io.Closeable
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import kafka.zk.EmbeddedZookeeper
+import org.apache.kafka.common.network.ListenerName
 import org.locationtech.geomesa.utils.io.PathUtils
 
 class EmbeddedKafka extends Closeable {
@@ -31,7 +32,7 @@ class EmbeddedKafka extends Closeable {
     TestUtils.createServer(new KafkaConfig(config))
   }
 
-  val brokers = s"127.0.0.1:${server.socketServer.boundPort()}"
+  val brokers = s"127.0.0.1:${server.boundPort(ListenerName.normalised("PLAINTEXT"))}"
 
   // for kafka 1.0.0:
   // import org.apache.kafka.common.network.ListenerName

--- a/geomesa-lambda/geomesa-lambda-datastore/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-datastore/pom.xml
@@ -101,7 +101,6 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
         </dependency>
-        <!-- TODO support 0.10? -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${scala.binary.version}</artifactId>
@@ -139,10 +138,13 @@
             <classifier>test</classifier>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <classifier>test</classifier>
+        </dependency>
+        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <version>2.7.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-lambda/geomesa-lambda-datastore/src/test/scala/org/locationtech/geomesa/lambda/EmbeddedKafka.scala
+++ b/geomesa-lambda/geomesa-lambda-datastore/src/test/scala/org/locationtech/geomesa/lambda/EmbeddedKafka.scala
@@ -13,6 +13,7 @@ import java.io.Closeable
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import kafka.zk.EmbeddedZookeeper
+import org.apache.kafka.common.network.ListenerName
 import org.locationtech.geomesa.utils.io.PathUtils
 
 class EmbeddedKafka extends Closeable {
@@ -30,7 +31,7 @@ class EmbeddedKafka extends Closeable {
     TestUtils.createServer(new KafkaConfig(config))
   }
 
-  val brokers = s"127.0.0.1:${server.socketServer.boundPort()}"
+  val brokers = s"127.0.0.1:${server.boundPort(ListenerName.normalised("PLAINTEXT"))}"
 
   override def close(): Unit = {
     try { server.shutdown() } catch { case _: Throwable => }

--- a/geomesa-lambda/pom.xml
+++ b/geomesa-lambda/pom.xml
@@ -62,6 +62,8 @@
                 <version>${zkclient.version}</version>
                 <scope>provided</scope>
             </dependency>
+
+            <!-- test dependencies -->
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_${scala.binary.version}</artifactId>
@@ -82,6 +84,29 @@
                         <artifactId>jopt-simple</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
+                <classifier>test</classifier>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>slf4j-log4j12</artifactId>
+                        <groupId>org.slf4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.xerial.snappy</groupId>
+                        <artifactId>snappy-java</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-test</artifactId>
+                <version>2.7.1</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,9 @@
         <hbase.guava.version>12.0.1</hbase.guava.version>
         <cassandra.version>3.0.0</cassandra.version>
         <cassandra.guava.version>18.0</cassandra.guava.version>
-        <kafka.version>0.9.0.1</kafka.version> <!-- also supports: 0.10.2.1, 1.0.0 -->
-        <zkclient.version>0.7</zkclient.version> <!-- corresponding versions: 0.10, 0.10 -->
-        <kafka.jopt.version>3.2</kafka.jopt.version> <!-- corresponding versions: 4.9, 5.0.4 -->
+        <kafka.version>1.0.1</kafka.version> <!-- also supports: 0.10.2.1, 0.9.0.1 -->
+        <zkclient.version>0.10</zkclient.version> <!-- corresponding versions: 0.10, 0.7 -->
+        <kafka.jopt.version>5.0.4</kafka.jopt.version> <!-- corresponding versions: 4.9, 3.2 -->
 
         <arrow.version>0.6.0</arrow.version>
         <netty.version>4.0.41.Final</netty.version>


### PR DESCRIPTION
* 0.10 and 0.9 are still supported

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>