### PR TITLE
GEOMESA-2478 Update Maven plugins to current versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,7 @@ GeoMesa uses JIRA to track ongoing development and issues:
 Building
 --------
 
-GeoMesa requires Maven 3.2.2 or later to build:
-
-```
-geomesa> mvn clean install
-```
+See the instructinos in README.md.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Requirements:
 
 * [Git](http://git-scm.com/)
 * [Java JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
-* [Apache Maven](http://maven.apache.org/) 3.2.2 or later
+* [Apache Maven](http://maven.apache.org/) 3.3.9 or later
 
 Use Git to download the source code. Navigate to the destination directory, then run:
 
@@ -185,3 +185,8 @@ provides the script `build/mvn`, which is a wrapper around Maven that downloads 
 [Zinc](https://github.com/typesafehub/zinc), a fast incremental compiler:
 
     build/mvn clean install -T8 -DskipTests
+
+If the Zinc build fails with an error finding "javac", try setting the JAVA_HOME
+environment variable to point to the root of your JDK.  Example from a Mac:
+
+    JAVA_HOME="/Library/Java/JavaVirtualMachines/jdk1.8.0_51.jdk/Contents/Home" build/mvn clean install

--- a/build/README.md
+++ b/build/README.md
@@ -169,7 +169,7 @@ Requirements:
 
 * [Git](http://git-scm.com/)
 * [Java JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
-* [Apache Maven](http://maven.apache.org/) 3.2.2 or later
+* [Apache Maven](http://maven.apache.org/) 3.3.9 or later
 
 Use Git to download the source code. Navigate to the destination directory, then run:
 
@@ -185,3 +185,8 @@ provides the script `build/mvn`, which is a wrapper around Maven that downloads 
 [Zinc](https://github.com/typesafehub/zinc), a fast incremental compiler:
 
     build/mvn clean install -T8 -DskipTests
+
+If the Zinc build fails with an error finding "javac", try setting the JAVA_HOME
+environment variable to point to the root of your JDK.  Example from a Mac:
+
+    JAVA_HOME="/Library/Java/JavaVirtualMachines/jdk1.8.0_51.jdk/Contents/Home" build/mvn clean install

--- a/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
@@ -178,7 +178,6 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.1.13</version>
                 <executions>
                     <execution>
                         <goals>

--- a/geomesa-fs/geomesa-fs-tools/pom.xml
+++ b/geomesa-fs/geomesa-fs-tools/pom.xml
@@ -111,7 +111,6 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.1.13</version>
                 <executions>
                     <execution>
                         <goals>

--- a/geomesa-lambda/geomesa-lambda-tools/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-tools/pom.xml
@@ -174,7 +174,6 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.1.13</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -2351,6 +2351,12 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <!-- 3.1.0 was released 2018-04-14. -->
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>1.6.0</version>
@@ -2366,6 +2372,12 @@
                     <artifactId>maven-jar-plugin</artifactId>
                     <!-- 3.1.0 was released 2018-04-06. -->
                     <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <!-- 3.0.0-M1 was released 2018-09-23. -->
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -2455,6 +2467,12 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <!-- 3.0.1 was released 2018-05-28. -->
                     <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <!-- 3.7.1 was released 2018-04-27. -->
+                    <version>3.7.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2515,7 +2515,8 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>2.10</version>
+                    <!-- 3.0 was released 2016-08-20 and is the latest as of 2018-11-30. -->
+                    <version>3.0</version>
                     <configuration>
                         <header>build/copyright/ccri.txt</header>
                         <validHeaders>

--- a/pom.xml
+++ b/pom.xml
@@ -2448,7 +2448,7 @@
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>2.2.1</version>
+                    <version>2.2.5</version>
                     <configuration>
                         <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
                         <runOnlyOnce>false</runOnlyOnce>

--- a/pom.xml
+++ b/pom.xml
@@ -2334,8 +2334,18 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.3.2</version>
+                    <!-- 3.8.0 was released 2018-07-26. -->
+                    <version>3.8.0</version>
                     <configuration>
+                        <!-- Turn off 'useIncrementalCompilation' to keep this plugin
+                             from recompiling Java files that the scala-maven-plugin
+                             already compiled.  The scala-maven-plugin generates .class
+                             files from Java sources when its 'incremental' option is
+                             turned on (as it is in the 'zinc' profile).  In this case,
+                             maven-compiler-plugin 3.0 to current (3.8.0) erroneously
+                             detects changes and re-compiles the Java files unless this
+                             option is turned off.  -->
+                        <useIncrementalCompilation>false</useIncrementalCompilation>
                         <source>1.8</source>
                         <target>1.8</target>
                     </configuration>
@@ -2348,21 +2358,25 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <!-- 3.1.0 was released 2018-04-23. -->
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <!-- 3.1.0 was released 2018-04-06. -->
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <!-- 3.1.1 was released 2018-05-19. -->
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
+                    <!-- 3.1.0 was released 2017-08-13. -->
                     <version>3.1.0</version>
                     <configuration>
                       <tarLongFileMode>posix</tarLongFileMode>
@@ -2371,7 +2385,8 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <!-- 3.2.1 was released 2018-11-12. -->
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
@@ -2404,12 +2419,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.21.0</version>
+                    <!-- 3.0.0-M1 was released 2018-11-07. -->
+                    <version>3.0.0-M1</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.surefire</groupId>
                             <artifactId>surefire-junit4</artifactId>
-                            <version>2.21.0</version>
+                            <version>3.0.0-M1</version>
                         </dependency>
                     </dependencies>
                     <configuration>
@@ -2425,21 +2441,25 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <!-- 3.0.0-M1 was released 2018-09-23. -->
                     <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <!-- 3.0.1 was released 2016-06-18. -->
+                    <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <!-- 3.0.1 was released 2018-05-28. -->
+                    <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
+                    <!-- 2.5.3 was released 2015-10-17 and is the latest as of 2018-11-29. -->
                     <version>2.5.3</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -2510,7 +2530,8 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.3.1</version>
+                    <!-- 3.0.0-M2 was released 2018-06-16. -->
+                    <version>3.0.0-M2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -2520,7 +2541,8 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.17</version>
+                    <!-- 3.0.0 was released 2018-01-07. -->
+                    <version>3.0.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.slf4j</groupId>
@@ -2537,7 +2559,8 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.5</version>
+                    <!-- 1.6 was released 2015-01-19 and is the latest as of 2018-11-29. -->
+                    <version>1.6</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2403,7 +2403,8 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <!-- 3.4.4 was released 2018-11-01.  It requires Maven version >= 3.3.9. -->
+                    <version>3.4.4</version>
                     <configuration>
                         <dependencies>
                             <dependency>


### PR DESCRIPTION
See the messages on the individual commits.  I'd recommend leaving them separate because they each address slightly different concerns and there's a chance you might want to revert one or the other in the future -- but I'm happy to squash them if you prefer.

The main way I tested these changes was to compare the output of a full "build/mvn clean install" before and after each change.  The only non-trivial differences in the output were in some tests, e.g. org.locationtech.geomesa.hbase.nativeapi.GeoMesaIndexTest and GeoMesaQueryTest.  There were differences in the kinds of errors that these tests report, e.g. "caught end of stream exception" vs "Connection refused" -- but these differences seemed random, not related to the changes I was making.

I did all this work on a Mac with a Oracle JDK 1.8.0_51.  Might be good for someone to test these changes on Linux.