### PR TITLE
GEOMESA-2314 TWKB geometry serialization

### DIFF
--- a/docs/user/datastores/index_config.rst
+++ b/docs/user/datastores/index_config.rst
@@ -182,6 +182,38 @@ provide some benefit when exporting data in certain formats (e.g. Arrow):
     Ensure that you use valid UUIDs if you indicate that you are using them. Otherwise you will experience
     exceptions writing and/or reading data.
 
+Configuring Geometry Serialization
+----------------------------------
+
+By default, geometries are serialized using a modified version of the well-known binary (WKB) format. Alternatively,
+geometries may be serialized using the
+`tiny well-known binary (TWKB) <https://github.com/TWKB/Specification/blob/master/twkb.md>`__ format. TWKB will be
+smaller on disk, but does not allow full double floating point precision. For point geometries, TWKB will take
+4-12 bytes (depending on the precision specified), compared to 18 bytes for WKB. For line strings, polygons, or
+other geometries with multiple coordinates, the space savings will be greater due to TWKB's delta encoding scheme.
+
+For any geometry type attribute, TWKB serialization can be enabled by setting the floating point precision
+through the ``precision`` user-data key. Precision indicates the number of decimal places that will be stored, and
+must be between -7 and 7, inclusive. A negative precision can be used to indicate rounding of whole numbers to the
+left of the decimal place. For reference, 6 digits of latitude/longitude precision can store a resolution of
+approximately 10cm.
+
+For geometries with more than two dimensions, the precision of the Z and M dimensions may be specified separately.
+Generally these dimensions do not need to be stored with the same resolution as X/Y. By default, Z will
+be stored with precision 1, and M with precision 0. To change this, specify the additional precisions after
+the X/Y precision, separated with commas. For example, ``6,1,0`` would set the X/Y precision to 6, the Z
+precision to 1 and the M precision to 0. Z and M precisions must be between 0 and 7, inclusive.
+
+TWKB serialization can be set when creating a new schema, but can also be enabled at any time through the
+``updateSchema`` method. If modifying an existing schema, any data already written will not be updated.
+
+.. code-block:: java
+
+    SimpleFeatureType sft = ...
+    sft.getDescriptor("geom").getUserData().put("precision", "4");
+
+See :ref:`attribute_options` for details on how to set attribute options.
+
 Configuring Column Groups
 -------------------------
 

--- a/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/SerializationOption.scala
+++ b/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/SerializationOption.scala
@@ -8,6 +8,8 @@
 
 package org.locationtech.geomesa.features
 
+import org.locationtech.geomesa.features.SerializationOption.Value
+
 /**
  * Options to be applied when encoding.  The same options must be specified when decoding.
  */
