### PR TITLE
GEOMESA-2025 HBase coprocessors ignore visibilities

### DIFF
--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/coprocessor/GeoMesaCoprocessor.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/coprocessor/GeoMesaCoprocessor.scala
@@ -61,6 +61,9 @@ class GeoMesaCoprocessor extends GeoMesaCoprocessorService with Coprocessor with
       val results = ArrayBuffer.empty[Array[Byte]]
       scanList.foreach { scan =>
         scan.setFilter(filterList)
+        // Enable Visibilities by delegating to the Region Server configured Coprocessors
+        env.getRegion.getCoprocessorHost.preScannerOpen(scan)
+
         // TODO: Explore use of MultiRangeFilter
         val scanner = env.getRegion.getScanner(scan)
         aggregator.setScanner(scanner)

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseVisibilityTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseVisibilityTest.scala
@@ -13,6 +13,7 @@ import java.security.PrivilegedExceptionAction
 import java.util
 
 import com.typesafe.scalalogging.LazyLogging
+import com.vividsolutions.jts.geom.Envelope
 import org.apache.hadoop.hbase.TableName
 import org.apache.hadoop.hbase.client.security.SecurityCapability
 import org.apache.hadoop.hbase.client.{Connection, ConnectionFactory}
@@ -23,8 +24,13 @@ import org.geotools.data.simple.SimpleFeatureStore
 import org.geotools.data.{DataStoreFinder, Query, Transaction}
 import org.geotools.factory.Hints
 import org.geotools.filter.text.ecql.ECQL
+import org.geotools.geometry.jts.ReferencedEnvelope
+import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.filter.FilterHelper
 import org.locationtech.geomesa.hbase.data.HBaseDataStoreParams._
+import org.locationtech.geomesa.index.conf.QueryHints
+import org.locationtech.geomesa.index.iterators.DensityScan
 import org.locationtech.geomesa.security.AuthorizationsProvider
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
@@ -48,10 +54,10 @@ class HBaseVisibilityTest extends HBaseTest with LazyLogging {
   var user1Conn: Connection = _
   var user2Conn: Connection = _
   var privConn:  Connection = _
-  var dynConn:  Connection = _
+  var dynConn:   Connection = _
 
   def setAuths(user: String, auths: Array[String]): Unit = {
-    adminUser.runAs(new PrivilegedExceptionAction[Unit](){
+    adminUser.runAs(new PrivilegedExceptionAction[Unit]() {
       override def run(): Unit = {
         VisibilityClient.setAuths(adminConn, auths, user)
       }
@@ -59,7 +65,7 @@ class HBaseVisibilityTest extends HBaseTest with LazyLogging {
   }
 
   def getAuths(user: String): Seq[String] = {
-    adminUser.runAs(new PrivilegedExceptionAction[Seq[String]](){
+    adminUser.runAs(new PrivilegedExceptionAction[Seq[String]]() {
       override def run(): Seq[String] = {
         VisibilityClient.getAuths(adminConn, user).getAuthList.map(_.toStringUtf8)
       }
@@ -67,7 +73,7 @@ class HBaseVisibilityTest extends HBaseTest with LazyLogging {
   }
 
   def clearAllAuths(user: String): Unit = {
-    adminUser.runAs(new PrivilegedExceptionAction[Unit](){
+    adminUser.runAs(new PrivilegedExceptionAction[Unit]() {
       override def run(): Unit = {
         VisibilityClient.clearAuths(adminConn, getAuths(user).toArray, user)
       }
@@ -82,10 +88,10 @@ class HBaseVisibilityTest extends HBaseTest with LazyLogging {
     privUser  = User.createUserForTesting(cluster.getConfiguration, "privUser", Array.empty[String])
     dynUser   = User.createUserForTesting(cluster.getConfiguration, "dynUser",  Array.empty[String])
 
-    adminUser.runAs(new PrivilegedExceptionAction[Unit](){
+    adminUser.runAs(new PrivilegedExceptionAction[Unit]() {
       override def run(): Unit = {
         cluster.waitTableAvailable(TableName.valueOf("hbase:labels"), 50000)
-        val labels = Array[String]("extra","admin", "vis1", "vis2", "vis3", "super")
+        val labels = Array[String]("extra", "admin", "vis1", "vis2", "vis3", "super")
         adminConn = ConnectionFactory.createConnection(cluster.getConfiguration)
         VisibilityClient.addLabels(adminConn, labels)
         cluster.waitLabelAvailable(10000, labels: _*)
@@ -95,25 +101,25 @@ class HBaseVisibilityTest extends HBaseTest with LazyLogging {
       }
     })
 
-    user1.runAs(new PrivilegedExceptionAction[Unit](){
+    user1.runAs(new PrivilegedExceptionAction[Unit]() {
       override def run(): Unit = {
         user1Conn = ConnectionFactory.createConnection(cluster.getConfiguration)
       }
     })
 
-    user2.runAs(new PrivilegedExceptionAction[Unit](){
+    user2.runAs(new PrivilegedExceptionAction[Unit]() {
       override def run(): Unit = {
         user2Conn = ConnectionFactory.createConnection(cluster.getConfiguration)
       }
     })
 
-    privUser.runAs(new PrivilegedExceptionAction[Unit](){
+    privUser.runAs(new PrivilegedExceptionAction[Unit]() {
       override def run(): Unit = {
         privConn = ConnectionFactory.createConnection(cluster.getConfiguration)
       }
     })
 
-    dynUser.runAs(new PrivilegedExceptionAction[Unit](){
+    dynUser.runAs(new PrivilegedExceptionAction[Unit]() {
       override def run(): Unit = {
         dynConn = ConnectionFactory.createConnection(cluster.getConfiguration)
       }
@@ -284,6 +290,43 @@ class HBaseVisibilityTest extends HBaseTest with LazyLogging {
       val ids = fs.addFeatures(new ListFeatureCollection(sft, toAdd))
       ids.asScala.map(_.getID) must containTheSameElementsAs((0 until 10).map(_.toString))
 
+      val adminParams = Map(
+        ConnectionParam.getName -> adminConn,
+        HBaseCatalogParam.getName -> catalogTableName)
+
+      def getDensity(typeName: String, query: String, fs: SimpleFeatureStore): Double = {
+        val filter = ECQL.toFilter(query)
+        val envelope = FilterHelper.extractGeometries(filter, "geom").values.headOption match {
+          case None => ReferencedEnvelope.create(new Envelope(-180, 180, -90, 90), DefaultGeographicCRS.WGS84)
+          case Some(g) => ReferencedEnvelope.create(g.getEnvelopeInternal, DefaultGeographicCRS.WGS84)
+        }
+        val q = new Query(typeName, filter)
+        q.getHints.put(QueryHints.DENSITY_BBOX, envelope)
+        q.getHints.put(QueryHints.DENSITY_WIDTH, 500)
+        q.getHints.put(QueryHints.DENSITY_HEIGHT, 500)
+        val decode = DensityScan.decodeResult(envelope, 500, 500)
+        SelfClosingIterator(fs.getFeatures(q).features).flatMap(decode).toList.map(_._3).sum
+      }
+
+      def testQuery(ds: HBaseDataStore, typeName: String, filter: String, transforms: Array[String], results: Seq[SimpleFeature]) = {
+        val query = new Query(typeName, ECQL.toFilter(filter), transforms)
+        val fr = ds.getFeatureReader(query, Transaction.AUTO_COMMIT)
+        val features = SelfClosingIterator(fr).toList
+        val attributes = Option(transforms).getOrElse(ds.getSchema(typeName).getAttributeDescriptors.map(_.getLocalName).toArray)
+        features.map(_.getID) must containTheSameElementsAs(results.map(_.getID))
+        forall(features) { feature =>
+          feature.getAttributes must haveLength(attributes.length)
+          forall(attributes.zipWithIndex) { case (attribute, i) =>
+            feature.getAttribute(attribute) mustEqual feature.getAttribute(i)
+            feature.getAttribute(attribute) mustEqual results.find(_.getID == feature.getID).get.getAttribute(attribute)
+          }
+        }
+
+        val densitySize = getDensity(typeName, filter, ds.getFeatureSource(typeName))
+        densitySize mustEqual results.length
+        SelfClosingIterator(ds.getFeatureSource(typeName).getFeatures(query).features()).size mustEqual results.length
+      }
+
       forall(Seq(true, false)) { loose =>
         val ds = DataStoreFinder.getDataStore(params ++ Map(LooseBBoxParam.getName -> loose)).asInstanceOf[HBaseDataStore]
         forall(Seq(null, Array("geom"), Array("geom", "dtg"), Array("geom", "name"))) { transforms =>
@@ -295,24 +338,18 @@ class HBaseVisibilityTest extends HBaseTest with LazyLogging {
           testQuery(ds, typeName, "name = 'name5'", transforms, Seq.empty)
         }
       }
-    }
 
-    def testQuery(ds: HBaseDataStore, typeName: String, filter: String, transforms: Array[String], results: Seq[SimpleFeature]) = {
-      val query = new Query(typeName, ECQL.toFilter(filter), transforms)
-      val fr = ds.getFeatureReader(query, Transaction.AUTO_COMMIT)
-      val features = SelfClosingIterator(fr).toList
-      val attributes = Option(transforms).getOrElse(ds.getSchema(typeName).getAttributeDescriptors.map(_.getLocalName).toArray)
-      features.map(_.getID) must containTheSameElementsAs(results.map(_.getID))
-      forall(features) { feature =>
-        feature.getAttributes must haveLength(attributes.length)
-        forall(attributes.zipWithIndex) { case (attribute, i) =>
-          feature.getAttribute(attribute) mustEqual feature.getAttribute(i)
-          feature.getAttribute(attribute) mustEqual results.find(_.getID == feature.getID).get.getAttribute(attribute)
+      forall(Seq(true, false)) { loose =>
+        val ds = DataStoreFinder.getDataStore(adminParams ++ Map(LooseBBoxParam.getName -> loose)).asInstanceOf[HBaseDataStore]
+        forall(Seq(null, Array("geom"), Array("geom", "dtg"), Array("geom", "name"))) { transforms =>
+          testQuery(ds, typeName, "INCLUDE", transforms, toAdd)
+          testQuery(ds, typeName, "IN('0', '2')", transforms, Seq(toAdd(0), toAdd(2)))
+          testQuery(ds, typeName, "bbox(geom,38,48,52,62) and dtg DURING 2014-01-01T00:00:00.000Z/2014-01-08T12:00:00.000Z", transforms, toAdd.take(8))
+          testQuery(ds, typeName, "bbox(geom,42,48,52,62)", transforms, toAdd.drop(2))
+          testQuery(ds, typeName, "name < 'name5'", transforms, toAdd.take(5))
+          testQuery(ds, typeName, "name = 'name5'", transforms, Seq(toAdd(5)))
         }
       }
-      // TODO https://geomesa.atlassian.net/browse/GEOMESA-2025
-      // ds.getFeatureSource(typeName).getFeatures(query).size() mustEqual results.length
     }
   }
 }
-


### PR DESCRIPTION
* GeoMesa HBase coprocessor delegate to system coprocessors.
* Adds multiple users visibilities test cases.

Signed-off-by: Jim Hughes <jnh5y@ccri.com>