### PR TITLE
GEOMESA-2404 Fixes bugs with FSDS Orc Mapreduce Formats

### DIFF
--- a/geomesa-convert/geomesa-convert-all/src/test/scala/org/locationtech/geomesa/convert/URLConfigProviderTest.scala
+++ b/geomesa-convert/geomesa-convert-all/src/test/scala/org/locationtech/geomesa/convert/URLConfigProviderTest.scala
@@ -9,6 +9,8 @@
 package org.locationtech.geomesa.convert
 
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+import com.typesafe.config.ConfigFactory
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.utils.geotools.{SimpleFeatureTypeLoader, URLSftProvider}
 import org.mortbay.jetty.handler.AbstractHandler
@@ -110,6 +112,8 @@ class URLConfigProviderTest extends Specification {
         // Should be able to handle bad urls as well as good urls
         System.setProperty(URLConfigProvider.ConverterConfigURLs, s"http://localhost:$port/,http://fakeurl:80/foobar")
         System.setProperty(URLSftProvider.SftConfigURLs, s"http://localhost:$port/,http://fakeurl:80/foobar")
+        // This ensures that the URLConfigProvider's config will re-read
+        ConfigFactory.invalidateCaches()
 
         ConverterConfigLoader.listConverterNames must containAllOf(Seq("example-csv-url", "example-csv-url2"))
         SimpleFeatureTypeLoader.listTypeNames must containAllOf(Seq("example-csv-url", "example-csv-url2"))

--- a/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
@@ -49,6 +49,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>14.0.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
@@ -79,10 +80,12 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-common</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minicluster</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
@@ -46,6 +46,11 @@
 
         <!-- test dependencies -->
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>14.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.specs2</groupId>
             <artifactId>specs2-core_${scala.binary.version}</artifactId>
         </dependency>
@@ -60,6 +65,26 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minicluster</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -117,6 +142,14 @@
                                 <relocation>
                                     <pattern>org.apache.parquet</pattern>
                                     <shadedPattern>org.locationtech.geomesa.fs.shaded.org.apache.parquet</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.hadoop.hive</pattern>
+                                    <shadedPattern>org.locationtech.geomesa.fs.shaded.org.apache.hadoop.hive</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.hive</pattern>
+                                    <shadedPattern>org.locationtech.geomesa.fs.shaded.org.apache.hive</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>

--- a/geomesa-fs/geomesa-fs-spark-runtime/src/test/scala/org/locationtech/geomesa/fs/spark/FSSparkProviderTest.scala
+++ b/geomesa-fs/geomesa-fs-spark-runtime/src/test/scala/org/locationtech/geomesa/fs/spark/FSSparkProviderTest.scala
@@ -1,0 +1,179 @@
+/***********************************************************************
+ * Copyright (c) 2013-2018 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.spark
+
+import java.nio.file.{Files, Path}
+import java.time.temporal.ChronoUnit
+import java.util.Collections
+
+import com.typesafe.scalalogging.LazyLogging
+import com.vividsolutions.jts.geom._
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.hdfs.{HdfsConfiguration, MiniDFSCluster}
+import org.apache.spark.sql.{DataFrame, SQLContext, SQLTypes, SparkSession}
+import org.geotools.data.{DataStore, Transaction}
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.fs.FileSystemDataStoreFactory
+import org.locationtech.geomesa.fs.storage.common.PartitionScheme
+import org.locationtech.geomesa.fs.storage.common.partitions.DateTimeScheme
+import org.locationtech.geomesa.spark.SparkSQLTestUtils
+import org.locationtech.geomesa.utils.geotools.{FeatureUtils, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.io.WithClose
+import org.locationtech.geomesa.utils.text.WKTUtils
+import org.opengis.feature.simple.SimpleFeatureType
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.BeforeAfterAll
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class FSSparkProviderTest extends Specification with BeforeAfterAll with LazyLogging {
+
+  sequential
+
+  lazy val sftName: String = "chicago"
+  val tempDir: Path = Files.createTempDirectory("fsSparkTest")
+  var cluster: MiniDFSCluster = _
+  var directory: String = _
+
+  def spec: String = SparkSQLTestUtils.ChiSpec
+
+  def dtgField: Option[String] = Some("dtg")
+
+  lazy val params = Map(
+    "fs.path" -> directory,
+    "fs.encoding" -> "orc")
+  lazy val dsf: FileSystemDataStoreFactory = new FileSystemDataStoreFactory()
+  lazy val ds: DataStore = dsf.createDataStore(params)
+
+  var spark: SparkSession = null
+  var sc: SQLContext = null
+  var df: DataFrame = null
+
+  override def beforeAll(): Unit = {
+    // Start MiniCluster
+    val conf = new HdfsConfiguration()
+    conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, tempDir.toFile.getAbsolutePath)
+    cluster = new MiniDFSCluster.Builder(conf).build()
+    directory = cluster.getURI + s"/data/$sftName"
+    val ds = dsf.createDataStore(params)
+
+    val sft = SparkSQLTestUtils.ChicagoSpec
+    PartitionScheme.addToSft(sft, PartitionScheme(sft, "z2", Collections.singletonMap("z2-resolution", "8")))
+    ds.createSchema(sft)
+
+    SparkSQLTestUtils.ingestChicago(ds)
+  }
+
+  "FileSystem datastore Spark Data Tests" should {
+    // before
+    "start spark" >> {
+      spark = SparkSQLTestUtils.createSparkSession()
+      sc = spark.sqlContext
+      SQLTypes.init(sc)
+
+      df = spark.read
+        .format("geomesa")
+        .options(params.map { case (k, v) => k -> v.toString })
+        .option("geomesa.feature", "chicago")
+        .load()
+
+      logger.debug(df.schema.treeString)
+      df.createOrReplaceTempView("chicago")
+      true
+    }
+
+    "select * from chicago" >> {
+      sc.sql("select * from chicago").collect().length must beEqualTo(3)
+    }
+
+    "select count(*) from chicago" >> {
+      val rows = sc.sql("select count(*) from chicago").collect()
+      rows.length mustEqual(1)
+      rows.apply(0).get(0).asInstanceOf[Long] mustEqual(3l)
+    }
+
+    "select by secondary indexed attribute" >> {
+      val cases = df.select("case_number").where("case_number = 1").collect().map(_.getInt(0))
+      cases.length mustEqual 1
+    }
+
+    "complex st_buffer" >> {
+      val buf = sc.sql("select st_asText(st_bufferPoint(geom,10)) from chicago where case_number = 1").collect().head.getString(0)
+      sc.sql(
+        s"""
+           |select *
+           |from chicago
+           |where
+           |  st_contains(st_geomFromWKT('$buf'), geom)
+                        """.stripMargin
+      ).collect().length must beEqualTo(1)
+    }
+
+    "write data and properly index" >> {
+      val subset = sc.sql("select case_number,geom,dtg from chicago")
+      subset.write.format("geomesa")
+        .options(params.map { case (k, v) => k -> v.toString })
+        .option("geomesa.feature", "chicago2")
+        .save()
+
+      val sft = ds.getSchema("chicago2")
+      val enabledIndexes = sft.getUserData.get("geomesa.indices").asInstanceOf[String]
+      enabledIndexes.indexOf("z3") must be greaterThan -1
+    }.pendingUntilFixed("FSDS can't guess the parameters")
+
+    "Handle all the geometry types" >> {
+      val typeName = "orc"
+      val pt: Point              = WKTUtils.read("POINT(0 0)").asInstanceOf[Point]
+      val line: LineString       = WKTUtils.read("LINESTRING(0 0, 1 1, 4 4)").asInstanceOf[LineString]
+      val polygon: Polygon       = WKTUtils.read("POLYGON((10 10, 10 20, 20 20, 20 10, 10 10), (11 11, 19 11, 19 19, 11 19, 11 11))").asInstanceOf[Polygon]
+      val mpt: MultiPoint        = WKTUtils.read("MULTIPOINT((0 0), (1 1))").asInstanceOf[MultiPoint]
+      val mline: MultiLineString = WKTUtils.read("MULTILINESTRING ((0 0, 1 1), \n  (2 2, 3 3))").asInstanceOf[MultiLineString]
+      val mpolygon: MultiPolygon = WKTUtils.read("MULTIPOLYGON(((0 0, 1 0, 1 1, 0 0)), ((10 10, 10 20, 20 20, 20 10, 10 10), (11 11, 19 11, 19 19, 11 19, 11 11)))").asInstanceOf[MultiPolygon]
+
+      val sft: SimpleFeatureType = SimpleFeatureTypes.createType(typeName, "name:String,age:Int,dtg:Date," +
+        "*geom:MultiLineString:srid=4326,pt:Point,line:LineString,poly:Polygon,mpt:MultiPoint,mline:MultiLineString,mpoly:MultiPolygon")
+      PartitionScheme.addToSft(sft, new DateTimeScheme(DateTimeScheme.Formats.Daily.format, ChronoUnit.DAYS, 1, "dtg", false))
+
+      val features: Seq[ScalaSimpleFeature] = Seq.tabulate(10) { i =>
+        ScalaSimpleFeature.create(sft, s"$i", s"test$i", 100 + i, s"2017-06-0${5 + (i % 3)}T04:03:02.0001Z", s"MULTILINESTRING((0 0, 10 10.$i))",
+          pt, line, polygon, mpt, mline, mpolygon)
+      }
+
+      val ds = dsf.createDataStore(params)
+      ds.createSchema(sft)
+      WithClose(ds.getFeatureWriterAppend(typeName, Transaction.AUTO_COMMIT)) { writer =>
+        features.foreach { feature =>
+          FeatureUtils.copyToWriter(writer, feature, useProvidedFid = true)
+          writer.write()
+        }
+      }
+
+      df = spark.read
+        .format("geomesa")
+        .options(params.map { case (k, v) => k -> v.toString })
+        .option("geomesa.feature", typeName)
+        .load()
+
+      logger.debug(df.schema.treeString)
+      df.createOrReplaceTempView(typeName)
+      sc.sql(s"select * from $typeName").show()
+
+      true
+    }
+  }
+
+  override def afterAll(): Unit = {
+    // Stop MiniCluster
+    cluster.shutdown()
+    FileUtils.deleteDirectory(tempDir.toFile)
+  }
+}

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/jobs/OrcSimpleFeatureInputFormat.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/jobs/OrcSimpleFeatureInputFormat.scala
@@ -89,7 +89,9 @@ object OrcSimpleFeatureInputFormat {
   }
 
   def getReadColumns(conf: Configuration): Option[Set[Int]] =
-    Option(conf.get(ReadColumnsConfig)).map(_.split(",").map(_.toInt).toSet)
+    Option(conf.get(ReadColumnsConfig))
+      .filter(_.nonEmpty)
+      .map(_.split(",").map(_.toInt).toSet)
 
   class OrcSimpleFeatureRecordReader(delegate: RecordReader[NullWritable, OrcStruct], conf: Configuration)
       extends RecordReader[Void, SimpleFeature] {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/utils/OrcInputFormatReader.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/utils/OrcInputFormatReader.scala
@@ -35,27 +35,32 @@ object OrcInputFormatReader {
     var col = 0
     while (i < sft.getAttributeCount) {
       val bindings = ObjectType.selectType(sft.getDescriptor(i))
-      val reader = bindings.head match {
-        case ObjectType.GEOMETRY => col += 1; createGeometryReader(bindings(1), col - 1, col, i)
-        case ObjectType.DATE     => new DateInputFormatReader(col, i)
-        case ObjectType.STRING   => new StringInputFormatReader(col, i)
-        case ObjectType.INT      => new IntInputFormatReader(col, i)
-        case ObjectType.LONG     => new LongInputFormatReader(col, i)
-        case ObjectType.FLOAT    => new FloatInputFormatReader(col, i)
-        case ObjectType.DOUBLE   => new DoubleInputFormatReader(col, i)
-        case ObjectType.BOOLEAN  => new BooleanInputFormatReader(col, i)
-        case ObjectType.BYTES    => new BytesInputFormatReader(col, i)
-        case ObjectType.JSON     => new StringInputFormatReader(col, i)
-        case ObjectType.UUID     => new UuidInputFormatReader(col, i)
-        case ObjectType.LIST     => new ListInputFormatReader(col, i, bindings(1))
-        case ObjectType.MAP      => new MapInputFormatReader(col, i, bindings(1), bindings(2))
-        case _ => throw new IllegalArgumentException(s"Unexpected object type ${bindings.head}")
-      }
       if (columns.forall(_.contains(i))) {
+        val reader = bindings.head match {
+          case ObjectType.GEOMETRY => col += 1; createGeometryReader(bindings(1), col - 1, col, i)
+          case ObjectType.DATE     => new DateInputFormatReader(col, i)
+          case ObjectType.STRING   => new StringInputFormatReader(col, i)
+          case ObjectType.INT      => new IntInputFormatReader(col, i)
+          case ObjectType.LONG     => new LongInputFormatReader(col, i)
+          case ObjectType.FLOAT    => new FloatInputFormatReader(col, i)
+          case ObjectType.DOUBLE   => new DoubleInputFormatReader(col, i)
+          case ObjectType.BOOLEAN  => new BooleanInputFormatReader(col, i)
+          case ObjectType.BYTES    => new BytesInputFormatReader(col, i)
+          case ObjectType.JSON     => new StringInputFormatReader(col, i)
+          case ObjectType.UUID     => new UuidInputFormatReader(col, i)
+          case ObjectType.LIST     => new ListInputFormatReader(col, i, bindings(1))
+          case ObjectType.MAP      => new MapInputFormatReader(col, i, bindings(1), bindings(2))
+          case _ => throw new IllegalArgumentException(s"Unexpected object type ${bindings.head}")
+        }
         builder += reader
+        col += 1
+      } else {
+        bindings.head match {
+          case ObjectType.GEOMETRY => col += 2
+          case _                   => col += 1
+        }
       }
       i += 1
-      col += 1
     }
 
     if (fid) {

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureSpecParser.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureSpecParser.scala
@@ -185,7 +185,7 @@ private class SimpleFeatureSpecParser extends BasicParser {
 
   // single sft option
   private def sftOption: Rule1[(String, String)] = rule("FeatureTypeOption") {
-    (oneOrMore(char | ".") ~> { s => s } ~ "=" ~ sftOptionValue) ~~> { (k, v) => (k, v) }
+    (oneOrMore(char | anyOf(".-")) ~> { s => s } ~ "=" ~ sftOptionValue) ~~> { (k, v) => (k, v) }
   }
 
   // value for an sft option


### PR DESCRIPTION
* Creates Spark+FSDS test framework and applies it to ORC format.
* Handles count(*) projection case.
* Fixes various ORC MR format reading bugs.
* Allows SimpleFeatureSpecs to have -'s in userData (without attributes).

Signed-off-by: Jim Hughes <jnh5y@ccri.com>