### PR TITLE
GEOMESA-2402 Use one-sided date filters in z-range planning

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryFilterSplitterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryFilterSplitterTest.scala
@@ -478,11 +478,14 @@ class QueryFilterSplitterTest extends Specification {
       val splitter = new FilterSplitter(sft, GeoMesaFeatureIndexFactory.create(null, sft, sft.getIndices), None)
       val filter = f("dtg TEQUALS 2014-01-01T12:30:00.000Z")
       val options = splitter.getQueryOptions(filter)
-      options must haveLength(1)
-      options.head.strategies must haveLength(1)
-      options.head.strategies.head.index.name mustEqual AttributeIndex.name
-      options.head.strategies.head.primary must beSome(filter)
-      options.head.strategies.head.secondary must beNone
+      options must haveLength(2)
+      foreach(options)(_.strategies must haveLength(1))
+      val strategies = options.map(_.strategies.head)
+      strategies.map(_.index.name) must containTheSameElementsAs(Seq(AttributeIndex.name, Z3Index.name))
+      foreach(strategies) { strategy =>
+        strategy.primary must beSome(filter)
+        strategy.secondary must beNone
+      }
     }
 
     "provide only one option on OR queries of high cardinality indexed attributes" >> {

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/visitor/FilterExtractingVisitor.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/visitor/FilterExtractingVisitor.scala
@@ -23,14 +23,14 @@ object FilterExtractingVisitor {
   def apply(filter: Filter,
             attribute: String,
             sft: SimpleFeatureType,
-            predicate: (Filter) => Boolean = (_) => true): (Option[Filter], Option[Filter]) = {
+            predicate: Filter => Boolean = _ => true): (Option[Filter], Option[Filter]) = {
     val visitor = new FilterExtractingVisitor(attribute, sft, predicate)
     val (yes, no) = filter.accept(visitor, null).asInstanceOf[(Filter, Filter)]
     (Option(yes), Option(no))
   }
 }
 
-class FilterExtractingVisitor(attribute: String, sft: SimpleFeatureType, predicate: (Filter) => Boolean)
+class FilterExtractingVisitor(attribute: String, sft: SimpleFeatureType, predicate: Filter => Boolean)
     extends FilterVisitor {
 
   import org.locationtech.geomesa.filter.{andOption, ff, orOption}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
@@ -458,6 +458,7 @@ object GeoMesaFeatureIndex {
 
   // deprecated methods
 
+  // noinspection ScalaDeprecation
   @deprecated("Deprecated with no replacement")
   def formatTableName(catalog: String, suffix: String, sft: SimpleFeatureType): String = {
     if (sft.isTableSharing) {
@@ -467,14 +468,17 @@ object GeoMesaFeatureIndex {
     }
   }
 
+  // noinspection ScalaDeprecation
   @deprecated("Deprecated with no replacement")
   def formatSoloTableName(prefix: String, suffix: String, typeName: String): String =
     concatenate(prefix, hexEncodeNonAlphaNumeric(typeName), suffix)
 
+  // noinspection ScalaDeprecation
   @deprecated("Deprecated with no replacement")
   def formatSharedTableName(prefix: String, suffix: String): String =
     concatenate(prefix, suffix)
 
+  // noinspection ScalaDeprecation
   @deprecated("Deprecated with no replacement")
   def tableSuffix(index: GeoMesaFeatureIndex[_, _], partition: Option[String] = None): String = {
     val base = if (index.version == 1) { index.name } else { concatenate(index.name, s"v${index.version}") }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
@@ -68,7 +68,7 @@ object Z3Filter {
   val EpochKey  = "epoch"
 
   def apply(values: Z3IndexValues): Z3Filter = {
-    val Z3IndexValues(sfc, _, spatialBounds, _, temporalBounds) = values
+    val Z3IndexValues(sfc, _, spatialBounds, _, temporalBounds, _) = values
 
     val xy: Array[Array[Int]] = spatialBounds.map { case (xmin, ymin, xmax, ymax) =>
       Array(sfc.lon.normalize(xmin), sfc.lat.normalize(ymin), sfc.lon.normalize(xmax), sfc.lat.normalize(ymax))

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3IndexKeySpace.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.index.index.z3
 
 import java.util.Date
 
-import org.locationtech.jts.geom.{Geometry, Point}
+import com.typesafe.scalalogging.LazyLogging
 import org.geotools.factory.Hints
 import org.locationtech.geomesa.curve.BinnedTime.TimeToBinnedTime
 import org.locationtech.geomesa.curve.{BinnedTime, XZ3SFC}
@@ -23,6 +23,7 @@ import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDa
 import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.utils.geotools.{GeometryUtils, WholeWorldPolygon}
 import org.locationtech.geomesa.utils.index.ByteArrays
+import org.locationtech.jts.geom.{Geometry, Point}
 import org.locationtech.sfcurve.IndexRange
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
@@ -30,7 +31,7 @@ import org.opengis.filter.Filter
 import scala.util.control.NonFatal
 
 class XZ3IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, geomField: String, dtgField: String)
-    extends IndexKeySpace[XZ3IndexValues, Z3IndexKey] {
+    extends IndexKeySpace[XZ3IndexValues, Z3IndexKey] with LazyLogging {
 
   import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
@@ -116,7 +117,7 @@ class XZ3IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, 
     // disjoint geometries are ok since they could still intersect a polygon
     if (intervals.disjoint) {
       explain("Disjoint dates extracted, short-circuiting to empty query")
-      return XZ3IndexValues(sfc, FilterValues.empty, Seq.empty, FilterValues.empty, Map.empty)
+      return XZ3IndexValues(sfc, FilterValues.empty, Seq.empty, FilterValues.empty, Map.empty, Seq.empty)
     }
 
     // compute our ranges based on the coarse bounds for our query
@@ -128,21 +129,23 @@ class XZ3IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, 
 
     // calculate map of weeks to time intervals in that week
     val timesByBin = scala.collection.mutable.Map.empty[Short, (Double, Double)]
+    val unboundedBins = Seq.newBuilder[(Short, Short)]
 
-    def updateTime(week: Short, lt: Double, ut: Double): Unit = {
-      val times = timesByBin.get(week) match {
+    def updateTime(bin: Short, lt: Double, ut: Double): Unit = {
+      val times = timesByBin.get(bin) match {
         case None => (lt, ut)
         case Some((min, max)) => (math.min(min, lt), math.max(max, ut))
       }
-      timesByBin(week) = times
+      timesByBin(bin) = times
     }
 
     // note: intervals shouldn't have any overlaps
     intervals.foreach { interval =>
+      val (lower, upper) = boundsToDates(interval.bounds)
+      val BinnedTime(lb, lt) = dateToIndex(lower)
+      val BinnedTime(ub, ut) = dateToIndex(upper)
+
       if (interval.isBoundedBothSides) {
-        val (lower, upper) = boundsToDates(interval.bounds)
-        val BinnedTime(lb, lt) = dateToIndex(lower)
-        val BinnedTime(ub, ut) = dateToIndex(upper)
         if (lb == ub) {
           updateTime(lb, lt, ut)
         } else {
@@ -150,15 +153,21 @@ class XZ3IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, 
           updateTime(ub, sfc.zBounds._1, ut)
           Range.inclusive(lb + 1, ub - 1).foreach(b => timesByBin(b.toShort) = sfc.zBounds)
         }
+      } else if (interval.lower.value.isDefined) {
+        updateTime(lb, lt, sfc.zBounds._2)
+        unboundedBins += (((lb + 1).toShort, Short.MaxValue))
+      } else if (interval.upper.value.isDefined) {
+        updateTime(ub, sfc.zBounds._1, ut)
+        unboundedBins += ((0, (ub - 1).toShort))
       }
     }
 
     // make our underlying index values available to other classes in the pipeline for processing
-    XZ3IndexValues(sfc, geometries, xy, intervals, timesByBin.toMap)
+    XZ3IndexValues(sfc, geometries, xy, intervals, timesByBin.toMap, unboundedBins.result())
   }
 
   override def getRanges(values: XZ3IndexValues, multiplier: Int): Iterator[ScanRange[Z3IndexKey]] = {
-    val XZ3IndexValues(sfc, _, xy, _, timesByBin) = values
+    val XZ3IndexValues(sfc, _, xy, _, timesByBin, unboundedBins) = values
 
     // note: `target` will always be Some, as ScanRangesTarget has a default value
     val target = QueryProperties.ScanRangesTarget.option.map { t =>
@@ -170,10 +179,20 @@ class XZ3IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, 
 
     lazy val wholePeriodRanges = toZRanges(sfc.zBounds)
 
-    timesByBin.iterator.flatMap { case (bin, times) =>
+    val bounded = timesByBin.iterator.flatMap { case (bin, times) =>
       val zs = if (times.eq(sfc.zBounds)) { wholePeriodRanges } else { toZRanges(times) }
       zs.map(r => BoundedRange(Z3IndexKey(bin, r.lower), Z3IndexKey(bin, r.upper)))
     }
+
+    val unbounded = unboundedBins.iterator.map {
+      case (lower, Short.MaxValue) => LowerBoundedRange(Z3IndexKey(lower, 0L))
+      case (0, upper)              => UpperBoundedRange(Z3IndexKey(upper, Long.MaxValue))
+      case (lower, upper) =>
+        logger.error(s"Unexpected unbounded bin endpoints: $lower:$upper")
+        UnboundedRange(Z3IndexKey(0, 0L))
+    }
+
+    bounded ++ unbounded
   }
 
   override def getRangeBytes(ranges: Iterator[ScanRange[Z3IndexKey]], tier: Boolean): Iterator[ByteRange] = {
@@ -181,6 +200,15 @@ class XZ3IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, 
       ranges.map {
         case BoundedRange(lo, hi) =>
           BoundedByteRange(ByteArrays.toBytes(lo.bin, lo.z), ByteArrays.toBytesFollowingPrefix(hi.bin, hi.z))
+
+        case LowerBoundedRange(lo) =>
+          BoundedByteRange(ByteArrays.toBytes(lo.bin, lo.z), ByteRange.UnboundedUpperRange)
+
+        case UpperBoundedRange(hi) =>
+          BoundedByteRange(ByteRange.UnboundedLowerRange, ByteArrays.toBytesFollowingPrefix(hi.bin, hi.z))
+
+        case UnboundedRange(_) =>
+          BoundedByteRange(ByteRange.UnboundedLowerRange, ByteRange.UnboundedUpperRange)
 
         case r =>
           throw new IllegalArgumentException(s"Unexpected range type $r")
@@ -191,6 +219,19 @@ class XZ3IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, 
           val lower = ByteArrays.toBytes(lo.bin, lo.z)
           val upper = ByteArrays.toBytesFollowingPrefix(hi.bin, hi.z)
           sharding.shards.map(p => BoundedByteRange(ByteArrays.concat(p, lower), ByteArrays.concat(p, upper)))
+
+        case LowerBoundedRange(lo) =>
+          val lower = ByteArrays.toBytes(lo.bin, lo.z)
+          val upper = ByteRange.UnboundedUpperRange
+          sharding.shards.map(p => BoundedByteRange(ByteArrays.concat(p, lower), ByteArrays.concat(p, upper)))
+
+        case UpperBoundedRange(hi) =>
+          val lower = ByteRange.UnboundedLowerRange
+          val upper = ByteArrays.toBytesFollowingPrefix(hi.bin, hi.z)
+          sharding.shards.map(p => BoundedByteRange(ByteArrays.concat(p, lower), ByteArrays.concat(p, upper)))
+
+        case UnboundedRange(_) =>
+          Seq(BoundedByteRange(ByteRange.UnboundedLowerRange, ByteRange.UnboundedUpperRange))
 
         case r =>
           throw new IllegalArgumentException(s"Unexpected range type $r")

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/package.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/package.scala
@@ -29,11 +29,13 @@ package object z3 {
                            geometries: FilterValues[Geometry],
                            spatialBounds: Seq[(Double, Double, Double, Double)],
                            intervals: FilterValues[Bounds[ZonedDateTime]],
-                           temporalBounds: Map[Short, Seq[(Long, Long)]])
+                           temporalBounds: Map[Short, Seq[(Long, Long)]],
+                           temporalUnbounded: Seq[(Short, Short)])
 
   case class XZ3IndexValues(sfc: XZ3SFC,
                             geometries: FilterValues[Geometry],
                             spatialBounds: Seq[(Double, Double, Double, Double)],
                             intervals: FilterValues[Bounds[ZonedDateTime]],
-                            temporalBounds: Map[Short, (Double, Double)])
+                            temporalBounds: Map[Short, (Double, Double)],
+                            temporalUnbounded: Seq[(Short, Short)])
 }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/TestGeoMesaDataStore.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/TestGeoMesaDataStore.scala
@@ -133,7 +133,7 @@ object TestGeoMesaDataStore {
 
     override def explain(explainer: Explainer, prefix: String): Unit = {
       explainer(s"ranges (${ranges.length}): ${ranges.take(5).map(r =>
-        s"[${r.start.map(UnsignedBytes.toString).mkString(";")}:" +
+        s"[${r.start.map(UnsignedBytes.toString).mkString(";")}::" +
             s"${r.end.map(UnsignedBytes.toString).mkString(";")})").mkString(",")}")
       explainer(s"ecql: ${ecql.map(org.locationtech.geomesa.filter.filterToString).getOrElse("INCLUDE")}")
     }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/AttributeIndexTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/AttributeIndexTest.scala
@@ -185,6 +185,30 @@ class AttributeIndexTest extends Specification with LazyLogging {
       }
     }
 
+    "use implicit upper/lower bounds for one-sided secondary filters" in {
+      val ds = new TestGeoMesaDataStore(true)
+      ds.createSchema(sft)
+
+      WithClose(ds.getFeatureWriterAppend(typeName, Transaction.AUTO_COMMIT)) { writer =>
+        features.foreach { f =>
+          FeatureUtils.copyToWriter(writer, f, useProvidedFid = true)
+          writer.write()
+        }
+      }
+
+      val query = new Query(typeName, ECQL.toFilter("height = 12.0 AND dtg > '2014-01-01T11:45:00.000Z'"))
+
+      foreach(ds.getQueryPlan(query).flatMap(_.ranges)) { range =>
+        // verify that we have a z3 suffix...
+        // the base length is 10 : 1 (shard) + 2 (i) + 6 (lexicoded float) + 1 (null byte delimiter)
+        range.start.length must beGreaterThan(12)
+      }
+
+      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).map(_.getID).toList
+
+      results must containTheSameElementsAs(Seq("bob", "charles"))
+    }
+
     "handle large or'd attribute queries" in {
       // test against the attr+date tiered index, otherwise secondary z3 ranges slow everything down
       val spec = "attr:String,dtg:Date,*geom:Point:srid=4326;geomesa.indices.enabled='z3,attr:8:attr:dtg'"

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/index/FeatureStateFactory.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/index/FeatureStateFactory.scala
@@ -94,6 +94,8 @@ object FeatureStateFactory extends LazyLogging {
     override def insertIntoIndex(): Unit = index.insert(g, id, feature)
     override def removeFromIndex(): SimpleFeature = index.remove(g, id)
     override def retrieveFromIndex(): SimpleFeature = index.get(g, id)
+
+    override def toString: String = s"FeatureState($feature)"
   }
 
   /**
@@ -128,6 +130,8 @@ object FeatureStateFactory extends LazyLogging {
       future.cancel(false)
       super.removeFromIndex()
     }
+
+    override def toString: String = s"ExpiryState($feature)"
   }
 
   /**
@@ -142,6 +146,7 @@ object FeatureStateFactory extends LazyLogging {
     override def insertIntoIndex(): Unit = expiration.expire(this)
     override def retrieveFromIndex(): SimpleFeature = null
     override def removeFromIndex(): SimpleFeature = null
+    override def toString: String = s"ExpiredState($feature)"
   }
 
 


### PR DESCRIPTION
* Update Z3/XZ3IndexKeySpace to return bin-only ranges for unbounded dates

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>