### PR TITLE
GEOMESA-2394 Disabling auto distributed runtime check, as it can be slow

### DIFF
--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -172,15 +172,8 @@ a comma-separated list of arbitrary URLs. For more information on defining types
 geomesa.distributed.version.check
 +++++++++++++++++++++++++++++++++
 
-This property can be used to suppress checking for version mismatches in the distributed classpath. By default,
+This property can be used to check for version mismatches in the distributed classpath. When enabled,
 GeoMesa will throw an exception if it detects a major version discrepancy between the local classpath and
 the distributed classpath (e.g. HBase region servers or Accumulo tablet servers), as this will generally cause
-queries to fail. The version check may be suppressed by setting ths property to ``false``, although this is not
-recommended.
-
-geomesa.distributed.version.skip
-+++++++++++++++++++++++++++++++++
-
-This property can be used to suppress checking for version mismatches in the distributed classpath. In contrast
-to ``geomesa.distributed.version.check``, this property will totally bypass trying to load the distributed
-classpath version when set to ``true``.
+queries to fail. If not enabled, then classpath errors will not be detected proactively, and will likely result
+in runtime exceptions.

--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -107,9 +107,9 @@ stricter configuration parsing.
 Distributed Runtime Version Checks
 ----------------------------------
 
-To prevent unexpected bugs due to JAR version mismatches, GeoMesa will now throw an exception if it detects
-incompatible versions on the distributed classpath. This behavior may be disbled by setting the system properties
-``geomesa.distributed.version.check=false`` and/or ``geomesa.distributed.version.skip=true``.
+To prevent unexpected bugs due to JAR version mismatches, GeoMesa can scan the distributed classpath to
+verify compatible versions on the distributed classpath. This behavior may be enabled by setting the system
+property ``geomesa.distributed.version.check=true``.
 
 Shapefile Ingestion
 -------------------

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseTestRunnerTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseTestRunnerTest.scala
@@ -32,13 +32,13 @@ class HBaseTestRunnerTest extends Specification with BeforeAfterAll with LazyLog
 
   // add new tests here
   val specs = Seq(
-    new HBaseArrowTest,
-    new HBaseBinAggregatorTest,
-    new HBaseColumnGroupsTest,
-    new HBaseDataStoreTest,
+//    new HBaseArrowTest,
+//    new HBaseBinAggregatorTest,
+//    new HBaseColumnGroupsTest,
+    new HBaseDataStoreTest/*,
     new HBaseDensityFilterTest,
     new HBaseStatsAggregatorTest,
-    new HBaseVisibilityTest
+    new HBaseVisibilityTest*/
   )
 
   override def beforeAll(): Unit = {

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseTestRunnerTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseTestRunnerTest.scala
@@ -32,13 +32,13 @@ class HBaseTestRunnerTest extends Specification with BeforeAfterAll with LazyLog
 
   // add new tests here
   val specs = Seq(
-//    new HBaseArrowTest,
-//    new HBaseBinAggregatorTest,
-//    new HBaseColumnGroupsTest,
-    new HBaseDataStoreTest/*,
+    new HBaseArrowTest,
+    new HBaseBinAggregatorTest,
+    new HBaseColumnGroupsTest,
+    new HBaseDataStoreTest,
     new HBaseDensityFilterTest,
     new HBaseStatsAggregatorTest,
-    new HBaseVisibilityTest*/
+    new HBaseVisibilityTest
   )
 
   override def beforeAll(): Unit = {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/SchemaProperties.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/SchemaProperties.scala
@@ -12,6 +12,5 @@ import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemPropert
 
 object SchemaProperties {
   val ValidateDistributedClasspath = SystemProperty("geomesa.validate.distributed.classpath", "true")
-  val SkipDistributedVersion = SystemProperty("geomesa.distributed.version.skip", "false")
-  val CheckDistributedVersion = SystemProperty("geomesa.distributed.version.check", "true")
+  val CheckDistributedVersion = SystemProperty("geomesa.distributed.version.check", "false")
 }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/conf/GeoMesaSystemProperties.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/conf/GeoMesaSystemProperties.scala
@@ -22,6 +22,8 @@ object GeoMesaSystemProperties extends LazyLogging {
 
     def set(value: String): Unit = System.setProperty(property, value)
 
+    def clear(): Unit = System.clearProperty(property)
+
     def get: String = ConfigLoader.Config.get(property) match {
       case Some((value, true))  => value // final value - can't be overridden
       case Some((value, false)) => fromSysProps.getOrElse(value)


### PR DESCRIPTION
* Especially in large HBase clusters

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>