@@ -15,10 +17,10 @@ object SerializationOption extends Enumeration {
 
   type SerializationOption = Value
 
-  val WithUserData = Value
-  val WithoutId = Value
-  val Immutable = Value
-  val Lazy = Value
+  val WithUserData :Value = Value
+  val WithoutId    :Value = Value
+  val Immutable    :Value = Value
+  val Lazy         :Value = Value
 
   implicit class SerializationOptions(val options: Set[SerializationOption]) extends AnyVal {
 

--- a/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/serialization/DimensionalBounds.scala
+++ b/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/serialization/DimensionalBounds.scala
@@ -1,0 +1,200 @@
+/***********************************************************************
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.features.serialization
+
+import com.vividsolutions.jts.geom._
+
+/**
+  * Extracts the bounds from a geometry. The generic geometry envelope only deals with X and Y, this
+  * also supports Z and M
+  *
+  * Operations expect a non-empty geometry
+  *
+  * @tparam T geometry type
+  */
+trait DimensionalBounds[T <: Geometry] {
+
+  /**
+    * Get bounds for the x dimension
+    *
+    * @param geometry geometry, not null and not empty
+    * @return (min, max)
+    */
+  def x(geometry: T): (Double, Double) = (geometry.getEnvelopeInternal.getMinX, geometry.getEnvelopeInternal.getMaxX)
+
+  /**
+    * Get bounds for the y dimension
+    *
+    * @param geometry geometry, not null and not empty
+    * @return (min, max)
+    */
+  def y(geometry: T): (Double, Double) = (geometry.getEnvelopeInternal.getMinY, geometry.getEnvelopeInternal.getMaxY)
+
+  /**
+    * Get bounds for the z dimension
+    *
+    * @param geometry geometry, not null and not empty
+    * @return (min, max)
+    */
+  def z(geometry: T): (Double, Double)
+
+  /**
+    * Get bounds for the m dimension
+    *
+    * @param geometry geometry, not null and not empty
+    * @return (min, max)
+    */
+  def m(geometry: T): (Double, Double) =
+    // TODO implement once JTS supports M
+    throw new NotImplementedError("JTS doesn't support M dimension")
+}
+
+object DimensionalBounds {
+
+  implicit object LineStringBounds extends DimensionalBounds[LineString] {
+    override def z(geometry: LineString): (Double, Double) = {
+      var min = geometry.getCoordinateN(0).z
+      var max = min
+      var i = 1
+      while (i < geometry.getNumPoints) {
+        val z = geometry.getCoordinateN(i).z
+        if (z < min) {
+          min = z
+        } else if (z > max) {
+          max = z
+        }
+        i += 1
+      }
+      (min, max)
+    }
+  }
+
+  implicit object PolygonBounds extends DimensionalBounds[Polygon] {
+    override def z(geometry: Polygon): (Double, Double) = {
+      var ring = geometry.getExteriorRing
+      var min = ring.getCoordinateN(0).z
+      var max = min
+      var i = 1
+      while (i < ring.getNumPoints) {
+        val z = ring.getCoordinateN(i).z
+        if (z < min) {
+          min = z
+        } else if (z > max) {
+          max = z
+        }
+        i += 1
+      }
+      val numRings = geometry.getNumInteriorRing
+      var j = 0
+      while (j < numRings) {
+        ring = geometry.getInteriorRingN(j)
+        i = 0
+        while (i < ring.getNumPoints) {
+          val z = ring.getCoordinateN(i).z
+          if (z < min) {
+            min = z
+          } else if (z > max) {
+            max = z
+          }
+          i += 1
+        }
+        j += 1
+      }
+      (min, max)
+    }
+  }
+
+  implicit object MultiPointBounds extends DimensionalBounds[MultiPoint] {
+    override def z(geometry: MultiPoint): (Double, Double) = {
+      var min = geometry.getGeometryN(0).asInstanceOf[Point].getCoordinate.z
+      var max = min
+      var i = 1
+      while (i < geometry.getNumGeometries) {
+        val z = geometry.getGeometryN(i).asInstanceOf[Point].getCoordinate.z
+        if (z < min) {
+          min = z
+        } else if (z > max) {
+          max = z
+        }
+        i += 1
+      }
+      (min, max)
+    }
+  }
+
+  implicit object MultiLineStringBounds extends DimensionalBounds[MultiLineString] {
+    override def z(geometry: MultiLineString): (Double, Double) = {
+      var (min, max) = LineStringBounds.z(geometry.getGeometryN(0).asInstanceOf[LineString])
+      var i = 1
+      while (i < geometry.getNumGeometries) {
+        val (mini, maxi) = LineStringBounds.z(geometry.getGeometryN(i).asInstanceOf[LineString])
+        if (mini < min) {
+          min = min
+        }
+        if (maxi > max) {
+          max = maxi
+        }
+        i += 1
+      }
+      (min, max)
+    }
+  }
+
+  implicit object MultiPolygonBounds extends DimensionalBounds[MultiPolygon] {
+    override def z(geometry: MultiPolygon): (Double, Double) = {
+      var (min, max) = PolygonBounds.z(geometry.getGeometryN(0).asInstanceOf[Polygon])
+      var i = 1
+      while (i < geometry.getNumGeometries) {
+        val (mini, maxi) = PolygonBounds.z(geometry.getGeometryN(i).asInstanceOf[Polygon])
+        if (mini < min) {
+          min = min
+        }
+        if (maxi > max) {
+          max = maxi
+        }
+        i += 1
+      }
+      (min, max)
+    }
+  }
+
+  implicit object GeometryCollectionBounds extends DimensionalBounds[GeometryCollection] {
+    override def z(geometry: GeometryCollection): (Double, Double) = {
+      var (min, max) = geometry.getGeometryN(0) match {
+        case g: Point              => (g.getCoordinate.z, g.getCoordinate.z)
+        case g: LineString         => LineStringBounds.z(g)
+        case g: Polygon            => PolygonBounds.z(g)
+        case g: MultiPoint         => MultiPointBounds.z(g)
+        case g: MultiLineString    => MultiLineStringBounds.z(g)
+        case g: MultiPolygon       => MultiPolygonBounds.z(g)
+        case g: GeometryCollection => GeometryCollectionBounds.z(g)
+      }
+      var i = 1
+      while (i < geometry.getNumGeometries) {
+        val (mini, maxi) = geometry.getGeometryN(i) match {
+          case g: Point              => (g.getCoordinate.z, g.getCoordinate.z)
+          case g: LineString         => LineStringBounds.z(g)
+          case g: Polygon            => PolygonBounds.z(g)
+          case g: MultiPoint         => MultiPointBounds.z(g)
+          case g: MultiLineString    => MultiLineStringBounds.z(g)
+          case g: MultiPolygon       => MultiPolygonBounds.z(g)
+          case g: GeometryCollection => GeometryCollectionBounds.z(g)
+        }
+        if (mini < min) {
+          min = min
+        }
+        if (maxi > max) {
+          max = maxi
+        }
+        i += 1
+      }
+      (min, max)
+    }
+  }
+}

--- a/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/serialization/TwkbSerialization.scala
+++ b/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/serialization/TwkbSerialization.scala
@@ -1,0 +1,645 @@
+/***********************************************************************
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.features.serialization
+
+import com.vividsolutions.jts.geom._
+import org.locationtech.geomesa.utils.geometry.GeometryPrecision.TwkbPrecision
+
+/**
+  * Based on the TWKB standard: https://github.com/TWKB/Specification/blob/master/twkb.md
+  *
+  * For backwards compatibility, also reads original serialization, with the `LegacyGeometrySerialization` trait
+  */
+// noinspection LanguageFeature
+trait TwkbSerialization[T <: NumericWriter, V <: NumericReader]
+    extends VarIntEncoding[T, V] with WkbSerialization[T, V] {
+
+  import DimensionalBounds._
+  import TwkbSerialization.FlagBytes._
+  import TwkbSerialization.GeometryBytes._
+  import TwkbSerialization.ZeroByte
+
+  private val factory = new GeometryFactory()
+  private val csFactory = factory.getCoordinateSequenceFactory
+
+  /**
+    * Serialize a geometry
+    *
+    * For explanation of precisions, see `org.locationtech.geomesa.utils.geometry.GeometryPrecision`
+    *
+    * @param out output
+    * @param geometry geometry
+    * @param precision precision for encoding x, y, z, m
+    */
+  def serialize(out: T, geometry: Geometry, precision: TwkbPrecision = TwkbPrecision()): Unit = {
+    if (geometry == null) {
+      out.writeByte(ZeroByte)
+    } else {
+      // choose our state to correspond with the dimensions in the geometry
+      implicit val state: DeltaState = {
+        // note that we only check the first coordinate - if a geometry is written with different
+        // dimensions in each coordinate, some information may be lost
+        val coord = geometry.getCoordinate
+        // check for dimensions - use NaN != NaN to verify z coordinate
+        // TODO check for M coordinate when added to JTS
+        if (coord == null || coord.z != coord.z) {
+          new XYState(precision.xy)
+        } else {
+          new XYZState(precision.xy, precision.z)
+        }
+      }
+
+      geometry match {
+        case g: Point =>
+          if (g.isEmpty) {
+            state.writeMetadata(out, TwkbPoint, empty = true, bbox = false)
+          } else {
+            state.writeMetadata(out, TwkbPoint, empty = false, bbox = false)
+            state.writeCoordinate(out, g.getCoordinate)
+          }
+
+        case g: LineString =>
+          if (g.isEmpty) {
+            state.writeMetadata(out, TwkbLineString, empty = true, bbox = false)
+          } else {
+            state.writeMetadata(out, TwkbLineString, empty = false, bbox = true)
+            state.writeBoundingBox(out, g)
+          }
+          writeLineString(out, g)
+
+        case g: Polygon =>
+          if (g.isEmpty) {
+            state.writeMetadata(out, TwkbPolygon, empty = true, bbox = false)
+          } else {
+            state.writeMetadata(out, TwkbPolygon, empty = false, bbox = true)
+            state.writeBoundingBox(out, g)
+          }
+          writePolygon(out, g)
+
+        case g: MultiPoint =>
+          if (g.isEmpty) {
+            state.writeMetadata(out, TwkbMultiPoint, empty = true, bbox = false)
+          } else {
+            state.writeMetadata(out, TwkbMultiPoint, empty = false, bbox = true)
+            state.writeBoundingBox(out, g)
+          }
+          writeMultiPoint(out, g)
+
+        case g: MultiLineString =>
+          if (g.isEmpty) {
+            state.writeMetadata(out, TwkbMultiLineString, empty = true, bbox = false)
+          } else {
+            state.writeMetadata(out, TwkbMultiLineString, empty = false, bbox = true)
+            state.writeBoundingBox(out, g)
+          }
+          writeMultiLineString(out, g)
+
+        case g: MultiPolygon =>
+          if (g.isEmpty) {
+            state.writeMetadata(out, TwkbMultiPolygon, empty = true, bbox = false)
+          } else {
+            state.writeMetadata(out, TwkbMultiPolygon, empty = false, bbox = true)
+            state.writeBoundingBox(out, g)
+          }
+          writeMultiPolygon(out, g)
+
+        case g: GeometryCollection =>
+          if (g.isEmpty) {
+            state.writeMetadata(out, TwkbCollection, empty = true, bbox = false)
+          } else {
+            state.writeMetadata(out, TwkbCollection, empty = false, bbox = true)
+            state.writeBoundingBox(out, g)
+          }
+          writeCollection(out, g)
+      }
+    }
+  }
+
+  /**
+    * Deserialize a geometry
+    *
+    * @param in input
+    * @return
+    */
+  def deserialize(in: V): Geometry = {
+    val precisionAndType = in.readByte()
+    if (precisionAndType == ZeroByte) {
+      null
+    } else if (precisionAndType == NOT_NULL_BYTE) {
+      // TODO this overlaps with twkb point type with precision 0
+      deserializeWkb(in)
+    } else {
+      // first byte contains the geometry type in the first 4 bits and the x-y precision in the second 4 bits
+      val geomType = (precisionAndType & 0x0F).toByte
+      val precision = VarIntEncoding.zigzagDecode((precisionAndType & 0xF0) >>> 4)
+
+      // second byte contains flags for optional elements
+      val flags = in.readByte()
+      val hasBoundingBox = (flags & BoundingBoxFlag) != 0
+      val hasExtendedDims = (flags & ExtendedDimsFlag) != 0
+      val isEmpty = (flags & EmptyFlag) != 0
+
+      // extended dims indicates the presence of z and/or m
+      // we create our state tracker based on the dimensions that are present
+      implicit val state: DeltaState = if (hasExtendedDims) {
+        // z and m precisions are indicated in the next byte, where (from right to left):
+        //   bit 0 indicates presence of z dimension
+        //   bit 1 indicates presence of m dimension
+        //   bits 2-5 indicate z precision
+        //   bits 6-8 indicate m precision
+        val extendedDims = in.readByte()
+        if ((extendedDims & 0x01) != 0) { // indicates z dimension
+          if ((extendedDims & 0x02) != 0) { // indicates m dimension
+            new XYZMState(precision, (extendedDims & 0x1C) >> 2, (extendedDims & 0xE0) >>> 5)
+          } else {
+            new XYZState(precision, (extendedDims & 0x1C) >> 2)
+          }
+        } else if ((extendedDims & 0x02) != 0) {  // indicates m dimension
+          new XYMState(precision, (extendedDims & 0xE0) >>> 5)
+        } else {
+          // not sure why anyone would indicate extended dims but set them all false...
+          new XYState(precision)
+        }
+      } else {
+        new XYState(precision)
+      }
+
+      // size is the length of the remainder of the geometry, after the size attribute
+      // we don't currently use size - parsing will fail if size is actually present
+
+      // val hasSize = (flags & FlagBytes.SizeFlag) != 0
+      // if (hasSize) {
+      //   val size = readUnsignedVarInt(in)
+      // }
+
+      // bounding box is not currently used, but we write it in anticipation of future filter optimizations
+      if (hasBoundingBox) {
+        state.skipBoundingBox(in)
+      }
+
+      // children geometries can be written with an id list
+      // we don't currently use ids - parsing will fail if ids are actually present
+      // val hasIds = (flags & FlagBytes.IdsFlag) != 0
+
+      geomType match {
+        case TwkbPoint => factory.createPoint(if (isEmpty) { null } else { csFactory.create(readPointArray(in, 1)) })
+        case TwkbLineString      => readLineString(in)
+        case TwkbPolygon         => readPolygon(in)
+        case TwkbMultiPoint      => readMultiPoint(in)
+        case TwkbMultiLineString => readMultiLineString(in)
+        case TwkbMultiPolygon    => readMultiPolygon(in)
+        case TwkbCollection      => readCollection(in)
+        case _ => throw new IllegalArgumentException(s"Invalid TWKB geometry type $geomType")
+      }
+    }
+  }
+
+  private def writeLineString(out: T, g: LineString)(implicit state: DeltaState): Unit =
+      writePointArray(out, g.getCoordinateSequence, g.getNumPoints)
+
+  private def readLineString(in: V)(implicit state: DeltaState): LineString =
+    factory.createLineString(csFactory.create(readPointArray(in, readUnsignedVarInt(in))))
+
+  private def writePolygon(out: T, g: Polygon)(implicit state: DeltaState): Unit = {
+    if (g.isEmpty) {
+      writeUnsignedVarInt(out, 0)
+    } else {
+      val numRings = g.getNumInteriorRing
+      writeUnsignedVarInt(out, numRings + 1) // include exterior ring in count
+      // note: don't write final point for each ring, as they should duplicate the first point
+      var ring = g.getExteriorRing.getCoordinateSequence
+      writePointArray(out, ring, ring.size() - 1)
+      var j = 0
+      while (j < numRings) {
+        ring = g.getInteriorRingN(j).getCoordinateSequence
+        writePointArray(out, ring, ring.size() - 1)
+        j += 1
+      }
+    }
+  }
+
+  private def readPolygon(in: V)(implicit state: DeltaState): Polygon = {
+    val numRings = readUnsignedVarInt(in)
+    if (numRings == 0) { factory.createPolygon(null, null) } else {
+      val exteriorRing = readLinearRing(in, readUnsignedVarInt(in))
+      val interiorRings = Array.ofDim[LinearRing](numRings - 1)
+      var i = 1
+      while (i < numRings) {
+        interiorRings(i - 1) = readLinearRing(in, readUnsignedVarInt(in))
+        i += 1
+      }
+      factory.createPolygon(exteriorRing, interiorRings)
+    }
+  }
+
+  private def writeMultiPoint(out: T, g: MultiPoint)(implicit state: DeltaState): Unit = {
+    val length = g.getNumPoints
+    writeUnsignedVarInt(out, length)
+    var i = 0
+    while (i < length) {
+      state.writeCoordinate(out, g.getGeometryN(i).asInstanceOf[Point].getCoordinate)
+      i += 1
+    }
+  }
+
+  private def readMultiPoint(in: V)(implicit state: DeltaState): MultiPoint = {
+    val numPoints = readUnsignedVarInt(in)
+    if (numPoints == 0) { factory.createMultiPoint(null: CoordinateSequence) } else {
+      // note: id list would go here, with one ID per point
+      factory.createMultiPoint(readPointArray(in, numPoints).map(factory.createPoint))
+    }
+  }
+
+  private def writeMultiLineString(out: T, g: MultiLineString)(implicit state: DeltaState): Unit = {
+    val length = g.getNumGeometries
+    writeUnsignedVarInt(out, length)
+    var i = 0
+    while (i < length) {
+      val line = g.getGeometryN(i).asInstanceOf[LineString].getCoordinateSequence
+      writePointArray(out, line, line.size())
+      i += 1
+    }
+  }
+
+  private def readMultiLineString(in: V)(implicit state: DeltaState): MultiLineString = {
+    val numLineStrings = readUnsignedVarInt(in)
+    if (numLineStrings == 0) { factory.createMultiLineString(null) } else {
+      // note: id list would go here, with one ID per line string
+      val lineStrings = Array.ofDim[LineString](numLineStrings)
+      var i = 0
+      while (i < numLineStrings) {
+        lineStrings(i) = readLineString(in)
+        i += 1
+      }
+      factory.createMultiLineString(lineStrings)
+    }
+  }
+
+  private def writeMultiPolygon(out: T, g: MultiPolygon)(implicit state: DeltaState): Unit = {
+    val length = g.getNumGeometries
+    writeUnsignedVarInt(out, length)
+    var i = 0
+    while (i < length) {
+      writePolygon(out, g.getGeometryN(i).asInstanceOf[Polygon])
+      i += 1
+    }
+  }
+
+  private def readMultiPolygon(in: V)(implicit state: DeltaState): MultiPolygon = {
+    val numPolygons = readUnsignedVarInt(in)
+    if (numPolygons == 0) { factory.createMultiPolygon(null) } else {
+      // note: id list would go here, with one ID per polygon
+      val polygons = Array.ofDim[Polygon](numPolygons)
+      var i = 0
+      while (i < numPolygons) {
+        polygons(i) = readPolygon(in)
+        i += 1
+      }
+      factory.createMultiPolygon(polygons)
+    }
+  }
+
+  private def writeCollection(out: T, g: GeometryCollection)(implicit state: DeltaState): Unit = {
+    val length = g.getNumGeometries
+    writeUnsignedVarInt(out, length)
+    var i = 0
+    while (i < length) {
+      serialize(out, g.getGeometryN(i))
+      i += 1
+    }
+  }
+
+  private def readCollection(in: V): GeometryCollection = {
+    val numGeoms = readUnsignedVarInt(in)
+    if (numGeoms == 0) { factory.createGeometryCollection(null) } else {
+      // note: id list would go here, with one ID per sub geometry
+      val geoms = Array.ofDim[Geometry](numGeoms)
+      var i = 0
+      while (i < numGeoms) {
+        geoms(i) = deserialize(in)
+        i += 1
+      }
+      factory.createGeometryCollection(geoms)
+    }
+  }
+
+  private def writePointArray(out: T, coords: CoordinateSequence, length: Int)(implicit state: DeltaState): Unit = {
+    writeUnsignedVarInt(out, length)
+    var i = 0
+    while (i < length) {
+      state.writeCoordinate(out, coords.getCoordinate(i))
+      i += 1
+    }
+  }
+
+  private def readPointArray(in: V, length: Int)(implicit state: DeltaState): Array[Coordinate] = {
+    val result = Array.ofDim[Coordinate](length)
+    var i = 0
+    while (i < length) {
+      result(i) = state.readCoordinate(in)
+      i += 1
+    }
+    result
+  }
+
+  private def readLinearRing(in: V, length: Int)(implicit state: DeltaState): LinearRing = {
+    if (length == 0) { factory.createLinearRing(null: CoordinateSequence) } else {
+      val result = Array.ofDim[Coordinate](length + 1)
+      var i = 0
+      while (i < length) {
+        result(i) = state.readCoordinate(in)
+        i += 1
+      }
+      // linear rings should not store the final, duplicate point, but still need it for the geometry
+      result(length) = result(0)
+      factory.createLinearRing(csFactory.create(result))
+    }
+  }
+
+  /**
+    * TWKB only reads and writes the delta from one coordinate to the next, which generally saves space
+    * over absolute values. This trait tracks the values used for delta calculations over a single
+    * read or write operation
+    */
+  private sealed trait DeltaState {
+
+    /**
+      * Write metadata, which includes the geometry and precision byte, the flag byte, and optionally
+      * an extended precision byte
+      *
+      * @param out output
+      * @param geometryType geometry type
+      * @param empty indicate that the geometry is empty
+      * @param bbox indicate that a bbox will be written
+      */
+    def writeMetadata(out: T, geometryType: Byte, empty: Boolean, bbox: Boolean): Unit
+
+    /**
+      * Writes out a bounding box. Each dimension stores a min value and a delta to the max value
+      *
+      * @param out output
+      * @param geometry geometry
+      * @param bounds bounds operation
+      * @tparam G geometry type
+      */
+    def writeBoundingBox[G <: Geometry](out: T, geometry: G)(implicit bounds: DimensionalBounds[G]): Unit
+
+    /**
+      * Skips over a bounding box. We don't currently use the bounding box when reading
+      *
+      * @param in in
+      */
+    def skipBoundingBox(in: V): Unit
+
+    /**
+      * Write a coordinate
+      *
+      * @param out output
+      * @param coordinate coordinate
+      */
+    def writeCoordinate(out: T, coordinate: Coordinate): Unit
+
+    /**
+      * Read a coordinate
+      *
+      * @param in input
+      * @return
+      */
+    def readCoordinate(in: V): Coordinate
+
+    /**
+      * Reset the state back to its original state, suitable for re-use
+      */
+    def reset(): Unit
+  }
+
+  private class XYState(precision: Int) extends DeltaState {
+
+    private val p: Double = math.pow(10, precision)
+    private var x: Int = 0
+    private var y: Int = 0
+
+    protected val boundingBoxFlag: Byte = BoundingBoxFlag
+    protected val emptyFlag: Byte = EmptyFlag
+    protected val dimensionsFlag: Byte = ZeroByte
+
+    override def writeMetadata(out: T, geometryType: Byte, empty: Boolean, bbox: Boolean): Unit = {
+      // write the geometry type and the main precision
+      out.writeByte(((VarIntEncoding.zigzagEncode(precision) << 4) | geometryType).toByte)
+      // write the flag byte
+      out.writeByte(if (bbox) { boundingBoxFlag } else if (empty) { emptyFlag } else { dimensionsFlag })
+    }
+
+    override def writeCoordinate(out: T, coordinate: Coordinate): Unit = {
+      val cx = math.round(coordinate.x * p).toInt
+      val cy = math.round(coordinate.y * p).toInt
+      writeVarInt(out, cx - x)
+      writeVarInt(out, cy - y)
+      x = cx
+      y = cy
+    }
+
+    override def readCoordinate(in: V): Coordinate = {
+      x = x + readVarInt(in)
+      y = y + readVarInt(in)
+      new Coordinate(x / p, y / p)
+    }
+
+    override def writeBoundingBox[G <: Geometry](out: T, geometry: G)(implicit bounds: DimensionalBounds[G]): Unit = {
+      val (minX, maxX) = bounds.x(geometry)
+      val intX = math.round(minX * p).toInt
+      writeVarInt(out, intX)
+      writeVarInt(out, math.round(maxX * p).toInt - intX)
+      val (minY, maxY) = bounds.y(geometry)
+      val intY = math.round(minY * p).toInt
+      writeVarInt(out, intY)
+      writeVarInt(out, math.round(maxY * p).toInt - intY)
+    }
+
+    override def skipBoundingBox(in: V): Unit = {
+      skipVarInt(in)
+      skipVarInt(in)
+      skipVarInt(in)
+      skipVarInt(in)
+    }
+
+    override def reset(): Unit = {
+      x = 0
+      y = 0
+    }
+  }
+
+  private abstract class ExtendedState(precision: Int) extends XYState(precision) {
+
+    protected def extendedDims: Byte
+
+    override protected val boundingBoxFlag: Byte = (ExtendedDimsFlag | BoundingBoxFlag).toByte
+    override protected val emptyFlag: Byte = (ExtendedDimsFlag | EmptyFlag).toByte
+    override protected val dimensionsFlag: Byte = ExtendedDimsFlag
+
+    override def writeMetadata(out: T, geometryType: Byte, empty: Boolean, bbox: Boolean): Unit = {
+      super.writeMetadata(out, geometryType, empty, bbox)
+      // write the extended precision values
+      out.writeByte(extendedDims)
+    }
+  }
+
+  private class XYZState(precision: Int, zPrecision: Int) extends ExtendedState(precision) {
+
+    private val pz: Double = math.pow(10, zPrecision)
+    private var z: Int = 0
+
+    // sets bits for z dim, and its precisions
+    override protected val extendedDims: Byte = (0x01 | ((zPrecision & 0x03) << 2)).toByte
+
+    override def writeBoundingBox[G <: Geometry](out: T, geometry: G)(implicit bounds: DimensionalBounds[G]): Unit = {
+      super.writeBoundingBox(out, geometry)
+      val (minZ, maxZ) = bounds.z(geometry)
+      val intZ = math.round(minZ * pz).toInt
+      writeVarInt(out, intZ)
+      writeVarInt(out, math.round(maxZ * pz).toInt - intZ)
+    }
+
+    override def writeCoordinate(out: T, coordinate: Coordinate): Unit = {
+      super.writeCoordinate(out, coordinate)
+      val cz = math.round(coordinate.z * pz).toInt
+      writeVarInt(out, cz - z)
+      z = cz
+    }
+
+    override def readCoordinate(in: V): Coordinate = {
+      val coord = super.readCoordinate(in)
+      z = z + readVarInt(in)
+      coord.z = z / pz
+      coord
+    }
+
+    override def skipBoundingBox(in: V): Unit = {
+      super.skipBoundingBox(in)
+      skipVarInt(in)
+      skipVarInt(in)
+    }
+
+    override def reset(): Unit = {
+      super.reset()
+      z = 0
+    }
+  }
+
+  private class XYMState(precision: Int, mPrecision: Int) extends ExtendedState(precision) {
+
+    private val pm: Double = math.pow(10, mPrecision)
+    private var m: Int = 0
+
+    // sets bit for m dim, and its precisions
+    override protected val extendedDims: Byte = (0x02 | ((mPrecision & 0x03) << 5)).toByte
+
+    override def writeBoundingBox[G <: Geometry](out: T, geometry: G)(implicit bounds: DimensionalBounds[G]): Unit = {
+      super.writeBoundingBox(out, geometry)
+      val (minM, maxM) = bounds.m(geometry)
+      val intM = math.round(minM * pm).toInt
+      writeVarInt(out, intM)
+      writeVarInt(out, math.round(maxM * pm).toInt - intM)
+    }
+
+    override def writeCoordinate(out: T, coordinate: Coordinate): Unit = {
+      super.writeCoordinate(out, coordinate)
+      val cm = 0 // TODO math.round(coordinate.m * pm).toInt
+      writeVarInt(out, cm - m)
+      m = cm
+    }
+
+    override def readCoordinate(in: V): Coordinate = {
+      val coord = super.readCoordinate(in)
+      m = m + readVarInt(in)
+      // TODO set m as 4th ordinate when supported by jts
+      coord
+    }
+
+    override def skipBoundingBox(in: V): Unit = {
+      super.skipBoundingBox(in)
+      skipVarInt(in)
+      skipVarInt(in)
+    }
+
+    override def reset(): Unit = {
+      super.reset()
+      m = 0
+    }
+  }
+
+  private class XYZMState(precision: Int, zPrecision: Int, mPrecision: Int) extends XYZState(precision, zPrecision) {
+
+    private val pm: Double = math.pow(10, mPrecision)
+    private var m: Int = 0
+
+    // sets bits for both z and m dims, and their precisions
+    override protected val extendedDims: Byte =
+      (0x03 | ((zPrecision & 0x03) << 2) | ((mPrecision & 0x03) << 5)).toByte
+
+    override def writeBoundingBox[G <: Geometry](out: T, geometry: G)(implicit bounds: DimensionalBounds[G]): Unit = {
+      super.writeBoundingBox(out, geometry)
+      val (minM, maxM) = bounds.m(geometry)
+      val intM = math.round(minM * pm).toInt
+      writeVarInt(out, intM)
+      writeVarInt(out, math.round(maxM * pm).toInt - intM)
+    }
+
+    override def writeCoordinate(out: T, coordinate: Coordinate): Unit = {
+      super.writeCoordinate(out, coordinate)
+      val cm = 0 // TODO math.round(coordinate.m * pm).toInt
+      writeVarInt(out, cm - m)
+      m = cm
+    }
+
+    override def readCoordinate(in: V): Coordinate = {
+      val coord = super.readCoordinate(in)
+      m = m + readVarInt(in)
+      // TODO set m as 4th ordinate when supported by jts
+      coord
+    }
+
+    override def skipBoundingBox(in: V): Unit = {
+      super.skipBoundingBox(in)
+      skipVarInt(in)
+      skipVarInt(in)
+    }
+
+    override def reset(): Unit = {
+      super.reset()
+      m = 0
+    }
+  }
+}
+
+object TwkbSerialization {
+
+  val MaxPrecision: Byte = 7
+
+  private val ZeroByte: Byte = 0
+
+  // twkb constants
+  object GeometryBytes {
+    val TwkbPoint           :Byte = 1
+    val TwkbLineString      :Byte = 2
+    val TwkbPolygon         :Byte = 3
+    val TwkbMultiPoint      :Byte = 4
+    val TwkbMultiLineString :Byte = 5
+    val TwkbMultiPolygon    :Byte = 6
+    val TwkbCollection      :Byte = 7
+  }
+
+  object FlagBytes {
+    val BoundingBoxFlag  :Byte = 0x01
+    val SizeFlag         :Byte = 0x02
+    val IdsFlag          :Byte = 0x04
+    val ExtendedDimsFlag :Byte = 0x08
+    val EmptyFlag        :Byte = 0x10
+  }
+}

--- a/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/serialization/VarIntEncoding.scala
+++ b/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/serialization/VarIntEncoding.scala
@@ -1,0 +1,144 @@
+/***********************************************************************
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+/**
+  * Portions derived from google protocol buffers, which are:
+  *
+  * Copyright 2008 Google Inc.  All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are
+  * met:
+  *
+  * * Redistributions of source code must retain the above copyright
+  * notice, this list of conditions and the following disclaimer.
+  * * Redistributions in binary form must reproduce the above
+  * copyright notice, this list of conditions and the following disclaimer
+  * in the documentation and/or other materials provided with the
+  * distribution.
+  * * Neither the name of Google Inc. nor the names of its
+  * contributors may be used to endorse or promote products derived from
+  * this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  */
+
+package org.locationtech.geomesa.features.serialization
+
+// noinspection LanguageFeature
+trait VarIntEncoding[T <: NumericWriter, V <: NumericReader] {
+
+  /**
+    * Writes a variable length signed int. The int will first be zig-zag encoded to prevent small
+    * negative values from taking up the max number of bytes
+    *
+    * @param writer writer
+    * @param value int
+    */
+  def writeVarInt(writer: T, value: Int): Unit = writeUnsignedVarInt(writer, VarIntEncoding.zigzagEncode(value))
+
+  /**
+    * Writes a variable length unsigned int. Small values will be encoded with fewer bytes
+    *
+    * @param writer writer
+    * @param value int
+    */
+  def writeUnsignedVarInt(writer: T, value: Int): Unit = {
+    var remaining = value
+    while ((remaining & ~0x7F) != 0) {
+      writer.writeByte(((remaining & 0x7F) | 0x80).toByte)
+      remaining = remaining >>> 7
+    }
+    writer.writeByte(remaining.toByte)
+  }
+
+  /**
+    * Reads a signed int encoded with `writeVarInt`
+    *
+    * @param reader reader
+    * @return
+    */
+  def readVarInt(reader: V): Int = VarIntEncoding.zigzagDecode(readUnsignedVarInt(reader))
+
+  /**
+    * Reads an unsigned int encoded with `writeUnsignedVarInt`
+    *
+    * @param reader reader
+    * @return
+    */
+  def readUnsignedVarInt(reader: V): Int = {
+    var byte = reader.readByte()
+    if ((byte & 0x80) == 0) {
+      byte
+    } else {
+      var result = byte & 0x7F
+      var offset = 7
+      while (offset < 32) {
+        byte = reader.readByte()
+        result = result | ((byte & 0x7f) << offset)
+        if ((byte & 0x80) == 0) {
+          return result
+        }
+        offset += 7
+      }
+      throw new IllegalArgumentException("Did not find last byte of encoded VarInt")
+    }
+  }
+
+  /**
+    * Skip over a variable length int, either signed or unsigned
+    *
+    * @param reader reader
+    */
+  def skipVarInt(reader: V): Unit = {
+    var byte = reader.readByte()
+    if ((byte & 0x80) != 0) {
+      byte = reader.readByte()
+      var count = 2
+      while ((byte & 0x80) != 0) {
+        if (count == 5) {
+          throw new IllegalArgumentException("Did not find last byte of encoded VarInt")
+        }
+        byte = reader.readByte()
+        count += 1
+      }
+    }
+  }
+}
+
+object VarIntEncoding {
+
+  /**
+    * Takes a signed int and zig-zag encodes it to an unsigned int
+    *
+    * See https://github.com/TWKB/Specification/blob/master/twkb.md#zigzag-encode
+    *
+    * @param n signed int
+    * @return unsigned int, with small absolute values encoded as small numbers
+    */
+  def zigzagEncode(n: Int): Int = (n << 1) ^ (n >> 31)
+
+  /**
+    * Takes a zig-zag encoded unsigned int and restores the original signed int
+    *
+    * @param n unsigned, zig-zag encoded int
+    * @return signed int
+    */
+  def zigzagDecode(n: Int): Int = (n >>> 1) ^ -(n & 1)
+}

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/serialization/KryoGeometrySerialization.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/serialization/KryoGeometrySerialization.scala
@@ -9,8 +9,6 @@
 package org.locationtech.geomesa.features.kryo.serialization
 
 import com.esotericsoftware.kryo.io.{Input, Output}
-import org.locationtech.geomesa.features.serialization.GeometrySerialization
+import org.locationtech.geomesa.features.serialization.TwkbSerialization
 
-object KryoGeometrySerialization extends GeometrySerialization[Output, Input]
-
-
+object KryoGeometrySerialization extends TwkbSerialization[Output, Input]

--- a/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/KryoGeometrySerializerTest.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/KryoGeometrySerializerTest.scala
@@ -36,24 +36,22 @@ class KryoGeometrySerializerTest extends Specification {
       ).map(WKTUtils.read)
 
       "using byte arrays" >> {
-        geoms.foreach { geom =>
+        foreach(geoms) { geom =>
           val out = new Output(512)
           KryoGeometrySerialization.serialize(out, geom)
           val in = new Input(out.toBytes)
           val deserialized = KryoGeometrySerialization.deserialize(in)
           deserialized mustEqual geom
         }
-        success
       }
       "using streams" >> {
-        geoms.foreach { geom =>
+        foreach(geoms) { geom =>
           val out = new Output(new ByteArrayOutputStream(), 512)
           KryoGeometrySerialization.serialize(out, geom)
           val in = new Input(new ByteArrayInputStream(out.toBytes))
           val deserialized = KryoGeometrySerialization.deserialize(in)
           deserialized mustEqual geom
         }
-        success
       }
     }
 

--- a/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/schema/KuduColumnAdapter.scala
+++ b/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/schema/KuduColumnAdapter.scala
@@ -80,8 +80,8 @@ object KuduColumnAdapter {
       case ObjectType.UUID     => UuidColumnAdapter(name, config)
       case ObjectType.BYTES    => BytesColumnAdapter(name, config)
       case ObjectType.JSON     => StringColumnAdapter(name, config)
-      case ObjectType.LIST     => KryoColumnAdapter(name, bindings, config)
-      case ObjectType.MAP      => KryoColumnAdapter(name, bindings, config)
+      case ObjectType.LIST     => KryoColumnAdapter(name, bindings, descriptor, config)
+      case ObjectType.MAP      => KryoColumnAdapter(name, bindings, descriptor, config)
       case ObjectType.GEOMETRY =>
         if (bindings(1) == ObjectType.POINT) {
           PointColumnAdapter(sft, name, config, descriptor != sft.getGeometryDescriptor)
@@ -387,11 +387,13 @@ object KuduColumnAdapter {
   /**
     * Encodes variable-size types (lists and maps) for storing in a fixed number of columns (i.e. one)
     */
-  case class KryoColumnAdapter(name: String, bindings: Seq[ObjectType], config: ColumnConfiguration)
-      extends KuduColumnAdapter[AnyRef] {
+  case class KryoColumnAdapter(name: String,
+                               bindings: Seq[ObjectType],
+                               descriptor: AttributeDescriptor,
+                               config: ColumnConfiguration) extends KuduColumnAdapter[AnyRef] {
 
     // note: reader and writer handle null values
-    private val writer = KryoFeatureSerialization.matchWriter(bindings)
+    private val writer = KryoFeatureSerialization.matchWriter(bindings, descriptor)
     private val reader = KryoFeatureDeserialization.matchReader(bindings)
 
     private val column = s"${name}_sft"

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geometry/GeometryPrecision.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geometry/GeometryPrecision.scala
@@ -1,0 +1,39 @@
+/***********************************************************************
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.geometry
+
+sealed trait GeometryPrecision
+
+object GeometryPrecision {
+
+  case object FullPrecision extends GeometryPrecision
+
+  /**
+    * Precision for serialized geometries
+    *
+    * Precision is the number of base-10 decimal places stored. A positive precision implies retaining
+    * information to the right of the decimal place, while a negative precision implies rounding up to
+    * the left of the decimal place
+    *
+    * See https://github.com/TWKB/Specification/blob/master/twkb.md#type--precision
+    *
+    * If precision exceeds the max precision for TWKB serialization, full double serialization will
+    * be used instead
+    *
+    * @param xy 4-bit signed integer precision for the x and y dimensions
+    *           for lat/lon, a precision of 6 is about 10cm
+    * @param z 3-bit unsigned integer precision for the z dimension (if used)
+    *          for meters, precision of 1 is 10cm
+    * @param m 3-bit unsigned integer precision for the z dimension (if used)
+    *          for milliseconds, precision of 0 is 1ms
+    */
+  case class TwkbPrecision(xy: Byte = 6, z: Byte = 1, m: Byte = 0) extends GeometryPrecision {
+    require(xy < 8 && xy > -8 && z < 8 && z > -1 && m < 8 && m > -1, s"Invalid TWKB precision: $xy,$z,$m")
+  }
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -17,6 +17,7 @@ import org.geotools.geometry.DirectPosition2D
 import org.locationtech.geomesa.curve.TimePeriod.TimePeriod
 import org.locationtech.geomesa.curve.{TimePeriod, XZSFC}
 import org.locationtech.geomesa.utils.conf.SemanticVersion
+import org.locationtech.geomesa.utils.geometry.GeometryPrecision
 import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
 import org.locationtech.geomesa.utils.index.VisibilityLevel
 import org.locationtech.geomesa.utils.index.VisibilityLevel.VisibilityLevel
@@ -175,6 +176,16 @@ object RichAttributeDescriptors {
       ad.getUserData.containsKey(USER_DATA_MAP_KEY_TYPE) && ad.getUserData.containsKey(USER_DATA_MAP_VALUE_TYPE)
 
     def isMultiValued: Boolean = isList || isMap
+
+    def getPrecision: GeometryPrecision = {
+      Option(ad.getUserData.get(OPT_PRECISION).asInstanceOf[String]).map(_.split(',')) match {
+        case None => GeometryPrecision.FullPrecision
+        case Some(Array(xy)) => GeometryPrecision.TwkbPrecision(xy.toByte)
+        case Some(Array(xy, z)) => GeometryPrecision.TwkbPrecision(xy.toByte, z.toByte)
+        case Some(Array(xy, z, m)) => GeometryPrecision.TwkbPrecision(xy.toByte, z.toByte, m.toByte)
+        case Some(p) => throw new IllegalArgumentException(s"Invalid geometry precision: ${p.mkString(",")}")
+      }
+    }
   }
 
   implicit class RichAttributeTypeBuilder(val builder: AttributeTypeBuilder) extends AnyVal {

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
@@ -72,6 +72,7 @@ object SimpleFeatureTypes {
     val OPT_BIN_TRACK_ID = "bin-track-id"
     val OPT_CQ_INDEX     = "cq-index"
     val OPT_JSON         = "json"
+    val OPT_PRECISION    = "precision"
   }
 
   private [geomesa] object AttributeConfigs {


### PR DESCRIPTION
* TWKB serialization can be enabled on geometry attributes (opt-in)
* Serialization precision can be specified with the per-attribute user data 'precision' flag
* Both TWKB and WKB serialization are supported, even within a single schema

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>