### PR TITLE
GEOMESA-2400 Remove netty from spark-runtime jars

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-spark-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-spark-runtime/pom.xml
@@ -110,6 +110,7 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
+                                    <exclude>io.netty:*</exclude>
                                     <exclude>org.slf4j:*</exclude>
                                     <exclude>org.geotools:gt-render:*</exclude>
                                     <exclude>org.geotools:gt-coverage:*</exclude>

--- a/geomesa-bigtable/geomesa-bigtable-spark-runtime/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-spark-runtime/pom.xml
@@ -121,6 +121,7 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
+                                    <exclude>io.netty:*</exclude>
                                     <exclude>org.slf4j:*</exclude>
                                     <exclude>org.geotools:gt-render:*</exclude>
                                     <exclude>org.geotools:gt-coverage:*</exclude>

--- a/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
@@ -77,6 +77,7 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
+                                    <exclude>io.netty:*</exclude>
                                     <exclude>org.slf4j:*</exclude>
                                     <exclude>org.geotools:gt-render:*</exclude>
                                     <exclude>org.geotools:gt-coverage:*</exclude>

--- a/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
@@ -157,6 +157,7 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
+                                    <exclude>io.netty:*</exclude>
                                     <exclude>org.slf4j:*</exclude>
                                     <exclude>org.geotools:gt-render:*</exclude>
                                     <exclude>org.geotools:gt-coverage:*</exclude>

--- a/geomesa-kudu/geomesa-kudu-spark-runtime/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-spark-runtime/pom.xml
@@ -83,6 +83,7 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
+                                    <exclude>io.netty:*</exclude>
                                     <exclude>org.slf4j:*</exclude>
                                     <exclude>org.geotools:gt-render:*</exclude>
                                     <exclude>org.geotools:gt-coverage:*</exclude>


### PR DESCRIPTION
* Removes io.netty from all 5 Spark runtimes.

Signed-off-by: Jim Hughes <jnh5y@ccri.com>