### PR TITLE
GEOMESA-2397 CompositeConverter - allow for calling `next` without `hasNext`

### DIFF
--- a/geomesa-convert/geomesa-convert-all/src/test/scala/org/locationtech/geomesa/convert/testing/CompositeTextConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-all/src/test/scala/org/locationtech/geomesa/convert/testing/CompositeTextConverterTest.scala
@@ -115,13 +115,9 @@ class CompositeTextConverterTest extends Specification with LazyLogging {
     "call next without hasNext" in {
       val converter = SimpleFeatureConverter(sft, "comp1")
       converter must not(beNull)
-
-      // TODO enable this once GEOMESA-2397 is done
-      val first = converter.process(new ByteArrayInputStream("3 5050".getBytes)).next
-      first.getID must be equalTo "50.050.0"
-
-      1 mustEqual 1
-    }.pendingUntilFixed("GEOMESA-2397")
+      val iter = converter.process(new ByteArrayInputStream("3 5050".getBytes))
+      iter.next.getID mustEqual "50.050.0"
+    }
 
     "be built using old api" in {
       import org.locationtech.geomesa.convert.SimpleFeatureConverters

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/composite/CompositeConverter.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/composite/CompositeConverter.scala
@@ -39,9 +39,9 @@ class CompositeConverter(val targetSft: SimpleFeatureType, delegates: Seq[(Predi
   }
 
   override def process(is: InputStream, ec: EvaluationContext): CloseableIterator[SimpleFeature] = {
-    val setEc: (Int) => Unit = ec match {
-      case c: CompositeEvaluationContext => (i) => c.setCurrent(i)
-      case _ => (_) => Unit
+    val setEc: Int => Unit = ec match {
+      case c: CompositeEvaluationContext => i => c.setCurrent(i)
+      case _ => _ => Unit
     }
     val toEval = Array.ofDim[Any](1)
 
@@ -77,7 +77,7 @@ class CompositeConverter(val targetSft: SimpleFeatureType, delegates: Seq[(Predi
         }
       }
 
-      override def next(): SimpleFeature = delegate.next
+      override def next(): SimpleFeature = if (hasNext) { delegate.next } else { Iterator.empty.next }
 
       override def close(): Unit = {
         CloseWithLogging(delegate)


### PR DESCRIPTION
Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>