### PR TITLE
GEOMESA-2234 Support gt,gteq,lt,lteq,between queries on strings in CQEngine

### DIFF
--- a/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/index/KafkaFeatureCacheTest.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/index/KafkaFeatureCacheTest.scala
@@ -166,6 +166,39 @@ class KafkaFeatureCacheTest extends Specification with Mockito {
       }
     }
 
+    // turns out Geotools supports querying on string attributes with numeric greaterThan etc
+    "string queries" >> {
+      val ticker = new MockTicker
+
+      val cache = new FeatureCacheCqEngine(sft, Duration.Inf, Duration.Inf, Duration("10ms"))(ticker)
+      try {
+        val stringFilter = ECQL.toFilter("trackId > 0")
+
+        cache.put(track0v0)
+
+        cache.size() mustEqual 1
+        cache.query(stringFilter).size must be greaterThan 0
+      } finally {
+        cache.close()
+      }
+    }
+
+    "like queries" >> {
+      val ticker = new MockTicker
+
+      val cache = new FeatureCacheCqEngine(sft, Duration.Inf, Duration.Inf, Duration("10ms"))(ticker)
+      try {
+        val stringFilter = ECQL.toFilter("trackId ILIKE 'T%'")
+
+        cache.put(track0v0)
+
+        cache.size() mustEqual 1
+        cache.query(stringFilter).size must be greaterThan 0
+      } finally {
+        cache.close()
+      }
+    }
+
     "check consistency" >> {
       skipped("intermittent travis failures")
 

--- a/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/utils/CQEngineQueryVisitor.scala
+++ b/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/utils/CQEngineQueryVisitor.scala
@@ -247,6 +247,7 @@ class CQEngineQueryVisitor(sft: SimpleFeatureType) extends AbstractFilterVisitor
           case c if classOf[java.lang.Long   ].isAssignableFrom(c) => BuildLongGTEQuery(name, lo.asInstanceOf[java.lang.Long])
           case c if classOf[java.lang.Float  ].isAssignableFrom(c) => BuildFloatGTEQuery(name, lo.asInstanceOf[java.lang.Float])
           case c if classOf[java.lang.Double ].isAssignableFrom(c) => BuildDoubleGTEQuery(name, lo.asInstanceOf[java.lang.Double])
+          case c if classOf[java.util.Date   ].isAssignableFrom(c) => BuildDateGTEQuery(name, lo.asInstanceOf[java.util.Date])
           case c if classOf[java.lang.String   ].isAssignableFrom(c) => BuildStringGTEQuery(name, lo.asInstanceOf[java.lang.String])
           case c => throw new RuntimeException(s"PropertyIsLessThanOrEqualTo: $c not supported")
         }

--- a/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/utils/CQEngineQueryVisitor.scala
+++ b/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/utils/CQEngineQueryVisitor.scala
@@ -149,6 +149,7 @@ class CQEngineQueryVisitor(sft: SimpleFeatureType) extends AbstractFilterVisitor
           case c if classOf[java.lang.Float  ].isAssignableFrom(c) => BuildFloatGTQuery(name, lo.asInstanceOf[java.lang.Float])
           case c if classOf[java.lang.Double ].isAssignableFrom(c) => BuildDoubleGTQuery(name, lo.asInstanceOf[java.lang.Double])
           case c if classOf[java.util.Date   ].isAssignableFrom(c) => BuildDateGTQuery(name, lo.asInstanceOf[java.util.Date])
+          case c if classOf[java.lang.String ].isAssignableFrom(c) => BuildStringGTQuery(name, lo.asInstanceOf[java.lang.String])
           case c => throw new RuntimeException(s"PropertyIsGreaterThan: $c not supported")
         }
       case (None, Some(hi)) =>
