### PR TITLE
GEOMESA-2380 GeoMesa Datastore should use Lenient SymVer

### DIFF
--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStore.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStore.scala
@@ -313,7 +313,7 @@ abstract class GeoMesaDataStore[DS <: GeoMesaDataStore[DS, F, W], F <: WrappedFe
     *
     * @return client version
     */
-  def getClientVersion: SemanticVersion = SemanticVersion(GeoMesaProperties.ProjectVersion)
+  def getClientVersion: SemanticVersion = SemanticVersion(GeoMesaProperties.ProjectVersion, lenient = true)
 
   /**
     * Gets the geomesa version


### PR DESCRIPTION
GeoMesa Datastore should use Lenient SymVer so users that are not familiar with symver encounter unexpected version errors less often.

Signed-off-by: Austin Heyne <aheyne@ccri.com>