### PR TITLE
GEOMESA-2518 Add fast temporal filter implementations

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryPlannerTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/QueryPlannerTest.scala
@@ -30,9 +30,9 @@ class QueryPlannerTest extends Specification with TestWithDataStore {
 
   override val spec = "*geom:Point,dtg:Date,s:String"
   val sf = new ScalaSimpleFeature(sft, "id")
-  sf.setAttributes(Array[AnyRef]("POINT(45 45)", "2014/10/10T00:00:00Z", "string"))
+  sf.setAttributes(Array[AnyRef]("POINT(45 45)", "2014-10-10T00:00:00Z", "string"))
   val sf2 = new ScalaSimpleFeature(sft, "id2")
-  sf2.setAttributes(Array[AnyRef]("POINT(45 45)", "2014/10/10T00:00:00Z", "astring"))
+  sf2.setAttributes(Array[AnyRef]("POINT(45 45)", "2014-10-10T00:00:00Z", "astring"))
 
   addFeatures(Seq(sf, sf2))
 

--- a/geomesa-features/geomesa-feature-avro/src/test/scala/org/locationtech/geomesa/features/avro/AvroSimpleFeatureFactoryTest.scala
+++ b/geomesa-features/geomesa-feature-avro/src/test/scala/org/locationtech/geomesa/features/avro/AvroSimpleFeatureFactoryTest.scala
@@ -10,10 +10,9 @@ package org.locationtech.geomesa.features.avro
 
 import org.geotools.factory.CommonFactoryFinder
 import org.geotools.feature.simple.SimpleFeatureBuilder
-import org.geotools.geometry.GeometryBuilder
-import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.text.WKTUtils
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -30,16 +29,17 @@ class AvroSimpleFeatureFactoryTest extends Specification {
 
   "SimpleFeatureBuilder should return an AvroSimpleFeature when using an AvroSimpleFeatureFactory" in {
     AvroSimpleFeatureFactory.init
-    val geomBuilder = new GeometryBuilder(DefaultGeographicCRS.WGS84)
     val featureFactory = CommonFactoryFinder.getFeatureFactory(null)
     val sft = SimpleFeatureTypes.createType("testavro", "name:String,geom:Point:srid=4326")
     val builder = new SimpleFeatureBuilder(sft, featureFactory)
     builder.reset()
     builder.add("Hello")
-    builder.add(geomBuilder.createPoint(1,1))
+    builder.add("POINT (1 1)")
     val feature = builder.buildFeature("id")
 
     feature.getClass mustEqual classOf[AvroSimpleFeature]
+    feature.getAttribute(0) mustEqual "Hello"
+    feature.getAttribute(1) mustEqual WKTUtils.read("POINT (1 1)")
   }
 
 }

--- a/geomesa-features/geomesa-feature-avro/src/test/scala/org/locationtech/geomesa/features/avro/AvroSimpleFeatureTest.scala
+++ b/geomesa-features/geomesa-feature-avro/src/test/scala/org/locationtech/geomesa/features/avro/AvroSimpleFeatureTest.scala
@@ -120,7 +120,6 @@ class AvroSimpleFeatureTest extends Specification {
         ",l:MultiPolygon,m:GeometryCollection"
       )
 
-
       val f = new AvroSimpleFeature(new FeatureIdImpl("fakeid"), sft)
       f.setAttribute("a","")
       f.setAttribute("b","")

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/expression/FastTemporalOperator.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/expression/FastTemporalOperator.scala
@@ -1,0 +1,142 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.filter.expression
+
+import java.util.Date
+
+import org.locationtech.geomesa.utils.geotools.converters.FastConverter
+import org.opengis.filter.FilterVisitor
+import org.opengis.filter.MultiValuedFilter.MatchAction
+import org.opengis.filter.expression.{Expression, Literal}
+import org.opengis.filter.temporal.{After, Before, BinaryTemporalOperator, During}
+import org.opengis.temporal.Period
+
+/**
+  * Fast temporal filters that avoid repeatedly evaluating literals
+  */
+object FastTemporalOperator {
+
+  def after(exp1: Expression, exp2: Literal): After = new FastAfterLiteral(exp1, exp2)
+  def after(exp1: Literal, exp2: Expression): After = new FastAfterExpression(exp1, exp2)
+
+  def before(exp1: Expression, exp2: Literal): Before = new FastBeforeLiteral(exp1, exp2)
+  def before(exp1: Literal, exp2: Expression): Before = new FastBeforeExpression(exp1, exp2)
+
+  def during(exp1: Expression, exp2: Literal): During = new FastDuring(exp1, exp2)
+
+  /**
+    * After filter comparing an expression (e.g. property or function) to a literal
+    *
+    * @param exp1 expression
+    * @param exp2 literal
+    */
+  private final class FastAfterLiteral(exp1: Expression, exp2: Literal)
+      extends FastTemporalOperator(exp1, exp2, After.NAME) with After {
+
+    private val lit = FastConverter.convert(exp2.evaluate(null), classOf[Date])
+
+    override def evaluate(obj: AnyRef): Boolean = {
+      val date = exp1.evaluate(obj).asInstanceOf[Date]
+      date != null && date.after(lit)
+    }
+
+    override def accept(visitor: FilterVisitor, extraData: AnyRef): AnyRef = visitor.visit(this, extraData)
+  }
+
+  /**
+    * After filter comparing a literal to an expression (e.g. property or function)
+    *
+    * @param exp1 literal
+    * @param exp2 expression
+    */
+  private final class FastAfterExpression(exp1: Literal, exp2: Expression)
+      extends FastTemporalOperator(exp1, exp2, After.NAME) with After {
+
+    private val lit = FastConverter.convert(exp1.evaluate(null), classOf[Date])
+
+    override def evaluate(obj: AnyRef): Boolean = {
+      val date = exp2.evaluate(obj).asInstanceOf[Date]
+      date != null && lit.after(date)
+    }
+
+    override def accept(visitor: FilterVisitor, extraData: AnyRef): AnyRef = visitor.visit(this, extraData)
+  }
+
+  /**
+    * Before filter comparing an expression (e.g. property or function) to a literal
+    *
+    * @param exp1 expression
+    * @param exp2 literal
+    */
+  private final class FastBeforeLiteral(exp1: Expression, exp2: Literal)
+      extends FastTemporalOperator(exp1, exp2, Before.NAME) with Before {
+
+    private val lit = FastConverter.convert(exp2.evaluate(null), classOf[Date])
+
+    override def evaluate(obj: AnyRef): Boolean = {
+      val date = exp1.evaluate(obj).asInstanceOf[Date]
+      date != null && date.before(lit)
+    }
+
+    override def accept(visitor: FilterVisitor, extraData: AnyRef): AnyRef = visitor.visit(this, extraData)
+  }
+
+  /**
+    * Before filter comparing a literal to an expression (e.g. property or function)
+    *
+    * @param exp1 literal
+    * @param exp2 expression
+    */
+  private final class FastBeforeExpression(exp1: Literal, exp2: Expression) extends
+      FastTemporalOperator(exp1, exp2, Before.NAME) with Before {
+
+    private val lit = FastConverter.convert(exp1.evaluate(null), classOf[Date])
+
+    override def evaluate(obj: AnyRef): Boolean = {
+      val date = exp1.evaluate(obj).asInstanceOf[Date]
+      date != null && lit.before(date)
+    }
+
+    override def accept(visitor: FilterVisitor, extraData: AnyRef): AnyRef = visitor.visit(this, extraData)
+  }
+
+
+  /**
+    * During filter comparing an expression (e.g. property or function) to a literal
+    *
+    * @param exp1 expression
+    * @param exp2 literal
+    */
+  private final class FastDuring(exp1: Expression, exp2: Literal)
+      extends FastTemporalOperator(exp1, exp2, During.NAME) with During {
+
+    private val lit = FastConverter.convert(exp2.evaluate(null), classOf[Period])
+    private val beg = lit.getBeginning.getPosition.getDate
+    private val end = lit.getEnding.getPosition.getDate
+
+    override def evaluate(obj: AnyRef): Boolean = {
+      val date = exp1.evaluate(obj).asInstanceOf[Date]
+      date != null && date.after(beg) && date.before(end)
+    }
+
+    override def accept(visitor: FilterVisitor, extraData: AnyRef): AnyRef = visitor.visit(this, extraData)
+  }
+}
+
+sealed private abstract class FastTemporalOperator(exp1: Expression, exp2: Expression, op: String)
+    extends BinaryTemporalOperator {
+
+  override def getExpression1: Expression = exp1
+
+  override def getExpression2: Expression = exp2
+
+  override def getMatchAction: MatchAction = MatchAction.ANY
+
+  override def toString: String = s"[ $exp1 $op $exp2 ]"
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/converters/FastConverter.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/converters/FastConverter.scala
@@ -69,7 +69,7 @@ object FastConverter extends StrictLogging {
       }
     }
 
-    logger.warn(s"Could not convert $value (of type ${value.getClass.getName}) to ${binding.getName}")
+    logger.warn(s"Could not convert '$value' (of type ${value.getClass.getName}) to ${binding.getName}")
 
     null.asInstanceOf[T]
   }


### PR DESCRIPTION
* FastDuring, FastAfter and FastBefore
* GeoTools temporal filters try to convert every value into
  a Period, which fails every time for our common use cases

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>