### PR TITLE
GEOMESA-2315 Map JTS to Shapely types for use with PySpark

### DIFF
--- a/geomesa-spark/geomesa-spark-core/src/main/scala/org/apache/spark/geomesa/api/python/GeoMesaSeDerUtil.scala
+++ b/geomesa-spark/geomesa-spark-core/src/main/scala/org/apache/spark/geomesa/api/python/GeoMesaSeDerUtil.scala
@@ -1,0 +1,51 @@
+/***********************************************************************
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.apache.spark.geomesa.api.python
+
+import java.io.OutputStream
+
+import com.typesafe.scalalogging.LazyLogging
+import com.vividsolutions.jts.geom.Geometry
+import net.razorvine.pickle.{IObjectPickler, Pickler}
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.api.python.SerDeUtil
+import org.apache.spark.rdd.RDD
+import org.locationtech.geomesa.utils.text.WKBUtils
+
+object GeoMesaSeDerUtil extends LazyLogging {
+
+  implicit def toPickledRDD(rdd: RDD[_]): JavaRDD[Array[Byte]] =
+    rdd.mapPartitions{ i =>  AutoBatchedPickler(i) }.toJavaRDD
+
+  implicit def toPickledRDD(jrdd: JavaRDD[_]): JavaRDD[Array[Byte]] = toPickledRDD(jrdd.rdd)
+
+}
+
+object AutoBatchedPickler extends LazyLogging {
+
+  val module = "geomesa_pyspark.types"
+  val function = "_deserialize_from_wkb"
+
+  val pickler = new IObjectPickler {
+    def pickle(o: Object, os: OutputStream, p: Pickler): Unit = {
+      import net.razorvine.pickle.Opcodes
+      os.write(Opcodes.GLOBAL)
+      os.write(s"$module\n$function\n".getBytes)
+      p.save(WKBUtils.write(o.asInstanceOf[Geometry]))
+      os.write(Opcodes.TUPLE1)
+      os.write(Opcodes.REDUCE)
+    }
+  }
+  Pickler.registerCustomPickler(classOf[Geometry], pickler)
+  logger.info("registered JTS Geometry to WKB pickler")
+
+  def apply(i: Iterator[Any]): AutoBatchedPickler =  new AutoBatchedPickler(i)
+}
+
+class AutoBatchedPickler(i: Iterator[Any]) extends SerDeUtil.AutoBatchedPickler(i)

--- a/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/GeoMesaSpark.scala
+++ b/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/GeoMesaSpark.scala
@@ -57,7 +57,6 @@ trait Schema {
 
 class SpatialRDD(rdd: RDD[SimpleFeature], sft: SimpleFeatureType) extends RDD[SimpleFeature](rdd) with Schema {
 
-  GeoMesaSparkKryoRegistratorEndpoint.init()
   GeoMesaSparkKryoRegistrator.register(sft)
 
   private val sft_name = sft.getTypeName
@@ -70,6 +69,8 @@ class SpatialRDD(rdd: RDD[SimpleFeature], sft: SimpleFeatureType) extends RDD[Si
 }
 
 object SpatialRDD {
+
+  GeoMesaSparkKryoRegistratorEndpoint.init()
 
   def apply(rdd: RDD[SimpleFeature], schema: SimpleFeatureType) = new SpatialRDD(rdd, schema)
 

--- a/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/api/python/PythonGeoMesaSpark.scala
+++ b/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/api/python/PythonGeoMesaSpark.scala
@@ -1,0 +1,56 @@
+/***********************************************************************
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.spark.api.python
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
+import org.geotools.data.Query
+import org.locationtech.geomesa.spark.{GeoMesaSpark, Schema, SpatialRDD, SpatialRDDProvider}
+import org.locationtech.geomesa.spark.api.java.JavaSpatialRDD
+import org.opengis.feature.simple.SimpleFeature
+
+import scala.collection.JavaConversions._
+
+object PythonGeoMesaSpark {
+  def apply(params: java.util.Map[String, _ <: java.io.Serializable]) =
+    PythonSpatialRDDProvider(GeoMesaSpark.apply(params.asInstanceOf[java.util.Map[String, java.io.Serializable]]))
+}
+
+object PythonSpatialRDDProvider {
+  def apply(provider: SpatialRDDProvider) = new PythonSpatialRDDProvider(provider)
+}
+
+class PythonSpatialRDDProvider(provider: SpatialRDDProvider) {
+  def rdd(conf: Configuration,
+          jsc: JavaSparkContext,
+          params: java.util.Map[String, String],
+          query: Query): PythonSpatialRDD =
+    provider.rdd(conf, jsc.sc, params.toMap, query)
+}
+
+object PythonSpatialRDD {
+
+  implicit def toPythonSpatialRDD(rdd: SpatialRDD): PythonSpatialRDD = PythonSpatialRDD(rdd)
+
+  def apply(rdd: JavaSpatialRDD) = new PythonSpatialRDD(rdd)
+}
+
+class PythonSpatialRDD(jsrdd: JavaSpatialRDD) extends JavaRDD[SimpleFeature](jsrdd) with Schema {
+
+  import org.apache.spark.geomesa.api.python.GeoMesaSeDerUtil._
+
+  def schema = jsrdd.schema
+
+  def asValueList:          JavaRDD[Array[Byte]]  = jsrdd.asValueList
+  def asKeyValueTupleList:  JavaRDD[Array[Byte]]  = jsrdd.asKeyValueArrayList
+  def asKeyValueDict:       JavaRDD[Array[Byte]]  = jsrdd.asKeyValueMap
+  def asGeoJSONString:      JavaRDD[Array[Byte]]  = jsrdd.asGeoJSONString
+}
+
+

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/apache/spark/sql/jts/AbstractGeometryUDT.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/apache/spark/sql/jts/AbstractGeometryUDT.scala
@@ -24,7 +24,7 @@ import scala.reflect._
 abstract class AbstractGeometryUDT[T >: Null <: Geometry: ClassTag](override val simpleString: String)
   extends UserDefinedType[T] {
 
-  override def pyUDT: String = "geomesa_pyspark.spark.GeometryUDT"
+  override def pyUDT: String = s"geomesa_pyspark.types.${getClass.getSimpleName}"
 
   override def serialize(obj: T): InternalRow = {
     new GenericInternalRow(Array[Any](WKBUtils.write(obj)))

--- a/geomesa-spark/geomesa_pyspark/src/main/python/geomesa_pyspark/__init__.py
+++ b/geomesa-spark/geomesa_pyspark/src/main/python/geomesa_pyspark/__init__.py
@@ -1,14 +1,16 @@
 import glob
 import os.path
 import pkgutil
+import re
 import sys
 import tempfile
 import zipfile
-
+import types
 
 __version__ = '${python.version}'
 
 PACKAGE_EXTENSIONS = {'.zip', '.egg', '.jar'}
+PACKAGE_DEV = re.compile("[.]dev[0-9]*$")
 
 
 def configure(jars=[], packages=[], files=[], spark_home=None, spark_master='yarn', tmp_path=None):
@@ -91,7 +93,7 @@ def process_executor_packages(executor_packages, tmp_path=None):
             zip_name = "%s.zip" % executor_package if package_version is None\
                 else "%s-%s.zip" % (executor_package, package_version) 
             zip_path = os.path.join(tmp_path, zip_name)
-            if not os.path.isfile(zip_path):
+            if (not os.path.isfile(zip_path)) or ((package_version and PACKAGE_DEV.search(package_version)) is not None):
                 zip_package(package_path, zip_path)
             executor_files.append(zip_path)
                 

--- a/geomesa-spark/geomesa_pyspark/src/main/python/geomesa_pyspark/spark.py
+++ b/geomesa-spark/geomesa_pyspark/src/main/python/geomesa_pyspark/spark.py
@@ -1,7 +1,5 @@
 from py4j.java_gateway import java_import
 from pyspark import RDD, SparkContext
-from pyspark.sql.types import UserDefinedType, StructField, BinaryType
-from pyspark.sql import Row
 
 
 class GeoMesaSpark:
@@ -12,12 +10,12 @@ class GeoMesaSpark:
         java_import(self.jvm, "org.apache.hadoop.conf.Configuration")
         java_import(self.jvm, "org.geotools.data.Query")
         java_import(self.jvm, "org.geotools.filter.text.ecql.ECQL")
-        java_import(self.jvm, "org.locationtech.geomesa.spark.api.java.JavaGeoMesaSpark")
-        java_import(self.jvm, "org.locationtech.geomesa.spark.api.java.JavaSpatialRDDProvider")
-        java_import(self.jvm, "org.locationtech.geomesa.spark.api.java.JavaSpatialRDD")
+        java_import(self.jvm, "org.locationtech.geomesa.spark.api.python.PythonGeoMesaSpark")
+        java_import(self.jvm, "org.locationtech.geomesa.spark.api.python.PythonSpatialRDDProvider")
+        java_import(self.jvm, "org.locationtech.geomesa.spark.api.python.PythonSpatialRDD")
 
     def apply(self, params):
-        provider = self.jvm.JavaGeoMesaSpark.apply(params)
+        provider = self.jvm.PythonGeoMesaSpark.apply(params)
         return SpatialRDDProvider(self.sc, params, provider)
 
 
@@ -33,15 +31,15 @@ class SpatialRDDProvider:
         return self.__pyrdd(jrdd)
 
     def rdd_dict(self, typename, ecql):
-        jrdd = self.__jrdd(typename, ecql).asPyKeyValueMap()
+        jrdd = self.__jrdd(typename, ecql).asKeyValueDict()
         return self.__pyrdd(jrdd)
 
     def rdd_tuples(self, typename, ecql):
-        jrdd = self.__jrdd(typename, ecql).asPyKeyValueList()
+        jrdd = self.__jrdd(typename, ecql).asKeyValueTupleList()
         return self.__pyrdd(jrdd)
 
     def rdd_values(self, typename, ecql):
-        jrdd = self.__jrdd(typename, ecql).asPyValueList()
+        jrdd = self.__jrdd(typename, ecql).asValueList()
         return self.__pyrdd(jrdd)
 
     def __jrdd(self, typename, ecql):
@@ -50,31 +48,4 @@ class SpatialRDDProvider:
         return self.provider.rdd(self.jvm.Configuration(), self.sc._jsc, self.params, query)
 
     def __pyrdd(self, jrdd):
-        return RDD(self.jvm.SerDe.javaToPython(jrdd), self.sc)
-
-
-class GeometryUDT(UserDefinedType):
-    jvm = None
-
-    @classmethod
-    def sqlType(self):
-        return StructField("wkb", BinaryType(), False)
-
-    @classmethod
-    def module(cls):
-        return 'geomesa_pyspark'
-
-    @classmethod
-    def scalaUDT(cls):
-        return 'org.apache.spark.sql.jts.GeometryUDT'
-
-    def serialize(self, obj):
-        if obj is None:
-            return None
-        return Row(obj.toBytes)
-
-    def deserialize(self, datum):
-        if self.jvm is None:
-            self.jvm = SparkContext._active_spark_context._gateway.jvm
-            java_import(self.jvm, "org.locationtech.geomesa.spark.jts.util.JavaAbstractGeometryUDT")
-        return self.jvm.JavaAbstractGeometryUDT.deserialize(datum[0])
+        return RDD(jrdd, self.sc)

--- a/geomesa-spark/geomesa_pyspark/src/main/python/geomesa_pyspark/types.py
+++ b/geomesa-spark/geomesa_pyspark/src/main/python/geomesa_pyspark/types.py
@@ -1,0 +1,86 @@
+from pyspark.sql.types import UserDefinedType, StructField, BinaryType, StructType
+from shapely import wkb
+from shapely.geometry import LinearRing, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon
+from shapely.geometry.base import BaseGeometry
+from shapely.geometry.collection import GeometryCollection
+
+
+class ShapelyGeometryUDT(UserDefinedType):
+
+    @classmethod
+    def sqlType(cls):
+        return StructType([StructField("wkb", BinaryType(), True)])
+
+    @classmethod
+    def module(cls):
+        return 'geomesa_pyspark.types'
+
+    @classmethod
+    def scalaUDT(cls):
+        return 'org.apache.spark.sql.jts.' + cls.__name__
+
+    def serialize(self, obj):
+        return [_serialize_to_wkb(obj)]
+
+    def deserialize(self, datum):
+        return _deserialize_from_wkb(datum[0])
+
+
+class PointUDT(ShapelyGeometryUDT):
+    pass
+
+
+class LineStringUDT(ShapelyGeometryUDT):
+    pass
+
+
+class PolygonUDT(ShapelyGeometryUDT):
+    pass
+
+
+class MultiPointUDT(ShapelyGeometryUDT):
+    pass
+
+
+class MultiLineStringUDT(ShapelyGeometryUDT):
+    pass
+
+
+class MultiPolygonUDT(ShapelyGeometryUDT):
+    pass
+
+
+class GeometryUDT(ShapelyGeometryUDT):
+    pass
+
+
+class GeometryCollectionUDT(ShapelyGeometryUDT):
+    pass
+
+
+def _serialize_to_wkb(data):
+    if isinstance(data, BaseGeometry):
+        return bytearray(data.wkb)
+    return None
+
+
+def _deserialize_from_wkb(data):
+    if data is None:
+        return None
+    return wkb.loads(''.join(map(chr, data)))
+
+
+_deserialize_from_wkb.__safe_for_unpickling__ = True
+
+# inject some PySpark constructs into Shapely's geometry types
+Point.__UDT__ = PointUDT()
+MultiPoint.__UDT__ = MultiPointUDT()
+LineString.__UDT__ = LineStringUDT()
+MultiLineString.__UDT__ = MultiLineStringUDT()
+PolygonUDT.__UDT__ = PolygonUDT()
+MultiPolygon.__UDT__ = MultiPolygonUDT()
+BaseGeometry.__UDT__ = GeometryUDT()
+GeometryCollection.__UDT__ = GeometryCollection()
+
+# make Geometry dumps a little cleaner
+BaseGeometry.__repr__ = BaseGeometry.__str__

--- a/geomesa-spark/geomesa_pyspark/src/main/python/setup.py
+++ b/geomesa-spark/geomesa_pyspark/src/main/python/setup.py
@@ -5,5 +5,5 @@ setup(
     version='${python.version}',
     url='http://www.geomesa.org',
     packages=find_packages(),
-    install_requires=['pytz','pyspark>=2.1.1,<2.3.0']
+    install_requires=['pytz', 'shapely', 'pyspark>=2.1.1,<2.3.0']
 )


### PR DESCRIPTION
The current use of JTS JVM objects in PySpark via the Py4J bridge is problematic as the Py4J bridge is only available in the PySpark driver (and not executors). A more complete solution would be to map JTS (JVM) <-> Shapely (Python).