### PR TITLE
GEOMESA-2503 Don't block full table scans when max-features is specified

### DIFF
--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -152,6 +152,13 @@ For more granularity, it is also possible to specify the full-table scan behavio
 replaced with the schema name (e.g. "gdelt"). Properties set for an individual schema will take precedence
 over the globally-defined behavior.
 
+geomesa.scan.block-full-table.threshold
++++++++++++++++++++++++++++++++++++++++
+
+This property works in conjunction with ``geomesa.scan.block-full-table``, above. If a query puts a reasonable limit
+on the number of features that are returned (through the use of ``maxFeatures``), then it will not be blocked.
+The property is specified as an integer. By default, a limit of 1000 or less is allowed.
+
 geomesa.scan.ranges.target
 ++++++++++++++++++++++++++
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z2/Z2QueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z2/Z2QueryableIndex.scala
@@ -49,8 +49,10 @@ trait Z2QueryableIndex extends AccumuloFeatureIndex
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
     if (filter.primary.isEmpty) {
-      // check that full table scans are allowed
-      QueryProperties.BlockFullTableScans.onFullTableScan(sft.getTypeName, filter.filter.getOrElse(Filter.INCLUDE))
+      if (hints.getMaxFeatures.forall(_ > QueryProperties.BlockMaxThreshold.toInt.get)) {
+        // check that full table scans are allowed
+        QueryProperties.BlockFullTableScans.onFullTableScan(sft.getTypeName, filter.filter.getOrElse(Filter.INCLUDE))
+      }
       filter.secondary.foreach { f =>
         logger.warn(s"Running full table scan for schema ${sft.getTypeName} with filter ${filterToString(f)}")
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3QueryableIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/legacy/z3/Z3QueryableIndex.scala
@@ -55,8 +55,10 @@ trait Z3QueryableIndex extends AccumuloFeatureIndexType
     }
 
     if (filter.primary.isEmpty) {
-      // check that full table scans are allowed
-      QueryProperties.BlockFullTableScans.onFullTableScan(sft.getTypeName, filter.filter.getOrElse(Filter.INCLUDE))
+      if (hints.getMaxFeatures.forall(_ > QueryProperties.BlockMaxThreshold.toInt.get)) {
+        // check that full table scans are allowed
+        QueryProperties.BlockFullTableScans.onFullTableScan(sft.getTypeName, filter.filter.getOrElse(Filter.INCLUDE))
+      }
       filter.secondary.foreach { f =>
         logger.warn(s"Running full table scan for schema ${sft.getTypeName} with filter ${filterToString(f)}")
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
@@ -514,6 +514,13 @@ class AccumuloDataStoreQueryTest extends Specification with TestWithMultipleSfts
           val query = new Query(sft.getTypeName, ECQL.toFilter(filter))
           ds.getFeatureSource(sft.getTypeName).getFeatures(query).features must throwA[RuntimeException]
         }
+        // verify that we won't block if max features is set
+        foreach(fullScans) { filter =>
+          val query = new Query(sft.getTypeName, ECQL.toFilter(filter), 10, null: Array[String], null)
+          val features = SelfClosingIterator(ds.getFeatureSource(sft.getTypeName).getFeatures(query).features).toList
+          features mustEqual List(feature)
+        }
+
         // verify that we can override individually
         System.setProperty(s"geomesa.scan.${sft.getTypeName}.block-full-table", "false")
         foreach(fullScans) { filter =>

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseFeatureIndex.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/index/HBaseFeatureIndex.scala
@@ -96,8 +96,10 @@ trait HBaseFeatureIndex extends HBaseFeatureIndexType with ClientSideFiltering[R
               // the jar should be under hbase.dynamic.jars.dir to enable filters, so look there
               val dir = new Path(conf.get("hbase.dynamic.jars.dir"))
               WithClose(dir.getFileSystem(conf)) { fs =>
-                fs.listStatus(dir).collectFirst {
-                  case s if DistributedJarNamePattern.matcher(s.getPath.getName).matches() => s.getPath
+                if (!fs.isDirectory(dir)) { None } else {
+                  fs.listStatus(dir).collectFirst {
+                    case s if DistributedJarNamePattern.matcher(s.getPath.getName).matches() => s.getPath
+                  }
                 }
               }
             } catch {

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreTest.scala
@@ -97,6 +97,9 @@ class HBaseDataStoreTest extends HBaseTest with LazyLogging {
 
               // this query should be blocked
               testQuery(ds, typeName, "INCLUDE", transforms, toAdd) must throwA[RuntimeException]
+              // with max features set, it should go through - don't count, that will be blocked
+              testQuery(ds, new Query(typeName, ECQL.toFilter("INCLUDE"), 10, transforms, null), toAdd, count = false)
+
               QueryProperties.BlockFullTableScans.threadLocalValue.remove()
               // now it should go through
               testQuery(ds, typeName, "INCLUDE", transforms, toAdd)
@@ -285,10 +288,15 @@ class HBaseDataStoreTest extends HBaseTest with LazyLogging {
                 filter: String,
                 transforms: Array[String],
                 results: Seq[SimpleFeature]): MatchResult[Any] = {
-    val query = new Query(typeName, ECQL.toFilter(filter), transforms)
+    testQuery(ds, new Query(typeName, ECQL.toFilter(filter), transforms), results)
+  }
+
+  def testQuery(ds: HBaseDataStore, query: Query, results: Seq[SimpleFeature], count: Boolean = true): MatchResult[Any] = {
+
     val fr = ds.getFeatureReader(query, Transaction.AUTO_COMMIT)
     val features = SelfClosingIterator(fr).toList
-    val attributes = Option(transforms).getOrElse(ds.getSchema(typeName).getAttributeDescriptors.map(_.getLocalName).toArray)
+    val attributes = Option(query.getPropertyNames)
+        .getOrElse(ds.getSchema(query.getTypeName).getAttributeDescriptors.map(_.getLocalName).toArray)
     features.map(_.getID) must containTheSameElementsAs(results.map(_.getID))
     forall(features) { feature =>
       feature.getAttributes must haveLength(attributes.length)
@@ -298,25 +306,27 @@ class HBaseDataStoreTest extends HBaseTest with LazyLogging {
       }
     }
 
+    if (count) {
+      query.getFilter match {
+        case _: Id =>
+          // id filters use estimated stats based on the filter itself
+          ds.getFeatureSource(query.getTypeName).getCount(query) mustEqual results.length
+          ds.getFeatureSource(query.getTypeName).getFeatures(query).size() mustEqual results.length
+
+        case _ =>
+          ds.getFeatureSource(query.getTypeName).getCount(query) mustEqual -1
+          ds.getFeatureSource(query.getTypeName).getFeatures(query).size() mustEqual 0
+      }
+
+      query.getHints.put(QueryHints.EXACT_COUNT, true)
+      ds.getFeatureSource(query.getTypeName).getFeatures(query).size() mustEqual results.length
+    }
+
     // verify ranges are grouped appropriately to not cross shard boundaries
     forall(ds.getQueryPlan(query).flatMap(_.scans)) { scan =>
       if (scan.getStartRow.isEmpty || scan.getStopRow.isEmpty) { ok } else {
         scan.getStartRow()(0) mustEqual scan.getStopRow()(0)
       }
     }
-
-    query.getFilter match {
-      case _: Id =>
-        // id filters use estimated stats based on the filter itself
-        ds.getFeatureSource(typeName).getCount(query) mustEqual results.length
-        ds.getFeatureSource(typeName).getFeatures(query).size() mustEqual results.length
-
-      case _ =>
-        ds.getFeatureSource(typeName).getCount(query) mustEqual -1
-        ds.getFeatureSource(typeName).getFeatures(query).size() mustEqual 0
-    }
-
-    query.getHints.put(QueryHints.EXACT_COUNT, true)
-    ds.getFeatureSource(typeName).getFeatures(query).size() mustEqual results.length
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryHints.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryHints.scala
@@ -68,6 +68,7 @@ object QueryHints {
     val TRANSFORMS       = new ClassKey(classOf[String])
     val TRANSFORM_SCHEMA = new ClassKey(classOf[SimpleFeatureType])
     val SORT_FIELDS      = new ClassKey(classOf[String])
+    val MAX_FEATURES     = new ClassKey(classOf[java.lang.Integer])
     val SKIP_REDUCE      = new ClassKey(classOf[java.lang.Boolean])
 
     def toSortHint(sortBy: Array[SortBy]): String = {
@@ -157,6 +158,7 @@ object QueryHints {
       Option(hints.get(Internal.SORT_FIELDS).asInstanceOf[String]).map(Internal.fromSortHint).filterNot(_.isEmpty)
     def getSortReadableString: String =
       getSortFields.map(_.map { case (f, r) => s"$f ${if (r) "DESC" else "ASC" }"}.mkString(", ")).getOrElse("none")
+    def getMaxFeatures: Option[Int] = Option(hints.get(Internal.MAX_FEATURES).asInstanceOf[Integer]).map(_.intValue())
     def isExactCount: Option[Boolean] = Option(hints.get(EXACT_COUNT)).map(_.asInstanceOf[Boolean])
     def isLambdaQueryPersistent: Boolean =
       Option(hints.get(LAMBDA_QUERY_PERSISTENT).asInstanceOf[java.lang.Boolean]).forall(_.booleanValue)

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryProperties.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryProperties.scala
@@ -40,4 +40,6 @@ object QueryProperties {
       }
     }
   }
+
+  val BlockMaxThreshold = SystemProperty("geomesa.scan.block-full-table.threshold", "1000")
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryPlanner.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryPlanner.scala
@@ -242,6 +242,17 @@ object QueryPlanner extends LazyLogging {
     }
   }
 
+  /**
+    * Sets the max features from a query into the query hints
+    *
+    * @param query query
+    */
+  def setMaxFeatures(query: Query): Unit = {
+    if (!query.isMaxFeaturesUnlimited) {
+      query.getHints.put(QueryHints.Internal.MAX_FEATURES, Int.box(query.getMaxFeatures))
+    }
+  }
+
   private def computeSchema(sft: SimpleFeatureType, transforms: Seq[Definition]): SimpleFeatureType = {
     val descriptors: Seq[AttributeDescriptor] = transforms.map { definition =>
       definition.expression match {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryRunner.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryRunner.scala
@@ -55,6 +55,7 @@ trait QueryRunner {
 
     // set sorting in the query
     QueryPlanner.setQuerySort(sft, query)
+    QueryPlanner.setMaxFeatures(query)
 
     // add the bbox from the density query to the filter, if there is no more restrictive filter
     query.getHints.getDensityEnvelope.foreach { env =>


### PR DESCRIPTION
* `geomesa.scan.block-full-table.threshold` controls the threshold
  (default 1000)

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>