### PR TITLE
GEOMESA-2521 Handle null TypeName in Query from GS querylayer extension

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
@@ -677,7 +677,7 @@ class AccumuloDataStoreQueryTest extends Specification with TestWithMultipleSfts
     }
 
     "handle Query.ALL" in {
-      ds.getFeatureSource(defaultSft.getTypeName).getFeatures(Query.ALL).features() must throwAn[IllegalArgumentException]
+      ds.getFeatureSource(defaultSft.getTypeName).getFeatures(Query.ALL).features() must not throwAn[IllegalArgumentException]()
       ds.getFeatureReader(Query.ALL, Transaction.AUTO_COMMIT) must throwAn[IllegalArgumentException]
     }
   }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureSource.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureSource.scala
@@ -86,12 +86,15 @@ class GeoMesaFeatureSource(val ds: DataStore with HasGeoMesaStats,
     getFeatures(new Query(sft.getTypeName, filter))
 
   override def getFeatures(query: Query): SimpleFeatureCollection = {
-    // GeoServer querylayer extension generates query instances w/o type name set
-    if(query.getTypeName == null) {
-      logger.warn(s"Received Query with null TypeName, setting to ${sft.getTypeName}")
-      query.setTypeName(sft.getTypeName)
+    val q = query.getTypeName match {
+      case null =>
+        logger.debug(s"Received Query with null TypeName, setting to ${sft.getTypeName}")
+        val nq = new Query(query)
+        nq.setTypeName(sft.getTypeName)
+        nq
+      case _ => query
     }
-    collection(query, this)
+    collection(q, this)
   }
 
   override def getName: Name = getSchema.getName

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureSource.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureSource.scala
@@ -85,7 +85,14 @@ class GeoMesaFeatureSource(val ds: DataStore with HasGeoMesaStats,
   override def getFeatures(filter: Filter): SimpleFeatureCollection =
     getFeatures(new Query(sft.getTypeName, filter))
 
-  override def getFeatures(query: Query): SimpleFeatureCollection = collection(query, this)
+  override def getFeatures(query: Query): SimpleFeatureCollection = {
+    // GeoServer querylayer extension generates query instances w/o type name set
+    if(query.getTypeName == null) {
+      logger.warn(s"Received Query with null TypeName, setting to ${sft.getTypeName}")
+      query.setTypeName(sft.getTypeName)
+    }
+    collection(query, this)
+  }
 
   override def getName: Name = getSchema.getName
 

--- a/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreTest.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreTest.scala
@@ -448,8 +448,6 @@ class KafkaDataStoreTest extends Specification with Mockito with LazyLogging {
       def check = fs.getFeatures(q).features().close()
       // induce issue
       check must not throwA[NullPointerException]()
-      // show fix side effect, consistent with other GeoMesaDataStore Query mutations
-      q.getTypeName must be equalTo sft.getTypeName
     }
   }
 

--- a/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreTest.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreTest.scala
@@ -439,6 +439,20 @@ class KafkaDataStoreTest extends Specification with Mockito with LazyLogging {
     }
   }
 
+  "KafkaFeatureSource" should {
+    "handle Query instances with null TypeName (GeoServer querylayer extension implementation nuance)" >> {
+      val (p, c, sft) = createStorePair("querylayer")
+      p.createSchema(sft)
+      val fs = c.getFeatureSource(sft.getTypeName)
+      val q = new Query(null, Filter.INCLUDE)
+      def check = fs.getFeatures(q).features().close()
+      // induce issue
+      check must not throwA[NullPointerException]()
+      // show fix side effect, consistent with other GeoMesaDataStore Query mutations
+      q.getTypeName must be equalTo sft.getTypeName
+    }
+  }
+
   step {
     logger.info("Stopping embedded kafka/zk")
     kafka.close()


### PR DESCRIPTION
simple fix, not sure on use of mutation on Query instance, but consistent w/ other mutations in rest of implementation