### PR TITLE
GEOMESA-1159 Reduce number of ranges generated based on the number of…

### DIFF
--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -44,9 +44,7 @@ geomesa.scan.ranges.target
 This property provides a rough upper-limit for the number of row ranges that will be scanned for a single
 query. It is specified as a number. In general, more ranges will result in fewer false-positive rows being
 scanned, which will speed up most queries. However, too many ranges can take a long time to generate, and
-overwhelm clients, causing slowdowns. The optimal value depends on the environment. Note that for temporal
-queries against the Z3 or XZ3 index, the number of ranges will be multiplied by the number of time periods
-(e.g. weeks by default) being queried.
+overwhelm clients, causing slowdowns. The optimal value depends on the environment.
 
 geomesa.query.timeout
 +++++++++++++++++++++

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3QueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3QueryableIndex.scala
@@ -155,7 +155,11 @@ trait Z3QueryableIndex extends AccumuloFeatureIndexType
         }
       }
 
-      val rangeTarget = QueryProperties.ScanRangesTarget.option.map(_.toInt)
+      val rangeTarget = {
+        // note: this will always be Some, as ScanRangesTarget has a default value
+        val opt = QueryProperties.ScanRangesTarget.option
+        if (timesByBin.isEmpty) { opt.map(_.toInt) } else { opt.map(_.toInt / timesByBin.size) }
+      }
       def toZRanges(t: Seq[(Long, Long)]): Seq[(Array[Byte], Array[Byte])] = if (sft.isPoints) {
         sfc.ranges(xy, t, 64, rangeTarget).map(r => (Longs.toByteArray(r.lower), Longs.toByteArray(r.upper)))
       } else {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/IndexKeySpace.scala
@@ -72,9 +72,11 @@ abstract class IndexKeySpace[T, U](implicit val ordering: Ordering[U]) {
     * Creates ranges over the index keys
     *
     * @param values index values @see getIndexValues
+    * @param multiplier hint for how many times the ranges will be multiplied. can be used to
+    *                   inform the number of ranges generated
     * @return
     */
-  def getRanges(values: T): Iterator[ScanRange[U]]
+  def getRanges(values: T, multiplier: Int = 1): Iterator[ScanRange[U]]
 
   /**
     * Creates bytes from ranges

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/attribute/AttributeIndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/attribute/AttributeIndexKeySpace.scala
@@ -97,7 +97,8 @@ trait AttributeIndexKeySpace extends IndexKeySpace[AttributeIndexValues[Any], At
     AttributeIndexValues(attribute, i, bounds.asInstanceOf[FilterValues[Bounds[Any]]], binding.asInstanceOf[Class[Any]])
   }
 
-  override def getRanges(values: AttributeIndexValues[Any]): Iterator[ScanRange[AttributeIndexKey]] = {
+  override def getRanges(values: AttributeIndexValues[Any],
+                         multiplier: Int): Iterator[ScanRange[AttributeIndexKey]] = {
 
     import AttributeIndexKey.encodeForQuery
     import org.locationtech.geomesa.filter.WILDCARD_SUFFIX

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/id/IdIndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/id/IdIndexKeySpace.scala
@@ -46,7 +46,7 @@ trait IdIndexKeySpace extends IndexKeySpace[Set[Array[Byte]], Array[Byte]] {
     identifiers.map(serializer.apply)
   }
 
-  override def getRanges(values: Set[Array[Byte]]): Iterator[ScanRange[Array[Byte]]] =
+  override def getRanges(values: Set[Array[Byte]], multiplier: Int): Iterator[ScanRange[Array[Byte]]] =
     values.iterator.map(SingleRowRange.apply)
 
   override def getRangeBytes(ranges: Iterator[ScanRange[Array[Byte]]],

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/legacy/AttributeDateIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/legacy/AttributeDateIndex.scala
@@ -65,7 +65,7 @@ trait AttributeDateIndex[DS <: GeoMesaDataStore[DS, F, W], F <: WrappedFeature, 
     override def getIndexValues(sft: SimpleFeatureType, filter: Filter, explain: Explainer): (Option[String], Filter) =
       (sft.getDtgField, filter)
 
-    override def getRanges(values: (Option[String], Filter)): Iterator[ScanRange[Long]] = {
+    override def getRanges(values: (Option[String], Filter), multiplier: Int): Iterator[ScanRange[Long]] = {
       val (dtgField, filter) = values
       val intervals = dtgField.map(FilterHelper.extractIntervals(filter, _)).getOrElse(FilterValues.empty)
       intervals.values.iterator.map { bounds =>

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/XZ2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/XZ2IndexKeySpace.scala
@@ -64,10 +64,11 @@ trait XZ2IndexKeySpace extends IndexKeySpace[XZ2IndexValues, Long] {
     XZ2IndexValues(sfc, geometries, xy)
   }
 
-  override def getRanges(values: XZ2IndexValues): Iterator[ScanRange[Long]] = {
+  override def getRanges(values: XZ2IndexValues, multiplier: Int): Iterator[ScanRange[Long]] = {
     val XZ2IndexValues(sfc, _, xy) = values
-    val zs = sfc.ranges(xy, QueryProperties.ScanRangesTarget.option.map(_.toInt))
-    zs.iterator.map(r => BoundedRange(r.lower, r.upper))
+    // note: `target` will always be Some, as ScanRangesTarget has a default value
+    val target = QueryProperties.ScanRangesTarget.option.map(t => math.max(1, t.toInt / multiplier))
+    sfc.ranges(xy, target).iterator.map(r => BoundedRange(r.lower, r.upper))
   }
 
   override def getRangeBytes(ranges: Iterator[ScanRange[Long]],

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/Z2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/Z2IndexKeySpace.scala
@@ -69,11 +69,12 @@ trait Z2IndexKeySpace extends IndexKeySpace[Z2IndexValues, Long] {
     Z2IndexValues(sfc, geometries, xy)
   }
 
-  override def getRanges(values: Z2IndexValues): Iterator[ScanRange[Long]] = {
+  override def getRanges(values: Z2IndexValues, multiplier: Int): Iterator[ScanRange[Long]] = {
     val Z2IndexValues(_, _, xy) = values
     if (xy.isEmpty) { Iterator.empty } else {
-      val zs = sfc.ranges(xy, 64, QueryProperties.ScanRangesTarget.option.map(_.toInt))
-      zs.iterator.map(r => BoundedRange(r.lower, r.upper))
+      // note: `target` will always be Some, as ScanRangesTarget has a default value
+      val target = QueryProperties.ScanRangesTarget.option.map(t => math.max(1, t.toInt / multiplier))
+      sfc.ranges(xy, 64, target).iterator.map(r => BoundedRange(r.lower, r.upper))
     }
   }
 

--- a/geomesa-utils/src/main/resources/org/locationtech/geomesa/geomesa-site.xml.template
+++ b/geomesa-utils/src/main/resources/org/locationtech/geomesa/geomesa-site.xml.template
@@ -218,9 +218,7 @@
             number of Accumulo ranges that will be generated for a single
             query. In general, more ranges will result in less non-relevant
             rows being scanned in Accumulo. However, too many ranges can
-            overwhelm clients. Note that for temporal queries against the Z3
-            or XZ3 index, the number of ranges will be multiplied by the
-            number of time periods (weeks by default) being queried.
+            overwhelm clients.
         </description>
         <final>false</final>
     </property>


### PR DESCRIPTION
… prefixes being scanned

* 'geomesa.scan.ranges.target' is now divided by the number of weeks or attribute values being scanned
* Generally should allow for higher values of 'geomesa.scan.ranges.target' without performance degredation

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>