### PR TITLE
Relocate netty.io for Hadoop 3 compatibility

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
@@ -66,6 +66,10 @@
                                     <pattern>net.minidev.json</pattern>
                                     <shadedPattern>org.locationtech.geomesa.accumulo.shade.net.minidev.json</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>org.locationtech.geomesa.accumulo.shade.io.netty</shadedPattern>
+                                </relocation>
                             </relocations>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />

--- a/geomesa-hbase/geomesa-hbase-distributed-runtime/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-distributed-runtime/pom.xml
@@ -72,6 +72,10 @@
                                     <pattern>net.minidev.json</pattern>
                                     <shadedPattern>org.locationtech.geomesa.accumulo.shade.net.minidev.json</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>org.locationtech.geomesa.accumulo.shade.io.netty</shadedPattern>
+                                </relocation>
                             </relocations>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />


### PR DESCRIPTION
Relocate netty.io for Hadoop 3 compatibility.  Added a relocator in the distributed runtime for hbase and accumulo to relocate netty.io