### PR TITLE
GEOMESA-2281 SparkSQL - handling push-down casts

### DIFF
--- a/.travisbuild.sh
+++ b/.travisbuild.sh
@@ -21,7 +21,7 @@ if [[ $RESULT -ne 0 ]]; then
   echo -e "[ERROR] Build failed!\n"
 else
   # now run tests - using the maven executable, as zinc uses too much memory
-  mvn -o surefire:test -DargLine="-Duser.timezone=UTC -Xmx4g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dgeomesa.scan.ranges.target=500" 2>&1 | tee -a $BUILD_OUTPUT | grep -e 'Building GeoMesa' -e '\(maven-surefire-plugin\|maven-jar-plugin\|scala-maven-plugin.*:compile\)'
+  mvn surefire:test -DargLine="-Duser.timezone=UTC -Xmx4g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dgeomesa.scan.ranges.target=500" 2>&1 | tee -a $BUILD_OUTPUT | grep -e 'Building GeoMesa' -e '\(maven-surefire-plugin\|maven-jar-plugin\|scala-maven-plugin.*:compile\)'
   RESULT=${PIPESTATUS[0]} # capture the status of the maven build
 
   # dump out the end of the build log, to show success or errors

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/apache/spark/sql/SQLRules.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/apache/spark/sql/SQLRules.scala
@@ -8,6 +8,7 @@
 
 package org.apache.spark.sql
 
+import java.time.{LocalDateTime, ZoneId, ZoneOffset}
 import java.util.Date
 
 import com.typesafe.scalalogging.LazyLogging
@@ -22,7 +23,7 @@ import org.geotools.factory.CommonFactoryFinder
 import org.locationtech.geomesa.spark.jts.rules.GeometryLiteral
 import org.locationtech.geomesa.spark.jts.udf.SpatialRelationFunctions._
 import org.locationtech.geomesa.spark.{GeoMesaJoinRelation, GeoMesaRelation, RelationUtils}
-import org.opengis.filter.expression.{Expression => GTExpression}
+import org.opengis.filter.expression.{Expression => GTExpression, Literal => GTLiteral}
 import org.opengis.filter.{FilterFactory2, Filter => GTFilter}
 
 import scala.collection.JavaConversions._
@@ -107,20 +108,39 @@ object SQLRules extends LazyLogging {
         logger.debug(s"Got expr: $expr.  Don't know how to turn this into a GeoTools Expression.")
         None
     }
-
   }
 
-  def sparkExprToGTExpr(expr: Expression): Option[GTExpression] = {
-    expr match {
-      case GeometryLiteral(_, geom) => Some(ff.literal(geom))
-      case AttributeReference(name, _, _, _) if !name.equals("__fid__") => Some(ff.property(name))
-      // note: timestamps are defined in microseconds
-      case Literal(value, DataTypes.TimestampType) => Some(ff.literal(new Date(value.asInstanceOf[Long] / 1000)))
-      case Literal(value, _) => Some(ff.literal(value))
-      case _ =>
-        logger.debug(s"Got expr: $expr.  Don't know how to turn this into a GeoTools Expression.")
-        None
-    }
+  def sparkExprToGTExpr(expression: Expression): Option[GTExpression] = expression match {
+    case g: GeometryLiteral =>
+      Some(ff.literal(g.geom))
+
+    case a: AttributeReference if a.name != "__fid__" =>
+      Some(ff.property(a.name))
+
+    case c: Cast =>
+      lazy val zone = c.timeZoneId.map(ZoneId.of).orNull
+      sparkExprToGTExpr(c.child).map {
+        case lit: GTLiteral if lit.getValue.isInstanceOf[Date] && zone != null =>
+          val date = LocalDateTime.ofInstant(lit.getValue.asInstanceOf[Date].toInstant, zone)
+          ff.literal(new Date(date.atZone(ZoneOffset.UTC).toInstant.toEpochMilli))
+        case e => e
+      }
+
+    case lit: Literal if lit.dataType == DataTypes.StringType =>
+      // the actual class is org.apache.spark.unsafe.types.UTF8String, we need to make it
+      // a normal string so that geotools can handle it
+      Some(ff.literal(Option(lit.value).map(_.toString).orNull))
+
+    case lit: Literal if lit.dataType == DataTypes.TimestampType =>
+      // timestamps are defined as microseconds
+      Some(ff.literal(new Date(lit.value.asInstanceOf[Long] / 1000)))
+
+    case lit: Literal =>
+      Some(ff.literal(lit.value))
+
+    case _ =>
+      logger.debug(s"Can't turn expression into geotools: $expression")
+      None
   }
 
   // new optimizations rules


### PR DESCRIPTION
* Supports date queries without a cast to timestamp
  * e.g "dtg between '2016-01-01T00:00:00Z' and '2016-01-01T01:00:00Z'"

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>