### PR TITLE
GEOMESA-2329 Update to specs 4.3.2

### DIFF
--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -275,5 +275,7 @@ org.codehaus.groovy:groovy-jsr223	2.4.5	test
 org.geotools:gt-geometry	18.0	test
 org.jruby:jruby	9.0.4.0	test
 org.mortbay.jetty:jetty	6.1.26	test
-org.scalatra:scalatra-specs2_2.11	2.3.0	test
-org.specs2:specs2_2.11	2.3.13	test
+org.scalatra:scalatra-specs2_2.11	2.6.3	test
+org.specs2:specs2-core_2.11	4.3.2	test
+org.specs2:specs2-junit_2.11	4.3.2	test
+org.specs2:specs2-mock_2.11	4.3.2	test

--- a/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
@@ -132,11 +132,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
@@ -135,11 +135,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithDataStore.scala
@@ -8,9 +8,9 @@
 
 package org.locationtech.geomesa.accumulo
 
-import org.apache.accumulo.core.client.{Connector, Scanner}
 import org.apache.accumulo.core.client.mock.MockInstance
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
+import org.apache.accumulo.core.client.{Connector, Scanner}
 import org.apache.accumulo.core.data.Key
 import org.apache.accumulo.core.security.Authorizations
 import org.geotools.data.{DataStoreFinder, Query, Transaction}
@@ -25,7 +25,7 @@ import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.SimpleFeature
 import org.opengis.filter.Filter
 import org.specs2.mutable.Specification
-import org.specs2.specification.{Fragments, Step}
+import org.specs2.specification.core.Fragments
 
 import scala.collection.JavaConverters._
 
