### PR TITLE
GEOMESA-2429 Converters - converter-level caches in evaluation contex…

### DIFF
--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/CompositeConverter.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/CompositeConverter.scala
@@ -40,7 +40,6 @@ class CompositeConverterFactory[I] extends SimpleFeatureConverterFactory[I] {
 class CompositeConverter[I](val targetSFT: SimpleFeatureType, converters: Seq[(Predicate, SimpleFeatureConverter[I])])
     extends SimpleFeatureConverter[I] {
 
-
   override val caches: Map[String, EnrichmentCache] = Map.empty
 
   val predsWithIndex = converters.map(_._1).zipWithIndex.toIndexedSeq
@@ -101,6 +100,8 @@ class CompositeConverter[I](val targetSFT: SimpleFeatureType, converters: Seq[(P
   override def processSingleInput(i: I, ec: EvaluationContext): Iterator[SimpleFeature] = ???
 
   override def process(is: InputStream, ec: EvaluationContext): Iterator[SimpleFeature] = ???
+
+  override def close(): Unit = indexedConverters.foreach(_.close())
 }
 
 case class CompositeEvaluationContext(contexts: IndexedSeq[EvaluationContext]) extends EvaluationContext {

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverterFactory.scala
@@ -22,6 +22,7 @@ import org.locationtech.geomesa.convert.ValidationMode.ValidationMode
 import org.locationtech.geomesa.convert2.transforms.Expression
 import org.locationtech.geomesa.convert2.transforms.Expression.LiteralNull
 import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.utils.io.CloseWithLogging
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.JavaConversions._
@@ -442,6 +443,8 @@ trait ToSimpleFeatureConverter[I] extends SimpleFeatureConverter[I] with LazyLog
          ret.iterator
     }
   }
+
+  override def close(): Unit = caches.values.foreach(CloseWithLogging.apply)
 }
 
 @deprecated("Replaced with org.locationtech.geomesa.convert2.AbstractConverter")

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverters.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverters.scala
@@ -19,6 +19,7 @@ import org.locationtech.geomesa.convert2
 import org.locationtech.geomesa.convert2.{AbstractConverter, ConverterConfig}
 import org.locationtech.geomesa.utils.collection.{CloseableIterator, SelfClosingIterator}
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypeLoader
+import org.locationtech.geomesa.utils.io.CloseWithLogging
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 /**
@@ -101,6 +102,10 @@ object SimpleFeatureConverters extends LazyLogging {
     override def createEvaluationContext(globalParams: Map[String, Any], counter: Counter): EvaluationContext =
       converter.createEvaluationContext(globalParams, Map.empty, counter)
 
-    override def close(): Unit = open.asScala.foreach(_.close())
+    override def close(): Unit = {
+      open.asScala.foreach(CloseWithLogging.apply)
+      caches.values.foreach(CloseWithLogging.apply)
+      CloseWithLogging(converter)
+    }
   }
 }

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/SimpleFeatureConverter.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/SimpleFeatureConverter.scala
@@ -8,7 +8,7 @@
 
 package org.locationtech.geomesa.convert2
 
-import java.io.InputStream
+import java.io.{Closeable, InputStream}
 import java.util.ServiceLoader
 
 import com.typesafe.config.Config
@@ -23,7 +23,7 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 /**
   * Converts input streams into simple features
   */
-trait SimpleFeatureConverter {
+trait SimpleFeatureConverter extends Closeable {
 
   /**
     * Result feature type
@@ -136,5 +136,7 @@ object SimpleFeatureConverter extends StrictLogging {
                                          counter: Counter): EvaluationContext = {
       converter.createEvaluationContext(globalParams, counter)
     }
+
+    override def close(): Unit = converter.close()
   }
 }

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/composite/CompositeConverter.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/composite/CompositeConverter.scala
@@ -85,6 +85,8 @@ class CompositeConverter(val targetSft: SimpleFeatureType, delegates: Seq[(Predi
       }
     }
   }
+
+  override def close(): Unit = converters.foreach(CloseWithLogging.apply)
 }
 
 object CompositeConverter {

--- a/geomesa-convert/geomesa-convert-fixedwidth/src/test/scala/org/locationtech/geomesa/convert/fixedwidth/FixedWidthConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-fixedwidth/src/test/scala/org/locationtech/geomesa/convert/fixedwidth/FixedWidthConverterTest.scala
@@ -16,6 +16,7 @@ import com.vividsolutions.jts.geom.{Coordinate, Point}
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.io.WithClose
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -50,13 +51,14 @@ class FixedWidthConverterTest extends Specification {
         """.stripMargin)
 
       val sft = SimpleFeatureTypes.createType(ConfigFactory.load("sft_testsft.conf"))
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
 
-      val res = converter.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))).toList
-      res.size must be equalTo 2
-      res(0).getDefaultGeometry.asInstanceOf[Point].getCoordinate must be equalTo new Coordinate(55.0, 45.0)
-      res(1).getDefaultGeometry.asInstanceOf[Point].getCoordinate must be equalTo new Coordinate(65.0, 65.0)
+        val res = WithClose(converter.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        res.size must be equalTo 2
+        res(0).getDefaultGeometry.asInstanceOf[Point].getCoordinate must be equalTo new Coordinate(55.0, 45.0)
+        res(1).getDefaultGeometry.asInstanceOf[Point].getCoordinate must be equalTo new Coordinate(65.0, 65.0)
+      }
     }
 
     "set null values on out of order converter components until GEOMESA-1833 is completed" >> {
@@ -78,14 +80,15 @@ class FixedWidthConverterTest extends Specification {
         """.stripMargin)
 
       val sft = SimpleFeatureTypes.createType(ConfigFactory.load("sft_testsft.conf"))
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
 
-      val res = converter.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))).toList
-      res.size must be equalTo 2
-      res(0).getDefaultGeometry.asInstanceOf[Point].getCoordinate must be equalTo new Coordinate(55.0, 45.0)
-      res(1).getDefaultGeometry.asInstanceOf[Point].getCoordinate must be equalTo new Coordinate(65.0, 65.0)
-      res(1).getAttribute("anotherLat").asInstanceOf[Double] must be equalTo 65.0D
+        val res = WithClose(converter.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        res.size must be equalTo 2
+        res(0).getDefaultGeometry.asInstanceOf[Point].getCoordinate must be equalTo new Coordinate(55.0, 45.0)
+        res(1).getDefaultGeometry.asInstanceOf[Point].getCoordinate must be equalTo new Coordinate(65.0, 65.0)
+        res(1).getAttribute("anotherLat").asInstanceOf[Double] must be equalTo 65.0D
+      }
     }
 
     "process with validation on" >> {
@@ -103,11 +106,12 @@ class FixedWidthConverterTest extends Specification {
         """.stripMargin)
 
       val sft = SimpleFeatureTypes.createType(ConfigFactory.load("sft_testsft.conf"))
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
 
-      val res = converter.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))).toList
-      res.size must be equalTo 0
+        val res = WithClose(converter.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        res.size must be equalTo 0
+      }
     }
 
     "process user data" >> {
@@ -131,15 +135,16 @@ class FixedWidthConverterTest extends Specification {
         """.stripMargin)
 
       val sft = SimpleFeatureTypes.createType(ConfigFactory.load("sft_testsft.conf"))
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
 
-      val res = converter.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))).toList
-      res.size must be equalTo 2
-      res(0).getDefaultGeometry.asInstanceOf[Point].getCoordinate must be equalTo new Coordinate(55.0, 45.0)
-      res(1).getDefaultGeometry.asInstanceOf[Point].getCoordinate must be equalTo new Coordinate(65.0, 65.0)
-      res(0).getUserData.get("my.user.key") mustEqual 45.0
-      res(1).getUserData.get("my.user.key") mustEqual 65.0
+        val res = WithClose(converter.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        res.size must be equalTo 2
+        res(0).getDefaultGeometry.asInstanceOf[Point].getCoordinate must be equalTo new Coordinate(55.0, 45.0)
+        res(1).getDefaultGeometry.asInstanceOf[Point].getCoordinate must be equalTo new Coordinate(65.0, 65.0)
+        res(0).getUserData.get("my.user.key") mustEqual 45.0
+        res(1).getUserData.get("my.user.key") mustEqual 65.0
+      }
     }
   }
 }

--- a/geomesa-convert/geomesa-convert-jdbc/src/test/scala/org/locationtech/geomesa/convert/jdbc/JdbcConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-jdbc/src/test/scala/org/locationtech/geomesa/convert/jdbc/JdbcConverterTest.scala
@@ -74,13 +74,15 @@ class JdbcConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
 
-      val res = converter.process(new ByteArrayInputStream("select * from example".getBytes(StandardCharsets.UTF_8))).toList
-      // note: comparison has to be done backwards,
-      // as java.util.Date.equals(java.sql.Timestamp) != java.sql.Timestamp.equals(java.util.Date)
-      features mustEqual res
+        val sql = new ByteArrayInputStream("select * from example".getBytes(StandardCharsets.UTF_8))
+        val res = WithClose(converter.process(sql))(_.toList)
+        // note: comparison has to be done backwards,
+        // as java.util.Date.equals(java.sql.Timestamp) != java.sql.Timestamp.equals(java.util.Date)
+        features mustEqual res
+      }
     }
   }
 

--- a/geomesa-convert/geomesa-convert-json/src/test/scala/org/locationtech/geomesa/convert/json/JsonConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-json/src/test/scala/org/locationtech/geomesa/convert/json/JsonConverterTest.scala
@@ -17,6 +17,7 @@ import com.vividsolutions.jts.geom._
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.io.WithClose
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -117,17 +118,18 @@ class JsonConverterTest extends Specification {
       val pt1 = new Point(new Coordinate(0, 0), new PrecisionModel(PrecisionModel.FIXED), 4326)
       val pt2 = new Point(new Coordinate(1, 1), new PrecisionModel(PrecisionModel.FIXED), 4326)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))).toList
-      features must haveLength(2)
-      features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features(0).getDefaultGeometry must be equalTo pt1
-      features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-      features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-      features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
-      features(1).getDefaultGeometry must be equalTo pt2
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features must haveLength(2)
+        features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features(0).getDefaultGeometry must be equalTo pt1
+        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+        features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
+        features(1).getDefaultGeometry must be equalTo pt2
+      }
     }
 
     // NB: To enable this feature, we are reading the JSON path relative from the global context and the 'feature path'.
@@ -182,17 +184,18 @@ class JsonConverterTest extends Specification {
       val pt1 = new Point(new Coordinate(4, 5), new PrecisionModel(PrecisionModel.FIXED), 4326)
       val pt2 = new Point(new Coordinate(4, 5), new PrecisionModel(PrecisionModel.FIXED), 4326)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))).toList
-      features must haveLength(2)
-      features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features(0).getDefaultGeometry must be equalTo pt1
-      features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-      features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-      features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
-      features(1).getDefaultGeometry must be equalTo pt2
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features must haveLength(2)
+        features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features(0).getDefaultGeometry must be equalTo pt1
+        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+        features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
+        features(1).getDefaultGeometry must be equalTo pt2
+      }
     }
 
     "parse in single line-mode" >> {
@@ -261,17 +264,18 @@ class JsonConverterTest extends Specification {
       val pt1 = new Point(new Coordinate(0, 0), new PrecisionModel(PrecisionModel.FIXED), 4326)
       val pt2 = new Point(new Coordinate(1, 1), new PrecisionModel(PrecisionModel.FIXED), 4326)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes)).toList
-      features must haveLength(2)
-      features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features(0).getDefaultGeometry must be equalTo pt1
-      features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-      features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-      features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
-      features(1).getDefaultGeometry must be equalTo pt2
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes)))(_.toList)
+        features must haveLength(2)
+        features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features(0).getDefaultGeometry must be equalTo pt1
+        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+        features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
+        features(1).getDefaultGeometry must be equalTo pt2
+      }
     }
 
     "parse in multi line-mode" >> {
@@ -330,17 +334,18 @@ class JsonConverterTest extends Specification {
       val pt1 = new Point(new Coordinate(0, 0), new PrecisionModel(PrecisionModel.FIXED), 4326)
       val pt2 = new Point(new Coordinate(1, 1), new PrecisionModel(PrecisionModel.FIXED), 4326)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes)).toList
-      features must haveLength(2)
-      features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features(0).getDefaultGeometry must be equalTo pt1
-      features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-      features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-      features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
-      features(1).getDefaultGeometry must be equalTo pt2
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes)))(_.toList)
+        features must haveLength(2)
+        features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features(0).getDefaultGeometry must be equalTo pt1
+        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+        features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
+        features(1).getDefaultGeometry must be equalTo pt2
+      }
     }
 
     "parse nested feature nodes" >> {
@@ -399,17 +404,18 @@ class JsonConverterTest extends Specification {
       val pt1 = new Point(new Coordinate(0, 0), new PrecisionModel(PrecisionModel.FIXED), 4326)
       val pt2 = new Point(new Coordinate(1, 1), new PrecisionModel(PrecisionModel.FIXED), 4326)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))).toList
-      features must haveLength(2)
-      features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features(0).getDefaultGeometry must be equalTo pt1
-      features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-      features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-      features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
-      features(1).getDefaultGeometry must be equalTo pt2
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features must haveLength(2)
+        features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features(0).getDefaultGeometry must be equalTo pt1
+        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+        features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
+        features(1).getDefaultGeometry must be equalTo pt2
+      }
     }
 
     "use an ID hash for each node" >> {
@@ -465,10 +471,11 @@ class JsonConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))).toList
-      features(0).getID must be equalTo "a159e39826218d193761dc4480e8eb95"
-      features(1).getID must be equalTo "5ad94a63c273eac62689c636ea1ba408"
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features(0).getID must be equalTo "a159e39826218d193761dc4480e8eb95"
+        features(1).getID must be equalTo "5ad94a63c273eac62689c636ea1ba408"
+      }
 
     }
 
@@ -513,16 +520,17 @@ class JsonConverterTest extends Specification {
         val pt1 = new Point(new Coordinate(55, 56), new PrecisionModel(PrecisionModel.FIXED), 4326)
         val pt2 = new Point(new Coordinate(101, 89), new PrecisionModel(PrecisionModel.FIXED), 4326)
 
-        val converter = SimpleFeatureConverter(sft, parserConf)
-        val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))).toList
-        features must haveLength(2)
-        features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
-        features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
-        features(0).getDefaultGeometry must be equalTo pt1
+        WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+          val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))))(_.toList)
+          features must haveLength(2)
+          features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
+          features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
+          features(0).getDefaultGeometry must be equalTo pt1
 
-        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-        features(1).getDefaultGeometry must be equalTo pt2
+          features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+          features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+          features(1).getDefaultGeometry must be equalTo pt2
+        }
       }
 
       "allow specific sft geom and cast into it" >> {
@@ -561,14 +569,15 @@ class JsonConverterTest extends Specification {
             | }
           """.stripMargin)
 
-        val converter = SimpleFeatureConverter(sft, parserConf)
-        val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))).toList
-        features must haveLength(2)
-        features(0).getDefaultGeometry must beAnInstanceOf[LineString]
-        features(0).getDefaultGeometry mustEqual WKTUtils.read("LineString (55 56, 56 57)")
+        WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+          val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))))(_.toList)
+          features must haveLength(2)
+          features(0).getDefaultGeometry must beAnInstanceOf[LineString]
+          features(0).getDefaultGeometry mustEqual WKTUtils.read("LineString (55 56, 56 57)")
 
-        features(1).getDefaultGeometry must beAnInstanceOf[LineString]
-        features(1).getDefaultGeometry mustEqual WKTUtils.read("LineString (101 89, 102 88)")
+          features(1).getDefaultGeometry must beAnInstanceOf[LineString]
+          features(1).getDefaultGeometry mustEqual WKTUtils.read("LineString (101 89, 102 88)")
+        }
       }
 
       "parse points" >> {
@@ -610,16 +619,17 @@ class JsonConverterTest extends Specification {
         val pt1 = new Point(new Coordinate(55, 56), new PrecisionModel(PrecisionModel.FIXED), 4326)
         val pt2 = new Point(new Coordinate(101, 89), new PrecisionModel(PrecisionModel.FIXED), 4326)
 
-        val converter = SimpleFeatureConverter(sft, parserConf)
-        val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))).toList
-        features must haveLength(2)
-        features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
-        features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
-        features(0).getDefaultGeometry must be equalTo pt1
-
-        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-        features(1).getDefaultGeometry must be equalTo pt2
+        WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+          val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))))(_.toList)
+          features must haveLength(2)
+          features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
+          features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
+          features(0).getDefaultGeometry must be equalTo pt1
+  
+          features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+          features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+          features(1).getDefaultGeometry must be equalTo pt2
+        }
       }
 
       "parse mixed geometry" >> {
@@ -693,26 +703,27 @@ class JsonConverterTest extends Specification {
         val lineStr1 = geoFac.createLineString(Seq((102, 0), (103, 1), (104, 0), (105, 1)).map{ case (x,y) => new Coordinate(x, y)}.toArray)
         val poly1 = geoFac.createPolygon(Seq((100, 0), (101, 0), (101, 1), (100, 1), (100, 0)).map{ case (x,y) => new Coordinate(x, y)}.toArray)
 
-        val converter = SimpleFeatureConverter(sft, parserConf)
-        val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))).toList
-        features must haveLength(3)
-        features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
-        features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
-        features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-        features(0).getDefaultGeometry must beAnInstanceOf[Point]
-        features(0).getDefaultGeometry must be equalTo pt1
+        WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+          val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))))(_.toList)
+          features must haveLength(3)
+          features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
+          features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
+          features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+          features(0).getDefaultGeometry must beAnInstanceOf[Point]
+          features(0).getDefaultGeometry must be equalTo pt1
 
-        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-        features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
-        features(1).getDefaultGeometry must beAnInstanceOf[LineString]
-        features(1).getDefaultGeometry must be equalTo lineStr1
+          features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+          features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+          features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
+          features(1).getDefaultGeometry must beAnInstanceOf[LineString]
+          features(1).getDefaultGeometry must be equalTo lineStr1
 
-        features(2).getAttribute("number").asInstanceOf[Integer] mustEqual 789
-        features(2).getAttribute("color").asInstanceOf[String] mustEqual "green"
-        features(2).getAttribute("weight").asInstanceOf[Double] mustEqual 185
-        features(2).getDefaultGeometry must be equalTo poly1
-        features(2).getDefaultGeometry must beAnInstanceOf[Polygon]
+          features(2).getAttribute("number").asInstanceOf[Integer] mustEqual 789
+          features(2).getAttribute("color").asInstanceOf[String] mustEqual "green"
+          features(2).getAttribute("weight").asInstanceOf[Double] mustEqual 185
+          features(2).getDefaultGeometry must be equalTo poly1
+          features(2).getDefaultGeometry must beAnInstanceOf[Polygon]
+        }
       }
 
       "parse time in seconds" >> {
@@ -736,13 +747,14 @@ class JsonConverterTest extends Specification {
             | }
           """.stripMargin)
 
-        val converter = SimpleFeatureConverter(sft, parserConf)
-        val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))).toList
-        features must haveLength(1)
-        val f = features.head
-        f.getAttribute("number") mustEqual 123
-        f.getAttribute("dtg") mustEqual new Date(1000000)
-        f.getDefaultGeometry.toString mustEqual "POINT (0 0)"
+        WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+          val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))))(_.toList)
+          features must haveLength(1)
+          val f = features.head
+          f.getAttribute("number") mustEqual 123
+          f.getAttribute("dtg") mustEqual new Date(1000000)
+          f.getDefaultGeometry.toString mustEqual "POINT (0 0)"
+        }
       }
     }
 
@@ -776,12 +788,13 @@ class JsonConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val ec = converter.createEvaluationContext()
-      val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8)), ec).toList
-      features must haveLength(0)
-      ec.counter.getSuccess mustEqual 0
-      ec.counter.getFailure mustEqual 1
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val ec = converter.createEvaluationContext()
+        val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8)), ec))(_.toList)
+        features must haveLength(0)
+        ec.counter.getSuccess mustEqual 0
+        ec.counter.getFailure mustEqual 1
+      }
     }
 
     "parse and convert json arrays into lists" >> {
@@ -878,29 +891,31 @@ class JsonConverterTest extends Specification {
         """.stripMargin)
 
       forall(List((nestedJson, nestedConf),(simpleJson, simpleConf))) { case (json, conf) =>
-        val converter = SimpleFeatureConverter(advSft, conf)
-        val ec = converter.createEvaluationContext()
-        val features = converter.process(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), ec).toList
-        features must haveLength(1)
-        ec.counter.getSuccess mustEqual 1
-        ec.counter.getFailure mustEqual 0
+        WithClose(SimpleFeatureConverter(advSft, conf)) { converter =>
+          import scala.collection.JavaConversions._
 
-        import scala.collection.JavaConversions._
-        val f = features.head
+          val ec = converter.createEvaluationContext()
+          val features = WithClose(converter.process(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), ec))(_.toList)
+          features must haveLength(1)
+          ec.counter.getSuccess mustEqual 1
+          ec.counter.getFailure mustEqual 0
 
-        f.getAttribute("sList") must beAnInstanceOf[java.util.List[String]]
-        f.getAttribute("sList").asInstanceOf[java.util.List[String]].toSeq must containTheSameElementsAs(Seq("s1", "s2"))
+          val f = features.head
 
-        f.getAttribute("iList") must beAnInstanceOf[java.util.List[Integer]]
-        f.getAttribute("iList").asInstanceOf[java.util.List[Integer]].toSeq must containTheSameElementsAs(Seq(2))
+          f.getAttribute("sList") must beAnInstanceOf[java.util.List[String]]
+          f.getAttribute("sList").asInstanceOf[java.util.List[String]].toSeq must containTheSameElementsAs(Seq("s1", "s2"))
 
-        f.getAttribute("dList") must beAnInstanceOf[java.util.List[Double]]
-        f.getAttribute("dList").asInstanceOf[java.util.List[Double]].toSeq must containTheSameElementsAs(Seq(1.1, 2.2))
+          f.getAttribute("iList") must beAnInstanceOf[java.util.List[Integer]]
+          f.getAttribute("iList").asInstanceOf[java.util.List[Integer]].toSeq must containTheSameElementsAs(Seq(2))
 
-        f.getAttribute("uList") must beAnInstanceOf[java.util.List[UUID]]
-        f.getAttribute("uList").asInstanceOf[java.util.List[UUID]].toSeq must containTheSameElementsAs(
-          Seq(UUID.fromString("12345678-1234-1234-1234-123456781234"),
-            UUID.fromString("00000000-0000-0000-0000-000000000000")))
+          f.getAttribute("dList") must beAnInstanceOf[java.util.List[Double]]
+          f.getAttribute("dList").asInstanceOf[java.util.List[Double]].toSeq must containTheSameElementsAs(Seq(1.1, 2.2))
+
+          f.getAttribute("uList") must beAnInstanceOf[java.util.List[UUID]]
+          f.getAttribute("uList").asInstanceOf[java.util.List[UUID]].toSeq must containTheSameElementsAs(
+            Seq(UUID.fromString("12345678-1234-1234-1234-123456781234"),
+              UUID.fromString("00000000-0000-0000-0000-000000000000")))
+        }
       }
     }
 
@@ -962,39 +977,42 @@ class JsonConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(mapSft, mapConf)
-      val ec = converter.createEvaluationContext()
-      val features = converter.process(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), ec).toList
-      features must haveLength(1)
-      ec.counter.getSuccess mustEqual 1
-      ec.counter.getFailure mustEqual 0
+      WithClose(SimpleFeatureConverter(mapSft, mapConf)) { converter =>
+        import java.util.{Map => JMap}
 
-      import scala.collection.JavaConversions._
-      val f = features.head
+        import org.locationtech.geomesa.utils.geotools.Conversions.RichSimpleFeature
 
-      import java.util.{Map => JMap}
+        import scala.collection.JavaConversions._
 
-      import org.locationtech.geomesa.utils.geotools.Conversions.RichSimpleFeature
+        val ec = converter.createEvaluationContext()
+        val features = WithClose(converter.process(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), ec))(_.toList)
+        features must haveLength(1)
+        ec.counter.getSuccess mustEqual 1
+        ec.counter.getFailure mustEqual 0
 
-      val m = f.get[JMap[String,String]]("map1")
-      m must beAnInstanceOf[JMap[String,String]]
-      m.size() mustEqual 2
-      m("a") mustEqual "val1"
-      m("b") mustEqual "val2"
 
-      val m2 = f.get[JMap[String,String]]("map2")
-      m2 must beAnInstanceOf[JMap[String,String]]
-      m2.size mustEqual 3
-      m2("a") mustEqual "1.0"
-      m2("b") mustEqual "foobar"
-      m2("c") mustEqual "false"
+        val f = features.head
 
-      val m3 = f.get[JMap[Int,Boolean]]("map3")
-      m3 must beAnInstanceOf[JMap[Int,Boolean]]
-      m3.size mustEqual 3
-      m3(1) mustEqual true
-      m3(2) mustEqual false
-      m3(3) mustEqual true
+        val m = f.get[JMap[String,String]]("map1")
+        m must beAnInstanceOf[JMap[String,String]]
+        m.size() mustEqual 2
+        m("a") mustEqual "val1"
+        m("b") mustEqual "val2"
+
+        val m2 = f.get[JMap[String,String]]("map2")
+        m2 must beAnInstanceOf[JMap[String,String]]
+        m2.size mustEqual 3
+        m2("a") mustEqual "1.0"
+        m2("b") mustEqual "foobar"
+        m2("c") mustEqual "false"
+
+        val m3 = f.get[JMap[Int,Boolean]]("map3")
+        m3 must beAnInstanceOf[JMap[Int,Boolean]]
+        m3.size mustEqual 3
+        m3(1) mustEqual true
+        m3(2) mustEqual false
+        m3(3) mustEqual true
+      }
     }
 
     "parse user data" >> {
@@ -1040,14 +1058,15 @@ class JsonConverterTest extends Specification {
 
       val pt1 = new Point(new Coordinate(0, 0), new PrecisionModel(PrecisionModel.FIXED), 4326)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))).toList
-      features must haveLength(1)
-      features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features(0).getDefaultGeometry must be equalTo pt1
-      features(0).getUserData.get("my.user.key") mustEqual "red"
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(jsonStr.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features must haveLength(1)
+        features(0).getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features(0).getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features(0).getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features(0).getDefaultGeometry must be equalTo pt1
+        features(0).getUserData.get("my.user.key") mustEqual "red"
+      }
     }
 
     "parse longs, booleans, int, double, float" >> {
@@ -1096,20 +1115,21 @@ class JsonConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(typeSft, typeConf)
-      val ec = converter.createEvaluationContext()
-      val features = converter.process(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), ec).toList
-      features must haveLength(1)
-      ec.counter.getSuccess mustEqual 1
-      ec.counter.getFailure mustEqual 0
-      val f = features.head
+      WithClose(SimpleFeatureConverter(typeSft, typeConf)) { converter =>
+        val ec = converter.createEvaluationContext()
+        val features = WithClose(converter.process(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), ec))(_.toList)
+        features must haveLength(1)
+        ec.counter.getSuccess mustEqual 1
+        ec.counter.getFailure mustEqual 0
+        val f = features.head
 
-      import org.locationtech.geomesa.utils.geotools.Conversions.RichSimpleFeature
-      f.get[Int]("i") mustEqual 1
-      f.get[Long]("l") mustEqual Long.MaxValue
-      f.get[Double]("d") mustEqual 1.7976931348623157E8
-      f.get[Float]("f") mustEqual 1.023f
-      f.get[Boolean]("b") mustEqual false
+        import org.locationtech.geomesa.utils.geotools.Conversions.RichSimpleFeature
+        f.get[Int]("i") mustEqual 1
+        f.get[Long]("l") mustEqual Long.MaxValue
+        f.get[Double]("d") mustEqual 1.7976931348623157E8
+        f.get[Float]("f") mustEqual 1.023f
+        f.get[Boolean]("b") mustEqual false
+      }
     }
 
     "parse missing values as null" >> {
@@ -1137,11 +1157,12 @@ class JsonConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val in = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))
-      val features = converter.process(in).toList
-      features must haveLength(4)
-      features.map(_.getAttribute("name")) mustEqual Seq("name1", null, null, null)
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val in = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))
+        val features = WithClose(converter.process(in))(_.toList)
+        features must haveLength(4)
+        features.map(_.getAttribute("name")) mustEqual Seq("name1", null, null, null)
+      }
     }
 
     "handle invalid input" >> {
@@ -1160,13 +1181,14 @@ class JsonConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(typeSft, typeConf)
-      val ec = converter.createEvaluationContext()
-      val iter = converter.process(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), ec)
-      val features = iter.toList
-      features must haveLength(0)
-      ec.counter.getSuccess mustEqual 0
-      ec.counter.getFailure mustEqual 1
+      WithClose(SimpleFeatureConverter(typeSft, typeConf)) { converter =>
+        val ec = converter.createEvaluationContext()
+        val iter = converter.process(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), ec)
+        val features = iter.toList
+        features must haveLength(0)
+        ec.counter.getSuccess mustEqual 0
+        ec.counter.getFailure mustEqual 1
+      }
     }
 
     "parse geojson geometries" >> {
@@ -1193,12 +1215,13 @@ class JsonConverterTest extends Specification {
           |   ]
           | }
         """.stripMargin)
-      val converter = SimpleFeatureConverter(sft, conf)
-      val ec = converter.createEvaluationContext()
-      val in = new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8))
-      val features = converter.process(in, ec).toList
-      features must haveLength(8)
-      forall(features)(_.getDefaultGeometry must not(beNull))
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        val ec = converter.createEvaluationContext()
+        val in = new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8))
+        val features = WithClose(converter.process(in, ec))(_.toList)
+        features must haveLength(8)
+        forall(features)(_.getDefaultGeometry must not(beNull))
+      }
     }
 
     "infer schema from geojson files" >> {
@@ -1256,18 +1279,19 @@ class JsonConverterTest extends Specification {
       sft.getAttributeDescriptors.asScala.map(d => (d.getLocalName, d.getType.getBinding)) mustEqual
           Seq(("name", classOf[String]), ("demographics_age", classOf[Integer]), ("geom", classOf[Point]))
 
-      val converter = SimpleFeatureConverter(sft, inferred.get._2)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, inferred.get._2)) { converter =>
+        converter must not(beNull)
 
-      val features = converter.process(bytes).toList
-      features must haveLength(3)
+        val features = WithClose(converter.process(bytes))(_.toList)
+        features must haveLength(3)
 
-      val expected = Seq(
-        Seq("name1", null, WKTUtils.read("POINT (41 51)")),
-        Seq("name2", 2, WKTUtils.read("POINT (42 52)")),
-        Seq("name3", 3, WKTUtils.read("POINT (43 53)"))
-      )
-      features.map(_.getAttributes.asScala) must containTheSameElementsAs(expected)
+        val expected = Seq(
+          Seq("name1", null, WKTUtils.read("POINT (41 51)")),
+          Seq("name2", 2, WKTUtils.read("POINT (42 52)")),
+          Seq("name3", 3, WKTUtils.read("POINT (43 53)"))
+        )
+        features.map(_.getAttributes.asScala) must containTheSameElementsAs(expected)
+      }
     }
 
     "infer schemas with empty attributes" in {
@@ -1287,18 +1311,19 @@ class JsonConverterTest extends Specification {
       sft.getAttributeDescriptors.asScala.map(d => (d.getLocalName, d.getType.getBinding)) mustEqual
           Seq(("A", classOf[String]), ("geom", classOf[Point]))
 
-      val converter = SimpleFeatureConverter(sft, inferred.get._2)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, inferred.get._2)) { converter =>
+        converter must not(beNull)
 
-      val features = converter.process(bytes).toList
-      features must haveLength(3)
+        val features = WithClose(converter.process(bytes))(_.toList)
+        features must haveLength(3)
 
-      val expected = Seq(
-        Seq("foo", WKTUtils.read("POINT (164.2 -48.6732)")),
-        Seq("",    WKTUtils.read("POINT (154.3 -38.6832)")),
-        Seq("bar", WKTUtils.read("POINT (152.3 -38.7832)"))
-      )
-      features.map(_.getAttributes.asScala) must containTheSameElementsAs(expected)
+        val expected = Seq(
+          Seq("foo", WKTUtils.read("POINT (164.2 -48.6732)")),
+          Seq("",    WKTUtils.read("POINT (154.3 -38.6832)")),
+          Seq("bar", WKTUtils.read("POINT (152.3 -38.7832)"))
+        )
+        features.map(_.getAttributes.asScala) must containTheSameElementsAs(expected)
+      }
     }
 
     "infer schemas with three dimensional points" in {
@@ -1318,20 +1343,21 @@ class JsonConverterTest extends Specification {
       sft.getAttributeDescriptors.asScala.map(d => (d.getLocalName, d.getType.getBinding)) mustEqual
           Seq(("A", classOf[String]), ("geom", classOf[Point]))
 
-      val converter = SimpleFeatureConverter(sft, inferred.get._2)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, inferred.get._2)) { converter =>
+        converter must not(beNull)
 
-      val features = converter.process(bytes).toList
-      features must haveLength(3)
+        val features = WithClose(converter.process(bytes))(_.toList)
+        features must haveLength(3)
 
-      val expected = Seq(
-        Seq("foo", WKTUtils.read("POINT (164.2 -48.6732)")),
-        Seq("bar", WKTUtils.read("POINT (154.3 -38.6832 500.2)")),
-        Seq("baz", WKTUtils.read("POINT (152.3 -38.7832)"))
-      )
-      features.map(_.getAttributes.asScala) must containTheSameElementsAs(expected)
-      foreach(features.zip(expected)) { case (f, e) =>
-        f.getAttribute(1).asInstanceOf[Point].getCoordinate.equals3D(e(1).asInstanceOf[Point].getCoordinate) must beTrue
+        val expected = Seq(
+          Seq("foo", WKTUtils.read("POINT (164.2 -48.6732)")),
+          Seq("bar", WKTUtils.read("POINT (154.3 -38.6832 500.2)")),
+          Seq("baz", WKTUtils.read("POINT (152.3 -38.7832)"))
+        )
+        features.map(_.getAttributes.asScala) must containTheSameElementsAs(expected)
+        foreach(features.zip(expected)) { case (f, e) =>
+          f.getAttribute(1).asInstanceOf[Point].getCoordinate.equals3D(e(1).asInstanceOf[Point].getCoordinate) must beTrue
+        }
       }
     }
   }

--- a/geomesa-convert/geomesa-convert-redis-cache/src/test/scala/org/locationtech/geomesa/convert/redis/RedisEnrichmentCacheTest.scala
+++ b/geomesa-convert/geomesa-convert-redis-cache/src/test/scala/org/locationtech/geomesa/convert/redis/RedisEnrichmentCacheTest.scala
@@ -43,6 +43,7 @@ class RedisEnrichmentCacheTest extends Specification {
       val redis = new MockRedis
       val connBuilder = new RedisConnectionBuilder {
         override def getConn: Jedis = redis
+        override def close(): Unit = {}
       }
 
       val cache = new RedisEnrichmentCache(connBuilder, -1, true)
@@ -54,6 +55,7 @@ class RedisEnrichmentCacheTest extends Specification {
       val redis = new MockRedis
       val connBuilder = new RedisConnectionBuilder {
         override def getConn: Jedis = redis
+        override def close(): Unit = {}
       }
 
       val cache = new RedisEnrichmentCache(connBuilder, 1, true)
@@ -69,6 +71,7 @@ class RedisEnrichmentCacheTest extends Specification {
       val redis = new MockRedis
       val connBuilder = new RedisConnectionBuilder {
         override def getConn: Jedis = redis
+        override def close(): Unit = {}
       }
 
       val cache = new RedisEnrichmentCache(connBuilder, -1, false)

--- a/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/NewLinesTest.scala
+++ b/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/NewLinesTest.scala
@@ -15,6 +15,7 @@ import com.typesafe.config.ConfigFactory
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.io.WithClose
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -53,19 +54,21 @@ class NewLinesTest extends Specification {
     ))
 
     "process trailing newline" >> {
-      val converter = SimpleFeatureConverter(sft, conf)
-      val data = "45.0,45.0\n55.0,55.0\n"
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        val data = "45.0,45.0\n55.0,55.0\n"
 
-      val res = converter.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)))
-      res.length mustEqual 2
+        val res = WithClose(converter.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        res must haveLength(2)
+      }
     }
 
     "process middle of data newline" >> {
-      val converter = SimpleFeatureConverter(sft, conf)
-      val data = "45.0,45.0\n\n55.0,55.0\n"
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        val data = "45.0,45.0\n\n55.0,55.0\n"
 
-      val res = converter.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)))
-      res.length mustEqual 2
+        val res = WithClose(converter.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        res must haveLength(2)
+      }
     }
   }
 }

--- a/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/ValidatorTest.scala
+++ b/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/ValidatorTest.scala
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.curve.{BinnedTime, TimePeriod}
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.io.WithClose
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -68,44 +69,47 @@ class ValidatorTest extends Specification {
   "Converters" should {
     "skip empty dtg with default mode" >> {
       val conf = baseConf
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
-
-      converter.process(is("20160101,Point(2 2)")).toList.size mustEqual 1
-      converter.process(is(
-        """20160101,Point(2 2)
-          |"20160102",Point(2 2)""".stripMargin)).toList.size mustEqual 2
-      converter.process(is(
-        """20160101,Point(2 2)
-          |"",Point(2 2)""".stripMargin)).toList.size mustEqual 1
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
+  
+        WithClose(converter.process(is("20160101,Point(2 2)")))(_.toList) must haveLength(1)
+        WithClose(converter.process(is(
+          """20160101,Point(2 2)
+            |"20160102",Point(2 2)""".stripMargin)))(_.toList) must haveLength(2)
+            WithClose(converter.process(is(
+          """20160101,Point(2 2)
+            |"",Point(2 2)""".stripMargin)))(_.toList) must haveLength(1)
+      }
     }
 
     "throw exception with parse mode raise-errors in incremental mode" >> {
       val conf = baseConf.withFallback(ConfigFactory.parseString(
         """ { options.error-mode = raise-errors } """))
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
 
-      converter.process(is(
-        """20160101,Point(2 2)
-          |"20160102",Point(2 2)""".stripMargin)).toList.size mustEqual 2
-      converter.process(is(
-        """20160101,Point(2 2)
-          |"",Point(2 2)""".stripMargin)).toList should throwA[IOException]
+        WithClose(converter.process(is(
+          """20160101,Point(2 2)
+            |"20160102",Point(2 2)""".stripMargin)))(_.toList) must haveLength(2)
+        WithClose(converter.process(is(
+          """20160101,Point(2 2)
+            |"",Point(2 2)""".stripMargin)))(_.toList) should throwA[IOException]
+      }
     }
 
     "throw exception with parse mode raise-errors in batch mode" >> {
       val conf = baseConf.withFallback(ConfigFactory.parseString(
         """ { options.parse-mode = "batch", options.error-mode = raise-errors } """))
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
 
-      converter.process(is(
-        """20160101,Point(2 2)
-          |"20160102",Point(2 2)""".stripMargin)).toList.size mustEqual 2
-      converter.process(is(
-        """20160101,Point(2 2)
-          |"",Point(2 2)""".stripMargin)).toList should throwA[IOException]
+        WithClose(converter.process(is(
+          """20160101,Point(2 2)
+            |"20160102",Point(2 2)""".stripMargin)))(_.toList) must haveLength(2)
+        WithClose(converter.process(is(
+          """20160101,Point(2 2)
+            |"",Point(2 2)""".stripMargin)))(_.toList) should throwA[IOException]
+      }
     }
   }
 
@@ -114,74 +118,81 @@ class ValidatorTest extends Specification {
     "raise errors on bad dates" >> {
       val conf = baseConf.withFallback(ConfigFactory.parseString(
         """ { options.parse-mode = "batch", options.error-mode = raise-errors, options.validators = ["index"] } """))
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
 
-      val format = DateTimeFormatter.BASIC_ISO_DATE.withZone(ZoneOffset.UTC)
-      val tooYoung = BinnedTime.ZMinDate.minusDays(1).format(format)
-      val tooOld = BinnedTime.maxDate(TimePeriod.Week).plusDays(1).format(format)
-      converter.process(is("20371231,Point(2 2)")).toList.size mustEqual 1
-      converter.process(is("20371231,Point(2 2)")).next().point.getX mustEqual 2.0
-      converter.process(is("20371231,Point(2 2)")).next().point.getY mustEqual 2.0
-      converter.process(is(s"$tooYoung,Point(2 2)")) must throwAn[IOException]
-      converter.process(is(s"$tooOld,Point(2 2)")) must throwAn[IOException]
+        val format = DateTimeFormatter.BASIC_ISO_DATE.withZone(ZoneOffset.UTC)
+        val tooYoung = BinnedTime.ZMinDate.minusDays(1).format(format)
+        val tooOld = BinnedTime.maxDate(TimePeriod.Week).plusDays(1).format(format)
+        val res = WithClose(converter.process(is("20371231,Point(2 2)")))(_.toList)
+        res must haveLength(1)
+        res.head.point.getX mustEqual 2.0
+        res.head.point.getY mustEqual 2.0
+        converter.process(is(s"$tooYoung,Point(2 2)")) must throwAn[IOException]
+        converter.process(is(s"$tooOld,Point(2 2)")) must throwAn[IOException]
+      }
     }
 
     "skip records with bad dates" >> {
       val conf = baseConf.withFallback(ConfigFactory.parseString(
         """ { options.parse-mode = "batch", options.error-mode = skip-bad-records, options.validators = ["index"] } """))
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
 
-      val format = DateTimeFormatter.BASIC_ISO_DATE.withZone(ZoneOffset.UTC)
-      val tooOld = BinnedTime.maxDate(TimePeriod.Week).plusDays(1).format(format)
-      converter.process(is("20371231,Point(2 2)")).toList.size mustEqual 1
-      converter.process(is(s"$tooOld,Point(2 2)")).toList.size mustEqual 0
+        val format = DateTimeFormatter.BASIC_ISO_DATE.withZone(ZoneOffset.UTC)
+        val tooOld = BinnedTime.maxDate(TimePeriod.Week).plusDays(1).format(format)
+        WithClose(converter.process(is("20371231,Point(2 2)")))(_.toList) must haveLength(1)
+        WithClose(converter.process(is(s"$tooOld,Point(2 2)")))(_.toList) must haveLength(0)
+      }
     }
 
     "raise errors on bad geo" >> {
       val conf = baseConf.withFallback(ConfigFactory.parseString(
         """ { options.parse-mode = "batch", options.error-mode = raise-errors, options.validators = ["index"] } """))
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
 
-      converter.process(is("20120101,Point(2 2)")).toList.size mustEqual 1
-      converter.process(is("20120101,Point(2 2)")).next().point.getX mustEqual 2.0
-      converter.process(is("20120101,Point(2 2)")).next().point.getY mustEqual 2.0
-      converter.process(is("20120101,Point(200 200)")) must throwAn[IOException]
+        val res = WithClose(converter.process(is("20120101,Point(2 2)")))(_.toList)
+        res must haveLength(1)
+        res.head.point.getX mustEqual 2.0
+        res.head.point.getY mustEqual 2.0
+        converter.process(is("20120101,Point(200 200)")) must throwAn[IOException]
+      }
     }
 
     "skip records with bad geo" >> {
       val conf = baseConf.withFallback(ConfigFactory.parseString(
         """ { options.parse-mode = "batch", options.error-mode = skip-bad-records, options.validators = ["index"] } """))
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
 
-      converter.process(is("20120101,Point(2 2)")).toList.size mustEqual 1
-      converter.process(is("20120101,Point(2 2)")).next().point.getX mustEqual 2.0
-      converter.process(is("20120101,Point(2 2)")).next().point.getY mustEqual 2.0
-      converter.process(is("20120101,Point(200 200)")).toList.size mustEqual 0
+        val res = WithClose(converter.process(is("20120101,Point(2 2)")))(_.toList)
+        res must haveLength(1)
+        res.head.point.getX mustEqual 2.0
+        res.head.point.getY mustEqual 2.0
+        WithClose(converter.process(is("20120101,Point(200 200)")))(_.toList) must haveLength(0)
+      }
     }
 
     "skip bad geo records in batch mode" >> {
       val conf = baseConf.withFallback(ConfigFactory.parseString(
         """ { options.parse-mode = "batch", options.error-mode = skip-bad-records, options.validators = ["index"] } """))
-      val converter = SimpleFeatureConverter(sft, conf)
-      converter must not(beNull)
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        converter must not(beNull)
 
-      val res = converter.process(is(
-        """20120101,Point(2 2)
-          |20120102,Point(200 200)
-          |20120103,Point(3 3)
-          |20120104,Point(-181 -181)
-          |20120105,Point(4 4)
-        """.stripMargin)).toList
-      res.size mustEqual 3
-      res.sortBy(_.point.getY)
-      res(0).point.getY mustEqual 2.0
-      res(1).point.getY mustEqual 3.0
-      res(2).point.getY mustEqual 4.0
-
+        val res = converter.process(is(
+          """20120101,Point(2 2)
+            |20120102,Point(200 200)
+            |20120103,Point(3 3)
+            |20120104,Point(-181 -181)
+            |20120105,Point(4 4)
+          """.stripMargin)).toList
+        res must haveLength(3)
+        res.sortBy(_.point.getY)
+        res(0).point.getY mustEqual 2.0
+        res(1).point.getY mustEqual 3.0
+        res(2).point.getY mustEqual 4.0
+      }
     }
   }
 }

--- a/geomesa-convert/geomesa-convert-xml/src/test/scala/org/locationtech/geomesa/convert/xml/XmlConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-xml/src/test/scala/org/locationtech/geomesa/convert/xml/XmlConverterTest.scala
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.convert.SimpleFeatureConverters
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.io.WithClose
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -77,17 +78,18 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).toList
-      features must haveLength(2)
-      features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
-      features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-      features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-      features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
-      features(1).getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features must haveLength(2)
+        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+        features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
+        features(1).getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      }
     }
 
     "parse multiple features out of a single document with the geometry in the repeated XML tag" >> {
@@ -143,20 +145,21 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft2, parserConf)
-      val features = converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).toList
-      features must haveLength(2)
-      features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
-      features.head.getAttribute("geom").asInstanceOf[Point] mustEqual WKTUtils.read("POINT(1.23 4.23)").asInstanceOf[Point]
+      WithClose(SimpleFeatureConverter(sft2, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features must haveLength(2)
+        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        features.head.getAttribute("geom").asInstanceOf[Point] mustEqual WKTUtils.read("POINT(1.23 4.23)").asInstanceOf[Point]
 
-      features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-      features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-      features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
-      features(1).getAttribute("source").asInstanceOf[String] mustEqual "myxml"
-      features(1).getAttribute("geom").asInstanceOf[Point] mustEqual WKTUtils.read("POINT(4.56 7.56)").asInstanceOf[Point]
+        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+        features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
+        features(1).getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        features(1).getAttribute("geom").asInstanceOf[Point] mustEqual WKTUtils.read("POINT(4.56 7.56)").asInstanceOf[Point]
+      }
     }
 
     "parse nested feature nodes" >> {
@@ -199,17 +202,18 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).toList
-      features must haveLength(2)
-      features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
-      features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-      features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-      features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
-      features(1).getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features must haveLength(2)
+        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+        features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
+        features(1).getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      }
     }
 
     "apply xpath functions" >> {
@@ -243,13 +247,14 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).toList
-      features must haveLength(1)
-      features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127
-      features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features must haveLength(1)
+        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127
+        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      }
     }
 
     "use an ID hash for each node" >> {
@@ -288,19 +293,20 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).toList
-      features must haveLength(2)
-      features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
-      features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-      features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-      features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
-      features(1).getAttribute("source").asInstanceOf[String] mustEqual "myxml"
-      features.head.getID mustEqual "441dd9114a1a345fe59f0dfe461f01ca"
-      features(1).getID mustEqual "42aae6286c7204c3aa1aa99a4e8dae35"
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features must haveLength(2)
+        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+        features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
+        features(1).getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        features.head.getID mustEqual "441dd9114a1a345fe59f0dfe461f01ca"
+        features(1).getID mustEqual "42aae6286c7204c3aa1aa99a4e8dae35"
+      }
     }
 
     "validate with an xsd" >> {
@@ -339,24 +345,24 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        "parse as itr" >> {
+          val features = WithClose(converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))))(_.toList)
+          features must haveLength(1)
+          features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+          features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+          features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+          features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        }
 
-      "parse as itr" >> {
-        val features = converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).toList
-        features must haveLength(1)
-        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
-      }
-
-      "parse as stream" >> {
-        val features = converter.process(new ByteArrayInputStream(xml.replaceAllLiterally("\n", " ").getBytes(StandardCharsets.UTF_8))).toList
-        features must haveLength(1)
-        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        "parse as stream" >> {
+          val features = WithClose(converter.process(new ByteArrayInputStream(xml.replaceAllLiterally("\n", " ").getBytes(StandardCharsets.UTF_8))))(_.toList)
+          features must haveLength(1)
+          features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+          features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+          features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+          features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        }
       }
     }
 
@@ -398,14 +404,14 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-
-      val features = converter.process(new ByteArrayInputStream(xml.getBytes)).toList
-      features must haveLength(1)
-      features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(xml.getBytes)))(_.toList)
+        features must haveLength(1)
+        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      }
     }
 
     "parse xml in single line mode" >> {
@@ -448,20 +454,20 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(xml.getBytes)))(_.toList)
+        features must haveLength(2)
 
-      val features = converter.process(new ByteArrayInputStream(xml.getBytes)).toList
-      features must haveLength(2)
+        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
 
-      features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
-
-      features.last.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.last.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.last.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features.last.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        features.last.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.last.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.last.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features.last.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      }
     }
 
     "invalidate with an xsd" >> {
@@ -499,9 +505,10 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).toList
-      features must haveLength(0)
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features must haveLength(0)
+      }
     }
 
     "handle user data" >> {
@@ -538,14 +545,15 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).toList
-      features must haveLength(1)
-      features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127
-      features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
-      features.head.getUserData.get("my.user.key") mustEqual 127d
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features must haveLength(1)
+        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127
+        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        features.head.getUserData.get("my.user.key") mustEqual 127d
+      }
     }
 
     "Parse XMLs with a BOM" >> {
@@ -570,17 +578,18 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val xmlConverter = SimpleFeatureConverter(sft, parserConf)
-      val features = xmlConverter.process(xml.openStream()).toList
-      features must haveLength(2)
-      features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
-      features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
-      features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
-      features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
-      features(1).getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(xml.openStream()))(_.toList)
+        features must haveLength(2)
+        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        features(1).getAttribute("number").asInstanceOf[Integer] mustEqual 456
+        features(1).getAttribute("color").asInstanceOf[String] mustEqual "blue"
+        features(1).getAttribute("weight").asInstanceOf[Double] mustEqual 150
+        features(1).getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      }
     }
 
     "support namespaces with saxon" >> {
@@ -618,13 +627,14 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverter(sft, parserConf)
-      val features = converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))).toList
-      features must haveLength(1)
-      features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127
-      features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      WithClose(SimpleFeatureConverter(sft, parserConf)) { converter =>
+        val features = WithClose(converter.process(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))))(_.toList)
+        features must haveLength(1)
+        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127
+        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      }
     }
 
     "not use single line mode for v1 processInput/processSingleInput" >> {
@@ -660,20 +670,20 @@ class XmlConverterTest extends Specification {
           | }
         """.stripMargin)
 
-      val converter = SimpleFeatureConverters.build[String](sft, parserConf)
+      WithClose(SimpleFeatureConverters.build[String](sft, parserConf)) { converter =>
+        val features = converter.processInput(Iterator(xml, xml)).toList
+        features must haveLength(2)
 
-      val features = converter.processInput(Iterator(xml, xml)).toList
-      features must haveLength(2)
+        features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
 
-      features.head.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.head.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.head.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features.head.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
-
-      features.last.getAttribute("number").asInstanceOf[Integer] mustEqual 123
-      features.last.getAttribute("color").asInstanceOf[String] mustEqual "red"
-      features.last.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
-      features.last.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+        features.last.getAttribute("number").asInstanceOf[Integer] mustEqual 123
+        features.last.getAttribute("color").asInstanceOf[String] mustEqual "red"
+        features.last.getAttribute("weight").asInstanceOf[Double] mustEqual 127.5
+        features.last.getAttribute("source").asInstanceOf[String] mustEqual "myxml"
+      }
     }
   }
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
@@ -27,6 +27,8 @@ class ConverterStorage(fc: FileContext,
                        converter: SimpleFeatureConverter,
                        partitionScheme: PartitionScheme) extends FileSystemStorage {
 
+  // TODO close converter...
+
   private val metadata = new ConverterMetadata(fc, root, sft, partitionScheme)
 
   import scala.collection.JavaConverters._

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/ConverterInputFormat.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/ConverterInputFormat.scala
@@ -138,6 +138,7 @@ class ConverterRecordReader extends FileStreamRecordReader with LazyLogging {
       override def close(): Unit = {
         CloseWithLogging(featureReader)
         CloseWithLogging(iter)
+        CloseWithLogging(converter)
       }
     }
   }

--- a/geomesa-spark/geomesa-spark-converter/src/main/scala/org/locationtech/geomesa/spark/converter/ConverterSpatialRDDProvider.scala
+++ b/geomesa-spark/geomesa-spark-converter/src/main/scala/org/locationtech/geomesa/spark/converter/ConverterSpatialRDDProvider.scala
@@ -88,7 +88,7 @@ class ConverterSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
 
     // Verify the config before returning.
     try {
-      SimpleFeatureConverter(sft, ConfigFactory.parseString(converterConf))
+      SimpleFeatureConverter(sft, ConfigFactory.parseString(converterConf)).close()
     } catch {
       case NonFatal(e) => throw new IllegalArgumentException("Could not resolve converter", e)
     }


### PR DESCRIPTION
…ts can leak resources

* SimpleFeatureConverter changed to extend Closeable
* Caches configured at the converter level are shared between evaluation contexts

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>