### PR TITLE
GEOMESA-2486 Add system property for distributed lock timeout

### DIFF
--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -136,9 +136,7 @@ org.apache.commons:commons-math	2.2	compile
 org.apache.commons:commons-pool2	2.4.2	compile
 org.apache.commons:commons-text	1.4	compile
 org.apache.commons:commons-vfs2	2.1	compile
-org.apache.curator:curator-client	2.4.0	compile
 org.apache.curator:curator-client	4.0.1	compile
-org.apache.curator:curator-framework	2.4.0	compile
 org.apache.curator:curator-framework	4.0.1	compile
 org.apache.curator:curator-recipes	2.4.0	compile
 org.apache.curator:curator-recipes	4.0.1	compile

--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -46,6 +46,15 @@ geomesa.convert.scripts.path
 This property allows for adding files to the classpath. It should be set to a colon-separated list of file
 paths. This is useful for getting scripts onto the classpath for use by map-reduce ingest jobs.
 
+geomesa.distributed.lock.timeout
+++++++++++++++++++++++++++++++++
+
+The property controls the length of time a data store will wait to acquire a distributed lock before performing
+schema operations (``createSchema``, ``updateSchema`` and ``removeSchema``). As GeoMesa is often run in parallel,
+acquiring a distributed lock among different processes prevents metadata corruption that may result from multiple
+threads altering the schema simultaneously. The timeout is specified as a duration, e.g. ``1 minute`` or
+``30 seconds``, with a default value of ``2 minutes``.
+
 geomesa.distributed.version.check
 +++++++++++++++++++++++++++++++++
 

--- a/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
@@ -16,17 +16,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <!-- spark compatible version of apache curator -->
-                <groupId>org.apache.curator</groupId>
-                <artifactId>curator-client</artifactId>
-                <version>2.4.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/ZookeeperLocking.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/util/ZookeeperLocking.scala
@@ -15,6 +15,6 @@ trait ZookeeperLocking extends org.locationtech.geomesa.utils.zk.ZookeeperLockin
 
   def connector: Connector
 
-  override def mock: Boolean = connector.isInstanceOf[MockConnector]
-  override def zookeepers: String = connector.getInstance.getZooKeepers
+  override protected def mock: Boolean = connector.isInstanceOf[MockConnector]
+  override protected def zookeepers: String = connector.getInstance.getZooKeepers
 }

--- a/geomesa-hbase/geomesa-hbase-datastore/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-datastore/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>geomesa-security_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-zk-utils_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-data</artifactId>
         </dependency>

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStore.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStore.scala
@@ -14,6 +14,7 @@ import org.apache.hadoop.hbase.TableName
 import org.apache.hadoop.hbase.client._
 import org.apache.hadoop.hbase.filter.FilterList
 import org.apache.hadoop.hbase.security.visibility.Authorizations
+import org.apache.hadoop.hbase.zookeeper.ZKConfig
 import org.geotools.data.Query
 import org.geotools.factory.Hints
 import org.locationtech.geomesa.hbase._
@@ -30,12 +31,13 @@ import org.locationtech.geomesa.index.stats.{DistributedRunnableStats, GeoMesaSt
 import org.locationtech.geomesa.index.utils._
 import org.locationtech.geomesa.utils.bin.BinaryOutputEncoder
 import org.locationtech.geomesa.utils.io.WithClose
+import org.locationtech.geomesa.utils.zk.ZookeeperLocking
 import org.opengis.feature.simple.SimpleFeatureType
 
 import scala.util.control.NonFatal
 
 class HBaseDataStore(val connection: Connection, override val config: HBaseDataStoreConfig)
-    extends HBaseDataStoreType(config) with LocalLocking {
+    extends HBaseDataStoreType(config) with ZookeeperLocking {
 
   override val metadata: GeoMesaMetadata[String] =
     new HBaseBackedMetadata(connection, TableName.valueOf(config.catalog), MetadataStringSerializer)
@@ -46,6 +48,10 @@ class HBaseDataStore(val connection: Connection, override val config: HBaseDataS
     if (config.remoteFilter) { new DistributedRunnableStats(this) } else { new UnoptimizedRunnableStats(this) }
 
   override protected val featureWriterFactory: HBaseFeatureWriterFactory = new HBaseFeatureWriterFactory(this)
+
+  // zookeeper locking
+  override protected val mock: Boolean = false
+  override protected val zookeepers: String = ZKConfig.getZKQuorumServersString(connection.getConfiguration)
 
   @throws(classOf[IllegalArgumentException])
   override protected def validateNewSchema(sft: SimpleFeatureType): Unit = {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
@@ -357,9 +357,14 @@ abstract class MetadataBackedDataStore(config: NamespaceConfig) extends DataStor
     * Make sure that you 'release' the lock in a finally block.
     */
   protected [geomesa] def acquireCatalogLock(): Releasable = {
+    import org.locationtech.geomesa.index.DistributedLockTimeout
     val path = s"/org.locationtech.geomesa/ds/$catalog"
-    acquireDistributedLock(path, 120000).getOrElse {
-      throw new RuntimeException(s"Could not acquire distributed lock at '$path'")
+    val timeout = DistributedLockTimeout.toDuration.getOrElse {
+      // note: should always be a valid fallback value so this exception should never be triggered
+      throw new IllegalArgumentException(s"Couldn't convert '${DistributedLockTimeout.get}' to a duration")
+    }
+    acquireDistributedLock(path, timeout.toMillis).getOrElse {
+      throw new RuntimeException(s"Could not acquire distributed lock at '$path' within $timeout")
     }
   }
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/package.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/package.scala
@@ -22,4 +22,6 @@ package object index {
   val ZFilterCacheSize = SystemProperty("geomesa.cache.z-filters.size", "1000")
 
   val PartitionParallelScan = SystemProperty("geomesa.partition.scan.parallel", "false")
+
+  val DistributedLockTimeout = SystemProperty("geomesa.distributed.lock.timeout", "2 minutes")
 }

--- a/geomesa-zk-utils/src/main/scala/org/locationtech/geomesa/utils/zk/ZookeeperLocking.scala
+++ b/geomesa-zk-utils/src/main/scala/org/locationtech/geomesa/utils/zk/ZookeeperLocking.scala
@@ -18,8 +18,8 @@ import org.locationtech.geomesa.index.utils.{DistributedLocking, Releasable}
 
 trait ZookeeperLocking extends DistributedLocking {
 
-  def mock: Boolean
-  def zookeepers: String
+  protected def mock: Boolean
+  protected def zookeepers: String
 
   /**
     * Gets and acquires a distributed lock based on the key.

--- a/pom.xml
+++ b/pom.xml
@@ -1849,13 +1849,24 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>
+                <artifactId>curator-client</artifactId>
+                <version>4.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-framework</artifactId>
+                <version>4.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.curator</groupId>
                 <artifactId>curator-recipes</artifactId>
                 <version>4.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>
-                <artifactId>curator-client</artifactId>
+                <artifactId>curator-test</artifactId>
                 <version>4.0.1</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.thoughtworks.paranamer</groupId>


### PR DESCRIPTION
* Use `geomesa.distributed.lock.timeout` as a duration
* Add zookeeper distributed locking to HBase data store
* Standardize version of curator to 4.0.1

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>