### PR TITLE
GEOMESA-2473 Kafka - support initial load from a given time offset

### DIFF
--- a/docs/user/kafka/index_config.rst
+++ b/docs/user/kafka/index_config.rst
@@ -13,10 +13,16 @@ Initial Load (Replay)
 ---------------------
 
 By default, a Kafka consumer data store will start consuming from the end of a topic. This means that it will
-only see new updates that are written after it has spun up. Optionally, the consumer may start from the beginning
-of the topic, by setting ``kafka.consumer.from-beginning`` to ``true`` in the data store parameters. This
-allows a consumer to replay old messages and establish a baseline state. Note that a feature store will not return
-any query results during this initial load, until it has caught up to head state.
+only see new updates that are written after it has spun up. Optionally, the consumer may start from earlier
+in the topic, by setting ``kafka.consumer.read-back`` to a duration, such as ``1 hour``, in the data store
+parameters. This allows a consumer to replay old messages and establish a baseline state. To read the entire
+message queue, use the value ``Inf``.
+
+Reading back by a given interval is only supported in Kafka starting with version 0.10.1. Older versions will fall
+back to reading from the very beginning of the topic.
+
+Note that a feature store will not return any query results during this initial load, until it has caught up to
+head state.
 
 Also see :ref:`topic_compaction` for details on managing the size and history of the Kafka topic.
 

--- a/docs/user/kafka/usage.rst
+++ b/docs/user/kafka/usage.rst
@@ -45,9 +45,10 @@ Parameter                            Type    Description
                                              format. See `Producer Configs <http://kafka.apache.org/documentation.html#producerconfigs>`_
 ``kafka.consumer.config``            String  Configuration options for kafka consumer, in Java properties
                                              format. See `New Consumer Configs <http://kafka.apache.org/documentation.html#newconsumerconfigs>`_
-``kafka.consumer.from-beginning``    Boolean Start reading from the beginning of the topic (vs ignore existing messages). If enabled, features
-                                             will not be available for query until all existing messages are processed. However, feature
-                                             listeners will still be invoked as normal. See :ref:`kafka_initial_load`
+``kafka.consumer.read-back``         String  On start up, read messages that were written within this time frame (vs ignore old messages), e.g.
+                                             '1 hour'. Use 'Inf' to read all messages. If enabled, features will not be available for query until
+                                             all existing messages are processed. However, feature listeners will still be invoked as normal.
+                                             See :ref:`kafka_initial_load`
 ``kafka.consumer.count``             Integer Number of kafka consumers used per feature type. Set to 0 to disable consuming (i.e. producer only)
 ``kafka.topic.partitions``           Integer Number of partitions to use in new kafka topics
 ``kafka.topic.replication``          Integer Replication factor to use in new kafka topics

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaCacheLoader.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaCacheLoader.scala
@@ -17,12 +17,12 @@ import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecord}
 import org.geotools.data.simple.SimpleFeatureSource
 import org.geotools.data.{FeatureEvent, FeatureListener}
-import org.locationtech.geomesa.kafka.{KafkaConsumerVersions, RecordVersions}
 import org.locationtech.geomesa.kafka.consumer.ThreadedConsumer
-import org.locationtech.geomesa.kafka.data.KafkaDataStore.IndexConfig
+import org.locationtech.geomesa.kafka.data.KafkaDataStore.EventTimeConfig
 import org.locationtech.geomesa.kafka.index.KafkaFeatureCache
 import org.locationtech.geomesa.kafka.utils.GeoMessage.{Change, Clear, Delete}
 import org.locationtech.geomesa.kafka.utils.{GeoMessageSerializer, KafkaFeatureEvent}
