### PR TITLE
GEOMESA-2378 HBase - shuffle range groups to improve scan parallelism

### DIFF
--- a/docs/user/hbase/configuration.rst
+++ b/docs/user/hbase/configuration.rst
@@ -34,3 +34,15 @@ ingests where performance is of more concern than reliability. Available setting
 
 For addtional information see `HBase documentation
 <https://hbase.apache.org/apidocs/org/apache/hadoop/hbase/client/Durability.html>`__.
+
+geomesa.hbase.client.scanner.caching.size
++++++++++++++++++++++++++++++++++++++++++
+
+Set the number of rows that scanners will read ahead. If not set, the default caching will apply as configured in
+``hbase-site.xml``. Higher caching values will enable faster scanners but will use more memory.
+
+geomesa.hbase.query.block.caching.enabled
++++++++++++++++++++++++++++++++++++++++++
+
+Set whether blocks should be cached for scans, true by default. When true, default settings of the table and
+family are used (this will never override caching blocks if the block cache is disabled for that family or entirely).

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBasePlatform.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBasePlatform.scala
@@ -8,16 +8,16 @@
 
 package org.locationtech.geomesa.hbase.index
 
-import com.google.common.collect.Lists
+import java.util.Collections
+
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.hadoop.hbase.TableName
 import org.apache.hadoop.hbase.client.{Result, Scan}
 import org.apache.hadoop.hbase.filter.MultiRowRangeFilter.RowRange
 import org.apache.hadoop.hbase.filter.{FilterList, MultiRowRangeFilter, Filter => HFilter}
-import org.apache.hadoop.hbase.{HConstants, TableName}
-import org.locationtech.geomesa.hbase.HBaseFilterStrategyType
 import org.locationtech.geomesa.hbase.coprocessor.utils.CoprocessorConfig
 import org.locationtech.geomesa.hbase.data.{CoprocessorPlan, HBaseDataStore, HBaseQueryPlan, ScanPlan}