@@ -158,6 +159,7 @@ class CQEngineQueryVisitor(sft: SimpleFeatureType) extends AbstractFilterVisitor
           case c if classOf[java.lang.Float  ].isAssignableFrom(c) => BuildFloatLTQuery(name, hi.asInstanceOf[java.lang.Float])
           case c if classOf[java.lang.Double ].isAssignableFrom(c) => BuildDoubleLTQuery(name, hi.asInstanceOf[java.lang.Double])
           case c if classOf[java.util.Date   ].isAssignableFrom(c) => BuildDateLTQuery(name, hi.asInstanceOf[java.util.Date])
+          case c if classOf[java.lang.String   ].isAssignableFrom(c) => BuildStringLTQuery(name, hi.asInstanceOf[java.lang.String])
           case c => throw new RuntimeException(s"PropertyIsGreaterThan: $c not supported")
         }
       case _ => throw new RuntimeException(s"Can't parse greater than values ${filterToString(filter)}")
@@ -180,6 +182,7 @@ class CQEngineQueryVisitor(sft: SimpleFeatureType) extends AbstractFilterVisitor
           case c if classOf[java.lang.Float  ].isAssignableFrom(c) => BuildFloatGTEQuery(name, lo.asInstanceOf[java.lang.Float])
           case c if classOf[java.lang.Double ].isAssignableFrom(c) => BuildDoubleGTEQuery(name, lo.asInstanceOf[java.lang.Double])
           case c if classOf[java.util.Date   ].isAssignableFrom(c) => BuildDateGTEQuery(name, lo.asInstanceOf[java.util.Date])
+          case c if classOf[java.lang.String   ].isAssignableFrom(c) => BuildStringGTEQuery(name, lo.asInstanceOf[java.lang.String])
           case c => throw new RuntimeException(s"PropertyIsGreaterThanOrEqualTo: $c not supported")
         }
       case (None, Some(hi)) =>
@@ -189,6 +192,7 @@ class CQEngineQueryVisitor(sft: SimpleFeatureType) extends AbstractFilterVisitor
           case c if classOf[java.lang.Float  ].isAssignableFrom(c) => BuildFloatLTEQuery(name, hi.asInstanceOf[java.lang.Float])
           case c if classOf[java.lang.Double ].isAssignableFrom(c) => BuildDoubleLTEQuery(name, hi.asInstanceOf[java.lang.Double])
           case c if classOf[java.util.Date   ].isAssignableFrom(c) => BuildDateLTEQuery(name, hi.asInstanceOf[java.util.Date])
+          case c if classOf[java.lang.String   ].isAssignableFrom(c) => BuildStringLTEQuery(name, hi.asInstanceOf[java.lang.String])
           case c => throw new RuntimeException(s"PropertyIsGreaterThanOrEqualTo: $c not supported")
         }
       case _ => throw new RuntimeException(s"Can't parse greater than or equal to values ${filterToString(filter)}")
@@ -211,6 +215,7 @@ class CQEngineQueryVisitor(sft: SimpleFeatureType) extends AbstractFilterVisitor
           case c if classOf[java.lang.Float  ].isAssignableFrom(c) => BuildFloatGTQuery(name, lo.asInstanceOf[java.lang.Float])
           case c if classOf[java.lang.Double ].isAssignableFrom(c) => BuildDoubleGTQuery(name, lo.asInstanceOf[java.lang.Double])
           case c if classOf[java.util.Date   ].isAssignableFrom(c) => BuildDateGTQuery(name, lo.asInstanceOf[java.util.Date])
+          case c if classOf[java.lang.String   ].isAssignableFrom(c) => BuildStringGTQuery(name, lo.asInstanceOf[java.lang.String])
           case c => throw new RuntimeException(s"PropertyIsLessThan: $c not supported")
         }
       case (None, Some(hi)) =>
@@ -220,6 +225,7 @@ class CQEngineQueryVisitor(sft: SimpleFeatureType) extends AbstractFilterVisitor
           case c if classOf[java.lang.Float  ].isAssignableFrom(c) => BuildFloatLTQuery(name, hi.asInstanceOf[java.lang.Float])
           case c if classOf[java.lang.Double ].isAssignableFrom(c) => BuildDoubleLTQuery(name, hi.asInstanceOf[java.lang.Double])
           case c if classOf[java.util.Date   ].isAssignableFrom(c) => BuildDateLTQuery(name, hi.asInstanceOf[java.util.Date])
