### PR TITLE
GEOMESA-1730,GEOMESA-1479 GPX tutorial shouldn't depend on external code, docs fixes

### DIFF
--- a/docs/user/accumulo/install.rst
+++ b/docs/user/accumulo/install.rst
@@ -182,7 +182,7 @@ Update and re-source your ``~/.bashrc`` file to include the ``$GEOMESA_ACCUMULO_
     GeoMesa provides the ability to provide additional jars on the classpath using the environmental variable
     ``$GEOMESA_EXTRA_CLASSPATHS``. GeoMesa will prepend the contents of this environmental variable  to the computed
     classpath giving it highest precedence in the classpath. Users can provide directories of jar files or individual
-    files using a colon (``:``) as a delimiter. These entries will also be added the the mapreduce libjars variable.
+    files using a colon (``:``) as a delimiter. These entries will also be added the the map-reduce libjars variable.
     Use the ``geomesa-accumulo classpath`` command to print the final classpath that will be used when executing geomesa
     commands.
 

--- a/docs/user/cli/filesystems.rst
+++ b/docs/user/cli/filesystems.rst
@@ -63,7 +63,7 @@ For ``s3n``:
     <property>
         <name>mapreduce.application.classpath</name>
         <value>$HADOOP_MAPRED_HOME/share/hadoop/mapreduce/*:$HADOOP_MAPRED_HOME/share/hadoop/mapreduce/lib/*:$HADOOP_MAPRED_HOME/share/hadoop/tools/lib/*</value>
-        <description>The classpath specifically for mapreduce jobs. This override is needed so that s3 URLs work on hadoop 2.6.0+</description>
+        <description>The classpath specifically for map-reduce jobs. This override is needed so that s3 URLs work on hadoop 2.6.0+</description>
     </property>
     <property>
         <name>fs.s3n.impl</name>

--- a/docs/user/convert/extending.rst
+++ b/docs/user/convert/extending.rst
@@ -53,7 +53,7 @@ Adding Functions to the Geomesa Classpath
 
 After creating a JAR file with your transformation function and factory
 you can add these to the ``GEOMESA_EXTRA_CLASSPATHS`` environmental variable
-in order to expose them to the command line tools and distributed (mapreduce)
+in order to expose them to the command line tools and distributed (map-reduce)
 ingest jobs.
 
 A example of ingest with a transforms on the classpath is below:

--- a/docs/user/convert/function_overview.rst
+++ b/docs/user/convert/function_overview.rst
@@ -102,7 +102,7 @@ Installing Custom Scripts
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Custom scripting functions are made available to GeoMesa comamnd line tools or
-distributed (mapreduce) ingest via including them on the classpath or
+distributed (map-reduce) ingest via including them on the classpath or
 setting a system property.
 
 For local usage, geomesa defines the system property ``geomesa.convert.scripts.path``
@@ -134,7 +134,7 @@ inside the archive containing the scripts:
            42                     2 files
 
 For either zip or jar files add them to the extra classpaths in your environment to
-make them available for the tools or mapreduce ingest:
+make them available for the tools or map-reduce ingest:
 
 .. code-block:: bash
 

--- a/docs/user/convert/premade/osm-gpx.rst
+++ b/docs/user/convert/premade/osm-gpx.rst
@@ -1,54 +1,53 @@
 OpenStreetMap GPX Data
 ======================
 
-This directory provides GPS data traces from the OpenStreetMap project.
+This converter handles GPS data traces from the OpenStreetMap project.
 The GPS traces are a series of latitude/longitude pairs collected by OSM
 or uploaded by users. The datasets were last updated in 2013.
 
-Getting OSM-GPX data
+Getting OSM-GPX Data
 --------------------
 
 The OSM-GPX data set can be downloaded using the provided
-``download-data.sh`` script in ``$GEOMESA_ACCUMULO_HOME/bin/`` as such
+``download-data.sh`` script in ``$GEOMESA_HOME/bin/``:
 
-::
+.. code-block:: bash
 
-    ./download-data.sh osm-gpx
+    $ ./download-data.sh osm-gpx
 
-providing a desired region when prompted.
-
-Alternatively, download OSM\_GPX data
-`here <http://planet.openstreetmap.org/gps/>`__. It is formatted in a
-GPX 1.0 format, which is an XML format described by this
-`XSD <http://www.topografix.com/GPX/1/0/gpx.xsd>`__. Regional extracts
-of the dataset can be found
+Alternatively, download OSM\_GPX data `here <http://planet.openstreetmap.org/gps/>`__. It is formatted in the
+GPX 1.0 format, which is an XML format described by this `XSD <http://www.topografix.com/GPX/1/0/gpx.xsd>`__.
+Regional extracts of the dataset can be found
 `here <http://zverik.osm.rambler.ru/gps/files/extracts/index.html>`__.
 
-Cleaning the data
------------------
+Extracting the Data
+-------------------
 
-Before ingest, the .gpx files can be converted to CSV files through the use
-of `this converter <https://github.com/jahhulbert-ccri/osm-parsers>`__.
+Extract the downloaded tar.xz file into an appropriate directory. Note that it is important to keep the file
+structure of the extracted data, as it contains information on the track IDs that isn't available in the raw XML.
 
-Ingest Commands
----------------
+.. code-block:: bash
 
-Check that the ``osm-gpx`` simple feature type is available on the GeoMesa
-tools classpath. This is the default case.
+    $ cd /tmp
+    $ tar -xvf gpx-planet-2013-04-09.tar.xz
 
-::
+Ingest Command
+--------------
+
+Check that the ``osm-gpx`` simple feature type is available on the GeoMesa tools classpath. This is the default case.
+
+.. code-block:: bash
 
     $ geomesa-accumulo env | grep osm-gpx
 
-If it is not, merge the contents of ``reference.conf`` with
-``$GEOMESA_ACCUMULO_HOME/conf/application.conf``, or ensure that
-``reference.conf`` is in ``$GEOMESA_ACCUMULO_HOME/conf/sfts/osm-gpx``.
+If it is not, merge the contents of ``reference.conf`` with ``$GEOMESA_HOME/conf/application.conf``, or ensure that
+``reference.conf`` is in ``$GEOMESA_HOME/conf/sfts/osm-gpx``.
 
-Run the ingest. You may optionally point to a different accumulo
-instance using ``-i`` and ``-z`` options. See ``geomesa-accumulo help ingest``
-for more detail.
+Run the ingest. The exact command name will vary based on your back-end distribution. Try
+`geomesa help ingest` for available options.
 
-::
+.. code-block:: bash
 
-    $ geomesa-accumulo ingest -u USERNAME -c CATALOGNAME -s osm-gpx -C osm-gpx osm-data.csv
+    $ geomesa ingest -s osm-gpx -C osm-gpx '/tmp/gpx-planet-2013-04-09/**/*.gpx'
 