+import org.locationtech.geomesa.kafka.{KafkaConsumerVersions, RecordVersions}
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
@@ -102,7 +102,9 @@ object KafkaCacheLoader {
                              override protected val topic: String,
                              override protected val frequency: Long,
                              lazyDeserialization: Boolean,
-                             initialLoadConfig: Option[IndexConfig]) extends ThreadedConsumer with KafkaCacheLoader {
+                             doInitialLoad: Boolean,
+                             initialLoadConfig: Option[EventTimeConfig])
+      extends ThreadedConsumer with KafkaCacheLoader {
 
     private val serializer = GeoMessageSerializer(sft, `lazy` = lazyDeserialization)
 
@@ -110,13 +112,13 @@ object KafkaCacheLoader {
       case _: NoSuchMethodException => logger.warn("This version of Kafka doesn't support timestamps, using system time")
     }
 
-    initialLoadConfig match {
-      case None => startConsumers()
-      case Some(config) =>
-        // for the initial load, don't bother spatially indexing until we have the final state
-        val executor = Executors.newSingleThreadExecutor()
-        executor.submit(new InitialLoader(sft, consumers, topic, frequency, serializer, config, this))
-        executor.shutdown()
+    if (doInitialLoad) {
+      // for the initial load, don't bother spatially indexing until we have the final state
+      val executor = Executors.newSingleThreadExecutor()
+      executor.submit(new InitialLoader(sft, consumers, topic, frequency, serializer, initialLoadConfig, this))
+      executor.shutdown()
+    } else {
+      startConsumers()
     }
 
     override def close(): Unit = {
@@ -155,10 +157,10 @@ object KafkaCacheLoader {
                               override protected val topic: String,
                               override protected val frequency: Long,
                               serializer: GeoMessageSerializer,
-                              config: IndexConfig,
+                              eventTime: Option[EventTimeConfig],
                               toLoad: KafkaCacheLoaderImpl) extends ThreadedConsumer with Runnable {
 
-    private val cache = KafkaFeatureCache.nonIndexing(sft, config.eventTime)
+    private val cache = KafkaFeatureCache.nonIndexing(sft, eventTime)
 
     // track the offsets that we want to read to
     private val offsets = new ConcurrentHashMap[Int, Long]()

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreFactory.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreFactory.scala
@@ -74,6 +74,7 @@ object KafkaDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
       KafkaDataStoreFactoryParams.ZkPath,
       KafkaDataStoreFactoryParams.ConsumerCount,
       KafkaDataStoreFactoryParams.ConsumerConfig,
+      KafkaDataStoreFactoryParams.ConsumerReadBack,
       KafkaDataStoreFactoryParams.CacheExpiry,
       KafkaDataStoreFactoryParams.EventTime,
       KafkaDataStoreFactoryParams.SerializationType,
@@ -83,7 +84,6 @@ object KafkaDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
       KafkaDataStoreFactoryParams.IndexTiers,
       KafkaDataStoreFactoryParams.EventTimeOrdering,
       KafkaDataStoreFactoryParams.LazyFeatures,
-      KafkaDataStoreFactoryParams.ConsumeEarliest,
       KafkaDataStoreFactoryParams.AuditQueries,
       KafkaDataStoreFactoryParams.LooseBBox,
       KafkaDataStoreFactoryParams.Authorizations
@@ -104,7 +104,8 @@ object KafkaDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
     val consumers = {
       val count = ConsumerCount.lookup(params).intValue
       val props = ConsumerConfig.lookupOpt(params).map(_.asScala.toMap).getOrElse(Map.empty[String, String])
-      KafkaDataStore.ConsumerConfig(count, props, ConsumeEarliest.lookup(params).booleanValue)
+      val readBack = ConsumerReadBack.lookupOpt(params)
+      KafkaDataStore.ConsumerConfig(count, props, readBack)
     }
 
     val producers = {
@@ -120,8 +121,12 @@ object KafkaDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
         CqEngineIndices.lookupOpt(params) match {
           case Some(attributes) =>
             attributes.split(",").toSeq.map { attribute =>
-              val Array(name, indexType) = attribute.split(":", 2)
-              (name, CQIndexType.withName(indexType))
+              try {
+                val Array(name, indexType) = attribute.split(":", 2)
+                (name, CQIndexType.withName(indexType))
+              } catch {
+                case _: MatchError => throw new IllegalArgumentException(s"Invalid CQEngine index value: $attribute")
+              }
             }
 
           case None =>
@@ -227,7 +232,8 @@ object KafkaDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
   object KafkaDataStoreFactoryParams extends NamespaceParams {
     // deprecated lookups
     private val DeprecatedProducer = ConvertedParam[java.lang.Integer, java.lang.Boolean]("isProducer", v => if (v) { 0 } else { 1 })
-    private val DeprecatedOffset = ConvertedParam[java.lang.Boolean, String]("autoOffsetReset", v => "earliest".equalsIgnoreCase(v))
+    private val DeprecatedOffset = ConvertedParam[Duration, String]("autoOffsetReset", v => if ("earliest".equalsIgnoreCase(v)) { Duration.Inf } else { null })
+    private val DeprecatedEarliest = ConvertedParam[Duration, java.lang.Boolean]("kafka.consumer.from-beginning", v => if (v) { Duration.Inf } else { null })
     private val DeprecatedExpiry = ConvertedParam[Duration, java.lang.Long]("expirationPeriod", v => Duration(v, "ms"))
     private val DeprecatedConsistency = ConvertedParam[Duration, java.lang.Long]("consistencyCheck", v => Duration(v, "ms"))
     private val DeprecatedCleanup = new DeprecatedParam[Duration] {
@@ -245,7 +251,7 @@ object KafkaDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
     val ZkPath            = new GeoMesaParam[String]("kafka.zk.path", "Zookeeper discoverable path (namespace)", default = DefaultZkPath, deprecatedKeys = Seq("zkPath"))
     val ProducerConfig    = new GeoMesaParam[Properties]("kafka.producer.config", "Configuration options for kafka producer, in Java properties format. See http://kafka.apache.org/documentation.html#producerconfigs", largeText = true, deprecatedKeys = Seq("producerConfig"))
     val ConsumerConfig    = new GeoMesaParam[Properties]("kafka.consumer.config", "Configuration options for kafka consumer, in Java properties format. See http://kafka.apache.org/documentation.html#newconsumerconfigs", largeText = true, deprecatedKeys = Seq("consumerConfig"))
-    val ConsumeEarliest   = new GeoMesaParam[java.lang.Boolean]("kafka.consumer.from-beginning", "Start reading from the beginning of the topic (vs ignore old messages)", default = Boolean.box(false), deprecatedParams = Seq(DeprecatedOffset))
+    val ConsumerReadBack  = new GeoMesaParam[Duration]("kafka.consumer.read-back", "On start up, read messages that were written within this time frame (vs ignore old messages), e.g. '1 hour'. Use 'Inf' to read all messages", deprecatedParams = Seq(DeprecatedOffset, DeprecatedEarliest))
     val TopicPartitions   = new GeoMesaParam[Integer]("kafka.topic.partitions", "Number of partitions to use in new kafka topics", default = 1, deprecatedKeys = Seq("partitions"))
     val TopicReplication  = new GeoMesaParam[Integer]("kafka.topic.replication", "Replication factor to use in new kafka topics", default = 1, deprecatedKeys = Seq("replication"))
     val ConsumerCount     = new GeoMesaParam[Integer]("kafka.consumer.count", "Number of kafka consumers used per feature type. Set to 0 to disable consuming (i.e. producer only)", default = 1, deprecatedParams = Seq(DeprecatedProducer))

--- a/geomesa-kafka/geomesa-kafka-tools/src/main/scala/org/locationtech/geomesa/kafka/tools/KafkaDataStoreCommand.scala
+++ b/geomesa-kafka/geomesa-kafka-tools/src/main/scala/org/locationtech/geomesa/kafka/tools/KafkaDataStoreCommand.scala
@@ -19,13 +19,18 @@ trait KafkaDataStoreCommand extends DataStoreCommand[KafkaDataStore] {
 
   override def params: KafkaDataStoreParams
 
-  override def connection: Map[String, String] = Map[String, String](
-    KafkaDataStoreFactoryParams.Brokers.getName          -> params.brokers,
-    KafkaDataStoreFactoryParams.Zookeepers.getName       -> params.zookeepers,
-    KafkaDataStoreFactoryParams.ZkPath.getName           -> params.zkPath,
-    KafkaDataStoreFactoryParams.ConsumerCount.getName    -> params.numConsumers.toString,
-    KafkaDataStoreFactoryParams.TopicPartitions.getName  -> params.partitions.toString,
-    KafkaDataStoreFactoryParams.TopicReplication.getName -> params.replication.toString,
-    KafkaDataStoreFactoryParams.ConsumeEarliest.getName  -> params.fromBeginning.toString
-  ).filter(_._2 != null)
+  override def connection: Map[String, String] = {
+    val readBack = Option(params.readBack).map(_.toString).getOrElse {
+      if (params.fromBeginning) { "Inf" } else { null }
+    }
+    Map[String, String](
+      KafkaDataStoreFactoryParams.Brokers.getName          -> params.brokers,
+      KafkaDataStoreFactoryParams.Zookeepers.getName       -> params.zookeepers,
+      KafkaDataStoreFactoryParams.ZkPath.getName           -> params.zkPath,
+      KafkaDataStoreFactoryParams.ConsumerCount.getName    -> params.numConsumers.toString,
+      KafkaDataStoreFactoryParams.TopicPartitions.getName  -> params.partitions.toString,
+      KafkaDataStoreFactoryParams.TopicReplication.getName -> params.replication.toString,
+      KafkaDataStoreFactoryParams.ConsumerReadBack.getName -> readBack
+    ).filter(_._2 != null)
+  }
 }

--- a/geomesa-kafka/geomesa-kafka-tools/src/main/scala/org/locationtech/geomesa/kafka/tools/KafkaParams.scala
+++ b/geomesa-kafka/geomesa-kafka-tools/src/main/scala/org/locationtech/geomesa/kafka/tools/KafkaParams.scala
@@ -10,12 +10,16 @@ package org.locationtech.geomesa.kafka.tools
 
 import com.beust.jcommander.Parameter
 import org.locationtech.geomesa.kafka.data.KafkaDataStoreFactory
+import org.locationtech.geomesa.tools.utils.ParameterConverters.DurationConverter
+
+import scala.concurrent.duration.Duration
 
 /**
   * Shared Kafka-specific command line parameters
   */
 
 trait KafkaDataStoreParams {
+
   @Parameter(names = Array("-b", "--brokers"), description = "Brokers (host:port, comma separated)", required = true)
   var brokers: String = _
 
@@ -29,9 +33,11 @@ trait KafkaDataStoreParams {
   def replication: Int
   def partitions: Int
   def fromBeginning: Boolean
+  def readBack: Duration
 }
 
 trait ProducerDataStoreParams extends KafkaDataStoreParams {
+
   @Parameter(names = Array("--replication"), description = "Replication factor for Kafka topic")
   var replication: Int = 1 // note: can't use override modifier since it's a var
 
@@ -39,16 +45,20 @@ trait ProducerDataStoreParams extends KafkaDataStoreParams {
   var partitions: Int = 1 // note: can't use override modifier since it's a var
 
   override val numConsumers: Int = 0
+  override val readBack: Duration = null
   override val fromBeginning: Boolean = false
 }
 
 trait ConsumerDataStoreParams extends KafkaDataStoreParams {
+
   @Parameter(names = Array("--num-consumers"), description = "Number of consumer threads used for reading from Kafka")
   var numConsumers: Int = 1 // note: can't use override modifier since it's a var
 
-  // TODO support from oldest+n, oldest+t, newest-n, newest-t, time=t, offset=o
   @Parameter(names = Array("--from-beginning"), description = "Consume from the beginning or end of the topic")
   var fromBeginning: Boolean = false
+
+  @Parameter(names = Array("--read-back"), description = "Consume messages written within this time frame, e.g. '1 hour'", converter = classOf[DurationConverter])
+  var readBack: Duration = _
 
   override val replication: Int = 1
   override val partitions: Int = 1
@@ -58,5 +68,6 @@ trait StatusDataStoreParams extends KafkaDataStoreParams {
   override val numConsumers: Int = 0
   override val replication: Int = 1
   override val partitions: Int = 1
+  override val readBack: Duration = null
   override val fromBeginning: Boolean = false
 }

--- a/geomesa-kafka/geomesa-kafka-utils/src/main/scala/org/locationtech/geomesa/kafka/KafkaConsumerVersions.scala
+++ b/geomesa-kafka/geomesa-kafka-utils/src/main/scala/org/locationtech/geomesa/kafka/KafkaConsumerVersions.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.kafka
 
 import java.util.Collections
 
-import org.apache.kafka.clients.consumer.{Consumer, ConsumerRebalanceListener}
+import org.apache.kafka.clients.consumer.{Consumer, ConsumerRebalanceListener, OffsetAndTimestamp}
 import org.apache.kafka.common.TopicPartition
 
 /**
@@ -36,6 +36,9 @@ object KafkaConsumerVersions {
 
   def endOffsets(consumer: Consumer[_, _], topic: String, partitions: Seq[Int]): Map[Int, Long] =
     _endOffsets(consumer, topic, partitions)
+
+  def offsetsForTimes(consumer: Consumer[_, _], topic: String, partitions: Seq[Int], time: Long): Map[Int, Long] =
+    _offsetsForTimes(consumer, topic, partitions, time)
 
   private val _seekToBeginning: (Consumer[_, _], TopicPartition) => Unit = consumerTopicInvocation("seekToBeginning")
 
@@ -92,6 +95,24 @@ object KafkaConsumerVersions {
       val result = Map.newBuilder[Int, Long]
       result.sizeHint(offsets.size())
       offsets.asScala.foreach { case (tp, o) => result += (tp.partition -> o) }
+      result.result()
+    }
+  }
+
+  private val _offsetsForTimes: (Consumer[_, _], String, Seq[Int], Long) => Map[Int, Long] = {
+    import scala.collection.JavaConverters._
+    // note: this method doesn't exist until 0.10.1, so may be null
+    val method = methods.find(m => m.getName == "offsetsForTimes" && m.getParameterCount == 1).orNull
+    (consumer, topic, partitions, time) => {
+      if (method == null) {
+        throw new NoSuchMethodException(s"Couldn't find Consumer.offsetsForTimes method")
+      }
+      val timestamps = new java.util.HashMap[TopicPartition, java.lang.Long](partitions.length)
+      partitions.foreach(p => timestamps.put(new TopicPartition(topic, p), Long.box(time)))
+      val offsets = method.invoke(consumer, timestamps).asInstanceOf[java.util.Map[TopicPartition, OffsetAndTimestamp]]
+      val result = Map.newBuilder[Int, Long]
+      result.sizeHint(offsets.size())
+      offsets.asScala.foreach { case (tp, o) => if (o != null) { result += (tp.partition -> o.offset()) } }
       result.result()
     }
   }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/AbstractIngest.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/AbstractIngest.scala
@@ -202,7 +202,7 @@ abstract class AbstractIngest(val dsParams: Map[String, String],
 
     Command.user.info(s"Local ingestion complete in ${TextTools.getTime(start)}")
     if (files.lengthCompare(1) == 0) {
-      Command.user.info(getStatInfo(written.get, failed.get, input = s" for file: ${files.head.path}."))
+      Command.user.info(getStatInfo(written.get, failed.get, input = s" for file: ${files.head.path}"))
     } else {
       Command.user.info(getStatInfo(written.get, failed.get))
     }
@@ -253,7 +253,7 @@ object AbstractIngest {
     } else {
       s"and failed to ingest ${TextTools.getPlural(failures, "feature")}"
     }
-    s"$action ${TextTools.getPlural(successes, "feature")} $failureString$input."
+    s"$action ${TextTools.getPlural(successes, "feature")} $failureString$input"
   }
 
   sealed trait StatusCallback {


### PR DESCRIPTION
* Use `kafka.consumer.read-back` to specify how far back a consumer will start reading
* Kafka versions prior to 0.10.1 do not support time-based lookups, so the entire topic will be read
* `kafka.consumer.from-beginning` is deprecated, use `Inf` for the read-back value instead

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>