+          case c if classOf[java.lang.String   ].isAssignableFrom(c) => BuildStringLTQuery(name, hi.asInstanceOf[java.lang.String])
           case c => throw new RuntimeException(s"PropertyIsLessThan: $c not supported")
         }
       case _ => throw new RuntimeException(s"Can't parse less than values ${filterToString(filter)}")
@@ -241,7 +247,7 @@ class CQEngineQueryVisitor(sft: SimpleFeatureType) extends AbstractFilterVisitor
           case c if classOf[java.lang.Long   ].isAssignableFrom(c) => BuildLongGTEQuery(name, lo.asInstanceOf[java.lang.Long])
           case c if classOf[java.lang.Float  ].isAssignableFrom(c) => BuildFloatGTEQuery(name, lo.asInstanceOf[java.lang.Float])
           case c if classOf[java.lang.Double ].isAssignableFrom(c) => BuildDoubleGTEQuery(name, lo.asInstanceOf[java.lang.Double])
-          case c if classOf[java.util.Date   ].isAssignableFrom(c) => BuildDateGTEQuery(name, lo.asInstanceOf[java.util.Date])
+          case c if classOf[java.lang.String   ].isAssignableFrom(c) => BuildStringGTEQuery(name, lo.asInstanceOf[java.lang.String])
           case c => throw new RuntimeException(s"PropertyIsLessThanOrEqualTo: $c not supported")
         }
       case (None, Some(hi)) =>
@@ -251,6 +257,7 @@ class CQEngineQueryVisitor(sft: SimpleFeatureType) extends AbstractFilterVisitor
           case c if classOf[java.lang.Float  ].isAssignableFrom(c) => BuildFloatLTEQuery(name, hi.asInstanceOf[java.lang.Float])
           case c if classOf[java.lang.Double ].isAssignableFrom(c) => BuildDoubleLTEQuery(name, hi.asInstanceOf[java.lang.Double])
           case c if classOf[java.util.Date   ].isAssignableFrom(c) => BuildDateLTEQuery(name, hi.asInstanceOf[java.util.Date])
+          case c if classOf[java.lang.String   ].isAssignableFrom(c) => BuildStringLTEQuery(name, hi.asInstanceOf[java.lang.String])
           case c => throw new RuntimeException(s"PropertyIsLessThanOrEqualTo: $c not supported")
         }
       case _ => throw new RuntimeException(s"Can't parse less than or equal to values ${filterToString(filter)}")
@@ -294,6 +301,7 @@ class CQEngineQueryVisitor(sft: SimpleFeatureType) extends AbstractFilterVisitor
       case c if classOf[java.lang.Float  ].isAssignableFrom(c) => BuildFloatBetweenQuery(name, between.asInstanceOf[(java.lang.Float, java.lang.Float)])
       case c if classOf[java.lang.Double ].isAssignableFrom(c) => BuildDoubleBetweenQuery(name, between.asInstanceOf[(java.lang.Double, java.lang.Double)])
       case c if classOf[java.util.Date   ].isAssignableFrom(c) => BuildDateBetweenQuery(name, between.asInstanceOf[(java.util.Date, java.util.Date)])
+      case c if classOf[java.lang.String   ].isAssignableFrom(c) => BuildStringBetweenQuery(name, between.asInstanceOf[(java.lang.String, java.lang.String)])
       case c => throw new RuntimeException(s"PropertyIsBetween: $c not supported")
     }
   }

--- a/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/utils/QueryBuilder.scala
+++ b/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/utils/QueryBuilder.scala
@@ -8,6 +8,9 @@
 
 package org.locationtech.geomesa.memory.cqengine.utils
 
+import java.lang
+import java.util.Date
+
 import com.googlecode.cqengine.attribute.Attribute
 import com.googlecode.cqengine.query.simple.{Between, GreaterThan, LessThan, SimpleQuery}
 import org.opengis.feature.simple.SimpleFeature
