### PR TITLE
GEOMESA-2376 - Change converter field dependency calc to be non-recursive

### DIFF
--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/AbstractConverter.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/AbstractConverter.scala
@@ -266,9 +266,13 @@ object AbstractConverter {
     */
   private def addDependencies(field: Field, fieldMap: Map[String, Field], dag: Dag): Unit = {
     if (!dag.contains(field)) {
-      val deps = field.transforms.toSeq.flatMap(_.dependencies(Set(field), fieldMap)).toSet
-      dag.put(field, deps)
-      deps.foreach(addDependencies(_, fieldMap, dag))
+      val queue = scala.collection.mutable.Queue(field)
+      while (queue.nonEmpty) {
+        val next = queue.dequeue()
+        val deps = next.transforms.toSeq.flatMap(_.dependencies(Set(next), fieldMap))
+        dag.put(next, deps.toSet)
+        queue.enqueue(deps.filterNot(dag.contains): _*)
+      }
     }
   }
 


### PR DESCRIPTION
* Recursive function is slow when there are 100s of dependent fields

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>