### PR TITLE
GEOMESA-2524 Hand-walk FSDS metadata directory

### DIFF
--- a/docs/user/filesystem/sql.rst
+++ b/docs/user/filesystem/sql.rst
@@ -64,7 +64,10 @@ For example if you are using Amazon EMR with Spark 2.1.1 you can start up a shel
     . /etc/hadoop/conf/hadoop-env.sh
     . /etc/hadoop/conf/yarn-env.sh
     export HADOOP_CONF_DIR=/etc/hadoop/conf
-    spark-shell --jars $GEOMESA_FS_HOME/dist/spark/geomesa-fs-spark-runtime_2.11-$VERSION.jar --driver-memory 3g
+    spark-shell --jars $GEOMESA_FS_HOME/dist/spark/geomesa-fs-spark-runtime_2.11-$VERSION.jar \
+      --driver-memory 3g \
+      --conf 'spark.executor.extraJavaOptions=-Duser.timezone=UTC' \
+      --conf 'spark.driver.extraJavaOptions=-Duser.timezone=UTC'
 
 This will create a new spark shell from which you can load a GeoMesa FileSystem datastore from S3 or HDFS. A common
 usage pattern is to keep parquet files in S3 so they can be elastically queried with EMR and Spark. For example if you
@@ -79,7 +82,6 @@ have ingested GDELT data into S3 you can query it with SQL in the spark shell::
 
     // Select the top event codes
     spark.sql("SELECT eventCode, count(*) as count FROM gdelt " +
-              "WHERE dtg >= cast('2017-06-01T00:00:00.000' as timestamp) " +
-              "AND dtg <= cast('2017-06-30T00:00:00.000' as timestamp) " +
+              "WHERE dtg >= '2017-06-01T00:00:00Z' AND dtg <= '2017-06-30T00:00:00Z' " +
               "GROUP BY eventcode ORDER by count DESC").show()
 

--- a/docs/user/spark/providers.rst
+++ b/docs/user/spark/providers.rst
@@ -74,6 +74,13 @@ The ``FileSystemRDDProvider`` is a spatial RDD provider for GeoMesa file system 
 the ``geomesa-fs-spark`` module, and the shaded JAR-with-dependencies (which contains all the required
 dependencies for execution) is available in the ``geomesa-fs-spark-runtime`` module.
 
+.. warning::
+
+    It is important to set the system property ``user.timezone=UTC`` when using Spark with the
+    ``FileSystemDataStore``. When using ``spark-shell`` or ``spark-submit``, this can be done through
+    passing ``--conf 'spark.executor.extraJavaOptions=-Duser.timezone=UTC'`` and
+    ``--conf 'spark.driver.extraJavaOptions=-Duser.timezone=UTC'``
+
 This provider can read from and write to a GeoMesa ``FileSystemDataStore``. The configuration parameters
 are the same as those passed to ``DataStoreFinder.getDataStore()``. See :ref:`fsds_parameters` for details.
 

--- a/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/FileSystemFeatureStore.scala
+++ b/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/FileSystemFeatureStore.scala
@@ -15,7 +15,7 @@ import com.google.common.cache._
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.data.simple.DelegateSimpleFeatureReader
 import org.geotools.data.store.{ContentEntry, ContentFeatureStore}
-import org.geotools.data.{FeatureReader, FeatureWriter, Query}
+import org.geotools.data.{FeatureReader, FeatureWriter, Query, QueryCapabilities}
 import org.geotools.feature.collection.DelegateSimpleFeatureIterator
 import org.geotools.geometry.jts.ReferencedEnvelope
 import org.locationtech.geomesa.features.ScalaSimpleFeature
@@ -126,7 +126,6 @@ class FileSystemFeatureStore(val storage: FileSystemStorage,
     new DelegateSimpleFeatureReader(transformSft, new DelegateSimpleFeatureIterator(iter))
   }
 
-
   override def canLimit: Boolean = false
   override def canTransact: Boolean = false
   override def canEvent: Boolean = false
@@ -135,4 +134,12 @@ class FileSystemFeatureStore(val storage: FileSystemStorage,
 
   override def canRetype: Boolean = true
   override def canFilter: Boolean = true
+
+  override protected def buildQueryCapabilities(): QueryCapabilities = FileSystemFeatureStore.capabilities
+}
+
+object FileSystemFeatureStore {
+  private val capabilities = new QueryCapabilities() {
+    override def isUseProvidedFIDSupported: Boolean = true
+  }
 }

