### PR TITLE
GEOMESA-2484 Add converting of parsed values in AbstractConverter

### DIFF
--- a/docs/user/convert/jdbc.rst
+++ b/docs/user/convert/jdbc.rst
@@ -7,6 +7,11 @@ The JDBC converter allows you to create SimpleFeatures directly from a SQL selec
 existing database, using standard JDBC libraries. To use the JDBC converter, specify ``type = "jdbc"``
 in your converter definition.
 
+.. warning::
+
+    The JDBC converter does not sanitize queries. Be careful with inputs, as a malicious actor could
+    potentially execute SQL injection attacks.
+
 Configuration
 -------------
 

--- a/geomesa-convert/geomesa-convert-avro/src/main/scala/org/locationtech/geomesa/convert/avro/AvroConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-avro/src/main/scala/org/locationtech/geomesa/convert/avro/AvroConverterFactory.scala
@@ -208,7 +208,7 @@ object AvroConverterFactory {
           case (Some(s), None) => Right(SchemaString(s))
           case (None, Some(s)) => Right(SchemaFile(s))
           case _ =>
-            val reason = new FailureReason {
+            val reason: FailureReason = new FailureReason {
               override val description: String = "Exactly one of 'schema' or 'schema-file' must be defined"
             }
             cur.failed(reason)

--- a/geomesa-convert/geomesa-convert-avro/src/test/scala/org/locationtech/geomesa/convert/avro/AvroConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-avro/src/test/scala/org/locationtech/geomesa/convert/avro/AvroConverterTest.scala
@@ -102,7 +102,7 @@ class AvroConverterTest extends Specification with AvroUtils with LazyLogging {
       }
     }
 
-    "make avro bytes available as $0" >> {
+    "make avro bytes available as $0 with defined schemas" >> {
       val conf = ConfigFactory.parseString(
         """
           | {
@@ -110,6 +110,7 @@ class AvroConverterTest extends Specification with AvroUtils with LazyLogging {
           |   schema-file = "/schema.avsc"
           |   sft         = "testsft"
           |   id-field    = "md5($0)"
+          |   options = { verbose = true }
           |   fields = [
           |     { name = "tobj", transform = "avroPath($1, '/content$type=TObj')" },
           |     { name = "dtg",  transform = "date('yyyy-MM-dd', avroPath($tobj, '/kvmap[$k=dtg]/v'))" },
@@ -125,6 +126,50 @@ class AvroConverterTest extends Specification with AvroUtils with LazyLogging {
 
         // pass two messages to check message buffering for record bytes
         val res = WithClose(converter.process(new ByteArrayInputStream(bytes ++ bytes), ec))(_.toList)
+        res must haveLength(2)
+        foreach(res) { sf =>
+          sf.getID mustEqual Hashing.md5().hashBytes(bytes).toString
+          sf.getAttributeCount must be equalTo 2
+          sf.getAttribute("dtg") must not(beNull)
+        }
+
+        ec.counter.getFailure mustEqual 0L
+        ec.counter.getSuccess mustEqual 2L
+        ec.counter.getLineCount mustEqual 2L
+      }
+    }
+
+    "make avro bytes available as $0 with embedded schemas" >> {
+      val conf = ConfigFactory.parseString(
+        """
+          | {
+          |   type        = "avro"
+          |   sft         = "testsft"
+          |   schema      = "embedded"
+          |   id-field    = "md5($0)"
+          |   options = { verbose = true }
+          |   fields = [
+          |     { name = "tobj", transform = "avroPath($1, '/content$type=TObj')" },
+          |     { name = "dtg",  transform = "date('yyyy-MM-dd', avroPath($tobj, '/kvmap[$k=dtg]/v'))" },
+          |     { name = "lat",  transform = "avroPath($tobj, '/kvmap[$k=lat]/v')" },
+          |     { name = "lon",  transform = "avroPath($tobj, '/kvmap[$k=lon]/v')" },
+          |     { name = "geom", transform = "point($lon, $lat)" }
+          |   ]
+          | }
+        """.stripMargin)
+
+      val out = new ByteArrayOutputStream()
+      WithClose(new DataFileWriter(writer)) { fileWriter =>
+        fileWriter.create(schema, out)
+        fileWriter.append(obj)
+        fileWriter.append(obj)
+      }
+
+      WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+        val ec = converter.createEvaluationContext()
+
+        // pass two messages to check message buffering for record bytes
+        val res = WithClose(converter.process(new ByteArrayInputStream(out.toByteArray), ec))(_.toList)
         res must haveLength(2)
         foreach(res) { sf =>
           sf.getID mustEqual Hashing.md5().hashBytes(bytes).toString

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverters.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverters.scala
@@ -55,7 +55,7 @@ object SimpleFeatureConverters extends LazyLogging {
       case Some(c) => c.asInstanceOf[SimpleFeatureConverter[I]]
       case None =>
         val converters = factories.iterator.flatMap(_.apply(sft, converterConf)).collect {
-          case c: AbstractConverter[_, _, _] => c.asInstanceOf[AbstractConverter[_ <: ConverterConfig, _, _]]
+          case c: AbstractConverter[_, _, _, _] => c.asInstanceOf[AbstractConverter[_, _ <: ConverterConfig, _, _]]
         }
         if (converters.hasNext) { new SimpleFeatureConverterWrapper(converters.next) } else {
           throw new IllegalArgumentException(s"Cannot find converter factory for type ${sft.getTypeName}")
@@ -69,7 +69,7 @@ object SimpleFeatureConverters extends LazyLogging {
     * @param converter new converter
     * @tparam I type bounds
     */
-  class SimpleFeatureConverterWrapper[I](converter: AbstractConverter[_ <: ConverterConfig, _, _]) extends
+  class SimpleFeatureConverterWrapper[I](converter: AbstractConverter[_, _ <: ConverterConfig, _, _]) extends
       SimpleFeatureConverter[I] {
 
     private val open =

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/SimpleFeatureConverter.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/SimpleFeatureConverter.scala
@@ -58,6 +58,7 @@ object SimpleFeatureConverter extends StrictLogging {
   val factories: List[SimpleFeatureConverterFactory] =
     ServiceLoader.load(classOf[SimpleFeatureConverterFactory]).asScala.toList
 
+  // noinspection ScalaDeprecation
   private val factoriesV1 = ServiceLoader.load(classOf[convert.SimpleFeatureConverterFactory[_]]).asScala.toList
 
   logger.debug(s"Found ${factories.size + factoriesV1.size} factories: " +
@@ -125,6 +126,7 @@ object SimpleFeatureConverter extends StrictLogging {
     }
   }
 
+  // noinspection ScalaDeprecation
   class SimpleFeatureConverterWrapper(converter: convert.SimpleFeatureConverter[_]) extends SimpleFeatureConverter {
 
     override def targetSft: SimpleFeatureType = converter.targetSFT

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/package.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/package.scala
@@ -11,8 +11,7 @@ package org.locationtech.geomesa
 import java.nio.charset.Charset
 
 import com.typesafe.config.Config
-import org.locationtech.geomesa.convert.Modes.ErrorMode
-import org.locationtech.geomesa.convert.Modes.ParseMode
+import org.locationtech.geomesa.convert.Modes.{ErrorMode, ParseMode}
 import org.locationtech.geomesa.convert.{EvaluationContext, SimpleFeatureValidator}
 import org.locationtech.geomesa.convert2.transforms.Expression
 

--- a/geomesa-convert/geomesa-convert-jdbc/src/main/scala/org/locationtech/geomesa/convert/jdbc/JdbcConverter.scala
+++ b/geomesa-convert/geomesa-convert-jdbc/src/main/scala/org/locationtech/geomesa/convert/jdbc/JdbcConverter.scala
@@ -9,12 +9,13 @@
 package org.locationtech.geomesa.convert.jdbc
 
 import java.io.InputStream
-import java.sql.{DriverManager, PreparedStatement, ResultSet}
+import java.nio.charset.Charset
+import java.sql.{Connection, DriverManager, PreparedStatement, ResultSet}
 
 import com.typesafe.config.Config
 import org.apache.commons.io.IOUtils
 import org.locationtech.geomesa.convert._
-import org.locationtech.geomesa.convert.jdbc.JdbcConverter.JdbcConfig
+import org.locationtech.geomesa.convert.jdbc.JdbcConverter.{JdbcConfig, ResultSetIterator, StatementIterator}
 import org.locationtech.geomesa.convert2.AbstractConverter.{BasicField, BasicOptions}
 import org.locationtech.geomesa.convert2.transforms.Expression
 import org.locationtech.geomesa.convert2.{AbstractConverter, ConverterConfig}
@@ -24,69 +25,22 @@ import org.opengis.feature.simple.SimpleFeatureType
 
 import scala.annotation.tailrec
 
-class JdbcConverter(targetSft: SimpleFeatureType,
-                    config: JdbcConfig,
-                    fields: Seq[BasicField],
-                    options: BasicOptions)
-    extends AbstractConverter(targetSft, config, fields, options) {
+class JdbcConverter(sft: SimpleFeatureType, config: JdbcConfig, fields: Seq[BasicField], options: BasicOptions)
+    extends AbstractConverter[ResultSet, JdbcConfig, BasicField, BasicOptions](sft, config, fields, options) {
 
   private val connection = DriverManager.getConnection(config.connection)
+
+  override protected def parse(is: InputStream, ec: EvaluationContext): CloseableIterator[ResultSet] =
+    new StatementIterator(connection, is, options.encoding)
+
+  override protected def values(parsed: CloseableIterator[ResultSet],
+                                ec: EvaluationContext): CloseableIterator[Array[Any]] = {
+    new ResultSetIterator(parsed, ec.counter)
+  }
 
   override def close(): Unit = {
     CloseWithLogging(connection)
     super.close()
-  }
-
-  override protected def read(is: InputStream, ec: EvaluationContext): CloseableIterator[Array[Any]] =
-    new StatementIterator(is, ec.counter)
-
-  class StatementIterator private [JdbcConverter] (is: InputStream, counter: Counter)
-      extends CloseableIterator[Array[Any]] {
-
-    private val statements = IOUtils.lineIterator(is, options.encoding) // TODO split on ; ?
-
-    private var statement: PreparedStatement = _
-    private var results: ResultSet = _
-    private var _next = false
-    private var array: Array[Any] = _
-
-    @tailrec
-    override final def hasNext: Boolean = _next || {
-      Option(results).foreach(CloseWithLogging.apply)
-      Option(statement).foreach(CloseWithLogging.apply)
-      if (!statements.hasNext) {
-        false
-      } else {
-        val sql = statements.next.trim()
-        statement = connection.prepareCall(if (sql.endsWith(";")) { sql } else { s"$sql;" })
-        results = statement.executeQuery()
-        array = Array.ofDim[Any](1 + results.getMetaData.getColumnCount)
-        _next = results.next()
-        hasNext
-      }
-    }
-
-    override def next(): Array[Any] = {
-      counter.incLineCount()
-
-      array(0) = "" // leave 0 empty for the entire row
-      var i = 1
-      while (i < array.length) {
-        array(i) = results.getObject(i) // results are 1-indexed
-        i += 1
-      }
-      array(0) = array.mkString // set the whole row value for reference
-
-      _next = results.next()
-
-      array
-    }
-
-    override def close(): Unit = {
-      Option(results).foreach(CloseWithLogging.apply)
-      Option(statement).foreach(CloseWithLogging.apply)
-      CloseWithLogging(is)
-    }
   }
 }
 
@@ -97,4 +51,99 @@ object JdbcConverter {
                         idField: Option[Expression],
                         caches: Map[String, Config],
                         userData: Map[String, Expression]) extends ConverterConfig
+
+  /**
+    * Converts the input to statements and executes them.
+    *
+    * Note: the ResultSets are not closed, this should be done by the caller
+    *
+    * @param connection connection
+    * @param is input
+    * @param encoding input encoding
+    */
+  class StatementIterator private [JdbcConverter] (connection: Connection, is: InputStream, encoding: Charset)
+      extends CloseableIterator[ResultSet] {
+
+    private val statements = IOUtils.lineIterator(is, encoding) // TODO split on ; ?
+
+    private var statement: PreparedStatement = _
+    private var results: ResultSet = _
+
+    override final def hasNext: Boolean = results != null || {
+      Option(statement).foreach(CloseWithLogging.apply)
+      if (!statements.hasNext) {
+        statement = null
+        results = null
+        false
+      } else {
+        val sql = statements.next.trim()
+        statement = connection.prepareCall(if (sql.endsWith(";")) { sql } else { s"$sql;" })
+        results = statement.executeQuery()
+        true
+      }
+    }
+
+    override def next(): ResultSet = {
+      if (!hasNext) { Iterator.empty.next() } else {
+        val res = results
+        results = null
+        res
+      }
+    }
+
+    override def close(): Unit = {
+      Option(statement).foreach(CloseWithLogging.apply)
+      CloseWithLogging(statements)
+    }
+  }
+
+  /**
+    * Converts result sets into values
+    *
+    * @param iter result sets
+    * @param counter counter
+    */
+  class ResultSetIterator private [JdbcConverter] (iter: CloseableIterator[ResultSet], counter: Counter)
+      extends CloseableIterator[Array[Any]] {
+
+    private var results: ResultSet = _
+    private var array: Array[Any] = _
+    private var hasNextResult = false
+
+    @tailrec
+    override final def hasNext: Boolean = hasNextResult || {
+      Option(results).foreach(CloseWithLogging.apply)
+      if (!iter.hasNext) {
+        results = null
+        false
+      } else {
+        results = iter.next
+        array = Array.ofDim[Any](results.getMetaData.getColumnCount + 1)
+        hasNextResult = results.next()
+        hasNext
+      }
+    }
+
+    override def next(): Array[Any] = {
+      if (!hasNext) { Iterator.empty.next() } else {
+        counter.incLineCount()
+        // the first column will hold the entire row, but set it empty here to
+        // avoid the previous row being captured in mkString, below
+        array(0) = ""
+        var i = 1
+        while (i < array.length) {
+          array(i) = results.getObject(i) // note: results are 1-indexed
+          i += 1
+        }
+        array(0) = array.mkString // set the whole row value for reference
+        hasNextResult = results.next()
+        array
+      }
+    }
+
+    override def close(): Unit = {
+      Option(results).foreach(CloseWithLogging.apply)
+      CloseWithLogging(iter)
+    }
+  }
 }

--- a/geomesa-convert/geomesa-convert-json/src/main/scala/org/locationtech/geomesa/convert/json/JsonConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-json/src/main/scala/org/locationtech/geomesa/convert/json/JsonConverterFactory.scala
@@ -49,7 +49,7 @@ class JsonConverterFactory extends AbstractConverterFactory[JsonConverter, JsonC
       reader.setLenient(true)
 
       val elements = {
-        val iter = new Iterator[JsonElement] {
+        val iter: Iterator[JsonElement] = new Iterator[JsonElement] {
           private val parser = new JsonParser
           override def hasNext: Boolean = reader.peek() != JsonToken.END_DOCUMENT
           override def next(): JsonElement = parser.parse(reader)

--- a/geomesa-convert/geomesa-convert-shp/src/main/scala/org/locationtech/geomesa/convert/shp/ShapefileConverter.scala
+++ b/geomesa-convert/geomesa-convert-shp/src/main/scala/org/locationtech/geomesa/convert/shp/ShapefileConverter.scala
@@ -8,16 +8,11 @@
 
 package org.locationtech.geomesa.convert.shp
 
-import java.io.{File, InputStream}
-import java.net.URL
+import java.io.InputStream
 import java.util.Collections
-import java.util.concurrent.atomic.AtomicBoolean
 
-import com.typesafe.scalalogging.LazyLogging
-import org.apache.hadoop.fs.FsUrlStreamHandlerFactory
 import org.geotools.data.shapefile.{ShapefileDataStore, ShapefileDataStoreFactory}
-import org.geotools.data.{DataStoreFinder, FeatureReader, Query}
-import org.locationtech.geomesa.convert.shp.ShapefileConverter.ShapefileIterator
+import org.geotools.data.{DataStoreFinder, Query}
 import org.locationtech.geomesa.convert.{Counter, EnrichmentCache, EvaluationContext}
 import org.locationtech.geomesa.convert2.AbstractConverter
 import org.locationtech.geomesa.convert2.AbstractConverter.{BasicConfig, BasicField, BasicOptions}
@@ -27,8 +22,8 @@ import org.locationtech.geomesa.utils.io.{CloseWithLogging, PathUtils}
 import org.locationtech.geomesa.utils.text.TextTools
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
-class ShapefileConverter(targetSft: SimpleFeatureType, config: BasicConfig, fields: Seq[BasicField], options: BasicOptions)
-    extends AbstractConverter(targetSft, config, fields, options)  {
+class ShapefileConverter(sft: SimpleFeatureType, config: BasicConfig, fields: Seq[BasicField], options: BasicOptions)
+    extends AbstractConverter[SimpleFeature, BasicConfig, BasicField, BasicOptions](sft, config, fields, options)  {
 
   import org.locationtech.geomesa.convert.shp.ShapefileFunctionFactory.{InputSchemaKey, InputValuesKey}
 
@@ -41,7 +36,7 @@ class ShapefileConverter(targetSft: SimpleFeatureType, config: BasicConfig, fiel
     super.createEvaluationContext(globalParams ++ shpParams, caches, counter)
   }
 
-  override protected def read(is: InputStream, ec: EvaluationContext): CloseableIterator[Array[Any]] = {
+  override protected def parse(is: InputStream, ec: EvaluationContext): CloseableIterator[SimpleFeature] = {
     CloseWithLogging(is) // we don't use the input stream, just close it
 
     val path = ec.getInputFilePath.getOrElse {
@@ -50,8 +45,8 @@ class ShapefileConverter(targetSft: SimpleFeatureType, config: BasicConfig, fiel
     }
     val ds = ShapefileConverter.getDataStore(path)
     val schema = ds.getSchema()
-    val array = Array.ofDim[Any](schema.getAttributeCount + 1)
     val names = Array.tabulate(schema.getAttributeCount)(i => schema.getDescriptor(i).getLocalName)
+    val array = Array.ofDim[Any](schema.getAttributeCount + 1)
 
     val i = ec.indexOf(InputSchemaKey)
     val j = ec.indexOf(InputValuesKey)
@@ -64,13 +59,59 @@ class ShapefileConverter(targetSft: SimpleFeatureType, config: BasicConfig, fiel
       ec.set(j, array)
     }
 
-    new ShapefileIterator(ds, array, ec.counter)
+    val q = new Query
+    // Only ask to reproject if the Shapefile has a CRS
+    if (ds.getSchema.getCoordinateReferenceSystem != null) {
+      q.setCoordinateSystemReproject(CRS_EPSG_4326)
+    } else {
+      logger.warn(s"Shapefile does not have CRS info")
+    }
+
+    val reader = CloseableIterator(ds.getFeatureSource.getReader(q)).map { f => ec.counter.incLineCount(); f }
+
+    CloseableIterator(reader, { CloseWithLogging(reader); ds.dispose() })
+  }
+
+  override protected def values(parsed: CloseableIterator[SimpleFeature],
+                                ec: EvaluationContext): CloseableIterator[Array[Any]] = {
+    val i = ec.indexOf(InputValuesKey)
+    val j = ec.indexOf(InputSchemaKey)
+
+    if (i == -1 || j == -1) {
+      logger.warn("Input schema not found in evaluation context, shapefile functions " +
+          s"${TextTools.wordList(new ShapefileFunctionFactory().functions.map(_.names.head))} will not be available")
+    }
+
+    if (i == -1) {
+      var array: Array[Any] = null
+      parsed.map { feature =>
+        if (array == null) {
+          array = Array.ofDim(feature.getAttributeCount + 1)
+        }
+        var i = 1
+        while (i < array.length) {
+          array(i) = feature.getAttribute(i - 1)
+          i += 1
+        }
+        array(0) = feature.getID
+        array
+      }
+    } else {
+      val array = ec.get(i).asInstanceOf[Array[Any]]
+      parsed.map { feature =>
+        var i = 1
+        while (i < array.length) {
+          array(i) = feature.getAttribute(i - 1)
+          i += 1
+        }
+        array(0) = feature.getID
+        array
+      }
+    }
   }
 }
 
 object ShapefileConverter {
-
-  private val factorySet = new AtomicBoolean(false)
 
   /**
     * Creates a URL, needed for the shapefile data store
@@ -79,53 +120,11 @@ object ShapefileConverter {
     * @return
     */
   def getDataStore(path: String): ShapefileDataStore = {
-    val url = PathUtils.getUrl(path)
-    val params = Collections.singletonMap(ShapefileDataStoreFactory.URLP.key, url)
+    val params = Collections.singletonMap(ShapefileDataStoreFactory.URLP.key, PathUtils.getUrl(path))
     val ds = DataStoreFinder.getDataStore(params).asInstanceOf[ShapefileDataStore]
     if (ds == null) {
       throw new IllegalArgumentException(s"Could not read shapefile using path '$path'")
     }
     ds
-  }
-
-  /**
-    * Iterator for reading a shapefile
-    *
-    * @param ds data store to read from
-    * @param array attributes array
-    * @param counter line counter
-    */
-  class ShapefileIterator(ds: ShapefileDataStore, array: Array[Any], counter: Counter)
-      extends CloseableIterator[Array[Any]] with LazyLogging {
-
-    val q = new Query
-    // Only ask to reproject if the Shapefile has a CRS
-    if (ds.getSchema.getCoordinateReferenceSystem != null) {
-      q.setCoordinateSystemReproject(CRS_EPSG_4326)
-    } else {
-      logger.warn(s"Shapefile does not have CRS info.")
-    }
-    private val features: FeatureReader[SimpleFeatureType, SimpleFeature] =
-      ds.getFeatureSource.getReader(q)
-
-    override def hasNext: Boolean = features.hasNext
-
-    override def next(): Array[Any] = {
-      counter.incLineCount()
-
-      val feature = features.next
-      var i = 1
-      while (i < array.length) {
-        array(i) = feature.getAttribute(i - 1)
-        i += 1
-      }
-      array(0) = feature.getID
-      array
-    }
-
-    override def close(): Unit = {
-      CloseWithLogging(features)
-      ds.dispose()
-    }
   }
 }

--- a/geomesa-convert/geomesa-convert-shp/src/main/scala/org/locationtech/geomesa/convert/shp/ShapefileFunctionFactory.scala
+++ b/geomesa-convert/geomesa-convert-shp/src/main/scala/org/locationtech/geomesa/convert/shp/ShapefileFunctionFactory.scala
@@ -30,18 +30,27 @@ object ShapefileFunctionFactory {
     private var i = -1
     private var values: Array[Any] = _
 
-    override val names = Seq("shp")
+    override val names: Seq[String] = Seq("shp")
 
     override def getInstance: ShapefileAttribute = new ShapefileAttribute()
 
     override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = {
       if (i == -1) {
         val names = ctx.get(ctx.indexOf(InputSchemaKey)).asInstanceOf[Array[String]]
+        if (names == null) {
+          throw new IllegalArgumentException("Input schema not found in evaluation context, " +
+              "'shp' function is not available")
+        }
         i = names.indexOf(args(0).asInstanceOf[String]) + 1 // 0 is fid
         if (i == 0) {
-          throw new IllegalArgumentException(s"Attribute '${args(0)}' does not exist in shapefile: ${names.mkString(", ")}")
+          throw new IllegalArgumentException(s"Attribute '${args(0)}' does not exist in shapefile: " +
+              names.mkString(", "))
         }
         values = ctx.get(ctx.indexOf(InputValuesKey)).asInstanceOf[Array[Any]]
+        if (values == null) {
+          throw new IllegalArgumentException("Input values not found in evaluation context, " +
+              "'shp' function is not available")
+        }
       }
       values(i)
     }
@@ -51,13 +60,17 @@ object ShapefileFunctionFactory {
 
     private var values: Array[Any] = _
 
-    override val names = Seq("shpFeatureId")
+    override val names: Seq[String] = Seq("shpFeatureId")
 
     override def getInstance: ShapefileFeatureId = new ShapefileFeatureId()
 
     override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = {
       if (values == null) {
         values = ctx.get(ctx.indexOf(InputValuesKey)).asInstanceOf[Array[Any]]
+        if (values == null) {
+          throw new IllegalArgumentException("Input values not found in evaluation context, " +
+              "'shpFeatureId' function is not available")
+        }
       }
       values(0)
     }

--- a/geomesa-convert/geomesa-convert-simplefeature/pom.xml
+++ b/geomesa-convert/geomesa-convert-simplefeature/pom.xml
@@ -23,6 +23,10 @@
             <groupId>org.specs2</groupId>
             <artifactId>specs2-junit_${scala.binary.version}</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/geomesa-convert/geomesa-convert-simplefeature/src/main/resources/META-INF/services/org.locationtech.geomesa.convert2.SimpleFeatureConverterFactory
+++ b/geomesa-convert/geomesa-convert-simplefeature/src/main/resources/META-INF/services/org.locationtech.geomesa.convert2.SimpleFeatureConverterFactory
@@ -1,0 +1,1 @@
+org.locationtech.geomesa.convert2.simplefeature.FeatureToFeatureConverterFactory

--- a/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert/simplefeature/SimpleFeatureSimpleFeatureConverter.scala
+++ b/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert/simplefeature/SimpleFeatureSimpleFeatureConverter.scala
@@ -13,6 +13,7 @@ import java.io.InputStream
 import org.locationtech.geomesa.convert._
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
+@deprecated("replaced with FeatureToFeatureConverter")
 class SimpleFeatureSimpleFeatureConverter(inputSFT: SimpleFeatureType,
                                           val targetSFT: SimpleFeatureType,
                                           val idBuilder: Transformers.Expr,

--- a/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert/simplefeature/SimpleFeatureSimpleFeatureConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert/simplefeature/SimpleFeatureSimpleFeatureConverterFactory.scala
@@ -17,6 +17,7 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.immutable
 
+@deprecated("replaced with FeatureToFeatureConverter")
 class SimpleFeatureSimpleFeatureConverterFactory extends AbstractSimpleFeatureConverterFactory[SimpleFeature] {
 
   override protected def typeToProcess: String = "simple-feature"

--- a/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert2/simplefeature/FeatureToFeatureConverter.scala
+++ b/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert2/simplefeature/FeatureToFeatureConverter.scala
@@ -1,0 +1,70 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert2.simplefeature
+
+import java.io.InputStream
+
+import com.typesafe.config.Config
+import org.locationtech.geomesa.convert.EvaluationContext
+import org.locationtech.geomesa.convert2.{AbstractConverter, SimpleFeatureConverter}
+import org.locationtech.geomesa.convert2.AbstractConverter.{BasicField, BasicOptions}
+import org.locationtech.geomesa.convert2.simplefeature.FeatureToFeatureConverterFactory.FeatureToFeatureConfig
+import org.locationtech.geomesa.utils.collection.CloseableIterator
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+
+/**
+  * Converter used to transform one simple feature type into another. This converter is a special use-case,
+  * and does not implement the normal `process` method for parsing an input stream. Instead, call
+  * `convert` directly.
+  *
+  * @param sft simple feature type
+  * @param config converter config
+  * @param fields converter fields
+  * @param options converter options
+  */
+class FeatureToFeatureConverter(sft: SimpleFeatureType,
+                                config: FeatureToFeatureConfig,
+                                fields: Seq[BasicField],
+                                options: BasicOptions)
+    extends AbstractConverter[SimpleFeature, FeatureToFeatureConfig, BasicField, BasicOptions](sft, config, fields, options)  {
+
+  override protected def parse(is: InputStream, ec: EvaluationContext): CloseableIterator[SimpleFeature] =
+    throw new NotImplementedError()
+
+  override protected def values(parsed: CloseableIterator[SimpleFeature],
+                                ec: EvaluationContext): CloseableIterator[Array[Any]] = {
+    var array = Array.empty[Any]
+    parsed.map { feature =>
+      ec.counter.incLineCount()
+      if (feature.getAttributeCount + 1 != array.length) {
+        array = Array.ofDim(feature.getAttributeCount + 1)
+      }
+      var i = 0
+      while (i < array.length - 1) {
+        array(i) = feature.getAttribute(i)
+        i += 1
+      }
+      array(array.length - 1) = feature.getID
+      array
+    }
+  }
+}
+
+object FeatureToFeatureConverter {
+
+  /**
+    * Gets a typed feature to feature converter
+    *
+    * @param sft simple feature type
+    * @param conf config
+    * @return
+    */
+  def apply(sft: SimpleFeatureType, conf: Config): FeatureToFeatureConverter =
+    SimpleFeatureConverter(sft, conf).asInstanceOf[FeatureToFeatureConverter]
+}

--- a/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert2/simplefeature/FeatureToFeatureConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert2/simplefeature/FeatureToFeatureConverterFactory.scala
@@ -1,0 +1,114 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert2.simplefeature
+
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+import org.locationtech.geomesa.convert2.AbstractConverter.{BasicField, BasicOptions}
+import org.locationtech.geomesa.convert2.AbstractConverterFactory._
+import org.locationtech.geomesa.convert2.simplefeature.FeatureToFeatureConverterFactory.{FeatureToFeatureConfig, FeatureToFeatureConfigConvert}
+import org.locationtech.geomesa.convert2.transforms.Expression
+import org.locationtech.geomesa.convert2.{AbstractConverterFactory, ConverterConfig, SimpleFeatureConverter, SimpleFeatureConverterFactory}
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypeLoader
+import org.opengis.feature.simple.SimpleFeatureType
+import pureconfig.ConfigObjectCursor
+import pureconfig.error.ConfigReaderFailures
+
+import scala.util.control.NonFatal
+
+class FeatureToFeatureConverterFactory extends SimpleFeatureConverterFactory {
+
+  import FeatureToFeatureConverterFactory.TypeToProcess
+
+  import scala.collection.JavaConverters._
+
+  private implicit def configConvert: ConverterConfigConvert[FeatureToFeatureConfig] =
+    FeatureToFeatureConfigConvert
+
+  private implicit def fieldConvert: FieldConvert[BasicField] = BasicFieldConvert
+
+  private implicit def optsConvert: ConverterOptionsConvert[BasicOptions] = BasicOptionsConvert
+
+  override def apply(sft: SimpleFeatureType, conf: Config): Option[SimpleFeatureConverter] = {
+    if (!conf.hasPath("type") || !conf.getString("type").equalsIgnoreCase(TypeToProcess)) { None } else {
+      val (config, fields, opts) = try {
+        val c = AbstractConverterFactory.standardDefaults(conf)
+        val config = pureconfig.loadConfigOrThrow[FeatureToFeatureConfig](c)
+        val fields = pureconfig.loadConfigOrThrow[Seq[BasicField]](c)
+        val opts = pureconfig.loadConfigOrThrow[BasicOptions](c)
+        (config, fields, opts)
+      } catch {
+        case NonFatal(e) => throw new IllegalArgumentException(s"Invalid configuration: ${e.getMessage}")
+      }
+      opts.validators.init(sft)
+
+      val inputSft = SimpleFeatureTypeLoader.sftForName(config.inputSft).getOrElse {
+        throw new IllegalArgumentException(s"Could not load input sft ${config.inputSft}")
+      }
+      // FID is put in as the last attribute, we copy it over here
+      // TODO: does this have any implications for global params in the evaluation context?
+      val id = if (config.idField.isDefined) { config } else {
+        config.copy(idField = Some(Expression.Column(inputSft.getAttributeCount)))
+      }
+
+      // add transform expressions to look up the attribute attribute
+      val columns = fields.map { field =>
+        field.transforms match {
+          case None => field.copy(transforms = Some(Expression.Column(inputSft.indexOf(field.name))))
+          case Some(Expression.FieldLookup(n)) => field.copy(transforms = Some(Expression.Column(inputSft.indexOf(n))))
+          case _ => field
+        }
+      }
+
+      // any matching fields that aren't explicitly defined will be copied over by default
+      val defaults = {
+        val names = fields.map(_.name).toSet
+        sft.getAttributeDescriptors.asScala.map(_.getLocalName).filterNot(names.contains).map { name =>
+          val i = inputSft.indexOf(name)
+          if (i == -1) {
+            BasicField(name, Some(Expression.LiteralNull))
+          } else {
+            BasicField(name, Some(Expression.Column(i)))
+          }
+        }
+      }
+
+      Some(new FeatureToFeatureConverter(sft, id, columns ++ defaults, opts))
+    }
+  }
+}
+
+object FeatureToFeatureConverterFactory {
+
+  val TypeToProcess: String = "simple-feature"
+
+  private val InputSftPath = "input-sft"
+
+  case class FeatureToFeatureConfig(`type`: String,
+                                    inputSft: String,
+                                    idField: Option[Expression],
+                                    caches: Map[String, Config],
+                                    userData: Map[String, Expression]) extends ConverterConfig
+
+  object FeatureToFeatureConfigConvert extends ConverterConfigConvert[FeatureToFeatureConfig] with StrictLogging {
+
+    override protected def decodeConfig(cur: ConfigObjectCursor,
+                                        `type`: String,
+                                        idField: Option[Expression],
+                                        caches: Map[String, Config],
+                                        userData: Map[String, Expression]): Either[ConfigReaderFailures, FeatureToFeatureConfig] = {
+      for { sftName <- cur.atKey(InputSftPath).right.flatMap(_.asString).right } yield {
+        FeatureToFeatureConfig(`type`, sftName, idField, caches, userData)
+      }
+    }
+
+    override protected def encodeConfig(config: FeatureToFeatureConfig, base: java.util.Map[String, AnyRef]): Unit =
+      base.put(InputSftPath, config.inputSft)
+  }
+}

--- a/geomesa-convert/geomesa-convert-simplefeature/src/test/resources/log4j.xml
+++ b/geomesa-convert/geomesa-convert-simplefeature/src/test/resources/log4j.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.EnhancedPatternLayout">
+            <param name="ConversionPattern" value="[%d] %5p %c{1}: %m%n"/>
+        </layout>
+    </appender>
+
+    <category name="org.apache.zookeeper">
+        <priority value="warn"/>
+    </category>
+    <category name="org.apache.accumulo">
+        <priority value="warn"/>
+    </category>
+    <category name="org.apache.hadoop">
+        <priority value="warn"/>
+    </category>
+    <category name="hsqldb">
+        <priority value="warn"/>
+    </category>
+    <category name="org.locationtech.geomesa.convert">
+        <priority value="error"/>
+    </category>
+    <category name="org.locationtech.geomesa.convert2">
+        <priority value="error"/>
+    </category>
+
+    <root>
+        <priority value="info"/>
+        <appender-ref ref="CONSOLE" />
+    </root>
+</log4j:configuration>

--- a/geomesa-convert/geomesa-convert-simplefeature/src/test/resources/reference.conf
+++ b/geomesa-convert/geomesa-convert-simplefeature/src/test/resources/reference.conf
@@ -7,4 +7,3 @@ geomesa.sfts.intype = {
     { name = "geom",   type = "Point"   }
   ]
 }
-

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/collection/CircularByteQueue.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/collection/CircularByteQueue.scala
@@ -1,0 +1,150 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.collection
+
+/**
+  * Growable byte queue that holds values in a circular array to minimize allocations
+  *
+  * @param initialSize initial buffer size
+  */
+class CircularByteQueue(initialSize: Int = 16) {
+
+  private var array = Array.ofDim[Byte](initialSize)
+  private var start = 0
+  private var length = 0
+
+  /**
+    * Number of bytes stored in this buffer
+    *
+    * @return
+    */
+  def size: Int = length
+
+  /**
+    * Current remaining capacity. In general this is not relevant, as the queue will grow as needed,
+    * but it can be useful for debugging
+    *
+    * @return current capacity of the buffer
+    */
+  def capacity: Int = array.length - length
+
+  /**
+    * Enqueue a single byte
+    *
+    * @param byte byte
+    */
+  def += (byte: Byte): Unit = enqueue(byte)
+
+  /**
+    * Enqueue multiple bytes
+    *
+    * @param bytes bytes
+    */
+  def ++= (bytes: Array[Byte]): Unit = enqueue(bytes, 0, bytes.length)
+
+  /**
+    * Enqueue a single byte
+    *
+    * @param byte byte
+    */
+  def enqueue(byte: Byte): Unit = {
+    ensure(1)
+    var last = start + length
+    if (last >= array.length) {
+      last -= array.length
+    }
+    array(last) = byte
+    length += 1
+  }
+
+  /**
+    * Enqueue multiple bytes
+    *
+    * @param bytes bytes
+    * @param offset offset into the array to start reading, must be valid for the bytes passed in
+    * @param count number of bytes to enqueue, must be valid for the size of the bytes and offset passed in
+    */
+  def enqueue(bytes: Array[Byte], offset: Int, count: Int): Unit = {
+    ensure(count)
+    var first = start + length
+    if (first >= array.length) {
+      first -= array.length
+    }
+    if (first + count < array.length) {
+      System.arraycopy(bytes, offset, array, first, count)
+    } else {
+      val tail = array.length - first
+      System.arraycopy(bytes, offset, array, first, tail)
+      System.arraycopy(bytes, offset + tail, array, 0, count - tail)
+    }
+    length += count
+  }
+
+  /**
+    * Dequeue bytes
+    *
+    * @param count number of bytes to remove
+    * @return
+    */
+  def dequeue(count: Int): Array[Byte] = {
+    val total = math.min(length, count)
+    val result = Array.ofDim[Byte](total)
+    if (start + total <= array.length) {
+      System.arraycopy(array, start, result, 0, total)
+    } else {
+      val tail = array.length - start
+      System.arraycopy(array, start, result, 0, tail)
+      System.arraycopy(array, 0, result, tail, total - tail)
+    }
+    start += total
+    if (start >= array.length) {
+      start -= array.length
+    }
+    length -= total
+    result
+  }
+
+  /**
+    * Drop bytes
+    *
+    * @param count number of bytes to drop
+    */
+  def drop(count: Int): Unit = {
+    val total = math.min(length, count)
+    start += total
+    if (start >= array.length) {
+      start -= array.length
+    }
+    length -= total
+  }
+
+  /**
+    * Grow the array as needed to fit an additional number of bytes
+    *
+    * @param count bytes to fit
+    */
+  private def ensure(count: Int): Unit = {
+    if (length + count > array.length) {
+      var newSize = array.length * 2
+      while (newSize < length + count) {
+        newSize = newSize * 2
+      }
+      val tmp = Array.ofDim[Byte](newSize)
+      if (start + length <= array.length) {
+        System.arraycopy(array, start, tmp, 0, length)
+      } else {
+        val tailBytes = array.length - start
+        System.arraycopy(array, start, tmp, 0, tailBytes)
+        System.arraycopy(array, 0, tmp, tailBytes, length - tailBytes)
+      }
+      array = tmp
+      start = 0
+    }
+  }
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/collection/CloseableIterator.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/collection/CloseableIterator.scala
@@ -11,8 +11,9 @@ package org.locationtech.geomesa.utils.collection
 import java.io.Closeable
 
 import org.geotools.data.FeatureReader
-import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureIterator}
 import org.geotools.feature.FeatureIterator
+import org.locationtech.geomesa.utils.collection.CloseableIterator.{CloseableIteratorImpl, ConcatCloseableIterator, FlatMapCloseableIterator}
+import org.locationtech.geomesa.utils.io.CloseQuietly
 import org.opengis.feature.Feature
 import org.opengis.feature.`type`.FeatureType
 import org.opengis.feature.simple.SimpleFeature
@@ -30,67 +31,106 @@ object CloseableIterator {
   implicit def iteratorToCloseable[A](iter: Iterator[A]): CloseableIterator[A] = apply(iter)
 
   // This apply method provides us with a simple interface for creating new CloseableIterators.
-  def apply[A](iter: Iterator[A], closeIter: => Unit = {}): CloseableIterator[A] =
-    new CloseableIterator[A] {
-      override def hasNext: Boolean = iter.hasNext
-      override def next(): A = iter.next()
-      override def close(): Unit = closeIter
-    }
+  def apply[A](iter: Iterator[A], close: => Unit = Unit): CloseableIterator[A] =
+    new CloseableIteratorImpl[A](iter, close)
 
   // This apply method provides us with a simple interface for creating new CloseableIterators.
   def apply[A <: Feature, B <: FeatureType](iter: FeatureReader[B, A]): CloseableIterator[A] =
-    new CloseableIterator[A] {
-      override def hasNext: Boolean = iter.hasNext
-      override def next(): A = iter.next()
-      override def close(): Unit = iter.close()
-    }
+    new CloseableFeatureReaderIterator(iter)
 
   def apply(iter: FeatureIterator[SimpleFeature]): CloseableIterator[SimpleFeature] =
-    new CloseableIterator[SimpleFeature] {
-      override def hasNext: Boolean = iter.hasNext
-      override def next(): SimpleFeature  = iter.next()
-      override def close(): Unit = iter.close()
-    }
+    new CloseableFeatureIterator(iter)
+
+  def single[A](elem: A, close: => Unit = Unit): CloseableIterator[A] =
+    new CloseableSingleIterator(elem, close)
+
+  def fill[A](length: Int, close: => Unit = Unit)(elem: => A): CloseableIterator[A] =
+    new CloseableIteratorImpl(Iterator.fill(length)(elem), close)
 
   def empty[A]: CloseableIterator[A] = empty
 
   private def wrap[A](t: GenTraversableOnce[A]): CloseableIterator[A] = t match {
     case c: CloseableIterator[A] => c
-    case c => CloseableIterator(c.toIterator)
-  }
-}
-
-trait CloseableIterator[+A] extends Iterator[A] with Closeable {
-
-  self =>
-
-  import CloseableIterator.empty
-
-  override def map[B](f: A => B): CloseableIterator[B] = CloseableIterator(super.map(f), self.close())
-
-  override def filter(p: A => Boolean): CloseableIterator[A] = CloseableIterator(super.filter(p), self.close())
-
-  override def take(n: Int): CloseableIterator[A] = CloseableIterator(super.take(n), self.close())
-
-  override def collect[B](pf: PartialFunction[A, B]): CloseableIterator[B] =
-    CloseableIterator(super.collect(pf), self.close())
-
-  override def ++[B >: A](that: => GenTraversableOnce[B]): CloseableIterator[B] = {
-    lazy val applied = CloseableIterator.wrap(that)
-    val queue = new scala.collection.mutable.Queue[() => CloseableIterator[B]]
-    queue.enqueue(() => self)
-    queue.enqueue(() => applied)
-    new ConcatCloseableIterator[B](queue)
+    case c => new CloseableIteratorImpl(c.toIterator, Unit)
   }
 
-  override def flatMap[B](f: A => GenTraversableOnce[B]): CloseableIterator[B] = new CloseableIterator[B] {
+  class CloseableIteratorImpl[A](iter: Iterator[A], closeIter: => Unit) extends CloseableIterator[A] {
+    override def hasNext: Boolean = iter.hasNext
+    override def next(): A = iter.next()
+    override def close(): Unit = closeIter
+  }
+
+  private final class CloseableFeatureReaderIterator[A <: Feature, B <: FeatureType](iter: FeatureReader[B, A])
+      extends CloseableIterator[A] {
+    override def hasNext: Boolean = iter.hasNext
+    override def next(): A = iter.next()
+    override def close(): Unit = iter.close()
+  }
+
+  private final class CloseableFeatureIterator(iter: FeatureIterator[SimpleFeature])
+      extends CloseableIterator[SimpleFeature] {
+    override def hasNext: Boolean = iter.hasNext
+    override def next(): SimpleFeature  = iter.next()
+    override def close(): Unit = iter.close()
+  }
+
+  private final class CloseableSingleIterator[A](elem: A, closeIter: => Unit) extends CloseableIterator[A] {
+    private var result = true
+    override def hasNext: Boolean = result
+    override def next(): A = if (result) { result = false; elem } else { empty.next() }
+    override def close(): Unit = closeIter
+  }
+
+  /**
+    * Based on scala's ++ iterator implementation
+    *
+    * Avoid stack overflows when applying ++ to lots of iterators by flattening the unevaluated
+    * iterators out into a vector of closures.
+    */
+  private final class ConcatCloseableIterator[+A](queue: scala.collection.mutable.Queue[() => CloseableIterator[A]])
+      extends CloseableIterator[A] {
+
+    private [this] var current: CloseableIterator[A] = queue.dequeue()()
+
+    // Advance current to the next non-empty iterator
+    // current is set to empty when all iterators are exhausted
+    @tailrec
+    private [this] def advance(): Boolean = {
+      current.close()
+      if (queue.isEmpty) {
+        current = CloseableIterator.empty
+        false
+      } else {
+        current = queue.dequeue()()
+        current.hasNext || advance()
+      }
+    }
+
+    override def hasNext: Boolean = current.hasNext || advance()
+    override def next(): A = current.next
+
+    override def close(): Unit = {
+      current.close()
+      queue.foreach(_.apply().close())
+      queue.clear()
+    }
+
+    override def ++[B >: A](that: => GenTraversableOnce[B]): CloseableIterator[B] = {
+      lazy val applied = CloseableIterator.wrap(that)
+      new ConcatCloseableIterator[B](queue.+:(() => current).:+(() => applied))
+    }
+  }
+
+  private final class FlatMapCloseableIterator[A, B](source: CloseableIterator[A], f: A => GenTraversableOnce[B])
+      extends CloseableIterator[B] {
+
     private var cur: CloseableIterator[B] = empty
 
     @tailrec
     override def hasNext: Boolean = cur.hasNext || {
       cur.close()
-      if (self.hasNext) {
-        cur = CloseableIterator.wrap(f(self.next()))
+      if (source.hasNext) {
+        cur = CloseableIterator.wrap(f(source.next()))
         hasNext
       } else {
         cur = empty
@@ -98,79 +138,31 @@ trait CloseableIterator[+A] extends Iterator[A] with Closeable {
       }
     }
 
-    override def next(): B = (if (hasNext) cur else empty).next()
+    override def next(): B = if (hasNext) { cur.next() } else { empty.next() }
 
-    override def close(): Unit = { cur.close(); self.close() }
+    override def close(): Unit = CloseQuietly(cur, source).foreach(f => throw f)
   }
 }
 
-/**
-  * Based on scala's ++ iterator implementation
-  *
-  * Avoid stack overflows when applying ++ to lots of iterators by flattening the unevaluated
-  * iterators out into a vector of closures.
-  */
-private [collection] final class ConcatCloseableIterator[+A](queue: scala.collection.mutable.Queue[() => CloseableIterator[A]])
-    extends CloseableIterator[A] {
+trait CloseableIterator[+A] extends Iterator[A] with Closeable {
 
-  private [this] var current: CloseableIterator[A] = queue.dequeue()()
+  override def map[B](f: A => B): CloseableIterator[B] = new CloseableIteratorImpl(super.map(f), close())
 
-  // Advance current to the next non-empty iterator
-  // current is set to empty when all iterators are exhausted
-  private [this] def advance(): Boolean = {
-    current.close()
-    if (queue.isEmpty) {
-      current = CloseableIterator.empty
-      false
-    } else {
-      current = queue.dequeue()()
-      current.hasNext || advance()
-    }
-  }
-  override def hasNext: Boolean = current.hasNext || advance()
-  override def next(): A = current.next
+  override def filter(p: A => Boolean): CloseableIterator[A] = new CloseableIteratorImpl(super.filter(p), close())
 
-  override def close(): Unit = {
-    current.close()
-    queue.foreach(_.apply().close())
-    queue.clear()
-  }
+  override def take(n: Int): CloseableIterator[A] = new CloseableIteratorImpl(super.take(n), close())
+
+  override def collect[B](pf: PartialFunction[A, B]): CloseableIterator[B] =
+    new CloseableIteratorImpl(super.collect(pf), close())
 
   override def ++[B >: A](that: => GenTraversableOnce[B]): CloseableIterator[B] = {
-    lazy val applied = that match {
-      case c: CloseableIterator[B] => c
-      case c => CloseableIterator(c.toIterator)
-    }
-    new ConcatCloseableIterator(queue.+:(() => current).:+(() => applied))
+    lazy val applied = CloseableIterator.wrap(that)
+    val queue = new scala.collection.mutable.Queue[() => CloseableIterator[B]]
+    queue.enqueue(() => this)
+    queue.enqueue(() => applied)
+    new ConcatCloseableIterator[B](queue)
   }
-}
 
-// By 'self-closing', we mean that the iterator will automatically call close once it is completely exhausted.
-trait SelfClosingIterator[+A] extends CloseableIterator[A]
-
-object SelfClosingIterator {
-
-  def apply[A](iter: Iterator[A], closeIter: => Unit = {}): SelfClosingIterator[A] =
-    new SelfClosingIterator[A] {
-      override def hasNext: Boolean = {
-        val iterHasNext = iter.hasNext
-        if (!iterHasNext) {
-          close()
-        }
-        iterHasNext
-      }
-      override def next(): A = iter.next()
-      override def close(): Unit = closeIter
-    }
-
-  def apply[A](iter: Iterator[A] with Closeable): SelfClosingIterator[A] = apply(iter, iter.close())
-
-  def apply[A](iter: CloseableIterator[A]): SelfClosingIterator[A] = apply(iter, iter.close())
-
-  def apply[A <: Feature, B <: FeatureType](fr: FeatureReader[B, A]): SelfClosingIterator[A] =
-    apply(CloseableIterator(fr))
-
-  def apply(iter: SimpleFeatureIterator): SelfClosingIterator[SimpleFeature] = apply(CloseableIterator(iter))
-
-  def apply(c: SimpleFeatureCollection): SelfClosingIterator[SimpleFeature] = apply(c.features)
+  override def flatMap[B](f: A => GenTraversableOnce[B]): CloseableIterator[B] =
+    new FlatMapCloseableIterator(this, f)
 }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/collection/SelfClosingIterator.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/collection/SelfClosingIterator.scala
@@ -1,0 +1,48 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.collection
+
+import java.io.Closeable
+
+import org.geotools.data.FeatureReader
+import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureIterator}
+import org.locationtech.geomesa.utils.collection.CloseableIterator.CloseableIteratorImpl
+import org.opengis.feature.Feature
+import org.opengis.feature.`type`.FeatureType
+import org.opengis.feature.simple.SimpleFeature
+
+import scala.collection.Iterator
+
+// By 'self-closing', we mean that the iterator will automatically call close once it is completely exhausted.
+trait SelfClosingIterator[+A] extends CloseableIterator[A] {
+  abstract override def hasNext: Boolean = {
+    val res = super.hasNext
+    if (!res) {
+      close()
+    }
+    res
+  }
+}
+
+object SelfClosingIterator {
+
+  def apply[A](iter: Iterator[A], closeIter: => Unit = {}): SelfClosingIterator[A] =
+    new CloseableIteratorImpl(iter, closeIter) with SelfClosingIterator[A]
+
+  def apply[A](iter: Iterator[A] with Closeable): SelfClosingIterator[A] = apply(iter, iter.close())
+
+  def apply[A](iter: CloseableIterator[A]): SelfClosingIterator[A] = apply(iter, iter.close())
+
+  def apply[A <: Feature, B <: FeatureType](fr: FeatureReader[B, A]): SelfClosingIterator[A] =
+    apply(CloseableIterator(fr))
+
+  def apply(iter: SimpleFeatureIterator): SelfClosingIterator[SimpleFeature] = apply(CloseableIterator(iter))
+
+  def apply(c: SimpleFeatureCollection): SelfClosingIterator[SimpleFeature] = apply(c.features)
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/CopyingInputStream.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/CopyingInputStream.scala
@@ -8,39 +8,68 @@
 
 package org.locationtech.geomesa.utils.io
 
-import java.io.{ByteArrayOutputStream, InputStream}
+import java.io.InputStream
+
+import org.locationtech.geomesa.utils.collection.CircularByteQueue
 
 /**
-  * Proxies an input stream, copying any bytes read to `copy`
+  * Proxies an input stream, copying any bytes read. The number of copied bytes can be checked with `copied`,
+  * discarded with `drop`, and returned with `replay` (which will also drop the bytes).
   *
-  * @param in input stream to proxy
+  * Note: this class is not thread-safe
+  *
+  * @param wrapped input stream to proxy
+  * @param initialBuffer initial size of the array allocated for copying bytes on read. The array will grow as needed
   */
-class CopyingInputStream(in: InputStream) extends InputStream {
+class CopyingInputStream(wrapped: InputStream, initialBuffer: Int = 16) extends InputStream {
 
-  val copy: ByteArrayOutputStream = new ByteArrayOutputStream()
-
+  // circular buffer holding our copied bytes
+  private val copy = new CircularByteQueue(initialBuffer)
   private var skipped = Array.empty[Byte]
 
+  /**
+    * The number of bytes currently available for replaying from the underlying stream
+    *
+    * @return
+    */
+  def copied: Int = copy.size
+
+  /**
+    * Discard bytes that have been copied from the underlying stream
+    *
+    * @param count number of bytes to discard
+    */
+  def drop(count: Int): Unit = copy.drop(count)
+
+  /**
+    * Return bytes copied from the underlying stream, discarding them afterwards. If more bytes are requested
+    * than have been copied, only copied bytes will be returned
+    *
+    * @param count number of bytes to return
+    * @return
+    */
+  def replay(count: Int): Array[Byte] = copy.dequeue(count)
+
   override def read(): Int = {
-    val c = in.read()
+    val c = wrapped.read()
     if (c != -1) {
-      copy.write(c)
+      copy.enqueue(c.toByte)
     }
     c
   }
 
   override def read(b: Array[Byte]): Int = {
-    val count = in.read(b)
+    val count = wrapped.read(b)
     if (count != -1) {
-      copy.write(b, 0, count)
+      copy.enqueue(b, 0, count)
     }
     count
   }
 
   override def read(b: Array[Byte], off: Int, len: Int): Int = {
-    val count = in.read(b, off, len)
+    val count = wrapped.read(b, off, len)
     if (count != -1) {
-      copy.write(b, off, count)
+      copy.enqueue(b, off, count)
     }
     count
   }
@@ -56,36 +85,32 @@ class CopyingInputStream(in: InputStream) extends InputStream {
         if (toRead > skipped.length) {
           skipped = Array.ofDim(toRead)
         }
-        count = in.read(skipped, 0, toRead)
+        count = wrapped.read(skipped, 0, toRead)
         if (count != -1) {
-          copy.write(skipped, 0, count)
+          copy.enqueue(skipped, 0, count)
           total += count.toLong
         } else {
           remaining = 0
         }
       }
-      // release the byte buffer, as it is Int.MaxValue length
+      // release the byte buffer, as it is now Int.MaxValue length
       skipped = Array.empty
       total
     } else {
       if (n > skipped.length) {
         skipped = Array.ofDim(n.toInt)
       }
-      val count = in.read(skipped, 0, n.toInt)
+      val count = wrapped.read(skipped, 0, n.toInt)
       if (count != -1) {
-        copy.write(skipped, 0, count)
+        copy.enqueue(skipped, 0, count)
       }
       count.toLong
     }
   }
 
-  override def available(): Int = in.available()
+  override def available(): Int = wrapped.available()
 
-  override def markSupported(): Boolean = in.markSupported()
+  // note: mark/reset not supported, defer to default implementation that throws IllegalArgumentExceptions
 
-  override def mark(readlimit: Int): Unit = in.mark(readlimit)
-
-  override def reset(): Unit = in.reset()
-
-  override def close(): Unit = in.close()
+  override def close(): Unit = wrapped.close()
 }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/SafeClose.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/SafeClose.scala
@@ -18,7 +18,19 @@ import scala.util.control.NonFatal
   * Closes anything with a 'close' method without throwing an exception
   */
 trait SafeClose {
+
   def apply(c: AnyCloseable): Option[Throwable]
+
+  def apply(c1: AnyCloseable, c2: AnyCloseable): Option[Throwable] = apply(Seq(c1, c2))
+
+  def apply(cs: Seq[AnyCloseable]): Option[Throwable] = {
+    val errors = cs.flatMap(c => apply(c))
+    if (errors.isEmpty) { None } else {
+      val e = errors.head
+      errors.tail.foreach(e.addSuppressed)
+      Some(e)
+    }
+  }
 }
 
 object SafeClose {
@@ -60,7 +72,19 @@ object WithClose {
   * Flushes anything with a 'flush' method without throwing an exception
   */
 trait SafeFlush {
-  def apply(c: AnyFlushable): Option[Throwable]
+
+  def apply(f: AnyFlushable): Option[Throwable]
+
+  def apply(f1: AnyFlushable, f2: AnyFlushable): Option[Throwable] = apply(Seq(f1, f2))
+
+  def apply(fs: Seq[AnyFlushable]): Option[Throwable] = {
+    val errors = fs.flatMap(f => apply(f))
+    if (errors.isEmpty) { None } else {
+      val e = errors.head
+      errors.tail.foreach(e.addSuppressed)
+      Some(e)
+    }
+  }
 }
 
 object SafeFlush {
@@ -71,8 +95,8 @@ object SafeFlush {
   * Flushes and logs any exceptions
   */
 object FlushWithLogging extends SafeFlush with LazyLogging {
-  override def apply(c: AnyFlushable): Option[Throwable] = try { c.flush(); None } catch {
-    case NonFatal(e) => logger.warn(s"Error calling flush on '$c': ", e); Some(e)
+  override def apply(f: AnyFlushable): Option[Throwable] = try { f.flush(); None } catch {
+    case NonFatal(e) => logger.warn(s"Error calling flush on '$f': ", e); Some(e)
   }
 }
 
@@ -80,7 +104,7 @@ object FlushWithLogging extends SafeFlush with LazyLogging {
   * Flushes and catches any exceptions
   */
 object FlushQuietly extends SafeFlush {
-  override def apply(c: AnyFlushable): Option[Throwable] = try { c.flush(); None } catch {
+  override def apply(f: AnyFlushable): Option[Throwable] = try { f.flush(); None } catch {
     case NonFatal(e) => Some(e)
   }
 }

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/collection/CircularByteQueueTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/collection/CircularByteQueueTest.scala
@@ -1,0 +1,65 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.collection
+
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class CircularByteQueueTest extends Specification {
+
+  "CircularByteQueue" should {
+    "enqueue and dequeue values" >> {
+      val q = new CircularByteQueue(4)
+      q.size mustEqual 0
+      q.capacity mustEqual 4
+      (0 until 4).foreach(i => q.enqueue(i.toByte))
+      q.size mustEqual 4
+      q.capacity mustEqual 0
+      q.dequeue(4) mustEqual Array.tabulate[Byte](4)(_.toByte)
+      q.size mustEqual 0
+      q.capacity mustEqual 4
+    }
+    "grow when needed" >> {
+      val q = new CircularByteQueue(4)
+      q.size mustEqual 0
+      q.capacity mustEqual 4
+      (0 until 16).foreach(i => q.enqueue(i.toByte))
+      q.size mustEqual 16 // note: capacity doubles each time it grows
+      q.capacity mustEqual 0
+      q.dequeue(16) mustEqual Array.tabulate[Byte](16)(_.toByte)
+      q.size mustEqual 0
+      q.capacity mustEqual 16
+    }
+    "use circular storage" >> {
+      val q = new CircularByteQueue(4)
+      q.size mustEqual 0
+      q.capacity mustEqual 4
+      q.enqueue(Array[Byte](0, 1), 0, 2)
+      q.size mustEqual 2
+      q.capacity mustEqual 2
+      q.dequeue(1) mustEqual Array[Byte](0)
+      q.size mustEqual 1
+      q.capacity mustEqual 3
+      q.enqueue(Array[Byte](2, 3, 4), 0, 3)
+      q.size mustEqual 4
+      q.capacity mustEqual 0
+      q.dequeue(4) mustEqual Array[Byte](1, 2, 3, 4)
+      q.size mustEqual 0
+      q.capacity mustEqual 4
+      q.enqueue(Array[Byte](5, 6, 7), 0, 3)
+      q.size mustEqual 3
+      q.capacity mustEqual 1
+      q.dequeue(2) mustEqual Array[Byte](5, 6)
+      q.size mustEqual 1
+      q.capacity mustEqual 3
+    }
+  }
+}


### PR DESCRIPTION
* Add `convert` method to AbstractConverter
* Add type bound to AbstractConverter to reflect intermediate parsing
* Add FeatureToFeatureConverter for v2 simple feature transforms
* Add SafeClose methods to close/flush multiple objects at once
* Add `single` and `fill` CloseableIterators
  * Moved CloseableIterator implementations into the companion object
  * Moved SelfClosingIterator into separate class file
* Update CopyingInputStream to avoid allocating an extra array on copy

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>