+Note: be sure to use single quotes around the path to prevent the shell from expanding the wildcards.

--- a/docs/user/filesystem/architecture.rst
+++ b/docs/user/filesystem/architecture.rst
@@ -61,11 +61,13 @@ More information on defining partition schemes can be found in :ref:`fsds_partit
 Storage Formats
 ---------------
 
-* **Apache Parquet** - Apache Parquet is the leading interoperable columnar format in the Hadoop ecosystem. It provides
-  efficient compression, storage, and query of structured data. Apache Parquet is currently the only format that can be
-  used for writing data into the FileSystem datastore.
+* **Apache Parquet** - Apache Parquet is the leading interoperable columnar format in the Hadoop ecosystem. It
+  provides efficient compression, storage, and query of structured data.
+
+* **Apache ORC** - Apache ORC is a self-describing type-aware columnar file format designed for Hadoop workloads. It
+  is optimized for large streaming reads, but with integrated support for finding required rows quickly.
 
 * **Converter Storage** - The converter storage format is a synthetic format which allows you to overlay a GeoMesa converter
   on top of a filesystem using a defined partition scheme. This allows you to utilize existing data storage layouts of
   data stored in JSON, CSV, TSV, Avro, or other formats. Converters are pluggable allowing users to expose their own
-  custom storage formats if desired.
+  custom storage formats if desired. Converter storage is a read-only format.

--- a/docs/user/hbase/install.rst
+++ b/docs/user/hbase/install.rst
@@ -401,7 +401,7 @@ used by your installation.
     GeoMesa provides the ability to provide additional jars on the classpath using the environmental variable
     ``$GEOMESA_EXTRA_CLASSPATHS``. GeoMesa will prepend the contents of this environmental variable  to the computed
     classpath giving it highest precedence in the classpath. Users can provide directories of jar files or individual
-    files using a colon (``:``) as a delimiter. These entries will also be added the the mapreduce libjars variable.
+    files using a colon (``:``) as a delimiter. These entries will also be added the the map-reduce libjars variable.
     Use the ``geomesa-hbase classpath`` command to print the final classpath that will be used when executing geomesa
     commands.
 

--- a/geomesa-tools/conf/sfts/osm-gpx/README.md
+++ b/geomesa-tools/conf/sfts/osm-gpx/README.md
@@ -1,6 +1,7 @@
 # OpenStreetMap GPX Data for GeoMesa
 
-This directory provides GPS data traces from the OpenStreetMap project. The GPS traces are a series of latitude/longitude pairs collected by OSM or uploaded by users. The datasets were last updated in 2013.
+This converter handles GPS data traces from the OpenStreetMap project. The GPS traces are a series of
+latitude/longitude pairs collected by OSM or uploaded by users. The datasets were last updated in 2013.
 
 This readme describes the full process from original source data to GeoMesa ingest.
 
@@ -12,20 +13,30 @@ The OSM-GPX data set can be downloaded using the provided ```download-data.sh```
 
 providing a desired region when prompted.
 
-Alternatively, download OSM_GPX data [here](http://planet.openstreetmap.org/gps/). It is formatted in a GPX 1.0 format, which is an XML format described by this [XSD](http://www.topografix.com/GPX/1/0/gpx.xsd). Regional extracts of the dataset can be found [here](http://zverik.osm.rambler.ru/gps/files/extracts/index.html)
+Alternatively, download OSM_GPX data [here](http://planet.openstreetmap.org/gps/). It is formatted in a GPX 1.0
+format, which is an XML format described by this [XSD](http://www.topografix.com/GPX/1/0/gpx.xsd). Regional extracts
+of the dataset can be found [here](http://zverik.osm.rambler.ru/gps/files/extracts/index.html)
 
-## Cleaning the data
+## Extracting the Data
 
-Before ingest, the .gpx files can be converted to CSV files through use of [this converter](https://github.com/jahhulbert-ccri/osm-parsers)
+Extract the downloaded tar.xz file into an appropriate directory. Note that it is important to keep the file
+structure of the extracted data, as it contains information on the track IDs that isn't available in the raw XML.
 
-## Ingest Commands
+    cd /tmp
+    tar -xvf gpx-planet-2013-04-09.tar.xz
+
+## Ingest Command
 
 Check that `osm-gpx` simple feature type is available on the GeoMesa tools classpath. This is the default case.
 
     geomesa env | grep osm-gpx
 
-If it is not, merge the contents of `reference.conf` with `$GEOMESA_HOME/conf/application.conf`, or ensure that `reference.conf` is in `$GEOMESA_HOME/conf/sfts/osm-gpx`
+If it is not, merge the contents of `reference.conf` with `$GEOMESA_HOME/conf/application.conf`, or ensure
+that `reference.conf` is in `$GEOMESA_HOME/conf/sfts/osm-gpx`
 
-Run the ingest. You may optionally point to a different accumulo instance using `-i` and `-z` options. See `geomesa help ingest` for more detail.
+Run the ingest. The exact command name will vary based on your back-end distribution. Try
+`geomesa help ingest` for available options.
 
-    geomesa ingest -u USERNAME -c CATALOGNAME -s osm-gpx -C osm-gpx osm-data.csv
+    geomesa ingest -s osm-gpx -C osm-gpx '/tmp/gpx-planet-2013-04-09/**/*.gpx'
+
+Note: be sure to use single quotes around the path to prevent the shell from expanding the wildcards.

--- a/geomesa-tools/conf/sfts/osm-gpx/reference.conf
+++ b/geomesa-tools/conf/sfts/osm-gpx/reference.conf
@@ -17,19 +17,22 @@ geomesa {
     osm-gpx = {
       type = xml
       id-field = "md5(stringToBytes(concat(regexReplace('.*?(\\\\d+)\\\\.gpx'::r, '$1', $inputFilePath), xml2string($0))))"
-      feature-path = "trk/trkseg/trkpt"
+      feature-path = "gpx:trk/gpx:trkseg/gpx:trkpt"
       options {
         line-mode = "multi"
       }
       fields = [
-        { name = trackId,   path = "../../number/text()", transform = "concat(regexReplace('.*?(\\\\d+)\\\\.gpx'::r, '$1-', $inputFilePath), $0)" }
+        { name = trackId,   path = "../../gpx:number/text()", transform = "concat(regexReplace('.*?(\\\\d+)\\\\.gpx'::r, '$1-', $inputFilePath), $0)" }
         // TODO some nodes don't have elevation which fails this element
-        // { name = elevation, path = "ele/text()", transform = "$0::double" }
-        { name = dtg,   path = "time/text()", transform = "datetime(regexReplace('(:\\\\d{2})Z'::r, '$1.000Z', regexReplace('\\\\.\\\\d+Z'::r, 'Z', $0)))" }
+        // { name = elevation, path = "gpx:ele/text()", transform = "$0::double" }
+        { name = dtg,   path = "gpx:time/text()", transform = "datetime(regexReplace('(:\\\\d{2})Z'::r, '$1.000Z', regexReplace('\\\\.\\\\d+Z'::r, 'Z', $0)))" }
         { name = lat,   path = "@lat",        transform = "$0::double" }
         { name = lon,   path = "@lon",        transform = "$0::double" }
         { name = geom,                        transform = "point($lon, $lat)" }
       ]
+      xml-namespaces = {
+        gpx = "http://www.topografix.com/GPX/1/0"
+      }
     }
   } 
 }


### PR DESCRIPTION
* Updated osm-gpx converter to work with Saxon
* Fixing references to 'mapreduce' as 'map-reduce'
* Adding note on support for ORC in FSDS

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>