### PR TITLE
GEOMESA-2447 Refactor the CartesianProductIterator to remove costly m…

### DIFF
--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/iterators/CartesianProductIterable.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/iterators/CartesianProductIterable.scala
@@ -14,32 +14,51 @@ package org.locationtech.geomesa.utils.iterators
  * way to query the list size that is independent of the iterator itself.
  * (That is, asking for the size does not exhaust any iterator.)
  *
+ * NB:  The first sequence is the least significant; that is, it will
+ * increment fast while the last sequence is the most significant (will
+ * increment slowly).
+ *
  * @param seqs the list-of-lists whose items are to be recombined
  * @tparam T the type of items
  */
-case class CartesianProductIterable[T](seqs:Seq[Seq[T]]) extends Iterable[Seq[T]] {
-  // how many (total) combinations there will be in an iterator
-  lazy val expectedSize : Long = seqs.map(seq => seq.size.toLong).product
 
-  // create an iterator that will visit all possible combinations
-  // (every time you call this, you get a NEW iterator)
-  def iterator : Iterator[Seq[T]] = new Iterator[Seq[T]] {
-    // variable index that counts off the combinations
-    var index : Long = 0L
-    // current value (combination)
-    private def value : Seq[T] =
-      seqs.foldLeft(Seq[T](),index)((t,src) => t match { case (seqSoFar,idx) => {
-        val modulus : Int = src.size
-        val itemIndex : Int = (idx % modulus).toInt
-        val item : T = src(itemIndex)
-        (seqSoFar++Seq(item), idx / modulus)
-      }})._1
-    def next() : Seq[T] = {
-      val result = if (hasNext) value else null
-      index = index + 1L
+case class CartesianProductIterable(seqs: Seq[Seq[_]]) extends Iterable[Seq[_]] {
+  lazy val expectedSize: Int = seqs.map(_.size).product
+
+  def iterator: Iterator[Seq[_]] = new Iterator[Seq[_]] {
+    val n = seqs.size
+    val maxes = seqs.map(seq => seq.size)
+    val indexes = scala.collection.mutable.MutableList.fill(seqs.size)(0)
+    var nextItem: Option[Seq[_]] = if (isValid) Option(realize) else None
+  
+    def isValid: Boolean = (0 until n).forall(i => indexes(i) < maxes(i))
+  
+    def realize: Seq[_] = (0 until n).map(i => seqs(i)(indexes(i)))
+  
+    def hasNext: Boolean = nextItem.isDefined
+  
+    def next(): Seq[_] = {
+      if (nextItem.isEmpty) throw new Exception("Iterator exhausted")
+
+      val result = nextItem.get
+
+      // advance the internal state
+      nextItem = None
+      var j = 0
+      var done = false
+      while (j < n && !done) {
+        indexes(j) = indexes(j) + 1
+        if (indexes(j) >= maxes(j)) {
+          indexes(j) = 0
+          j = j + 1
+        } else {
+          done = true
+        }
+      }
+      if (done || j < n) nextItem = Option(realize)
+
       result
     }
-    def hasNext : Boolean = index < expectedSize
   }
 }
-
+ 


### PR DESCRIPTION
…odulus calls

Reworked the implementation so that it no longer uses the integer
division, but does a more direct iteration over array indexes.
The JIRA ticket contains a chart that shows, for the few test
cases run, the new implementation takes approximately half as
long to generate and exhaust the iterators over the product.

Signed-off-by: Chris Eichelberger <cne1x@ccri.com>