### PR TITLE
GEOMESA-2381 Test and fix OR

### DIFF
--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/expression/OrHashEquality.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/expression/OrHashEquality.scala
@@ -29,7 +29,7 @@ class OrHashEquality(property: PropertyName, values: HashSet[AnyRef]) extends Or
 
   import scala.collection.JavaConverters._
 
-  lazy private val children: Set[Filter] = values.map(value => factory.equals(property, factory.literal(value)))
+  private val children: Set[Filter] = values.map(value => factory.equals(property, factory.literal(value)))
 
   override def getChildren: java.util.List[Filter] = children.toList.asJava
 

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/expression/OrSequentialEquality.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/expression/OrSequentialEquality.scala
@@ -25,7 +25,7 @@ class OrSequentialEquality(property: PropertyName, values: Seq[AnyRef]) extends 
 
   import scala.collection.JavaConverters._
 
-  lazy private val children: Seq[Filter] = values.map(value => factory.equals(property, factory.literal(value)))
+  private val children: Seq[Filter] = values.map(value => factory.equals(property, factory.literal(value)))
 
   override def getChildren: java.util.List[Filter] = children.toList.asJava
 

--- a/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreTest.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreTest.scala
@@ -194,6 +194,8 @@ class KafkaDataStoreTest extends Specification with Mockito with LazyLogging {
           // query
           val queries = Seq(
             "strToUpperCase(name) = 'JONES'",
+            "name = 'jones' OR name = 'smith'",
+            "name = 'foo' OR name = 'bar' OR name = 'baz' OR name = 'blarg' OR name = 'jones' OR name = 'smith'",
             "name = 'jones'",
             "age < 25",
             "bbox(geom, -15, -15, -5, -5) AND age < 25",


### PR DESCRIPTION
1. Add an OR query to a Kafka unit test.
2. Children of OrHashEquality and OrSequentialEquality filters should not be
   lazy. The FastFilterFactory.sfts must be available when children are
   evaluated.