### PR TITLE
GEOMESA-2368 Compute bounds while ingesting data into the FSDS

### DIFF
--- a/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/FileSystemFeatureStore.scala
+++ b/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/FileSystemFeatureStore.scala
@@ -93,10 +93,10 @@ class FileSystemFeatureStore(storage: FileSystemStorage,
   override def buildFeatureType(): SimpleFeatureType = sft
   override def getCountInternal(query: Query): Int = {
     if (query == Query.ALL || query.getFilter.isInstanceOf[IncludeFilter]) {
-      storage.getMetadata.getFeatureCount
+      storage.getMetadata.getFeatureCount.toInt
     } else {
-      -1
-    }
+      -1L
+    }.toInt
   }
 
   override def getReaderInternal(original: Query): FeatureReader[SimpleFeatureType, SimpleFeature] = {

--- a/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/FileSystemFeatureStore.scala
+++ b/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/FileSystemFeatureStore.scala
@@ -23,6 +23,7 @@ import org.locationtech.geomesa.fs.storage.api.{FileSystemStorage, FileSystemWri
 import org.locationtech.geomesa.index.planning.QueryPlanner
 import org.locationtech.geomesa.utils.io.{CloseWithLogging, FlushWithLogging}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import org.opengis.filter.IncludeFilter
 
 import scala.concurrent.duration.Duration
 
@@ -88,9 +89,15 @@ class FileSystemFeatureStore(storage: FileSystemStorage,
     }
   }
 
-  override def getBoundsInternal(query: Query): ReferencedEnvelope = ReferencedEnvelope.EVERYTHING
+  override def getBoundsInternal(query: Query): ReferencedEnvelope = storage.getMetadata.getEnvelope
   override def buildFeatureType(): SimpleFeatureType = sft
-  override def getCountInternal(query: Query): Int = -1
+  override def getCountInternal(query: Query): Int = {
+    if (query == Query.ALL || query.getFilter.isInstanceOf[IncludeFilter]) {
+      storage.getMetadata.getFeatureCount
+    } else {
+      -1
+    }
+  }
 
   override def getReaderInternal(original: Query): FeatureReader[SimpleFeatureType, SimpleFeature] = {
     val query = new Query(original)

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/src/main/java/org/locationtech/geomesa/fs/storage/api/FileMetadata.java
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/src/main/java/org/locationtech/geomesa/fs/storage/api/FileMetadata.java
@@ -83,14 +83,14 @@ public interface FileMetadata {
      *
      * @return Feature count
      */
-    int getFeatureCount();
+    long getFeatureCount();
 
     /**
      * Increase the number of features
      *
      * @param count Number of additional features
      */
-    void increaseFeatureCount(int count);
+    void incrementFeatureCount(long count);
 
     /**
      * Get the bounds for the layer

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/src/main/java/org/locationtech/geomesa/fs/storage/api/FileMetadata.java
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/src/main/java/org/locationtech/geomesa/fs/storage/api/FileMetadata.java
@@ -8,8 +8,10 @@
 
 package org.locationtech.geomesa.fs.storage.api;
 
+import com.vividsolutions.jts.geom.Envelope;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.Path;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.feature.simple.SimpleFeatureType;
 
 import java.util.List;
@@ -75,6 +77,37 @@ public interface FileMetadata {
      * @return partitions
      */
     List<String> getPartitions();
+
+    /**
+     * The number of features in this layer
+     *
+     * @return Feature count
+     */
+    int getFeatureCount();
+
+    /**
+     * Increase the number of features
+     *
+     * @param count Number of additional features
+     */
+    void increaseFeatureCount(int count);
+
+    /**
+     * Get the bounds for the layer
+     * @return Layer bounds
+     */
+    ReferencedEnvelope getEnvelope();
+
+    /**
+     * Takes a new set of bounds and uses it to expand the existing bounds by
+     * @param envelope Envelope to expand by.
+     */
+    void expandBounds(Envelope envelope);
+
+    /**
+     * Call to write updated metadata to disk.
+     */
+    void persist();
 
     /**
      * The file names of any data files stored in the partition

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/pom.xml
@@ -53,6 +53,10 @@
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.pureconfig</groupId>
+            <artifactId>pureconfig_2.11</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.specs2</groupId>

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/FileMetadata.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/FileMetadata.scala
@@ -146,7 +146,7 @@ class FileMetadata private (fc: FileContext,
     }
   }
 
-  var internalCount = data.map(_.getInt("count")).getOrElse(0)
+  var internalCount = data.map(_.getLong("count")).getOrElse(0L)
   var bounds: Envelope = data.map { config =>
     if (config.hasPath("bounds")) {
     val doubles = config.getDoubleList("bounds")
@@ -154,28 +154,21 @@ class FileMetadata private (fc: FileContext,
     } else {
       null
     }
-  }.orNull
+  }.getOrElse(new Envelope())
 
-  override def getFeatureCount: Int = internalCount
-  override def increaseFeatureCount(count: Int): Unit = {
+  override def getFeatureCount: Long = internalCount
+  override def incrementFeatureCount(count: Long): Unit = {
     internalCount += count
   }
 
   override def getEnvelope: ReferencedEnvelope =
-    if (bounds == null) {
+    if (bounds.isNull) {
       ReferencedEnvelope.EVERYTHING
     } else {
       new ReferencedEnvelope(bounds, CRS_EPSG_4326)
     }
   override def expandBounds(envelope: Envelope): Unit = {
-    if (bounds == null) {
-      bounds = envelope
-    } else {
-      bounds = {
-        bounds.expandToInclude(envelope)
-        bounds
-      }
-    }
+      bounds.expandToInclude(envelope)
   }
 
   /**

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/FileMetadata.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/FileMetadata.scala
@@ -152,7 +152,7 @@ class FileMetadata private (fc: FileContext,
     val doubles = config.getDoubleList("bounds")
       new ReferencedEnvelope(doubles(0), doubles(1), doubles(2), doubles(3), CRS_EPSG_4326)
     } else {
-      null
+      new Envelope()
     }
   }.getOrElse(new Envelope())
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/FileMetadata.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/FileMetadata.scala
@@ -15,14 +15,19 @@ import java.util.concurrent.ConcurrentHashMap
 import com.github.benmanes.caffeine.cache.{CacheLoader, Caffeine}
 import com.typesafe.config._
 import com.typesafe.scalalogging.LazyLogging
+import com.vividsolutions.jts.geom.Envelope
 import org.apache.hadoop.fs.Options.{CreateOpts, Rename}
 import org.apache.hadoop.fs._
+import org.geotools.geometry.jts.ReferencedEnvelope
 import org.locationtech.geomesa.fs.storage.api.PartitionScheme
 import org.locationtech.geomesa.fs.storage.common.utils.PathCache
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.{CRS_EPSG_4326, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.io.WithClose
 import org.locationtech.geomesa.utils.stats.MethodProfiling
 import org.opengis.feature.simple.SimpleFeatureType
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 /**
   * FileMetadata implementation. Persists to disk after any change - prefer bulk operations when possible.
@@ -38,7 +43,8 @@ class FileMetadata private (fc: FileContext,
                             root: Path,
                             sft: SimpleFeatureType,
                             scheme: PartitionScheme,
-                            encoding: String)
+                            encoding: String,
+                            data: Option[Config])
     extends org.locationtech.geomesa.fs.storage.api.FileMetadata {
 
   import scala.collection.JavaConverters._
@@ -139,6 +145,40 @@ class FileMetadata private (fc: FileContext,
       FileMetadata.save(this)
     }
   }
+
+  var internalCount = data.map(_.getInt("count")).getOrElse(0)
+  var bounds: Envelope = data.map(_.getDoubleList("bounds")).map { doubles =>
+    new ReferencedEnvelope(doubles(0), doubles(1), doubles(2), doubles(3), CRS_EPSG_4326)
+  }.orNull
+
+  override def getFeatureCount: Int = internalCount
+  override def increaseFeatureCount(count: Int): Unit = {
+    internalCount += count
+  }
+
+  override def getEnvelope: ReferencedEnvelope =
+    if (bounds == null) {
+      ReferencedEnvelope.EVERYTHING
+    } else {
+      new ReferencedEnvelope(bounds, CRS_EPSG_4326)
+    }
+  override def expandBounds(envelope: Envelope): Unit = {
+    if (bounds == null) {
+      bounds = envelope
+    } else {
+      bounds = {
+        bounds.expandToInclude(envelope)
+        bounds
+      }
+    }
+  }
+
+  /**
+    * Call to write updated metadata to disk.
+    */
+  override def persist(): Unit = {
+    FileMetadata.save(this)
+  }
 }
 
 object FileMetadata extends MethodProfiling with LazyLogging {
@@ -180,7 +220,7 @@ object FileMetadata extends MethodProfiling with LazyLogging {
     if (PathCache.exists(fc, file)) {
       throw new IllegalArgumentException(s"Metadata file already exists at path '$file'")
     }
-    val metadata = new FileMetadata(fc, root, sft, scheme, encoding)
+    val metadata = new FileMetadata(fc, root, sft, scheme, encoding, None)
     cache.put((fc, file), metadata)
     save(metadata)
     metadata
@@ -228,12 +268,14 @@ object FileMetadata extends MethodProfiling with LazyLogging {
       // Load encoding
       val encoding = config.getString("encoding")
 
+      val data: Config = config.getConfig("data")
+
       // Load partition scheme - note we currently have to reload the SFT user data manually
       // which is why we have to add the partition scheme back to the SFT
       val scheme = PartitionScheme(sft, config.getConfig("partitionScheme"))
       PartitionScheme.addToSft(sft, scheme)
 
-      val metadata = new FileMetadata(fc, file.getParent, sft, scheme, encoding)
+      val metadata = new FileMetadata(fc, file.getParent, sft, scheme, encoding, Some(data))
 
       // Load Partitions
       profile {
@@ -261,6 +303,12 @@ object FileMetadata extends MethodProfiling with LazyLogging {
     val file = filePath(metadata.getRoot)
 
     val config = profile {
+      val dataConfig = ConfigFactory.empty()
+        .withValue("count", ConfigValueFactory.fromAnyRef(metadata.getFeatureCount))
+        .withValue("bounds", ConfigValueFactory.fromIterable(
+          Seq[Double](metadata.getEnvelope.getMinX, metadata.getEnvelope.getMaxX,
+            metadata.getEnvelope.getMinY, metadata.getEnvelope.getMaxY).asJava)).root()
+
       val sft = metadata.getSchema
       val sftConfig = SimpleFeatureTypes.toConfig(sft, includePrefix = false, includeUserData = true).root()
       ConfigFactory.empty()
@@ -268,6 +316,7 @@ object FileMetadata extends MethodProfiling with LazyLogging {
         .withValue("encoding", ConfigValueFactory.fromAnyRef(metadata.getEncoding))
         .withValue("partitionScheme", PartitionScheme.toConfig(metadata.getPartitionScheme).root())
         .withValue("partitions", ConfigValueFactory.fromMap(metadata.getPartitionFiles))
+        .withValue("data", dataConfig)
         .root
         .render(options)
     } ((_, time) => logger.debug(s"Created config for persistence in ${time}ms"))

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/MetadataObservingFileSystemWriter.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/MetadataObservingFileSystemWriter.scala
@@ -15,7 +15,7 @@ import org.opengis.feature.simple.SimpleFeature
 trait MetadataObservingFileSystemWriter extends FileSystemWriter {
   def metadata: org.locationtech.geomesa.fs.storage.api.FileMetadata
 
-  private var count = 0
+  private var count: Long= 0l
   private var bounds: Envelope = _
 
   override def write(feature: SimpleFeature): Unit = {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/MetadataObservingFileSystemWriter.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/MetadataObservingFileSystemWriter.scala
@@ -45,7 +45,7 @@ trait MetadataObservingFileSystemWriter extends FileSystemWriter {
 
   override def close(): Unit = {
     // Finalize metadata
-    metadata.increaseFeatureCount(count)
+    metadata.incrementFeatureCount(count)
     metadata.expandBounds(bounds)
     metadata.persist()
     closeInternal()

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/MetadataObservingFileSystemWriter.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/MetadataObservingFileSystemWriter.scala
@@ -1,0 +1,53 @@
+/***********************************************************************
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.storage.common
+
+import com.vividsolutions.jts.geom.{Envelope, Geometry}
+import org.locationtech.geomesa.fs.storage.api.FileSystemWriter
+import org.opengis.feature.simple.SimpleFeature
+
+trait MetadataObservingFileSystemWriter extends FileSystemWriter {
+  def metadata: org.locationtech.geomesa.fs.storage.api.FileMetadata
+
+  private var count = 0
+  private var bounds: Envelope = _
+
+  override def write(feature: SimpleFeature): Unit = {
+    // Update internal count/bounds/etc
+    count += 1
+    if (bounds == null) {
+      bounds = feature.getDefaultGeometry.asInstanceOf[Geometry].getEnvelopeInternal
+    } else {
+      bounds = {
+        bounds.expandToInclude(feature.getDefaultGeometry.asInstanceOf[Geometry].getEnvelopeInternal)
+        bounds
+      }
+    }
+    writeInternal(feature)
+  }
+
+  /**
+    * Implementing classes use this method to write SimpleFeatures to disk
+    * @param feature SimpleFeature to write
+    */
+  def writeInternal(feature: SimpleFeature): Unit
+
+  /**
+    * Implementing classes use this method to handle cleaning up writers, etc.
+    */
+  def closeInternal(): Unit
+
+  override def close(): Unit = {
+    // Finalize metadata
+    metadata.increaseFeatureCount(count)
+    metadata.expandBounds(bounds)
+    metadata.persist()
+    closeInternal()
+  }
+}

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
@@ -11,8 +11,10 @@ package org.locationtech.geomesa.fs.storage.converter
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicBoolean
 
+import com.vividsolutions.jts.geom.Envelope
 import org.apache.hadoop.fs.{FileContext, Path}
 import org.geotools.data.Query
+import org.geotools.geometry.jts.ReferencedEnvelope
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.fs.storage.api._
 import org.locationtech.geomesa.fs.storage.common.utils.PathCache
@@ -131,6 +133,21 @@ object ConverterStorage {
 
     override def setFiles(partitionsToFiles: java.util.Map[String, java.util.List[String]]): Unit =
       throw new UnsupportedOperationException("Converter storage does not support updating metadata")
+
+    override def getFeatureCount: Int =
+      throw new UnsupportedOperationException("Converter storage does not support counts")
+
+    override def increaseFeatureCount(count: Int): Unit =
+      throw new UnsupportedOperationException("Converter storage does not support counts")
+
+    override def getEnvelope: ReferencedEnvelope =
+      throw new UnsupportedOperationException("Converter storage does not support bounds")
+
+    override def expandBounds(envelope: Envelope): Unit =
+      throw new UnsupportedOperationException("Converter storage does not support bounds")
+
+    override def persist(): Unit =
+      throw new UnsupportedOperationException("Converter storage does not support persisting metatdata")
   }
 
   private def buildPartitionList(fc: FileContext,

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
@@ -134,7 +134,7 @@ object ConverterStorage {
     override def setFiles(partitionsToFiles: java.util.Map[String, java.util.List[String]]): Unit =
       throw new UnsupportedOperationException("Converter storage does not support updating metadata")
 
-    override def getFeatureCount: Int =
+    override def getFeatureCount: Long =
       throw new UnsupportedOperationException("Converter storage does not support counts")
 
     override def incrementFeatureCount(count: Long): Unit =

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
@@ -137,7 +137,7 @@ object ConverterStorage {
     override def getFeatureCount: Int =
       throw new UnsupportedOperationException("Converter storage does not support counts")
 
-    override def increaseFeatureCount(count: Int): Unit =
+    override def incrementFeatureCount(count: Long): Unit =
       throw new UnsupportedOperationException("Converter storage does not support counts")
 
     override def getEnvelope: ReferencedEnvelope =

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/OrcFileSystemStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/OrcFileSystemStorage.scala
@@ -33,7 +33,7 @@ class OrcFileSystemStorage(conf: Configuration, metadata: FileMetadata)
   override protected def extension: String = OrcFileSystemStorage.FileExtension
 
   override protected def createWriter(sft: SimpleFeatureType, file: Path): FileSystemWriter =
-    new OrcFileSystemWriter(sft, conf, file)
+    new OrcFileSystemWriter(sft, conf, file, metadata)
 
   override protected def createReader(sft: SimpleFeatureType,
                                       filter: Option[Filter],

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/ParquetFileSystemStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/ParquetFileSystemStorage.scala
@@ -16,7 +16,7 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.locationtech.geomesa.filter.FilterHelper
 import org.locationtech.geomesa.fs.storage.api._
 import org.locationtech.geomesa.fs.storage.common.jobs.StorageConfiguration
-import org.locationtech.geomesa.fs.storage.common.{FileSystemPathReader, MetadataFileSystemStorage}
+import org.locationtech.geomesa.fs.storage.common.{FileSystemPathReader, MetadataFileSystemStorage, MetadataObservingFileSystemWriter}
 import org.locationtech.geomesa.parquet.ParquetFileSystemStorage._
 import org.locationtech.geomesa.utils.io.CloseQuietly
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -25,23 +25,25 @@ import org.opengis.filter.Filter
 /**
   *
   * @param conf conf
-  * @param metadata metadata
+  * @param fileMetadata metadata
   */
-class ParquetFileSystemStorage(conf: Configuration, metadata: FileMetadata)
-    extends MetadataFileSystemStorage(conf, metadata) {
+class ParquetFileSystemStorage(conf: Configuration, fileMetadata: FileMetadata)
+    extends MetadataFileSystemStorage(conf, fileMetadata) {
 
   override protected val extension: String = FileExtension
 
   override protected def createWriter(sft: SimpleFeatureType, file: Path): FileSystemWriter = {
-    new FileSystemWriter {
+    new FileSystemWriter with MetadataObservingFileSystemWriter {
+      def metadata: FileMetadata = fileMetadata
+
       private val sftConf = new Configuration(conf)
       StorageConfiguration.setSft(sftConf, sft)
 
       private val writer = SimpleFeatureParquetWriter.builder(file, sftConf).build()
 
-      override def write(f: SimpleFeature): Unit = writer.write(f)
+      override def writeInternal(f: SimpleFeature): Unit = writer.write(f)
       override def flush(): Unit = {}
-      override def close(): Unit = CloseQuietly(writer)
+      override def closeInternal(): Unit = CloseQuietly(writer)
     }
   }
 


### PR DESCRIPTION
* Computes bounds and feature count during ingest.
* NB: There is no concurrency checking.  Multiple writers may clobber the metadata.

Signed-off-by: Jim Hughes <jnh5y@ccri.com>