### PR TITLE
Fix incorrect version in hbase-site.xml

### DIFF
--- a/geomesa-bigtable/geomesa-bigtable-tools/conf/hbase-site.xml
+++ b/geomesa-bigtable/geomesa-bigtable-tools/conf/hbase-site.xml
@@ -1,7 +1,7 @@
 <configuration>
   <property>
     <name>hbase.client.connection.impl</name>
-    <value>com.google.cloud.bigtable.hbase1_2.BigtableConnection</value>
+    <value>com.google.cloud.bigtable.hbase1_3.BigtableConnection</value>
   </property>
   <property>
     <name>google.bigtable.instance.id</name>


### PR DESCRIPTION
This fix is for the sample `hbase-site.xml` in the bigtable binaries. Since `pom.xml` and `hbase-site.xml` are looking for different versions of `bigtable.hbase`. 