### PR TITLE
GEOMESA-886 Fix spatial filter for density queries

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/KryoLazyDensityIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/KryoLazyDensityIteratorTest.scala
@@ -126,5 +126,18 @@ class KryoLazyDensityIteratorTest extends Specification with TestWithDataStore {
       compiled must haveLength(5)
       forall(compiled)(_ mustEqual 30)
     }
+
+    "Correctly apply filters smaller than the envelope" in {
+      // note: uses features from previous step
+      val q = new Query(sftName, ECQL.toFilter("BBOX(geom, 0.5, 33, 1.5, 40)"))
+      val envelope = new ReferencedEnvelope(-180, 180, -90, 90, org.locationtech.geomesa.utils.geotools.CRS_EPSG_4326)
+      q.getHints.put(QueryHints.DENSITY_BBOX, envelope)
+      q.getHints.put(QueryHints.DENSITY_WIDTH, 500)
+      q.getHints.put(QueryHints.DENSITY_HEIGHT, 500)
+      val decode = DensityScan.decodeResult(envelope, 500, 500)
+      val density = SelfClosingIterator(fs.getFeatures(q).features).flatMap(decode).toList
+      density.map(_._3).sum mustEqual 30
+    }
+
   }
 }


### PR DESCRIPTION
* Only use the density envelope to trim existing spatial filters

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>