-import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
+import org.locationtech.geomesa.hbase.{HBaseFilterStrategyType, HBaseSystemProperties}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 trait HBasePlatform extends HBaseIndexAdapter with LazyLogging {
@@ -65,49 +65,63 @@ trait HBasePlatform extends HBaseIndexAdapter with LazyLogging {
                                            originalRanges: Seq[Scan],
                                            colFamily: Array[Byte],
                                            hbaseFilters: Seq[HFilter]): Seq[Scan] = {
-    import scala.collection.JavaConversions._
+    import scala.collection.JavaConverters._
+
+    val cacheSize = HBaseSystemProperties.ScannerCaching.toInt
+    val cacheBlocks = HBaseSystemProperties.ScannerBlockCaching.toBoolean.get // has a default value so .get is safe
+
+    logger.debug(s"HBase client scanner: block caching: $cacheBlocks, caching: $cacheSize")
 
     val rowRanges = new java.util.ArrayList[RowRange](originalRanges.length)
     originalRanges.foreach(r => rowRanges.add(new RowRange(r.getStartRow, true, r.getStopRow, false)))
 
     val sortedRowRanges = MultiRowRangeFilter.sortAndMerge(rowRanges)
-    val numRanges = sortedRowRanges.length
+    val numRanges = sortedRowRanges.size()
     val numThreads = ds.config.queryThreads
     // TODO GEOMESA-1806 parameterize this?
     val rangesPerThread = math.min(ds.config.maxRangesPerExtendedScan, math.max(1, math.ceil(numRanges / numThreads * 2).toInt))
-    // TODO GEOMESA-1806 align partitions with region boundaries
-    val groupedRanges = Lists.partition(sortedRowRanges, rangesPerThread)
 
     // group scans into batches to achieve some client side parallelism
-    val groupedScans = groupedRanges.map { localRanges =>
-      // TODO GEOMESA-1806
-      // currently, this constructor will call sortAndMerge a second time
-      // this is unnecessary as we have already sorted and merged above
-      val mrrf = new MultiRowRangeFilter(localRanges)
-      // note: mrrf first priority
-      val filterList = new FilterList(hbaseFilters.+:(mrrf): _*)
+    val groupedScans = new java.util.ArrayList[Scan](sortedRowRanges.size() / rangesPerThread + 1)
 
-      val cacheSize = SystemProperty("geomesa.hbase.client.scanner.caching.size")
-        .toInt.getOrElse(HConstants.DEFAULT_HBASE_CLIENT_SCANNER_CACHING)
-      logger.debug(s"HBase client scanner caching size: $cacheSize")
+    // TODO GEOMESA-1806 align partitions with region boundaries
 
-      val cacheBlocks = SystemProperty("geomesa.hbase.query.block.caching.enabled")
-        .toBoolean.getOrElse(true)
-      logger.debug(s"Query block caching enabled: $cacheBlocks")
+    var i = 0
+    var start: Int = 0
 
-      val s = new Scan()
-      s.setStartRow(localRanges.head.getStartRow)
-      s.setStopRow(localRanges.get(localRanges.length - 1).getStopRow)
-      s.setFilter(filterList)
-      s.addColumn(colFamily, HBaseColumnGroups.default)
-      s.setCaching(cacheSize)
-      s.setCacheBlocks(cacheBlocks)
-      s
+    while (i < sortedRowRanges.size()) {
+      val mod = i % rangesPerThread
+      if (mod == 0) {
+        start = i
+      }
+      if (mod == rangesPerThread - 1 || i == sortedRowRanges.size() - 1) {
+        // TODO GEOMESA-1806
+        // currently, this constructor will call sortAndMerge a second time
+        // this is unnecessary as we have already sorted and merged above
+        val mrrf = new MultiRowRangeFilter(sortedRowRanges.subList(start, i + 1))
+        // note: mrrf first priority
+        val filterList = new FilterList(hbaseFilters.+:(mrrf): _*)
+
+        val s = new Scan()
+        s.setStartRow(sortedRowRanges.get(start).getStartRow)
+        s.setStopRow(sortedRowRanges.get(i).getStopRow)
+        s.setFilter(filterList)
+        s.addColumn(colFamily, HBaseColumnGroups.default)
+        s.setCacheBlocks(cacheBlocks)
+        cacheSize.foreach(s.setCaching)
+
+        // apply visibilities
+        ds.applySecurity(s)
+
+        groupedScans.add(s)
+      }
+      i += 1
     }
 
-    // Apply Visibilities
-    groupedScans.foreach(ds.applySecurity)
-    groupedScans
+    // shuffle the ranges, otherwise our threads will tend to all hit the same region server at once
+    Collections.shuffle(groupedScans)
+
+    groupedScans.asScala
   }
 
   private def configureCoprocessorScan(ds: HBaseDataStore,

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/package.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/package.scala
@@ -31,5 +31,7 @@ package object hbase {
     val CoprocessorPath = SystemProperty("geomesa.hbase.coprocessor.path")
     val WriteBatchSize = SystemProperty("geomesa.hbase.write.batch")
     val WalDurability = SystemProperty("geomesa.hbase.wal.durability")
+    val ScannerCaching = SystemProperty("geomesa.hbase.client.scanner.caching.size")
+    val ScannerBlockCaching = SystemProperty("geomesa.hbase.query.block.caching.enabled", "true")
   }
 }

--- a/geomesa-utils/src/main/resources/org/locationtech/geomesa/geomesa-site.xml.template
+++ b/geomesa-utils/src/main/resources/org/locationtech/geomesa/geomesa-site.xml.template
@@ -329,7 +329,7 @@
 
     <property>
         <name>geomesa.hbase.client.scanner.caching.size</name>
-        <value>2147483647</value>
+        <value></value>
         <description>Set the number of rows for caching that will be passed to scanners. If not set, the Configuration setting HConstants.HBASE_CLIENT_SCANNER_CACHING will
             apply. Higher caching values will enable faster scanners but will use more memory.
         </description>


### PR DESCRIPTION
* Ranges are sorted, so by default all our threads operate on ranges
  close to each other, likely on the same region server

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>