@@ -63,125 +66,148 @@ trait BetweenQueryBuilder extends CompQueryBuilder {
 
 object BuildIntGTQuery extends GTQueryBuilder {
   type VALUE = java.lang.Integer
-  override val valueClass = classOf[java.lang.Integer]
+  override val valueClass: Class[Integer] = classOf[java.lang.Integer]
   val orEqual = false
 }
 object BuildLongGTQuery extends GTQueryBuilder {
   type VALUE = java.lang.Long
-  override val valueClass = classOf[java.lang.Long]
+  override val valueClass: Class[lang.Long] = classOf[java.lang.Long]
   val orEqual = false
 }
 object BuildFloatGTQuery extends GTQueryBuilder {
   type VALUE = java.lang.Float
-  override val valueClass = classOf[java.lang.Float]
+  override val valueClass: Class[lang.Float] = classOf[java.lang.Float]
   val orEqual = false
 }
 object BuildDoubleGTQuery extends GTQueryBuilder {
   type VALUE = java.lang.Double
-  override val valueClass = classOf[java.lang.Double]
+  override val valueClass: Class[lang.Double] = classOf[java.lang.Double]
   val orEqual = false
 }
 object BuildDateGTQuery extends GTQueryBuilder {
   type VALUE = java.util.Date
-  override val valueClass = classOf[java.util.Date]
+  override val valueClass: Class[Date] = classOf[java.util.Date]
   val orEqual = false
 }
-
+object BuildStringGTQuery extends GTQueryBuilder {
+  type VALUE = java.lang.String
+  override val orEqual: Boolean = false
+  override val valueClass: Class[String] = classOf[VALUE]
+}
 object BuildIntGTEQuery extends GTQueryBuilder {
   type VALUE = java.lang.Integer
-  override val valueClass = classOf[java.lang.Integer]
+  override val valueClass: Class[Integer] = classOf[java.lang.Integer]
   val orEqual = true
 }
 object BuildLongGTEQuery extends GTQueryBuilder {
   type VALUE = java.lang.Long
-  override val valueClass = classOf[java.lang.Long]
+  override val valueClass: Class[lang.Long] = classOf[java.lang.Long]
   val orEqual = true
 }
 object BuildFloatGTEQuery extends GTQueryBuilder {
   type VALUE = java.lang.Float
-  override val valueClass = classOf[java.lang.Float]
+  override val valueClass: Class[lang.Float] = classOf[java.lang.Float]
   val orEqual = true
 }
 object BuildDoubleGTEQuery extends GTQueryBuilder {
   type VALUE = java.lang.Double
-  override val valueClass = classOf[java.lang.Double]
+  override val valueClass: Class[lang.Double] = classOf[java.lang.Double]
   val orEqual = true
 }
 object BuildDateGTEQuery extends GTQueryBuilder {
   type VALUE = java.util.Date
-  override val valueClass = classOf[java.util.Date]
+  override val valueClass: Class[Date] = classOf[java.util.Date]
+  val orEqual = true
+}
+object BuildStringGTEQuery extends GTQueryBuilder {
+  type VALUE = java.lang.String
+  override val valueClass: Class[String] = classOf[java.lang.String]
   val orEqual = true
 }
 
 object BuildIntLTQuery extends LTQueryBuilder {
   type VALUE = java.lang.Integer
-  override val valueClass = classOf[java.lang.Integer]
+  override val valueClass: Class[Integer] = classOf[java.lang.Integer]
   val orEqual = false
 }
 object BuildLongLTQuery extends LTQueryBuilder {
   type VALUE = java.lang.Long
-  override val valueClass = classOf[java.lang.Long]
+  override val valueClass: Class[lang.Long] = classOf[java.lang.Long]
   val orEqual = false
 }
 object BuildFloatLTQuery extends LTQueryBuilder {
   type VALUE = java.lang.Float
-  override val valueClass = classOf[java.lang.Float]
+  override val valueClass: Class[lang.Float] = classOf[java.lang.Float]
   val orEqual = false
 }
 object BuildDoubleLTQuery extends LTQueryBuilder {
   type VALUE = java.lang.Double
-  override val valueClass = classOf[java.lang.Double]
+  override val valueClass: Class[lang.Double] = classOf[java.lang.Double]
   val orEqual = false
 }
 object BuildDateLTQuery extends LTQueryBuilder {
   type VALUE = java.util.Date
-  override val valueClass = classOf[java.util.Date]
+  override val valueClass: Class[Date] = classOf[java.util.Date]
+  val orEqual = false
+}
+object BuildStringLTQuery extends LTQueryBuilder {
+  type VALUE = java.lang.String
+  override val valueClass: Class[String] = classOf[java.lang.String]
   val orEqual = false
 }
 
 object BuildIntLTEQuery extends LTQueryBuilder {
   type VALUE = java.lang.Integer
-  override val valueClass = classOf[java.lang.Integer]
+  override val valueClass: Class[Integer] = classOf[java.lang.Integer]
   val orEqual = true
 }
 object BuildLongLTEQuery extends LTQueryBuilder {
   type VALUE = java.lang.Long
-  override val valueClass = classOf[java.lang.Long]
+  override val valueClass: Class[lang.Long] = classOf[java.lang.Long]
   val orEqual = true
 }
 object BuildFloatLTEQuery extends LTQueryBuilder {
   type VALUE = java.lang.Float
-  override val valueClass = classOf[java.lang.Float]
+  override val valueClass: Class[lang.Float] = classOf[java.lang.Float]
   val orEqual = true
 }
 object BuildDoubleLTEQuery extends LTQueryBuilder {
   type VALUE = java.lang.Double
-  override val valueClass = classOf[java.lang.Double]
+  override val valueClass: Class[lang.Double] = classOf[java.lang.Double]
   val orEqual = true
 }
 object BuildDateLTEQuery extends LTQueryBuilder {
   type VALUE = java.util.Date
-  override val valueClass = classOf[java.util.Date]
+  override val valueClass: Class[Date] = classOf[java.util.Date]
+  val orEqual = true
+}
+object BuildStringLTEQuery extends LTQueryBuilder {
+  type VALUE = java.lang.String
+  override val valueClass: Class[String] = classOf[java.lang.String]
   val orEqual = true
 }
 
 object BuildIntBetweenQuery extends BetweenQueryBuilder {
   type VALUE = java.lang.Integer
-  override val valueClass = classOf[java.lang.Integer]
+  override val valueClass: Class[Integer] = classOf[java.lang.Integer]
 }
 object BuildLongBetweenQuery extends BetweenQueryBuilder {
   type VALUE = java.lang.Long
-  override val valueClass = classOf[java.lang.Long]
+  override val valueClass: Class[lang.Long] = classOf[java.lang.Long]
 }
 object BuildFloatBetweenQuery extends BetweenQueryBuilder {
   type VALUE = java.lang.Float
-  override val valueClass = classOf[java.lang.Float]
+  override val valueClass: Class[lang.Float] = classOf[java.lang.Float]
 }
 object BuildDoubleBetweenQuery extends BetweenQueryBuilder {
   type VALUE = java.lang.Double
-  override val valueClass = classOf[java.lang.Double]
+  override val valueClass: Class[lang.Double] = classOf[java.lang.Double]
 }
 object BuildDateBetweenQuery   extends BetweenQueryBuilder {
   type VALUE = java.util.Date
-  override val valueClass = classOf[java.util.Date]
+  override val valueClass: Class[Date] = classOf[java.util.Date]
+}
+object BuildStringBetweenQuery   extends BetweenQueryBuilder {
+  type VALUE = java.lang.String
+  override val valueClass: Class[String] = classOf[java.lang.String]
 }


### PR DESCRIPTION
* Geotools supports these queries against strings in general so users
  have come to expect them
* Added support for the queries to cqengine

Signed-off-by: Anthony Fox <anthonyfox@ccri.com>