### PR TITLE
GEOMESA-2331 allow geomesa_pyspark unit tests to be skipped

### DIFF
--- a/geomesa-spark/geomesa_pyspark/pom.xml
+++ b/geomesa-spark/geomesa_pyspark/pom.xml
@@ -102,6 +102,7 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
+                                    <skip>${skipTests}</skip>
                                     <workingDirectory>${project.basedir}/src/test/python</workingDirectory>
                                     <arguments>
                                         <argument>-m</argument>

--- a/geomesa-spark/geomesa_pyspark/src/test/python/test_types.py
+++ b/geomesa-spark/geomesa_pyspark/src/test/python/test_types.py
@@ -7,10 +7,10 @@ class PointUDTTest(TestCase):
 
     udt = Point.__UDT__
 
-    def test_point_udt(self):
+    def test_udt(self):
         self.assertIsInstance(self.udt, PointUDT)
 
-    def test_point_udt_roundtrip(self):
+    def test_udt_roundtrip(self):
         wkt = "POINT (30 10)"
         g = loads(wkt)
         self.assertEqual(self.udt.deserialize(self.udt.serialize(g)), g)
@@ -20,10 +20,10 @@ class LineStringUDTTest(TestCase):
 
     udt = LineString.__UDT__
 
-    def test_linestring_udt(self):
+    def test_udt(self):
         self.assertIsInstance(self.udt, LineStringUDT)
 
-    def test_linestring_udt_roundtrip(self):
+    def test_udt_roundtrip(self):
         wkt = "LINESTRING (30 10, 10 30, 40 40)"
         g = loads(wkt)
         self.assertEqual(self.udt.deserialize(self.udt.serialize(g)), g)
@@ -33,15 +33,15 @@ class PolygonUDTTest(TestCase):
 
     udt = Polygon.__UDT__
 
-    def test_polygon_udt(self):
+    def test_udt(self):
         self.assertIsInstance(self.udt, PolygonUDT)
 
-    def test_polygon_roundtrip(self):
+    def test_roundtrip(self):
         wkt = "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))"
         g = loads(wkt)
         self.assertEqual(self.udt.deserialize(self.udt.serialize(g)), g)
 
-    def test_polygon_roundtrip2(self):
+    def test_roundtrip2(self):
         wkt = "POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))"
         g = loads(wkt)
         self.assertEqual(self.udt.deserialize(self.udt.serialize(g)), g)
@@ -51,15 +51,15 @@ class MultiPointUDTTest(TestCase):
 
     udt = MultiPoint.__UDT__
     
-    def test_multipoint_udt(self):
+    def test_udt(self):
         self.assertIsInstance(self.udt, MultiPointUDT)
 
-    def test_multipoint_udt_roundtrip(self):
+    def test_udt_roundtrip(self):
         wkt = "MULTIPOINT ((10 40), (40 30), (20 20), (30 10))"
         g = loads(wkt)
         self.assertEqual(self.udt.deserialize(self.udt.serialize(g)), g)
 
-    def test_multipoint_udt_roundtrip2(self):
+    def test_udt_roundtrip2(self):
         wkt = "MULTIPOINT (10 40, 40 30, 20 20, 30 10)"
         g = loads(wkt)
         self.assertEqual(self.udt.deserialize(self.udt.serialize(g)), g)
@@ -69,10 +69,10 @@ class MultiLineStringUDTTest(TestCase):
 
     udt = MultiLineString.__UDT__
 
-    def test_multilinestring_udt(self):
+    def test_udt(self):
         self.assertIsInstance(self.udt, MultiLineStringUDT)
 
-    def test_multiLineString_udt_roundtrip(self):
+    def test_udt_roundtrip(self):
         wkt = "MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))"
         g = loads(wkt)
         self.assertEqual(self.udt.deserialize(self.udt.serialize(g)), g)
@@ -82,15 +82,15 @@ class MultiPolygonUDTTest(TestCase):
     
     udt = MultiPolygon.__UDT__
 
-    def test_multipolygon_udt(self):
+    def test_udt(self):
         self.assertIsInstance(self.udt, MultiPolygonUDT)
 
-    def test_multipolygon_udt_roundtrip(self):
+    def test_udt_roundtrip(self):
         wkt = "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))"
         g = loads(wkt)
         self.assertEqual(self.udt.deserialize(self.udt.serialize(g)), g)
 
-    def test_multipolygon_udt_roundtrip2(self):
+    def test_udt_roundtrip2(self):
         wkt = """MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)),
          ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),
           (30 20, 20 15, 20 25, 30 20)))"""
@@ -102,23 +102,23 @@ class MultiGeometryCollectionUDTTest(TestCase):
 
     udt = GeometryCollection.__UDT__
 
-    def test_geometrycollection_udt(self):
+    def test_udt(self):
         self.assertIsInstance(self.udt, GeometryCollectionUDT)
 
-    def test_geometrycollection_udt_roundtrip(self):
+    def test_udt_roundtrip(self):
         wkt = "GEOMETRYCOLLECTION(POINT(4 6),LINESTRING(4 6,7 10))"
         g = loads(wkt)
         self.assertEqual(self.udt.deserialize(self.udt.serialize(g)), g)
 
 
-class MultiGeometryUDTTest(TestCase):
+class GeometryUDTTest(TestCase):
 
     udt = BaseGeometry.__UDT__
     
-    def test_geometry_udt(self):
+    def test_udt(self):
         self.assertIsInstance(self.udt, GeometryUDT)
 
-    def test_geometry_udt_rouundtrip(self):
+    def test_udt_rouundtrip(self):
         wkt = "POINT (0 0)"
         g = loads(wkt)
         self.assertEqual(self.udt.deserialize(self.udt.serialize(g)), g)


### PR DESCRIPTION

... also cleaned up some test method naming