@@ -88,7 +88,7 @@ trait TestWithDataStore extends Specification {
   lazy val fs = ds.getFeatureSource(sftName)
 
   // after all tests, drop the tables we created to free up memory
-  override def map(fragments: => Fragments) = fragments ^ Step {
+  override def map(fragments: => Fragments): Fragments = fragments ^ fragmentFactory.step {
     ds.removeSchema(sftName)
     ds.dispose()
   }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithMultipleSfts.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/TestWithMultipleSfts.scala
@@ -24,7 +24,7 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 import org.opengis.filter.identity.FeatureId
 import org.specs2.mutable.Specification
-import org.specs2.specification.{Fragments, Step}
+import org.specs2.specification.core.Fragments
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -51,7 +51,7 @@ trait TestWithMultipleSfts extends Specification {
   val ds = DataStoreFinder.getDataStore(dsParams.asJava).asInstanceOf[AccumuloDataStore]
 
   // after all tests, drop the tables we created to free up memory
-  override def map(fragments: => Fragments) = fragments ^ Step {
+  override def map(fragments: => Fragments): Fragments = fragments ^ fragmentFactory.step {
     val to = connector.tableOperations()
     val tables = Seq(sftBaseName) ++ sfts.flatMap { sft =>
       Try(AccumuloFeatureIndex.indices(sft).map(_.getTableName(sft.getTypeName, ds))).getOrElse(Seq.empty)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreIdlTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreIdlTest.scala
@@ -9,7 +9,6 @@
 package org.locationtech.geomesa.accumulo.data
 
 import org.geotools.data._
-import org.geotools.factory.CommonFactoryFinder
 import org.geotools.referencing.CRS
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.TestWithDataStore
@@ -20,6 +19,8 @@ import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class AccumuloDataStoreIdlTest extends Specification with TestWithDataStore {
+
+  import org.locationtech.geomesa.filter.ff
 
   sequential
 
@@ -32,7 +33,6 @@ class AccumuloDataStoreIdlTest extends Specification with TestWithDataStore {
     sf
   })
 
-  val ff = CommonFactoryFinder.getFilterFactory2
   val srs = CRS.toSRS(org.locationtech.geomesa.utils.geotools.CRS_EPSG_4326)
 
   "AccumuloDataStore" should {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTransformsTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTransformsTest.scala
@@ -13,7 +13,7 @@ import java.util.Date
 import com.vividsolutions.jts.geom.Point
 import org.geotools.data._
 import org.geotools.data.simple.SimpleFeatureCollection
-import org.geotools.factory.{CommonFactoryFinder, Hints}
+import org.geotools.factory.Hints
 import org.geotools.feature.DefaultFeatureCollection
 import org.geotools.filter.text.cql2.CQL
 import org.geotools.filter.text.ecql.ECQL
@@ -32,6 +32,8 @@ import org.specs2.runner.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class AccumuloDataStoreTransformsTest extends Specification with TestWithMultipleSfts {
 
+  import org.locationtech.geomesa.filter.ff
+
   sequential
 
   val spec  = "name:String,dtg:Date,*geom:Point:srid=4326"
@@ -41,8 +43,6 @@ class AccumuloDataStoreTransformsTest extends Specification with TestWithMultipl
   val name = "myname"
   val date = Converters.convert("2012-01-01T00:00:00.000Z", classOf[Date])
   val geom = Converters.convert("POINT(45 49)", classOf[Point])
-
-  val ff = CommonFactoryFinder.getFilterFactory2
 
   def createFeature(sft: SimpleFeatureType) =
     Seq(new ScalaSimpleFeature(sft, "fid-1", Array(name, date, geom)))

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
@@ -30,14 +30,14 @@ import org.locationtech.geomesa.utils.text.WKTUtils
 import org.opengis.filter.Filter
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import org.specs2.specification.BeforeExample
+import org.specs2.specification.BeforeEach
 
 import scala.collection.JavaConversions._
 
 @RunWith(classOf[JUnitRunner])
-class AccumuloFeatureWriterTest extends Specification with TestWithDataStore with BeforeExample {
+class AccumuloFeatureWriterTest extends Specification with TestWithDataStore with BeforeEach {
 
-  override def before: Unit = clearTablesHard()
+  override def before: Any = clearTablesHard()
 
   sequential
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/filter/FilterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/filter/FilterTest.scala
@@ -13,7 +13,7 @@ import java.util.Date
 import com.typesafe.scalalogging.LazyLogging
 import com.vividsolutions.jts.geom.Coordinate
 import org.geotools.data.Query
-import org.geotools.factory.{CommonFactoryFinder, Hints}
+import org.geotools.factory.Hints
 import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.geotools.filter.text.ecql.ECQL
 import org.geotools.geometry.jts.JTSFactoryFinder
@@ -108,9 +108,10 @@ class FilterTest extends Specification with TestWithDataStore with LazyLogging {
 @RunWith(classOf[JUnitRunner])
 class IdQueryTest extends Specification with TestWithDataStore {
 
+  import org.locationtech.geomesa.filter.ff
+
   override val spec = "age:Int:index=join,name:String:index=join,dtg:Date,*geom:Point:srid=4326"
 
-  val ff = CommonFactoryFinder.getFilterFactory2
   val geomBuilder = JTSFactoryFinder.getGeometryFactory
   val builder = new SimpleFeatureBuilder(sft, new AvroSimpleFeatureFactory)
   val data = List(

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/FilterHelperTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/FilterHelperTest.scala
@@ -13,7 +13,6 @@ import java.time.{Instant, ZoneOffset, ZonedDateTime}
 import java.util.Date
 
 import com.typesafe.scalalogging.LazyLogging
-import org.geotools.factory.CommonFactoryFinder
 import org.geotools.filter.text.ecql.ECQL
 import org.geotools.geometry.jts.JTSFactoryFinder
 import org.geotools.temporal.`object`.{DefaultInstant, DefaultPeriod, DefaultPosition}
@@ -31,7 +30,9 @@ import scala.util.Random
 
 @RunWith(classOf[JUnitRunner])
 class FilterHelperTest extends Specification with LazyLogging {
-  val ff = CommonFactoryFinder.getFilterFactory2
+
+  import org.locationtech.geomesa.filter.ff
+
   val gf = JTSFactoryFinder.getGeometryFactory
 
   def dt2lit(dt: ZonedDateTime): Expression = ff.literal(Date.from(dt.toInstant))
@@ -142,7 +143,7 @@ class FilterHelperTest extends Specification with LazyLogging {
     }
 
     "return date1 to date2 for during filters" in {
-      forall(dts.combinations(2).map(sortDates)) { case (start, end) =>
+      forall(dts.combinations(2).map(sortDates).toSeq) { case (start, end) =>
 
         val filter = during(start, end)
 
@@ -154,7 +155,7 @@ class FilterHelperTest extends Specification with LazyLogging {
     }
 
     "offset dates for during filters" in {
-      forall(dts.combinations(2).map(sortDates)) { case (start, end) =>
+      forall(dts.combinations(2).map(sortDates).toSeq) { case (start, end) =>
         val filter = during(start, end)
         val extractedInterval = extractIntervals(filter, dtFieldName, handleExclusiveBounds = true).values.head
         val expectedInterval = Bounds(Bound(Some(start.plusSeconds(1)), inclusive = true), Bound(Some(end.minusSeconds(1)), inclusive = true))
@@ -162,7 +163,7 @@ class FilterHelperTest extends Specification with LazyLogging {
         extractedInterval must equalTo(expectedInterval)
       }
       val r = new Random(-7)
-      forall(dts.combinations(2).map(sortDates)) { case (s, e) =>
+      forall(dts.combinations(2).map(sortDates).toSeq) { case (s, e) =>
         val start = s.plus(r.nextInt(998) + 1, ChronoUnit.MILLIS)
         val end = e.plus(r.nextInt(998) + 1, ChronoUnit.MILLIS)
         val filter = during(start, end)
@@ -186,7 +187,7 @@ class FilterHelperTest extends Specification with LazyLogging {
     }
 
     "return appropriate interval for 'and'ed between/during filters" in {
-      forall(dtPairs.combinations(2)) { dtTuples =>
+      forall(dtPairs.combinations(2).toSeq) { dtTuples =>
         val t1 = dtTuples(0)
         val t2 = dtTuples(1)
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryStrategyDeciderTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryStrategyDeciderTest.scala
@@ -9,7 +9,6 @@
 package org.locationtech.geomesa.accumulo.index
 
 import org.geotools.data.Query
-import org.geotools.factory.CommonFactoryFinder
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.filter.TestFilters._
@@ -29,11 +28,11 @@ import scala.util.Random
 @RunWith(classOf[JUnitRunner])
 class QueryStrategyDeciderTest extends Specification with TestWithDataStore {
 
+  import org.locationtech.geomesa.filter.ff
+
   override val spec = "nameHighCardinality:String:index=join:cardinality=high,ageJoinIndex:Long:index=join," +
       "heightFullIndex:Float:index=full,dtgJoinIndex:Date:index=join,weightNoIndex:String," +
       "dtgNoIndex:Date,dtg:Date,*geom:Point:srid=4326"
-
-  val ff = CommonFactoryFinder.getFilterFactory2
 
   addFeatures {
     val r = new Random(-57L)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z2IdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z2IdxStrategyTest.scala
@@ -13,7 +13,6 @@ import java.util.Date
 import com.google.common.primitives.Longs
 import org.apache.accumulo.core.security.Authorizations
 import org.geotools.data.Query
-import org.geotools.factory.CommonFactoryFinder
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.TestWithDataStore
@@ -53,7 +52,6 @@ class Z2IdxStrategyTest extends Specification with TestWithDataStore {
     }
   addFeatures(features)
 
-  val ff = CommonFactoryFinder.getFilterFactory2
   val strategy = Z2Index
   val queryPlanner = ds.queryPlanner
   val output = ExplainNull
@@ -197,7 +195,7 @@ class Z2IdxStrategyTest extends Specification with TestWithDataStore {
       aggregates.size must beLessThan(10) // ensure some aggregation was done
       forall(aggregates) { a =>
         val window = a.grouped(16).map(BinaryOutputEncoder.decode(_).dtg).sliding(2).filter(_.length > 1)
-        forall(window)(w => w.head must beLessThanOrEqualTo(w(1)))
+        forall(window.toSeq)(w => w.head must beLessThanOrEqualTo(w(1)))
       }
       val bin = aggregates.flatMap(a => a.grouped(16).map(BinaryOutputEncoder.decode))
       bin must haveSize(10)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/Z3IdxStrategyTest.scala
@@ -13,7 +13,6 @@ import java.util.Date
 import com.google.common.primitives.{Longs, Shorts}
 import org.apache.accumulo.core.security.Authorizations
 import org.geotools.data.{Query, Transaction}
-import org.geotools.factory.CommonFactoryFinder
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.TestWithDataStore
@@ -66,8 +65,6 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       sf
     }
   addFeatures(features)
-
-  val ff = CommonFactoryFinder.getFilterFactory2
 
   def runQuery(filter: String, transforms: Array[String] = null): Iterator[SimpleFeature] =
     runQuery(new Query(sftName, ECQL.toFilter(filter), transforms))
@@ -281,7 +278,7 @@ class Z3IdxStrategyTest extends Specification with TestWithDataStore {
       aggregates.size must beLessThan(10) // ensure some aggregation was done
       forall(aggregates) { a =>
         val window = a.grouped(16).map(BinaryOutputEncoder.decode(_).dtg).sliding(2).filter(_.length > 1)
-        forall(window)(w => w.head must beLessThanOrEqualTo(w(1)))
+        forall(window.toSeq)(w => w.head must beLessThanOrEqualTo(w(1)))
       }
       val bin = aggregates.flatMap(a => a.grouped(16).map(BinaryOutputEncoder.decode))
       bin must haveSize(10)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/AttributeIndexIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/AttributeIndexIteratorTest.scala
@@ -12,7 +12,7 @@ import java.text.SimpleDateFormat
 import java.util.{Collections, Date, TimeZone}
 
 import org.geotools.data.Query
-import org.geotools.factory.{CommonFactoryFinder, Hints}
+import org.geotools.factory.Hints
 import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
@@ -54,8 +54,6 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
     }
   })
 
-  val ff = CommonFactoryFinder.getFilterFactory2
-
   val queryPlanner = ds.queryPlanner
 
   def query(filter: String, attributes: Array[String] = Array.empty) = {
@@ -73,7 +71,7 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
 
         results must haveSize(4)
         results.map(_.getAttributeCount) must contain(3).foreach
-        results.map(_.getAttribute("name").asInstanceOf[String]) must contain("b").foreach
+        foreach(results.map(_.getAttribute("name").asInstanceOf[String]))(_ must contain("b"))
         results.map(_.getAttribute("geom").toString) must contain("POINT (45 45)", "POINT (46 46)", "POINT (47 47)", "POINT (48 48)")
         results.map(_.getAttribute("dtg").asInstanceOf[Date]) must contain(dateToIndex).foreach
       }
@@ -84,7 +82,7 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
 
         results must haveSize(4)
         results.map(_.getAttributeCount) must contain(3).foreach
-        results.map(_.getAttribute("name").asInstanceOf[String]) must contain("a").foreach
+        foreach(results.map(_.getAttribute("name").asInstanceOf[String]))(_ must contain("a"))
         results.map(_.getAttribute("geom").toString) must contain("POINT (45 45)", "POINT (46 46)", "POINT (47 47)", "POINT (48 48)")
         results.map(_.getAttribute("dtg").asInstanceOf[Date]) must contain(dateToIndex).foreach
       }
@@ -95,8 +93,8 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
 
         results must haveSize(8)
         results.map(_.getAttributeCount) must contain(3).foreach
-        results.map(_.getAttribute("name").asInstanceOf[String]) must contain("c").exactly(4)
-        results.map(_.getAttribute("name").asInstanceOf[String]) must contain("d").exactly(4)
+        results.map(_.getAttribute("name").asInstanceOf[String]) must contain(beEqualTo("c")).exactly(4)
+        results.map(_.getAttribute("name").asInstanceOf[String]) must contain(beEqualTo("d")).exactly(4)
         results.map(_.getAttribute("geom").toString) must contain("POINT (45 45)", "POINT (46 46)", "POINT (47 47)", "POINT (48 48)")
         results.map(_.getAttribute("dtg").asInstanceOf[Date]) must contain(dateToIndex).foreach
       }
@@ -107,9 +105,9 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
 
         results must haveSize(12)
         results.map(_.getAttributeCount) must contain(3).foreach
-        results.map(_.getAttribute("name").asInstanceOf[String]) must contain("b").exactly(4)
-        results.map(_.getAttribute("name").asInstanceOf[String]) must contain("c").exactly(4)
-        results.map(_.getAttribute("name").asInstanceOf[String]) must contain("d").exactly(4)
+        results.map(_.getAttribute("name").asInstanceOf[String]) must contain(beEqualTo("b")).exactly(4)
+        results.map(_.getAttribute("name").asInstanceOf[String]) must contain(beEqualTo("c")).exactly(4)
+        results.map(_.getAttribute("name").asInstanceOf[String]) must contain(beEqualTo("d")).exactly(4)
         results.map(_.getAttribute("geom").toString) must contain("POINT (45 45)", "POINT (46 46)", "POINT (47 47)", "POINT (48 48)")
         results.map(_.getAttribute("dtg").asInstanceOf[Date]) must contain(dateToIndex).foreach
       }
@@ -145,7 +143,7 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
         results must haveSize(5)
         results.map(_.getAttributeCount) must contain(3).foreach
         results.map(_.getAttribute("age").asInstanceOf[Int]) must contain(1).foreach
-        results.map(_.getAttribute("geom").toString) must contain("POINT (45 45)").foreach
+        foreach(results.map(_.getAttribute("geom").toString))(_ must contain("POINT (45 45)"))
         results.map(_.getAttribute("dtg").asInstanceOf[Date]) must contain(dateToIndex).foreach
       }
 
@@ -157,8 +155,8 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
         results.map(_.getAttributeCount) must contain(3).foreach
         results.map(_.getAttribute("age").asInstanceOf[Int]) must contain(3).exactly(5)
         results.map(_.getAttribute("age").asInstanceOf[Int]) must contain(4).exactly(5)
-        results.map(_.getAttribute("geom").toString) must contain("POINT (47 47)").exactly(5)
-        results.map(_.getAttribute("geom").toString) must contain("POINT (48 48)").exactly(5)
+        results.map(_.getAttribute("geom").toString) must contain(beEqualTo("POINT (47 47)")).exactly(5)
+        results.map(_.getAttribute("geom").toString) must contain(beEqualTo("POINT (48 48)")).exactly(5)
         results.map(_.getAttribute("dtg").asInstanceOf[Date]) must contain(dateToIndex).foreach
       }
 
@@ -196,7 +194,7 @@ class AttributeIndexIteratorTest extends Specification with TestWithDataStore {
 
         results must haveSize(4)
         results.map(_.getAttributeCount) must contain(1).foreach
-        results.map(_.getAttribute("name").toString) must contain("b").foreach
+        foreach(results.map(_.getAttribute("name").toString))(_ must contain("b"))
       }
 
       "with additional filter applied" >> {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/process/knn/GenerateKNNQueryTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/process/knn/GenerateKNNQueryTest.scala
@@ -10,7 +10,6 @@ package org.locationtech.geomesa.process.knn
 
 import com.vividsolutions.jts.geom.GeometryCollection
 import org.geotools.data.{DataStoreFinder, Query}
-import org.geotools.factory.CommonFactoryFinder
 import org.geotools.referencing.CRS
 import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.junit.runner.RunWith
@@ -27,6 +26,8 @@ import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
 class GenerateKNNQueryTest extends Specification {
+
+  import org.locationtech.geomesa.filter.ff
 
   def createStore: AccumuloDataStore =
   // the specific parameter values should not matter, as we
@@ -50,8 +51,6 @@ class GenerateKNNQueryTest extends Specification {
   val fs = ds.getFeatureSource(sftName)
 
   val smallGH = GeoHash("dqb0tg")
-
-  val ff = CommonFactoryFinder.getFilterFactory2
 
   val WGS84 = DefaultGeographicCRS.WGS84
 
@@ -96,7 +95,7 @@ class GenerateKNNQueryTest extends Specification {
       val newFilter =  newQuery.getFilter
 
       // process the newFilter to split out the geometry part
-      val (geomFilters, otherFilters) = partitionPrimarySpatials(newFilter, sft)
+      val (geomFilters, _) = partitionPrimarySpatials(newFilter, sft)
 
       // rewrite the geometry filter
       val tweakedGeomFilters = geomFilters.map { filter =>

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/process/query/ProximitySearchProcessTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/process/query/ProximitySearchProcessTest.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.process.query
 
 import com.vividsolutions.jts.geom.{Coordinate, Point}
-import org.geotools.factory.{CommonFactoryFinder, Hints}
+import org.geotools.factory.Hints
 import org.geotools.feature.DefaultFeatureCollection
 import org.geotools.filter.text.ecql.ECQL
 import org.geotools.geometry.jts.JTSFactoryFinder
@@ -20,8 +20,7 @@ import org.locationtech.geomesa.accumulo.iterators.TestData
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.features.avro.AvroSimpleFeatureFactory
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
-import org.locationtech.geomesa.utils.geotools.GeometryUtils.geoFactory
-import org.locationtech.geomesa.utils.geotools.{GeometryUtils, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -34,7 +33,6 @@ class ProximitySearchProcessTest extends Specification with TestWithMultipleSfts
   sequential
 
   val geoFactory = JTSFactoryFinder.getGeometryFactory
-  val ff = CommonFactoryFinder.getFilterFactory2
 
   def getPoint(lat: Double, lon: Double, meters: Double): Point = {
     val calc = new GeodeticCalculator()
@@ -90,7 +88,7 @@ class ProximitySearchProcessTest extends Specification with TestWithMultipleSfts
       val prox = new ProximitySearchProcess
 
       // note: size returns an estimated amount, instead we need to actually count the features
-      def ex(p: Double) = SelfClosingIterator(prox.execute(inputFeatures, dataFeatures, p))
+      def ex(p: Double) = SelfClosingIterator(prox.execute(inputFeatures, dataFeatures, p)).toSeq
 
       ex(50.0)  must haveLength(0)
       ex(90.0)  must haveLength(0)
@@ -127,7 +125,7 @@ class ProximitySearchProcessTest extends Specification with TestWithMultipleSfts
 
       val prox = new ProximitySearchProcess
       // note: size returns an estimated amount, instead we need to actually count the features
-      SelfClosingIterator(prox.execute(queryLine, dataFeatures, 150000.0)) must haveLength(50)
+      SelfClosingIterator(prox.execute(queryLine, dataFeatures, 150000.0)).toSeq must haveLength(50)
     }
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-jobs/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/pom.xml
@@ -64,12 +64,12 @@
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/test/scala/org/locationtech/geomesa/jobs/accumulo/AccumuloJobUtilsTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/test/scala/org/locationtech/geomesa/jobs/accumulo/AccumuloJobUtilsTest.scala
@@ -49,7 +49,7 @@ class AccumuloJobUtilsTest extends Specification with TestWithDataStore {
     "load list of jars from class resource" in {
       AccumuloJobUtils.defaultLibJars must not(beNull)
       AccumuloJobUtils.defaultLibJars must not(beEmpty)
-      AccumuloJobUtils.defaultLibJars must contain("accumulo")
+      AccumuloJobUtils.defaultLibJars must contain("accumulo-core")
       AccumuloJobUtils.defaultLibJars must contain("libthrift")
     }
     "not return join plans for getSingleQueryPlan" in {

--- a/geomesa-accumulo/geomesa-accumulo-raster/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-raster/pom.xml
@@ -75,13 +75,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-accumulo/geomesa-accumulo-raster/src/test/scala/org/locationtech/geomesa/raster/data/QueryAndMosaicTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-raster/src/test/scala/org/locationtech/geomesa/raster/data/QueryAndMosaicTest.scala
@@ -14,8 +14,6 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.raster.RasterTestsUtils._
 import org.locationtech.geomesa.raster.util.RasterUtils
 import org.locationtech.geomesa.utils.geohash.BoundingBox
-import org.locationtech.geomesa.utils.stats.{NoOpTimings, Timings}
-import org.specs2.matcher.Matcher
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -55,8 +53,6 @@ class QueryAndMosaicTest extends Specification {
     testIteration += 1
     s"testQAMT_Table_$testIteration"
   }
-
-  def allBeTrue: Matcher[Iterator[Boolean]] = be_==(true).forall
 
   "Our Mosaicing" should {
     "Return the same tile we store" in {
@@ -113,7 +109,7 @@ class QueryAndMosaicTest extends Specification {
         val (mosaic, _) = RasterUtils.mosaicChunks(rasters.iterator, 16, 16, lessPreciseQBox)
         compareIntBufferedImages(mosaic, testRasterIntVSplit)
       }
-      res must allBeTrue
+      forall(res.toSeq)(_ must beTrue)
     }
 
     "Return the Correct thing for all Vertical case permutations with less precise query" in {
@@ -129,7 +125,7 @@ class QueryAndMosaicTest extends Specification {
         val (mosaic, _) = RasterUtils.mosaicChunks(rasters.iterator, 16, 16, lessPreciseQBox)
         compareIntBufferedImages(mosaic, testRasterIntVSplit)
       }
-      res must allBeTrue
+      forall(res.toSeq)(_ must beTrue)
     }
 
     "Return the Correct thing for all NW to SE case permutations with less precise query" in {
@@ -145,7 +141,7 @@ class QueryAndMosaicTest extends Specification {
         val (mosaic, _) = RasterUtils.mosaicChunks(rasters.iterator, 16, 16, lessPreciseQBox)
         compareIntBufferedImages(mosaic, testRasterIntVSplit)
       }
-      res must allBeTrue
+      forall(res.toSeq)(_ must beTrue)
     }
 
     "Return the Correct thing for all SW to NE case permutations with less precise query" in {
@@ -161,9 +157,7 @@ class QueryAndMosaicTest extends Specification {
         val (mosaic, _) = RasterUtils.mosaicChunks(rasters.iterator, 16, 16, lessPreciseQBox)
         compareIntBufferedImages(mosaic, testRasterIntVSplit)
       }
-      res must allBeTrue
+      forall(res.toSeq)(_ must beTrue)
     }
-
   }
-
 }

--- a/geomesa-accumulo/geomesa-accumulo-security/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-security/pom.xml
@@ -25,12 +25,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-spark-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-spark-runtime/pom.xml
@@ -75,8 +75,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-spark/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-spark/pom.xml
@@ -44,8 +44,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
@@ -121,8 +121,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>

--- a/geomesa-arrow/geomesa-arrow-datastore/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-datastore/pom.xml
@@ -24,7 +24,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-arrow/geomesa-arrow-gt/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-gt/pom.xml
@@ -31,7 +31,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-arrow/geomesa-arrow-tools/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-tools/pom.xml
@@ -32,7 +32,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-bigtable/geomesa-bigtable-datastore/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-datastore/pom.xml
@@ -91,7 +91,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
 
         <dependency>

--- a/geomesa-bigtable/geomesa-bigtable-tools/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-tools/pom.xml
@@ -36,7 +36,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/geomesa-blobstore/geomesa-blobstore-accumulo/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-accumulo/pom.xml
@@ -49,11 +49,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
 
     </dependencies>

--- a/geomesa-blobstore/geomesa-blobstore-api/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-api/pom.xml
@@ -39,11 +39,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
 
     </dependencies>

--- a/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-exif-handler/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-exif-handler/pom.xml
@@ -42,11 +42,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
 
     </dependencies>

--- a/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-gdal-handler/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-gdal-handler/pom.xml
@@ -42,11 +42,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
 
     </dependencies>

--- a/geomesa-blobstore/geomesa-blobstore-web/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-web/pom.xml
@@ -58,11 +58,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
 
     </dependencies>

--- a/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
@@ -63,11 +63,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
@@ -115,8 +110,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
@@ -275,25 +275,25 @@ class CassandraDataStoreTest extends Specification {
 
       ds.getSchema(typeName) must beNull
     }
+  }
 
-    def testQuery(ds: CassandraDataStore,
-                  typeName: String,
-                  filter: String,
-                  transforms: Array[String],
-                  results: Seq[SimpleFeature],
-                  explain: Option[Explainer] = None) = {
-      val query = new Query(typeName, ECQL.toFilter(filter), transforms)
-      explain.foreach(e => ds.getQueryPlan(query, explainer = e))
-      val fr = ds.getFeatureReader(query, Transaction.AUTO_COMMIT)
-      val features = SelfClosingIterator(fr).toList
-      val attributes = Option(transforms).getOrElse(ds.getSchema(typeName).getAttributeDescriptors.map(_.getLocalName).toArray)
-      features.map(_.getID) must containTheSameElementsAs(results.map(_.getID))
-      forall(features) { feature =>
-        feature.getAttributes must haveLength(attributes.length)
-        forall(attributes.zipWithIndex) { case (attribute, i) =>
-          feature.getAttribute(attribute) mustEqual feature.getAttribute(i)
-          feature.getAttribute(attribute) mustEqual results.find(_.getID == feature.getID).get.getAttribute(attribute)
-        }
+  def testQuery(ds: CassandraDataStore,
+                typeName: String,
+                filter: String,
+                transforms: Array[String],
+                results: Seq[SimpleFeature],
+                explain: Option[Explainer] = None) = {
+    val query = new Query(typeName, ECQL.toFilter(filter), transforms)
+    explain.foreach(e => ds.getQueryPlan(query, explainer = e))
+    val fr = ds.getFeatureReader(query, Transaction.AUTO_COMMIT)
+    val features = SelfClosingIterator(fr).toList
+    val attributes = Option(transforms).getOrElse(ds.getSchema(typeName).getAttributeDescriptors.map(_.getLocalName).toArray)
+    features.map(_.getID) must containTheSameElementsAs(results.map(_.getID))
+    forall(features) { feature =>
+      feature.getAttributes must haveLength(attributes.length)
+      forall(attributes.zipWithIndex) { case (attribute, i) =>
+        feature.getAttribute(attribute) mustEqual feature.getAttribute(i)
+        feature.getAttribute(attribute) mustEqual results.find(_.getID == feature.getID).get.getAttribute(attribute)
       }
     }
   }

--- a/geomesa-cassandra/geomesa-cassandra-tools/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-tools/pom.xml
@@ -107,8 +107,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
 
     </dependencies>

--- a/geomesa-convert/geomesa-convert-all/pom.xml
+++ b/geomesa-convert/geomesa-convert-all/pom.xml
@@ -57,8 +57,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-convert/geomesa-convert-avro/pom.xml
+++ b/geomesa-convert/geomesa-convert-avro/pom.xml
@@ -43,8 +43,11 @@
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-convert/geomesa-convert-common/pom.xml
+++ b/geomesa-convert/geomesa-convert-common/pom.xml
@@ -51,8 +51,11 @@
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert/common/TransformersTest.scala
+++ b/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert/common/TransformersTest.scala
@@ -48,12 +48,14 @@ class TransformersTest extends Specification {
         }
         "allow native ints" >> {
           val res = Transformers.parseTransform("1").eval(Array(null))
-          res must beAnInstanceOf[java.lang.Integer]
+          res must not(beNull)
+          res.getClass mustEqual classOf[java.lang.Integer]
           res mustEqual 1
         }
         "allow native longs" >> {
           val res = Transformers.parseTransform("1L").eval(Array(null))
-          res must beAnInstanceOf[java.lang.Long]
+          res must not(beNull)
+          res.getClass mustEqual classOf[java.lang.Long]
           res mustEqual 1L
         }
         "allow native floats" >> {
@@ -61,7 +63,8 @@ class TransformersTest extends Specification {
           foreach(tests) { case (s, expected) =>
             foreach(Seq("f", "F")) { suffix =>
               val res = Transformers.parseTransform(s + suffix).eval(Array(null))
-              res must beAnInstanceOf[java.lang.Float]
+              res must not(beNull)
+              res.getClass mustEqual classOf[java.lang.Float]
               res mustEqual expected
             }
           }
@@ -71,7 +74,8 @@ class TransformersTest extends Specification {
           foreach(tests) { case (s, expected) =>
             foreach(Seq("", "d", "D")) { suffix =>
               val res = Transformers.parseTransform(s + suffix).eval(Array(null))
-              res must beAnInstanceOf[java.lang.Double]
+              res must not(beNull)
+              res.getClass mustEqual classOf[java.lang.Double]
               res mustEqual expected
             }
           }
@@ -296,7 +300,8 @@ class TransformersTest extends Specification {
         val geoFac = new GeometryFactory()
         val geom = geoFac.createPoint(new Coordinate(55, 56)).asInstanceOf[Geometry]
         val res = trans.eval(Array(geom))
-        res must beAnInstanceOf[Point]
+        res must not(beNull)
+        res.getClass mustEqual classOf[Point]
         res.asInstanceOf[Point] mustEqual geoFac.createPoint(new Coordinate(55, 56))
       }
 
@@ -309,7 +314,8 @@ class TransformersTest extends Specification {
         // convert objects
         val geom = multiPoint.asInstanceOf[Geometry]
         val res = trans.eval(Array(geom))
-        res must beAnInstanceOf[MultiPoint]
+        res must not(beNull)
+        res.getClass mustEqual classOf[MultiPoint]
         res.asInstanceOf[MultiPoint] mustEqual WKTUtils.read("Multipoint((45.0 45.0), (50 52))")
       }
 
@@ -322,7 +328,8 @@ class TransformersTest extends Specification {
         // type conversion
         val geom = lineStr.asInstanceOf[Geometry]
         val res = trans.eval(Array(geom))
-        res must beAnInstanceOf[LineString]
+        res must not(beNull)
+        res.getClass mustEqual classOf[LineString]
         res.asInstanceOf[LineString] mustEqual WKTUtils.read("Linestring(102 0, 103 1, 104 0, 105 1)")
       }
 
@@ -338,7 +345,8 @@ class TransformersTest extends Specification {
         // type conversion
         val geom = multiLineStr.asInstanceOf[Geometry]
         val res = trans.eval(Array(geom))
-        res must beAnInstanceOf[MultiLineString]
+        res must not(beNull)
+        res.getClass mustEqual classOf[MultiLineString]
         res.asInstanceOf[MultiLineString] mustEqual WKTUtils.read("MultiLinestring((102 0, 103 1, 104 0, 105 1), (0 0, 1 2, 2 3, 4 5))")
       }
 
@@ -351,7 +359,8 @@ class TransformersTest extends Specification {
         // type conversion
         val geom = poly.asInstanceOf[Polygon]
         val res = trans.eval(Array(geom))
-        res must beAnInstanceOf[Polygon]
+        res must not(beNull)
+        res.getClass mustEqual classOf[Polygon]
         res.asInstanceOf[Polygon] mustEqual WKTUtils.read("polygon((100 0, 101 0, 101 1, 100 1, 100 0))")
       }
 
@@ -367,7 +376,8 @@ class TransformersTest extends Specification {
         // type conversion
         val geom = multiPoly.asInstanceOf[MultiPolygon]
         val res = trans.eval(Array(geom))
-        res must beAnInstanceOf[MultiPolygon]
+        res must not(beNull)
+        res.getClass mustEqual classOf[MultiPolygon]
         res.asInstanceOf[MultiPolygon] mustEqual WKTUtils.read("multipolygon(((100 0, 101 0, 101 1, 100 1, 100 0)), ((10 0, 11 0, 11 1, 10 1, 10 0)))")
       }
 
@@ -380,7 +390,8 @@ class TransformersTest extends Specification {
         // type conversion
         val geom = lineStr.asInstanceOf[Geometry]
         val res = trans.eval(Array(geom))
-        res must beAnInstanceOf[Geometry]
+        res must not(beNull)
+        res.asInstanceOf[AnyRef] must beAnInstanceOf[Geometry]
         res.asInstanceOf[Geometry] mustEqual WKTUtils.read("Linestring(102 0, 103 1, 104 0, 105 1)\"")
       }
 
@@ -401,7 +412,8 @@ class TransformersTest extends Specification {
         // type conversion
         val geom = geoCol.asInstanceOf[Geometry]
         val res = trans.eval(Array(geom))
-        res must beAnInstanceOf[GeometryCollection]
+        res must not(beNull)
+        res.getClass mustEqual classOf[GeometryCollection]
         res.asInstanceOf[GeometryCollection] mustEqual WKTUtils.read(
           "GeometryCollection(Linestring(102 0, 103 1, 104 0, 105 1), " +
           "multipolygon(((100 0, 101 0, 101 1, 100 1, 100 0)), ((10 0, 11 0, 11 1, 10 1, 10 0))))")
@@ -411,7 +423,8 @@ class TransformersTest extends Specification {
         val geom = WKTUtils.read("POINT (1113194.91 1689200.14)")
         val trans = Transformers.parseTransform("projectFrom('EPSG:3857',$1)")
         val transformed = trans.eval(Array("", geom))
-        transformed must beAnInstanceOf[Point]
+        transformed must not(beNull)
+        transformed.getClass mustEqual classOf[Point]
         transformed.asInstanceOf[Point].getX must beCloseTo(15d, 0.001)
         transformed.asInstanceOf[Point].getY must beCloseTo(10d, 0.001)
       }
@@ -427,19 +440,25 @@ class TransformersTest extends Specification {
         }
         "uuid" >> {
           val exp = Transformers.parseTransform("uuid()")
-          exp.eval(Array(null)) must anInstanceOf[String]
+          val res = exp.eval(Array(null))
+          res must not(beNull)
+          res.getClass mustEqual classOf[String]
         }
         "z3 uuid" >> {
           val exp = Transformers.parseTransform("uuidZ3($0, $1, 'week')")
           val geom = WKTUtils.read("POINT (103 1)")
           val date = Converters.convert("2018-01-01T00:00:00.000Z", classOf[Date])
-          exp.eval(Array(geom, date)) must anInstanceOf[String]
+          val res = exp.eval(Array(geom, date))
+          res must not(beNull)
+          res.getClass mustEqual classOf[String]
         }
         "z3 centroid uuid" >> {
           val exp = Transformers.parseTransform("uuidZ3Centroid($0, $1, 'week')")
           val geom = WKTUtils.read("LINESTRING (102 0, 103 1, 104 0, 105 1)")
           val date = Converters.convert("2018-01-01T00:00:00.000Z", classOf[Date])
-          exp.eval(Array(geom, date)) must anInstanceOf[String]
+          val res = exp.eval(Array(geom, date))
+          res must not(beNull)
+          res.getClass mustEqual classOf[String]
         }
         "base64" >> {
           val exp = Transformers.parseTransform("base64($0)")
@@ -749,7 +768,8 @@ class TransformersTest extends Specification {
         "buffer" >> {
           val exp = Transformers.parseTransform("cql:buffer($1, $2)")
           val buf = exp.eval(Array(null, "POINT(1 1)", 2.0))
-          buf must beAnInstanceOf[Polygon]
+          buf must not(beNull)
+          buf.getClass mustEqual classOf[Polygon]
           buf.asInstanceOf[Polygon].getCentroid.getX must beCloseTo(1, 0.0001)
           buf.asInstanceOf[Polygon].getCentroid.getY must beCloseTo(1, 0.0001)
           // note: area is not particularly close as there aren't very many points in the polygon
@@ -801,14 +821,16 @@ class TransformersTest extends Specification {
       "default delimiter" >> {
         val trans = Transformers.parseTransform("parseMap('String->Int', $0)")
         val res = trans.eval(Array("a->1,b->2,c->3"))
-        res must beAnInstanceOf[java.util.Map[String, Int]]
+        res must not(beNull)
+        res.asInstanceOf[AnyRef] must beAnInstanceOf[java.util.Map[String, Int]]
         res.asInstanceOf[java.util.Map[String, Int]].size mustEqual 3
         res.asInstanceOf[java.util.Map[String, Int]].toMap mustEqual Map("a" -> 1, "b" -> 2, "c" -> 3)
       }
       "custom delimiter" >> {
         val trans = Transformers.parseTransform("parseMap('String->Int', $0, '%', ';')")
         val res = trans.eval(Array("a%1;b%2;c%3"))
-        res must beAnInstanceOf[java.util.Map[String, Int]]
+        res must not(beNull)
+        res.asInstanceOf[AnyRef] must beAnInstanceOf[java.util.Map[String, Int]]
         res.asInstanceOf[java.util.Map[String, Int]].size mustEqual 3
         res.asInstanceOf[java.util.Map[String, Int]].toMap mustEqual Map("a" -> 1, "b" -> 2, "c" -> 3)
       }

--- a/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert2/TypeInferenceTest.scala
+++ b/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert2/TypeInferenceTest.scala
@@ -74,14 +74,14 @@ class TypeInferenceTest extends Specification with LazyLogging {
     }
     "merge up number types" in {
       val types = Seq(Seq(1d), Seq(1f), Seq(1L), Seq(1))
-      foreach(types.drop(0).permutations)(t => TypeInference.infer(t).map(_.typed) mustEqual Seq(DOUBLE))
-      foreach(types.drop(1).permutations)(t => TypeInference.infer(t).map(_.typed) mustEqual Seq(FLOAT))
-      foreach(types.drop(2).permutations)(t => TypeInference.infer(t).map(_.typed) mustEqual Seq(LONG))
+      foreach(types.drop(0).permutations.toSeq)(t => TypeInference.infer(t).map(_.typed) mustEqual Seq(DOUBLE))
+      foreach(types.drop(1).permutations.toSeq)(t => TypeInference.infer(t).map(_.typed) mustEqual Seq(FLOAT))
+      foreach(types.drop(2).permutations.toSeq)(t => TypeInference.infer(t).map(_.typed) mustEqual Seq(LONG))
     }
     "merge up geometry types" in {
       val types = Seq(Seq(point), Seq(lineString), Seq(polygon), Seq(multiPoint), Seq(multiLineString),
         Seq(multiPolygon), Seq(geometryCollection))
-      foreach(types.permutations)(t => TypeInference.infer(t).map(_.typed) mustEqual Seq(GEOMETRY))
+      foreach(types.permutations.toSeq)(t => TypeInference.infer(t).map(_.typed) mustEqual Seq(GEOMETRY))
     }
     "merge up null values" in {
       val values = Seq("a", 1, 1L, 1f, 1d, true, new Date(), Seq[Byte](0), uuid, point, lineString,

--- a/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
+++ b/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
@@ -27,8 +27,11 @@
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-convert/geomesa-convert-jdbc/pom.xml
+++ b/geomesa-convert/geomesa-convert-jdbc/pom.xml
@@ -19,8 +19,11 @@
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-convert/geomesa-convert-json/pom.xml
+++ b/geomesa-convert/geomesa-convert-json/pom.xml
@@ -31,8 +31,11 @@
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-convert/geomesa-convert-osm/pom.xml
+++ b/geomesa-convert/geomesa-convert-osm/pom.xml
@@ -75,8 +75,11 @@
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-convert/geomesa-convert-redis-cache/pom.xml
+++ b/geomesa-convert/geomesa-convert-redis-cache/pom.xml
@@ -22,8 +22,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-convert/geomesa-convert-scripting/pom.xml
+++ b/geomesa-convert/geomesa-convert-scripting/pom.xml
@@ -43,8 +43,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-convert/geomesa-convert-simplefeature/pom.xml
+++ b/geomesa-convert/geomesa-convert-simplefeature/pom.xml
@@ -16,13 +16,12 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
 
     </dependencies>

--- a/geomesa-convert/geomesa-convert-text/pom.xml
+++ b/geomesa-convert/geomesa-convert-text/pom.xml
@@ -33,8 +33,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-convert/geomesa-convert-xml/pom.xml
+++ b/geomesa-convert/geomesa-convert-xml/pom.xml
@@ -44,8 +44,11 @@
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-features/geomesa-feature-all/pom.xml
+++ b/geomesa-features/geomesa-feature-all/pom.xml
@@ -39,8 +39,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-features/geomesa-feature-avro/pom.xml
+++ b/geomesa-features/geomesa-feature-avro/pom.xml
@@ -57,8 +57,15 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-mock_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-features/geomesa-feature-common/pom.xml
+++ b/geomesa-features/geomesa-feature-common/pom.xml
@@ -26,8 +26,11 @@
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-features/geomesa-feature-kryo/pom.xml
+++ b/geomesa-features/geomesa-feature-kryo/pom.xml
@@ -49,7 +49,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessorTest.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessorTest.scala
@@ -25,7 +25,7 @@ class JsonPathPropertyAccessorTest extends Specification {
 
   sequential
 
-  val ff = CommonFactoryFinder.getFilterFactory2
+  private val filterFactory = CommonFactoryFinder.getFilterFactory2
   val sft = SimpleFeatureTypes.createType("json", "json:String:json=true,s:String,dtg:Date,*geom:Point:srid=4326")
 
   "JsonPathPropertyAccessor" should {
@@ -38,7 +38,7 @@ class JsonPathPropertyAccessorTest extends Specification {
     }
 
     "access json values in simple features" in {
-      val property = ff.property("$.json.foo")
+      val property = filterFactory.property("$.json.foo")
       val sf = new ScalaSimpleFeature(sft, "")
       sf.setAttribute(0, """{ "foo" : "bar" }""")
       property.evaluate(sf) mustEqual "bar"
@@ -47,7 +47,7 @@ class JsonPathPropertyAccessorTest extends Specification {
     }
 
     "access json values in simple features with spaces in the json path" in {
-      val property = ff.property("""$.json.['foo path']""")
+      val property = filterFactory.property("""$.json.['foo path']""")
       val sf = new ScalaSimpleFeature(sft, "")
       sf.setAttribute(0, """{ "foo path" : "bar" }""")
       property.evaluate(sf) mustEqual "bar"
@@ -56,7 +56,7 @@ class JsonPathPropertyAccessorTest extends Specification {
     }
 
     "access nested json values in simple features with a json path" in {
-      val property = ff.property("""$.json.foo.bar""")
+      val property = filterFactory.property("""$.json.foo.bar""")
       val sf = new ScalaSimpleFeature(sft, "")
       sf.setAttribute(0, """{ "foo" : { "bar" : 0 } }""")
       property.evaluate(sf) mustEqual 0
@@ -65,7 +65,7 @@ class JsonPathPropertyAccessorTest extends Specification {
     }
 
     "access non-json strings in simple features" in {
-      val property = ff.property("$.s.foo")
+      val property = filterFactory.property("$.s.foo")
       val sf = new ScalaSimpleFeature(sft, "")
       sf.setAttribute(1, """{ "foo" : "bar" }""")
       property.evaluate(sf) mustEqual "bar"
@@ -74,7 +74,7 @@ class JsonPathPropertyAccessorTest extends Specification {
     }
 
     "access json values in kryo serialized simple features" in {
-      val property = ff.property("$.json.foo")
+      val property = filterFactory.property("$.json.foo")
       val serializer = KryoFeatureSerializer(sft)
       val sf = serializer.getReusableFeature
       sf.setBuffer(serializer.serialize(new ScalaSimpleFeature(sft, "", Array("""{ "foo" : "bar" }""", null, null, null))))
@@ -84,7 +84,7 @@ class JsonPathPropertyAccessorTest extends Specification {
     }
 
     "access json values with spaces in kryo serialized simple features" in {
-      val property = ff.property("$.json.['foo path']")
+      val property = filterFactory.property("$.json.['foo path']")
       val serializer = KryoFeatureSerializer(sft)
       val sf = serializer.getReusableFeature
       sf.setBuffer(serializer.serialize(new ScalaSimpleFeature(sft, "", Array("""{ "foo path" : "bar" }""", null, null, null))))
@@ -105,7 +105,7 @@ class JsonPathPropertyAccessorTest extends Specification {
     "access attribute descriptors in simple feature types" in {
       import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 
-      val property = ff.property("$.json.foo")
+      val property = filterFactory.property("$.json.foo")
       val result = property.evaluate(sft)
       result must beAnInstanceOf[AttributeDescriptor]
       result.asInstanceOf[AttributeDescriptor].getLocalName mustEqual "json"
@@ -128,7 +128,7 @@ class JsonPathPropertyAccessorTest extends Specification {
       }
       forall(Seq(sf0, sf1)) { sf =>
         forall(Seq("$baz", "$.baz", "baz", "$.baz/a")) { path =>
-          ff.property(path).evaluate(sf) must beNull
+          filterFactory.property(path).evaluate(sf) must beNull
           ECQL.toFilter(s""""$path" = 'bar'""").evaluate(sf) must beFalse
         }
       }

--- a/geomesa-features/geomesa-feature-nio/pom.xml
+++ b/geomesa-features/geomesa-feature-nio/pom.xml
@@ -31,8 +31,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-filter/pom.xml
+++ b/geomesa-filter/pom.xml
@@ -46,8 +46,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>

--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterHelperTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterHelperTest.scala
@@ -12,7 +12,6 @@ import java.time.temporal.ChronoUnit
 import java.time.{ZoneOffset, ZonedDateTime}
 import java.util.Date
 
-import org.geotools.factory.CommonFactoryFinder
 import org.geotools.filter.text.ecql.ECQL
 import org.geotools.filter.{IsGreaterThanImpl, IsLessThenImpl, LiteralExpressionImpl}
 import org.geotools.util.Converters
@@ -29,8 +28,6 @@ class FilterHelperTest extends Specification {
 
   val sft = SimpleFeatureTypes.createType("FilterHelperTest",
     "dtg:Date,number:Int,a:Int,b:Int,c:Int,*geom:Point:srid=4326")
-
-  val ff = CommonFactoryFinder.getFilterFactory2
 
   def updateFilter(filter: Filter): Filter = QueryPlanFilterVisitor.apply(sft, filter)
 

--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterPackageObjectTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterPackageObjectTest.scala
@@ -16,7 +16,7 @@ import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.filter._
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import org.specs2.specification.Fragments
+import org.specs2.specification.core.Fragments
 
 import scala.collection.JavaConversions._
 
@@ -59,7 +59,8 @@ class FilterPackageObjectTest extends Specification with LazyLogging {
     }
 
     "handle ANDs with multiple predicates" in {
-      val filters = List(ECQL.toFilter("attr1 = val1"), ECQL.toFilter("attr2 = val2"), geomFilter).permutations.map(ff.and(_))
+      val filters = List(ECQL.toFilter("attr1 = val1"), ECQL.toFilter("attr2 = val2"), geomFilter)
+          .permutations.map(ff.and(_)).toSeq
 
       forall(filters) { filter => 
         val (geoms, nongeoms) = partitionPrimarySpatials(filter, sft)

--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/function/Convert2ViewerFunctionTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/function/Convert2ViewerFunctionTest.scala
@@ -12,7 +12,6 @@ package org.locationtech.geomesa.filter.function
 import java.util.Date
 
 import org.geotools.data.Base64
-import org.geotools.factory.CommonFactoryFinder
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.utils.bin.BinaryOutputEncoder
@@ -24,7 +23,7 @@ import org.specs2.runner.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class Convert2ViewerFunctionTest extends Specification {
 
-  val ff = CommonFactoryFinder.getFilterFactory2
+  import org.locationtech.geomesa.filter.ff
 
   "Convert2ViewerFunction" should {
     "convert inputs" in {

--- a/geomesa-fs/geomesa-fs-datastore/pom.xml
+++ b/geomesa-fs/geomesa-fs-datastore/pom.xml
@@ -57,14 +57,12 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>

--- a/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
@@ -47,8 +47,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>

--- a/geomesa-fs/geomesa-fs-spark/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark/pom.xml
@@ -51,8 +51,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/pom.xml
@@ -55,14 +55,12 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/pom.xml
@@ -41,12 +41,12 @@
       </dependency>
 
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
+        <groupId>org.specs2</groupId>
+        <artifactId>specs2-core_${scala.binary.version}</artifactId>
       </dependency>
       <dependency>
         <groupId>org.specs2</groupId>
-        <artifactId>specs2_${scala.binary.version}</artifactId>
+        <artifactId>specs2-junit_${scala.binary.version}</artifactId>
       </dependency>
     </dependencies>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/pom.xml
@@ -54,11 +54,11 @@
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/pom.xml
@@ -58,14 +58,12 @@
 
         <!-- Test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/ParquetFSTest.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/ParquetFSTest.scala
@@ -17,7 +17,6 @@ import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileContext, Path}
 import org.geotools.data.Query
-import org.geotools.factory.CommonFactoryFinder
 import org.geotools.filter.text.ecql.ECQL
 import org.geotools.geometry.jts.JTSFactoryFinder
 import org.junit.runner.RunWith
@@ -41,7 +40,6 @@ class ParquetFSTest extends Specification with AllExpectations {
 
   val gf = JTSFactoryFinder.getGeometryFactory
   val sft = SimpleFeatureTypes.createType("test", "name:String,age:Int,dtg:Date,*geom:Point:srid=4326")
-  val ff = CommonFactoryFinder.getFilterFactory2
 
   val tempDir = Files.createTempDirectory("geomesa")
   val fc = FileContext.getFileContext(tempDir.toUri)

--- a/geomesa-fs/geomesa-fs-tools/pom.xml
+++ b/geomesa-fs/geomesa-fs-tools/pom.xml
@@ -57,11 +57,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-geojson/geomesa-geojson-api/pom.xml
+++ b/geomesa-geojson/geomesa-geojson-api/pom.xml
@@ -44,14 +44,12 @@
 
         <!-- test deps -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
 
     </dependencies>

--- a/geomesa-geojson/geomesa-geojson-rest/pom.xml
+++ b/geomesa-geojson/geomesa-geojson-rest/pom.xml
@@ -47,19 +47,16 @@
 
         <!-- test deps -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
             <artifactId>scalatra-specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/geomesa-geojson/geomesa-geojson-rest/src/test/scala/org/locationtech/geomesa/geojson/servlet/GeoJsonServletTest.scala
+++ b/geomesa-geojson/geomesa-geojson-rest/src/test/scala/org/locationtech/geomesa/geojson/servlet/GeoJsonServletTest.scala
@@ -17,7 +17,7 @@ import org.locationtech.geomesa.utils.cache.FilePersistence
 import org.locationtech.geomesa.utils.io.PathUtils
 import org.scalatra.test.specs2.MutableScalatraSpec
 import org.specs2.runner.JUnitRunner
-import org.specs2.specification.{Fragments, Step}
+import org.specs2.specification.core.Fragments
 
 @RunWith(classOf[JUnitRunner])
 class GeoJsonServletTest extends MutableScalatraSpec {
@@ -36,7 +36,7 @@ class GeoJsonServletTest extends MutableScalatraSpec {
   def urlEncode(s: String): String = URLEncoder.encode(s, "UTF-8")
 
   // cleanup tmp dir after tests run
-  override def map(fragments: => Fragments) = super.map(fragments) ^ Step {
+  override def map(fragments: => Fragments): Fragments = super.map(fragments) ^ step {
     PathUtils.deleteRecursively(tmpDir)
   }
 

--- a/geomesa-hbase/geomesa-hbase-datastore/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-datastore/pom.xml
@@ -89,7 +89,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>

--- a/geomesa-hbase/geomesa-hbase-jobs/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-jobs/pom.xml
@@ -34,12 +34,12 @@
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
@@ -120,11 +120,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>

--- a/geomesa-hbase/geomesa-hbase-spark-runtime/src/test/scala/org/locationtech/geomesa/hbase/spark/HBaseSparkProviderIntegrationTest.scala
+++ b/geomesa-hbase/geomesa-hbase-spark-runtime/src/test/scala/org/locationtech/geomesa/hbase/spark/HBaseSparkProviderIntegrationTest.scala
@@ -11,7 +11,6 @@ package org.locationtech.geomesa.hbase.spark
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql.{DataFrame, SQLContext, SQLTypes, SparkSession}
 import org.geotools.data.{Query, Transaction}
-import org.geotools.factory.CommonFactoryFinder
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.hbase.data.HBaseDataStoreFactory
 import org.locationtech.geomesa.hbase.data.HBaseDataStoreParams._
@@ -25,14 +24,14 @@ import scala.collection.JavaConversions._
 @RunWith(classOf[JUnitRunner])
 class HBaseSparkProviderIntegrationTest extends Specification with LazyLogging {
 
+  import org.locationtech.geomesa.filter.ff
+
   sequential
 
   // START HBASE INSTANCE MANUALLY
   lazy val sftName: String = "chicago"
 
   def spec: String = SparkSQLTestUtils.ChiSpec
-
-  private val ff = CommonFactoryFinder.getFilterFactory2
 
   def dtgField: Option[String] = Some("dtg")
 

--- a/geomesa-hbase/geomesa-hbase-spark/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-spark/pom.xml
@@ -58,8 +58,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-hbase/geomesa-hbase-tools/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-tools/pom.xml
@@ -46,7 +46,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-index-api/pom.xml
+++ b/geomesa-index-api/pom.xml
@@ -47,8 +47,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/AttributeIndexTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/AttributeIndexTest.scala
@@ -92,7 +92,7 @@ class AttributeIndexTest extends Specification with LazyLogging {
         // validate that ranges do not overlap
         foreach(ds.getQueryPlan(q, explainer = explain)) { qp =>
           val ranges = qp.ranges.sortBy(_.start)(ByteArrays.ByteOrdering)
-          forall(ranges.sliding(2)) { case Seq(left, right) => overlaps(left, right) must beFalse }
+          forall(ranges.sliding(2).toSeq) { case Seq(left, right) => overlaps(left, right) must beFalse }
         }
         SelfClosingIterator(ds.getFeatureReader(q, Transaction.AUTO_COMMIT)).map(_.getID).toSeq
       }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/utils/bin/BinSorterTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/utils/bin/BinSorterTest.scala
@@ -55,7 +55,7 @@ class BinSorterTest extends Specification {
       val bytes = Arrays.copyOf(bin, bin.length)
       BinSorter.quickSort(bytes, 0, bytes.length - 16, 16)
       val result = bytes.grouped(16).map(BinaryOutputEncoder.decode).map(_.dtg).toSeq
-      forall(result.sliding(2))(s => s.head must beLessThanOrEqualTo(s.drop(1).head))
+      forall(result.sliding(2).toSeq)(s => s.head must beLessThanOrEqualTo(s.drop(1).head))
     }
     "mergesort" in {
       val bytes = Arrays.copyOf(bin, bin.length).grouped(48).toSeq
@@ -63,7 +63,7 @@ class BinSorterTest extends Specification {
       val result = BinSorter.mergeSort(bytes.iterator, 16).map {
         case (b, o) => BinaryOutputEncoder.decode(b.slice(o, o + 16)).dtg
       }
-      forall(result.sliding(2))(s => s.head must beLessThanOrEqualTo(s.drop(1).head))
+      forall(result.sliding(2).toSeq)(s => s.head must beLessThanOrEqualTo(s.drop(1).head))
     }
     "mergesort in place" in {
       val bytes = Arrays.copyOf(bin, bin.length).grouped(48)
@@ -73,7 +73,7 @@ class BinSorterTest extends Specification {
       BinSorter.quickSort(right, 0, right.length - 16, 16)
       val merged = BinSorter.mergeSort(left, right, 16)
       val result = merged.grouped(16).map(BinaryOutputEncoder.decode).map(_.dtg).toSeq
-      forall(result.sliding(2))(s => s.head must beLessThanOrEqualTo(s.drop(1).head))
+      forall(result.sliding(2).toSeq)(s => s.head must beLessThanOrEqualTo(s.drop(1).head))
     }
     "quicksort 24 byte records" in {
       val out = new ByteArrayOutputStream(24 * features.length)
@@ -89,7 +89,7 @@ class BinSorterTest extends Specification {
       val bytes = out.toByteArray
       BinSorter.quickSort(bytes, 0, bytes.length - 24, 24)
       val result = bytes.grouped(24).map(BinaryOutputEncoder.decode).map(_.dtg).toSeq
-      forall(result.sliding(2))(s => s.head must beLessThanOrEqualTo(s.drop(1).head))
+      forall(result.sliding(2).toSeq)(s => s.head must beLessThanOrEqualTo(s.drop(1).head))
     }
     "quicksort edge cases" in {
       val maxLength = 8 // anything more than 8 takes too long to run
@@ -106,7 +106,7 @@ class BinSorterTest extends Specification {
           val result = buffer.take(right + 16).grouped(16).map(BinaryOutputEncoder.decode).map(_.dtg).toSeq
           result must haveLength(i)
           if (result.length > 1) {
-            forall(result.sliding(2))(s => s.head must beLessThanOrEqualTo(s.drop(1).head))
+            forall(result.sliding(2).toSeq)(s => s.head must beLessThanOrEqualTo(s.drop(1).head))
           }
         }
       }

--- a/geomesa-jobs/pom.xml
+++ b/geomesa-jobs/pom.xml
@@ -49,12 +49,12 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-jupyter/geomesa-jupyter-leaflet/pom.xml
+++ b/geomesa-jupyter/geomesa-jupyter-leaflet/pom.xml
@@ -43,14 +43,12 @@
 
         <!-- test -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
 
     </dependencies>

--- a/geomesa-kafka/geomesa-kafka-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/pom.xml
@@ -94,8 +94,11 @@
         <!-- test -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_2.11</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/index/KafkaFeatureCacheTest.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/index/KafkaFeatureCacheTest.scala
@@ -18,10 +18,10 @@ import org.opengis.feature.simple.SimpleFeature
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
-import scala.concurrent.duration.Duration
-
 @RunWith(classOf[JUnitRunner])
 class KafkaFeatureCacheTest extends Specification {
+
+  import scala.concurrent.duration._
 
   sequential
 
@@ -42,7 +42,7 @@ class KafkaFeatureCacheTest extends Specification {
   def track(id: String, track: String): SimpleFeature = ScalaSimpleFeature.create(sft, id, id, track)
 
   def caches(expiry: Duration = Duration.Inf) =
-    Iterator(
+    Seq(
       KafkaFeatureCache(sft, IndexConfig(expiry, None, 360, 180, Seq.empty, lazyDeserialization = true)),
       KafkaFeatureCache(sft, IndexConfig(expiry, None, 360, 180, Seq(("geom", CQIndexType.GEOMETRY)), lazyDeserialization = true))
     )
@@ -127,8 +127,8 @@ class KafkaFeatureCacheTest extends Specification {
           cache.query(track0v0.getID) must beSome(track0v0)
           cache.query(wholeWorldFilter).toSeq mustEqual Seq(track0v0)
 
-          cache.query(track0v0.getID) must eventually(40, 100.millis)(beNone)
-          cache.query(wholeWorldFilter).toSeq must eventually(40, 100.millis)(beEmpty)
+          eventually(40, 100.millis)(cache.query(track0v0.getID) must beNone)
+          eventually(40, 100.millis)(cache.query(wholeWorldFilter).toSeq must beEmpty)
           cache.size() mustEqual 0
         } finally {
           cache.close()

--- a/geomesa-kafka/geomesa-kafka-tools/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-tools/pom.xml
@@ -86,7 +86,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-kafka/geomesa-kafka-utils/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-utils/pom.xml
@@ -37,7 +37,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/geomesa-kudu/geomesa-kudu-datastore/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-datastore/pom.xml
@@ -34,12 +34,16 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-mock_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/geomesa-kudu/geomesa-kudu-spark/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-spark/pom.xml
@@ -44,8 +44,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-kudu/geomesa-kudu-tools/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-tools/pom.xml
@@ -36,7 +36,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-lambda/geomesa-lambda-datastore/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-datastore/pom.xml
@@ -126,11 +126,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/geomesa-lambda/geomesa-lambda-datastore/src/test/scala/org/locationtech/geomesa/lambda/LambdaDataStoreTest.scala
+++ b/geomesa-lambda/geomesa-lambda-datastore/src/test/scala/org/locationtech/geomesa/lambda/LambdaDataStoreTest.scala
@@ -33,6 +33,7 @@ import org.specs2.matcher.MatchResult
 class LambdaDataStoreTest extends LambdaTest with LazyLogging {
 
   import scala.collection.JavaConversions._
+  import scala.concurrent.duration._
 
   sequential
 
@@ -137,8 +138,8 @@ class LambdaDataStoreTest extends LambdaTest with LazyLogging {
 
           // test queries against the transient store
           forall(Seq(ds, readOnly)) { store =>
-            store.transients.get(sft.getTypeName).read().toSeq must
-                eventually(40, 100.millis)(containTheSameElementsAs(features))
+            eventually(40, 100.millis)(store.transients.get(sft.getTypeName).read().toSeq must
+                containTheSameElementsAs(features))
             SelfClosingIterator(store.getFeatureReader(new Query(sft.getTypeName), Transaction.AUTO_COMMIT)).toSeq must
                 containTheSameElementsAs(features)
           }
@@ -152,7 +153,7 @@ class LambdaDataStoreTest extends LambdaTest with LazyLogging {
           ds.persist(sft.getTypeName)
           // test mixed queries against both stores
           forall(Seq(ds, readOnly)) { store =>
-            store.transients.get(sft.getTypeName).read().toSeq must eventually(40, 100.millis)(beEqualTo(features.drop(1)))
+            eventually(40, 100.millis)(store.transients.get(sft.getTypeName).read().toSeq must beEqualTo(features.drop(1)))
             SelfClosingIterator(store.getFeatureReader(new Query(sft.getTypeName), Transaction.AUTO_COMMIT)).toSeq must
                 containTheSameElementsAs(features)
           }
@@ -179,7 +180,7 @@ class LambdaDataStoreTest extends LambdaTest with LazyLogging {
           ds.persist(sft.getTypeName)
           // test queries against the persistent store
           forall(Seq(ds, readOnly)) { store =>
-            store.transients.get(sft.getTypeName).read() must eventually(40, 100.millis)(beEmpty)
+            eventually(40, 100.millis)(store.transients.get(sft.getTypeName).read() must beEmpty)
             SelfClosingIterator(store.getFeatureReader(new Query(sft.getTypeName), Transaction.AUTO_COMMIT)).toSeq must
                 containTheSameElementsAs(features)
           }

--- a/geomesa-lambda/geomesa-lambda-datastore/src/test/scala/org/locationtech/geomesa/lambda/LambdaTestRunnerTest.scala
+++ b/geomesa-lambda/geomesa-lambda-datastore/src/test/scala/org/locationtech/geomesa/lambda/LambdaTestRunnerTest.scala
@@ -17,12 +17,14 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.lambda.LambdaTestRunnerTest.LambdaTest
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
+import org.specs2.specification.BeforeAfterAll
+import org.specs2.specification.core.{Env, Fragments}
 
 /**
   * Base class for running all kafka/zk embedded tests
   */
 @RunWith(classOf[JUnitRunner])
-class LambdaTestRunnerTest extends Specification with LazyLogging {
+class LambdaTestRunnerTest extends Specification with BeforeAfterAll with LazyLogging {
 
   var kafka: EmbeddedKafka = _
 
@@ -33,16 +35,17 @@ class LambdaTestRunnerTest extends Specification with LazyLogging {
     new ZookeeperOffsetManagerTest
   )
 
-  step {
+  override def beforeAll(): Unit = {
     logger.info("Starting embedded kafka/zk")
     kafka = new EmbeddedKafka()
     logger.info("Started embedded kafka/zk")
     specs.foreach { s => s.brokers = kafka.brokers; s.zookeepers = kafka.zookeepers }
   }
 
-  specs.foreach(link)
+  override def map(fs: => Fragments, env: Env): Fragments =
+    specs.foldLeft(super.map(fs, env))((fragments, spec) => fragments ^ spec.fragments(env))
 
-  step {
+  override def afterAll(): Unit = {
     logger.info("Stopping embedded kafka/zk")
     kafka.close()
     logger.info("Stopped embedded kafka/zk")

--- a/geomesa-lambda/geomesa-lambda-datastore/src/test/scala/org/locationtech/geomesa/lambda/ZookeeperOffsetManagerTest.scala
+++ b/geomesa-lambda/geomesa-lambda-datastore/src/test/scala/org/locationtech/geomesa/lambda/ZookeeperOffsetManagerTest.scala
@@ -15,6 +15,8 @@ import org.locationtech.geomesa.lambda.stream.ZookeeperOffsetManager
 
 class ZookeeperOffsetManagerTest extends LambdaTest with LazyLogging {
 
+  import scala.concurrent.duration._
+
   sequential
 
   step {
@@ -39,10 +41,10 @@ class ZookeeperOffsetManagerTest extends LambdaTest with LazyLogging {
       })
 
       manager.setOffset("bar", 0, 1)
-      triggers.toMap must eventually(40, 100.millis)(beEqualTo(Map(0 -> 1, 1 -> 0, 2 -> 0)))
+      eventually(40, 100.millis)(triggers.toMap must beEqualTo(Map(0 -> 1, 1 -> 0, 2 -> 0)))
       manager.setOffset("bar", 0, 2)
       manager.setOffset("bar", 2, 1)
-      triggers.toMap must eventually(40, 100.millis)(beEqualTo(Map(0 -> 2, 1 -> 0, 2 -> 1)))
+      eventually(40, 100.millis)(triggers.toMap must beEqualTo(Map(0 -> 2, 1 -> 0, 2 -> 1)))
     }
   }
 

--- a/geomesa-lambda/geomesa-lambda-tools/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-tools/pom.xml
@@ -117,8 +117,11 @@
         <!-- test deps -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.accumulo</groupId>

--- a/geomesa-memory/geomesa-cqengine-datastore/pom.xml
+++ b/geomesa-memory/geomesa-cqengine-datastore/pom.xml
@@ -56,14 +56,12 @@
             <artifactId>gt-data</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-memory/geomesa-cqengine/pom.xml
+++ b/geomesa-memory/geomesa-cqengine/pom.xml
@@ -83,14 +83,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-memory/geomesa-cqengine/src/test/scala/org/locationtech/geomesa/memory/cqengine/utils/GeoCQEngineTest.scala
+++ b/geomesa-memory/geomesa-cqengine/src/test/scala/org/locationtech/geomesa/memory/cqengine/utils/GeoCQEngineTest.scala
@@ -17,82 +17,70 @@ import org.opengis.filter.Filter
 import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
+import org.specs2.specification.core.{Fragment, Fragments}
 
 @RunWith(classOf[JUnitRunner])
 class GeoCQEngineTest extends Specification with LazyLogging {
-  "GeoCQEngine" should {
-    "return correct number of results" >> {
-      import SampleFilters._
-      val feats = (0 until 1000).map(SampleFeatures.buildFeature)
 
-      // Set up CQEngine with no indexes
-      val cqNoIndexes = new GeoCQEngine(sft, Seq.empty)
-      cqNoIndexes.insert(feats)
+  import SampleFilters._
 
-      // Set up CQEngine with all indexes
-      val cqWithIndexes = new GeoCQEngine(sftWithIndexes, CQIndexType.getDefinedAttributes(sftWithIndexes) , enableFidIndex = true)
-      cqWithIndexes.insert(feats)
+  val feats = (0 until 1000).map(SampleFeatures.buildFeature)
 
-      def getGeoToolsCount(filter: Filter) = feats.count(filter.evaluate)
+  // Set up CQEngine with no indexes
+  val cqNoIndexes = new GeoCQEngine(sft, Seq.empty)
+  cqNoIndexes.insert(feats)
 
-      def getCQEngineCount(filter: Filter, cq: GeoCQEngine) = {
-        SelfClosingIterator(cq.query(filter)).size
+  // Set up CQEngine with all indexes
+  val cqWithIndexes = new GeoCQEngine(sftWithIndexes, CQIndexType.getDefinedAttributes(sftWithIndexes) , enableFidIndex = true)
+  cqWithIndexes.insert(feats)
+
+  def getGeoToolsCount(filter: Filter) = feats.count(filter.evaluate)
+
+  def getCQEngineCount(filter: Filter, cq: GeoCQEngine) = {
+    SelfClosingIterator(cq.query(filter)).size
+  }
+
+  def checkFilter(filter: Filter, cq: GeoCQEngine): MatchResult[Int] = {
+    val gtCount = getGeoToolsCount(filter)
+
+    val cqCount = getCQEngineCount(filter, cq)
+
+    val msg = s"GT: $gtCount CQ: $cqCount Filter: $filter"
+    if (gtCount == cqCount)
+      logger.debug(msg)
+    else
+      logger.error("MISMATCH: "+msg)
+
+    // since GT count is (presumably) correct
+    cqCount must equalTo(gtCount)
+  }
+
+  def buildFilterTests(name: String, filters: Seq[Filter]): Seq[Fragment] = {
+    for (f <- filters) yield {
+      s"return correct number of results for $name filter $f (geo-only index)" >> {
+        checkFilter(f, cqNoIndexes)
       }
-
-      def checkFilter(filter: Filter, cq: GeoCQEngine): MatchResult[Int] = {
-        val gtCount = getGeoToolsCount(filter)
-
-        val cqCount = getCQEngineCount(filter, cq)
-
-        val msg = s"GT: $gtCount CQ: $cqCount Filter: $filter"
-        if (gtCount == cqCount)
-          logger.debug(msg)
-        else
-          logger.error("MISMATCH: "+msg)
-
-        // since GT count is (presumably) correct
-        cqCount must equalTo(gtCount)
+      s"return correct number of results for $name filter $f (various indices)" >> {
+        checkFilter(f, cqWithIndexes)
       }
-
-      def runFilterTests(name: String, filters: Seq[Filter]) = {
-        examplesBlock {
-          for (f <- filters) {
-            s"$name filter $f (geo-only index)" in {
-              checkFilter(f, cqNoIndexes)
-            }
-            s"$name filter $f (various indices)" in {
-              checkFilter(f, cqWithIndexes)
-            }
-          }
-        }
-      }
-
-      runFilterTests("equality", equalityFilters)
-
-      runFilterTests("special", specialFilters)
-
-      runFilterTests("null", nullFilters)
-
-      runFilterTests("comparable", comparableFilters)
-
-      runFilterTests("temporal", temporalFilters)
-
-      runFilterTests("one level AND", oneLevelAndFilters)
-
-      runFilterTests("one level multiple AND", oneLevelMultipleAndsFilters)
-
-      runFilterTests("one level OR", oneLevelOrFilters)
-
-      runFilterTests("one level multiple OR", oneLevelMultipleOrsFilters)
-
-      runFilterTests("one level NOT", simpleNotFilters)
-
-      runFilterTests("basic spatial predicates", spatialPredicates)
-
-      runFilterTests("attribute predicates", attributePredicates)
-
-      runFilterTests("function predicates", functionPredicates)
-
     }
+  }
+
+  def runFilterTests(name: String, filters: Seq[Filter]): Fragments = Fragments(buildFilterTests(name, filters): _*)
+
+  "GeoCQEngine" should {
+    runFilterTests("equality", equalityFilters)
+    runFilterTests("special", specialFilters)
+    runFilterTests("null", nullFilters)
+    runFilterTests("comparable", comparableFilters)
+    runFilterTests("temporal", temporalFilters)
+    runFilterTests("one level AND", oneLevelAndFilters)
+    runFilterTests("one level multiple AND", oneLevelMultipleAndsFilters)
+    runFilterTests("one level OR", oneLevelOrFilters)
+    runFilterTests("one level multiple OR", oneLevelMultipleOrsFilters)
+    runFilterTests("one level NOT", simpleNotFilters)
+    runFilterTests("basic spatial predicates", spatialPredicates)
+    runFilterTests("attribute predicates", attributePredicates)
+    runFilterTests("function predicates", functionPredicates)
   }
 }

--- a/geomesa-metrics/pom.xml
+++ b/geomesa-metrics/pom.xml
@@ -76,12 +76,12 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/geomesa-process/geomesa-process-vector/pom.xml
+++ b/geomesa-process/geomesa-process-vector/pom.xml
@@ -49,11 +49,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/geomesa-process/geomesa-process-vector/src/test/scala/org/locationtech/geomesa/process/analytic/Point2PointProcessTest.scala
+++ b/geomesa-process/geomesa-process-vector/src/test/scala/org/locationtech/geomesa/process/analytic/Point2PointProcessTest.scala
@@ -58,7 +58,7 @@ class Point2PointProcessTest extends Specification {
     "properly create linestrings of groups of 2 coordinates" >> {
       import org.locationtech.geomesa.utils.geotools.Conversions._
       val res = p2p.execute(features, "myid", "dtg", 2, breakOnDay = false, filterSingularPoints = true)
-      SelfClosingIterator(res.features) must haveLength(8)
+      SelfClosingIterator(res.features).toSeq must haveLength(8)
 
       val f1 = SelfClosingIterator(p2p.execute(features.subCollection(ECQL.toFilter("myid = 'first'")),
         "myid", "dtg", 2, breakOnDay = false, filterSingularPoints = true).features).toSeq
@@ -122,13 +122,13 @@ class Point2PointProcessTest extends Specification {
       val res = p2p.execute(features.subCollection(filter),
         "myid", "dtg", 2, breakOnDay = false, filterSingularPoints = true)
       res.getSchema must not(beNull)
-      SelfClosingIterator(res.features) must haveLength(0)
+      SelfClosingIterator(res.features).toSeq must haveLength(0)
     }
 
     "group on non-string attributes" >> {
       import org.locationtech.geomesa.utils.geotools.Conversions._
       val res = p2p.execute(features, "myint", "dtg", 2, breakOnDay = false, filterSingularPoints = true)
-      SelfClosingIterator(res.features) must haveLength(8)
+      SelfClosingIterator(res.features).toSeq must haveLength(8)
 
       val f1 = SelfClosingIterator(p2p.execute(features.subCollection(ECQL.toFilter("myid = 'first'")),
         "myid", "dtg", 2, breakOnDay = false, filterSingularPoints = true).features).toSeq

--- a/geomesa-process/geomesa-process-vector/src/test/scala/org/locationtech/geomesa/process/query/ProximitySearchProcessTest.scala
+++ b/geomesa-process/geomesa-process-vector/src/test/scala/org/locationtech/geomesa/process/query/ProximitySearchProcessTest.scala
@@ -73,7 +73,7 @@ class ProximitySearchProcessTest extends Specification {
       val prox = new ProximitySearchProcess
 
       // note: size returns an estimated amount, instead we need to actually count the features
-      def ex(p: Double) = SelfClosingIterator(prox.execute(inputFeatures, dataFeatures, p))
+      def ex(p: Double) = SelfClosingIterator(prox.execute(inputFeatures, dataFeatures, p)).toSeq
 
       ex(50.0)  must haveLength(0)
       ex(90.0)  must haveLength(0)

--- a/geomesa-security/pom.xml
+++ b/geomesa-security/pom.xml
@@ -25,11 +25,15 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-mock_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-spark/geomesa-spark-converter/pom.xml
+++ b/geomesa-spark/geomesa-spark-converter/pom.xml
@@ -42,8 +42,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/geomesa-spark/geomesa-spark-geotools/pom.xml
+++ b/geomesa-spark/geomesa-spark-geotools/pom.xml
@@ -22,8 +22,11 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>

--- a/geomesa-spark/geomesa-spark-jts/pom.xml
+++ b/geomesa-spark/geomesa-spark-jts/pom.xml
@@ -45,8 +45,11 @@
         <!-- test -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/jts/JTSQueryTest.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/jts/JTSQueryTest.scala
@@ -19,26 +19,27 @@ import org.specs2.runner.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class JTSQueryTest extends Specification with TestEnvironment {
 
-  "spark jts module" should {
-    sequential
+  sequential
 
-    var df: DataFrame = null
-    var newDF: DataFrame = null
+  var df: DataFrame = _
+  var newDF: DataFrame = _
 
-    // before
-    step {
-      val schema = StructType(Array(StructField("name",StringType, nullable=false),
-                                    StructField("pointText", StringType, nullable=false),
-                                    StructField("polygonText", StringType, nullable=false),
-                                    StructField("latitude", DoubleType, nullable=false),
-                                    StructField("longitude", DoubleType, nullable=false)))
+  // before
+  step {
+    val schema = StructType(Array(StructField("name",StringType, nullable=false),
+      StructField("pointText", StringType, nullable=false),
+      StructField("polygonText", StringType, nullable=false),
+      StructField("latitude", DoubleType, nullable=false),
+      StructField("longitude", DoubleType, nullable=false)))
 
-      val dataFile = this.getClass.getClassLoader.getResource("jts-example.csv").getPath
-      df = spark.read.schema(schema)
+    val dataFile = this.getClass.getClassLoader.getResource("jts-example.csv").getPath
+    df = spark.read.schema(schema)
         .option("sep", "-")
         .option("timestampFormat", "yyyy/MM/dd HH:mm:ss ZZ")
         .csv(dataFile)
-    }
+  }
+
+  "spark jts module" should {
 
     "have rows with user defined types" >> {
 
@@ -68,10 +69,10 @@ class JTSQueryTest extends Specification with TestEnvironment {
         .count()
       countSQL mustEqual countDF
     }
+  }
 
-    // after
-    step {
-      spark.stop()
-    }
+  // after
+  step {
+    spark.stop()
   }
 }

--- a/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/jts/udf/GeometricCastFunctionsTest.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/test/scala/org/locationtech/geomesa/spark/jts/udf/GeometricCastFunctionsTest.scala
@@ -37,7 +37,7 @@ class GeometricCastFunctionsTest extends Specification with TestEnvironment {
         val pointTxt = "POINT(1 1)"
         val point = s"st_geomFromWKT('$pointTxt')"
         val df = sc.sql(s"select st_castToPoint($point)")
-        df.collect.head(0) must haveClass[Point]
+        df.collect.head(0).asInstanceOf[AnyRef] must haveClass[Point]
         dfBlank.select(st_castToPoint(st_geomFromWKT(pointTxt))).first must haveClass[Point]
       }
     }
@@ -52,7 +52,7 @@ class GeometricCastFunctionsTest extends Specification with TestEnvironment {
         val polygonTxt = "POLYGON((1 1, 1 2, 2 2, 2 1, 1 1))"
         val polygon = s"st_geomFromWKT('$polygonTxt')"
         val df = sc.sql(s"select st_castToPolygon($polygon)")
-        df.collect.head(0) must haveClass[Polygon]
+        df.collect.head(0).asInstanceOf[AnyRef] must haveClass[Polygon]
         dfBlank.select(st_castToPolygon(st_geomFromWKT(polygonTxt))).first must haveClass[Polygon]
       }
     }
@@ -67,7 +67,7 @@ class GeometricCastFunctionsTest extends Specification with TestEnvironment {
         val lineTxt = "LINESTRING(1 1, 2 2)"
         val line = s"st_geomFromWKT('$lineTxt')"
         val df = sc.sql(s"select st_castToLineString($line)")
-        df.collect.head(0) must haveClass[LineString]
+        df.collect.head(0).asInstanceOf[AnyRef] must haveClass[LineString]
         dfBlank.select(st_castToLineString(st_geomFromWKT(lineTxt))).first must haveClass[LineString]
       }
     }

--- a/geomesa-spark/geomesa-spark-sql/pom.xml
+++ b/geomesa-spark/geomesa-spark-sql/pom.xml
@@ -61,8 +61,11 @@
         <!-- test -->
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>

--- a/geomesa-spark/geomesa-spark-sql/src/test/scala/org/locationtech/geomesa/spark/SparkSQLDataTest.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/test/scala/org/locationtech/geomesa/spark/SparkSQLDataTest.scala
@@ -28,27 +28,28 @@ import scala.collection.JavaConversions._
 
 @RunWith(classOf[JUnitRunner])
 class SparkSQLDataTest extends Specification with LazyLogging {
+  sequential
+
+  val dsParams: JMap[String, String] = Map("cqengine" -> "true", "geotools" -> "true")
+  var ds: DataStore = _
+  var spark: SparkSession = _
+  var sc: SQLContext = _
+
+  var df: DataFrame = _
+  var dfIndexed: DataFrame = _
+  var dfPartitioned: DataFrame = _
+
   val createPoint = JTSFactoryFinder.getGeometryFactory.createPoint(_: Coordinate)
 
+  // before
+  step {
+    ds = DataStoreFinder.getDataStore(dsParams)
+    spark = SparkSQLTestUtils.createSparkSession()
+    sc = spark.sqlContext
+    SQLTypes.init(sc)
+  }
+
   "sql data tests" should {
-    sequential
-
-    val dsParams: JMap[String, String] = Map("cqengine" -> "true", "geotools" -> "true")
-    var ds: DataStore = null
-    var spark: SparkSession = null
-    var sc: SQLContext = null
-
-    var df: DataFrame = null
-    var dfIndexed: DataFrame = null
-    var dfPartitioned: DataFrame = null
-
-    // before
-    step {
-      ds = DataStoreFinder.getDataStore(dsParams)
-      spark = SparkSQLTestUtils.createSparkSession()
-      sc = spark.sqlContext
-      SQLTypes.init(sc)
-    }
 
     "ingest chicago" >> {
       SparkSQLTestUtils.ingestChicago(ds)

--- a/geomesa-stream/geomesa-stream-datastore/pom.xml
+++ b/geomesa-stream/geomesa-stream-datastore/pom.xml
@@ -31,8 +31,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/geomesa-stream/geomesa-stream-datastore/src/test/scala/org/locationtech/geomesa/stream/datastore/StreamDataStoreTest.scala
+++ b/geomesa-stream/geomesa-stream-datastore/src/test/scala/org/locationtech/geomesa/stream/datastore/StreamDataStoreTest.scala
@@ -15,7 +15,6 @@ import com.google.common.io.Resources
 import org.apache.commons.io.IOUtils
 import org.apache.commons.net.DefaultSocketFactory
 import org.geotools.data.DataStoreFinder
-import org.geotools.factory.CommonFactoryFinder
 import org.junit.runner.RunWith
 import org.opengis.feature.simple.SimpleFeature
 import org.opengis.filter.Filter
@@ -28,13 +27,16 @@ import scala.concurrent.Future
 @RunWith(classOf[JUnitRunner])
 class StreamDataStoreTest extends Specification {
 
+  import org.locationtech.geomesa.filter.ff
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
   sequential
 
   val count  = new AtomicLong(0)
   val count2 = new AtomicLong(0)
   val count3 = new AtomicLong(0)
 
-  val ff = CommonFactoryFinder.getFilterFactory2()
   val sourceConf =
     """
       |{

--- a/geomesa-stream/geomesa-stream-generic/pom.xml
+++ b/geomesa-stream/geomesa-stream-generic/pom.xml
@@ -45,8 +45,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/geomesa-stream/geomesa-stream-generic/src/test/scala/org/locationtech/geomesa/stream/generic/GenericSimpleFeatureStreamSourceTest.scala
+++ b/geomesa-stream/geomesa-stream-generic/src/test/scala/org/locationtech/geomesa/stream/generic/GenericSimpleFeatureStreamSourceTest.scala
@@ -27,6 +27,8 @@ import scala.concurrent.Future
 @RunWith(classOf[JUnitRunner])
 class GenericSimpleFeatureStreamSourceTest extends Specification  {
 
+  import scala.concurrent.ExecutionContext.Implicits.global
+
   "GenericSimpleFeatureStreamSource" should {
 
     val confString =

--- a/geomesa-tools/pom.xml
+++ b/geomesa-tools/pom.xml
@@ -101,12 +101,12 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/ConvertCommandTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/ConvertCommandTest.scala
@@ -110,7 +110,7 @@ class ConvertCommandTest extends Specification with LazyLogging {
           val ec = converter.createEvaluationContext(Map("inputFilePath" -> inputFile))
           val files = Iterator.single(inputFile).flatMap(PathUtils.interpretPath)
           val features = ConvertCommand.convertFeatures(files, converter, ec, None, None)
-          features must haveLength(3)
+          features.toSeq must haveLength(3)
         }
       }
       "export data" in {

--- a/geomesa-utils/pom.xml
+++ b/geomesa-utils/pom.xml
@@ -150,12 +150,16 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-mock_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GridSnapTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GridSnapTest.scala
@@ -80,19 +80,19 @@ class GridSnapTest extends Specification with LazyLogging {
       val bbox = new Envelope(0.0, 10.0, 0.0, 10.0)
       val gridSnap = new GridSnap(bbox, 10, 10)
 
-      val resultDiagonal = gridSnap.bresenhamLine(0, 0, 9, 9)
+      val resultDiagonal = gridSnap.bresenhamLine(0, 0, 9, 9).toSeq
       resultDiagonal must haveLength(9)
 
-      val resultVertical = gridSnap.bresenhamLine(0, 0, 0, 9)
+      val resultVertical = gridSnap.bresenhamLine(0, 0, 0, 9).toSeq
       resultVertical must haveLength(9)
 
-      val resultHorizontal = gridSnap.bresenhamLine(0, 0, 9, 0)
+      val resultHorizontal = gridSnap.bresenhamLine(0, 0, 9, 0).toSeq
       resultHorizontal must haveLength(9)
 
-      val resultSamePoint = gridSnap.bresenhamLine(0, 0, 0, 0)
+      val resultSamePoint = gridSnap.bresenhamLine(0, 0, 0, 0).toSeq
       resultSamePoint must haveLength(1)
 
-      val resultInverse = gridSnap.bresenhamLine(9, 9, 0, 0)
+      val resultInverse = gridSnap.bresenhamLine(9, 9, 0, 0).toSeq
       resultInverse must haveLength(9)
     }
 

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/iterators/DeduplicatingSimpleFeatureIteratorTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/iterators/DeduplicatingSimpleFeatureIteratorTest.scala
@@ -18,21 +18,21 @@ import org.specs2.runner.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class DeduplicatingSimpleFeatureIteratorTest extends Specification {
 
-  val ff = CommonFactoryFinder.getFilterFactory2
+  private val filterFactory = CommonFactoryFinder.getFilterFactory2
 
   "DeDuplicatingIterator" should {
     "filter on unique elements" in {
       val sft = SimpleFeatureTypes.createType("test", "*geom:Point:srid=4326")
       val attributes = Array[AnyRef]("POINT(0,0)")
       val features = Seq(
-        new SimpleFeatureImpl(attributes, sft, ff.featureId("1"), false),
-        new SimpleFeatureImpl(attributes, sft, ff.featureId("2"), false),
-        new SimpleFeatureImpl(attributes, sft, ff.featureId("0"), false),
-        new SimpleFeatureImpl(attributes, sft, ff.featureId("1"), false),
-        new SimpleFeatureImpl(attributes, sft, ff.featureId("3"), false),
-        new SimpleFeatureImpl(attributes, sft, ff.featureId("4"), false),
-        new SimpleFeatureImpl(attributes, sft, ff.featureId("1"), false),
-        new SimpleFeatureImpl(attributes, sft, ff.featureId("3"), false)
+        new SimpleFeatureImpl(attributes, sft, filterFactory.featureId("1"), false),
+        new SimpleFeatureImpl(attributes, sft, filterFactory.featureId("2"), false),
+        new SimpleFeatureImpl(attributes, sft, filterFactory.featureId("0"), false),
+        new SimpleFeatureImpl(attributes, sft, filterFactory.featureId("1"), false),
+        new SimpleFeatureImpl(attributes, sft, filterFactory.featureId("3"), false),
+        new SimpleFeatureImpl(attributes, sft, filterFactory.featureId("4"), false),
+        new SimpleFeatureImpl(attributes, sft, filterFactory.featureId("1"), false),
+        new SimpleFeatureImpl(attributes, sft, filterFactory.featureId("3"), false)
       )
       val deduped = new DeduplicatingSimpleFeatureIterator(features.toIterator).toSeq
       deduped must haveLength(5)

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/iterators/PlaybackIteratorTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/iterators/PlaybackIteratorTest.scala
@@ -42,7 +42,7 @@ class PlaybackIteratorTest extends Specification {
   "PlaybackIterator" should {
     "return features in sorted order" in {
       WithClose(new PlaybackIterator(ds, sft.getTypeName, interval, dtg, rate = 100f)) { iter =>
-        foreach(iter.sliding(2)) { case Seq(left, right) =>
+        foreach(iter.sliding(2).toSeq) { case Seq(left, right) =>
           left.getAttribute("dtg").asInstanceOf[Date].before(right.getAttribute("dtg").asInstanceOf[Date]) must beTrue
         }
       }
@@ -50,7 +50,7 @@ class PlaybackIteratorTest extends Specification {
     "query using windows" in {
       val window = Some(Duration("5 seconds"))
       WithClose(new PlaybackIterator(ds, sft.getTypeName, interval, dtg, window = window, rate = 100f)) { iter =>
-        foreach(iter.sliding(2)) { case Seq(left, right) =>
+        foreach(iter.sliding(2).toSeq) { case Seq(left, right) =>
           left.getAttribute("dtg").asInstanceOf[Date].before(right.getAttribute("dtg").asInstanceOf[Date]) must beTrue
         }
       }

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/iterators/SortingSimpleFeatureIteratorTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/iterators/SortingSimpleFeatureIteratorTest.scala
@@ -10,7 +10,6 @@ package org.locationtech.geomesa.utils.iterators
 
 import java.util.NoSuchElementException
 
-import org.geotools.factory.CommonFactoryFinder
 import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.utils.collection.CloseableIterator
@@ -23,8 +22,6 @@ import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class SortingSimpleFeatureIteratorTest extends Specification with Mockito {
-
-  val ff = CommonFactoryFinder.getFilterFactory
 
   "SortingSimpleFeatureIterator" should {
 

--- a/geomesa-web/geomesa-web-core/pom.xml
+++ b/geomesa-web/geomesa-web-core/pom.xml
@@ -50,19 +50,16 @@
         <!-- test deps -->
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
             <artifactId>scalatra-specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/geomesa-web/geomesa-web-core/src/test/scala/org/locationtech/geomesa/web/core/GeoMesaDataStoreServletTest.scala
+++ b/geomesa-web/geomesa-web-core/src/test/scala/org/locationtech/geomesa/web/core/GeoMesaDataStoreServletTest.scala
@@ -20,7 +20,7 @@ import org.scalatra.Ok
 import org.scalatra.json.NativeJsonSupport
 import org.scalatra.test.specs2.MutableScalatraSpec
 import org.specs2.runner.JUnitRunner
-import org.specs2.specification.{Fragments, Step}
+import org.specs2.specification.core.Fragments
 
 @RunWith(classOf[JUnitRunner])
 class GeoMesaDataStoreServletTest extends MutableScalatraSpec {
@@ -32,7 +32,7 @@ class GeoMesaDataStoreServletTest extends MutableScalatraSpec {
   def urlEncode(s: String): String = URLEncoder.encode(s, "UTF-8")
 
   // cleanup tmp dir after tests run
-  override def map(fragments: => Fragments) = super.map(fragments) ^ Step {
+  override def map(fragments: => Fragments): Fragments = super.map(fragments) ^ step {
     PathUtils.deleteRecursively(tmpDir)
   }
 
@@ -50,7 +50,7 @@ class GeoMesaDataStoreServletTest extends MutableScalatraSpec {
 
     get("/test") {
       try {
-        withDataStore((ds: DataStore) => { calledTest = true; Ok() })
+        withDataStore((_: DataStore) => { calledTest = true; Ok() })
       } catch {
         case e: Exception => handleError(s"Error creating index:", e)
       }

--- a/geomesa-web/geomesa-web-data/pom.xml
+++ b/geomesa-web/geomesa-web-data/pom.xml
@@ -108,12 +108,15 @@
 
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
             <artifactId>scalatra-specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>

--- a/geomesa-web/geomesa-web-stats/pom.xml
+++ b/geomesa-web/geomesa-web-stats/pom.xml
@@ -72,19 +72,16 @@
 
         <!-- test deps -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
             <artifactId>scalatra-specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/geomesa-z3/pom.xml
+++ b/geomesa-z3/pom.xml
@@ -30,8 +30,11 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
-            <scope>test</scope>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/geomesa-zk-utils/pom.xml
+++ b/geomesa-zk-utils/pom.xml
@@ -40,12 +40,12 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.binary.version}</artifactId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,8 @@
         <scalalogging.version>3.1.0</scalalogging.version>
         <log4j.version>1.2.17</log4j.version>
 
+        <specs2.version>4.3.2</specs2.version>
         <junit.version>4.12</junit.version>
-        <specs2.version>2.3.13</specs2.version>
 
         <!-- testing properties -->
         <maven.test.jvmargs>-Duser.timezone=UTC -Xms1g -Xmx8g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dgeomesa.scan.ranges.target=500</maven.test.jvmargs>
@@ -2574,7 +2574,19 @@
             </dependency>
             <dependency>
                 <groupId>org.specs2</groupId>
-                <artifactId>specs2_${scala.binary.version}</artifactId>
+                <artifactId>specs2-core_${scala.binary.version}</artifactId>
+                <version>${specs2.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.specs2</groupId>
+                <artifactId>specs2-junit_${scala.binary.version}</artifactId>
+                <version>${specs2.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.specs2</groupId>
+                <artifactId>specs2-mock_${scala.binary.version}</artifactId>
                 <version>${specs2.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -2593,7 +2605,7 @@
             <dependency>
                 <groupId>org.scalatra</groupId>
                 <artifactId>scalatra-specs2_${scala.binary.version}</artifactId>
-                <version>2.3.0</version> <!-- version that works with specs 2.3 -->
+                <version>${scalatra.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
* `forall`/`foreach`/`hasLength` no longer operate on iterators
* `ff` is a member variable in Specification, so can't be used as a top-level name
* `eventually` must come first, instead of before the matcher
* `link`-ed tests are not executed, instead `mapFragments` is used to link

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>