### PR TITLE
Locally this is breaking a test in geomesa-convert-all_2.11

### DIFF
--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureSpecParser.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureSpecParser.scala
@@ -185,7 +185,7 @@ private class SimpleFeatureSpecParser extends BasicParser {
 
   // single sft option
   private def sftOption: Rule1[(String, String)] = rule("FeatureTypeOption") {
-    (oneOrMore(char | ".") ~> { s => s } ~ "=" ~ sftOptionValue) ~~> { (k, v) => (k, v) }
+    (oneOrMore(char | anyOf(".-")) ~> { s => s } ~ "=" ~ sftOptionValue) ~~> { (k, v) => (k, v) }
   }
 
   // value for an sft option


### PR DESCRIPTION
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.195 s <<< FAILURE! - in org.locationtech.geomesa.convert.URLConfigProviderTest
[ERROR] URLConfigProvider should::pull in concatenated configs from a url(org.locationtech.geomesa.convert.URLConfigProviderTest)  Time elapsed: 0.023 s  <<< FAILURE!
org.specs2.reporter.SpecFailureAssertionFailedError: List(comp1, global3, global2, global1) does not contain example-csv-url, example-csv-url2 but contains comp1, global1, global3, global2

Signed-off-by: Jim Hughes <jnh5y@ccri.com>