--- a/geomesa-fs/geomesa-fs-spark-runtime/src/test/scala/org/locationtech/geomesa/fs/spark/FSSparkProviderTest.scala
+++ b/geomesa-fs/geomesa-fs-spark-runtime/src/test/scala/org/locationtech/geomesa/fs/spark/FSSparkProviderTest.scala
@@ -54,9 +54,9 @@ class FSSparkProviderTest extends Specification with BeforeAfterAll with LazyLog
   lazy val dsf: FileSystemDataStoreFactory = new FileSystemDataStoreFactory()
   lazy val ds: DataStore = dsf.createDataStore(params)
 
-  var spark: SparkSession = null
-  var sc: SQLContext = null
-  var df: DataFrame = null
+  var spark: SparkSession = _
+  var sc: SQLContext = _
+  var df: DataFrame = _
 
   override def beforeAll(): Unit = {
     // Start MiniCluster
@@ -99,6 +99,13 @@ class FSSparkProviderTest extends Specification with BeforeAfterAll with LazyLog
       val rows = sc.sql("select count(*) from chicago").collect()
       rows.length mustEqual(1)
       rows.apply(0).get(0).asInstanceOf[Long] mustEqual(3l)
+    }
+
+    "select by spatiotemporal filter" >> {
+      val rows = sc.sql("select * from chicago where st_intersects(geom, st_makeBbox(-80,35,-75,45)) AND " +
+          "dtg > '2016-01-01T12:00:00Z' AND dtg < '2016-01-02T12:00:00Z'").collect()
+      rows.length mustEqual 1
+      rows.apply(0).get(0) mustEqual "2"
     }
 
     "select by secondary indexed attribute" >> {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/src/main/java/org/locationtech/geomesa/fs/storage/api/StorageMetadata.java
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/src/main/java/org/locationtech/geomesa/fs/storage/api/StorageMetadata.java
@@ -8,14 +8,11 @@
 
 package org.locationtech.geomesa.fs.storage.api;
 
-import org.locationtech.jts.geom.Envelope;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.Path;
-import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.feature.simple.SimpleFeatureType;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Metadata for a FileSystemStorage instance
@@ -93,6 +90,14 @@ public interface StorageMetadata {
      * multiple threads or storage instances attempt to compact metadata simultaneously.
      */
     void compact();
+
+    /**
+     * Rewrite metadata in an optimized fashion
+     *
+     * Care should be taken with this method. Currently, there is no guarantee for correct behavior if
+     * multiple threads or storage instances attempt to compact metadata simultaneously.
+     */
+    default void compact(String partition) { compact(); }
 
     /**
      * Force pick up of any external changes

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/compact/CompactCommand.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/compact/CompactCommand.scala
@@ -10,8 +10,9 @@ package org.locationtech.geomesa.fs.tools.compact
 
 import java.io.File
 import java.util.Locale
+import java.util.concurrent.{CountDownLatch, Executors}
 
-import com.beust.jcommander.{ParameterException, Parameters}
+import com.beust.jcommander.{Parameter, ParameterException, Parameters}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.fs.Path
 import org.locationtech.geomesa.fs.FileSystemDataStore
@@ -29,6 +30,8 @@ import org.locationtech.geomesa.tools.{Command, DistributedRunParam, RequiredTyp
 import org.locationtech.geomesa.utils.classpath.ClassPathUtils
 import org.locationtech.geomesa.utils.io.PathUtils
 import org.locationtech.geomesa.utils.text.TextTools
+
+import scala.util.control.NonFatal
 
 class CompactCommand extends FsDataStoreCommand with LazyLogging {
 
@@ -68,15 +71,45 @@ class CompactCommand extends FsDataStoreCommand with LazyLogging {
 
     Command.user.info(s"Compacting ${toCompact.size} partitions in ${mode.toString.toLowerCase(Locale.US)} mode")
 
+    val start = System.currentTimeMillis()
+
     // compact metadata up-front, that will save us listing redundant metadata files for each partition
     storage.getMetadata.compact()
 
+    val statusCallback = new PrintProgress(System.err, TextTools.buildString(' ', 60), '\u003d', '\u003e', '\u003e')
+
     mode match {
       case RunModes.Local =>
-        toCompact.par.foreach { p =>
-          logger.info(s"Compacting ${p.name}")
-          storage.compact(p.name)
+        val total = toCompact.length
+        val latch = new CountDownLatch(total)
+        val executor = Executors.newFixedThreadPool(math.max(1, math.min(params.threads, total)))
+        try {
+          toCompact.foreach { p =>
+            executor.submit(
+              new Runnable() {
+                override def run(): Unit = {
+                  try {
+                    logger.info(s"Compacting ${p.name}")
+                    storage.compact(p.name)
+                  } catch {
+                    case NonFatal(e) => logger.error(s"Error processing partition '${p.name}':", e)
+                  } finally {
+                    latch.countDown()
+                  }
+                }
+              }
+            )
+          }
+        } finally {
+          executor.shutdown()
         }
+
+        while (latch.getCount > 0) {
+          Thread.sleep(1000)
+          statusCallback("", 1f - latch.getCount.toFloat / total, Seq.empty, done = false)
+        }
+        statusCallback("", 1f, Seq.empty, done = true)
+        Command.user.info(s"Local compaction complete in ${TextTools.getTime(start)}")
 
       case RunModes.Distributed =>
         val encoding = storage.getMetadata.getEncoding
@@ -88,9 +121,6 @@ class CompactCommand extends FsDataStoreCommand with LazyLogging {
           throw new ParameterException(s"Compaction is not supported for encoding '$encoding'")
         }
         val tempDir = Option(params.tempDir).map(t => new Path(t))
-        val statusCallback = new PrintProgress(System.err, TextTools.buildString(' ', 60), '\u003d', '\u003e', '\u003e')
-
-        val start = System.currentTimeMillis()
         val (success, failed) = job.run(connection, params.featureName, toCompact, tempDir,
           libjarsFileName, libjarsSearchPath, statusCallback)
         Command.user.info(s"Distributed compaction complete in ${TextTools.getTime(start)}")
@@ -99,13 +129,14 @@ class CompactCommand extends FsDataStoreCommand with LazyLogging {
       case RunModes.DistributedCombine =>
         throw new RuntimeException("DistributedCombine run mode is not supported with this command.")
     }
-
-    Command.user.info(s"Compaction completed")
   }
 }
 
 object CompactCommand {
   @Parameters(commandDescription = "Compact partitions")
   class CompactParams extends FsParams
-      with RequiredTypeNameParam with TempDirParam with PartitionParam with DistributedRunParam
+      with RequiredTypeNameParam with TempDirParam with PartitionParam with DistributedRunParam {
+    @Parameter(names = Array("-t", "--threads"), description = "Number of threads if using local mode")
+    var threads: Integer = 4
+  }
 }

--- a/geomesa-tools/conf/log4j.properties
+++ b/geomesa-tools/conf/log4j.properties
@@ -18,6 +18,7 @@ log4j.logger.org.apache.curator=warn
 log4j.logger.org.apache.hadoop=warn
 log4j.logger.com.google.bigtable.repackaged.io.grpc.internal.ManagedChannelImpl=warn
 log4j.logger.org.apache.parquet=warn
+log4j.logger.org.apache.orc=warn
 
 # log to stderr for user messages
 log4j.appender.user=org.apache.log4j.ConsoleAppender

--- a/pom.xml
+++ b/pom.xml
@@ -1749,6 +1749,7 @@
                 <groupId>org.apache.orc</groupId>
                 <artifactId>orc-core</artifactId>
                 <version>${orc.version}</version>
+                <classifier>nohive</classifier>
                 <exclusions>
                     <!-- excluded due to license issue -->
                     <exclusion>
@@ -1756,7 +1757,6 @@
                         <artifactId>jol-core</artifactId>
                     </exclusion>
                 </exclusions>
-                <classifier>nohive</classifier>
             </dependency>
             <dependency>
                 <groupId>org.apache.orc</groupId>


### PR DESCRIPTION
* Using FileContext.utils() is orders of magnitudes slower with large
  numbers of files
* Fix USE_PROVIDED_FID behavior for FSDS FeatureStore
* Add docs on setting user.timezone for spark sql

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>