### PR TITLE
GEOMESA-2493 Configurable query filtering for merged data store view

### DIFF
--- a/docs/user/merged_view.rst
+++ b/docs/user/merged_view.rst
@@ -59,6 +59,33 @@ For example, to merge a GeoMesa Accumulo data store with a PostGis data store, y
       ]
     }
 
+Query Filtering
+---------------
+
+If the stores being merged have known characteristics, filters can be applied selectively to each store in
+order to speed up queries. The filter is specified along with the other store parameters, under the key
+``geomesa.merged.store.filter``, and should be an ECQL filter string.
+
+The filter will be applied against any query, in addition to the query filter. This can be used to short-circuit
+queries that are not relevant for a particular store. For example, if one store contains features from the past
+24 hours, and a second store contains features older than 24 hours, then you could configure them with
+time-based filters:
+
+.. code-block:: json
+
+    {
+      "stores": [
+        {
+          // regular store parameters go here
+          "geomesa.merged.store.filter": "dtg >= currentDate('-P1D')"
+        },
+        {
+          // regular store parameters go here
+          "geomesa.merged.store.filter": "dtg < currentDate('-P1D')"
+        }
+      ]
+    }
+
 Config Provider
 ---------------
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/MergedDataStoreView.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/MergedDataStoreView.scala
@@ -19,6 +19,7 @@ import org.locationtech.geomesa.index.view.MergedQueryRunner.MergedStats
 import org.locationtech.geomesa.utils.geotools.{SchemaBuilder, SimpleFeatureTypes}
 import org.opengis.feature.`type`.{GeometryDescriptor, Name}
 import org.opengis.feature.simple.SimpleFeatureType
+import org.opengis.filter.Filter
 
 /**
   * Merged querying against multiple data stores
@@ -26,7 +27,7 @@ import org.opengis.feature.simple.SimpleFeatureType
   * @param stores delegate stores
   * @param namespace namespace
   */
-class MergedDataStoreView(val stores: Seq[DataStore], namespace: Option[String] = None)
+class MergedDataStoreView(val stores: Seq[(DataStore, Option[Filter])], namespace: Option[String] = None)
     extends HasGeoMesaStats with ReadOnlyDataStore {
 
   import scala.collection.JavaConverters._
@@ -37,7 +38,7 @@ class MergedDataStoreView(val stores: Seq[DataStore], namespace: Option[String] 
 
   override val stats: GeoMesaStats = new MergedStats(stores)
 
-  override def getTypeNames: Array[String] = stores.map(_.getTypeNames).reduceLeft(_ intersect _)
+  override def getTypeNames: Array[String] = stores.map(_._1.getTypeNames).reduceLeft(_ intersect _)
 
   override def getNames: java.util.List[Name] =
     java.util.Arrays.asList(getTypeNames.map(t => new NameImpl(namespace.orNull, t)): _*)
@@ -45,7 +46,7 @@ class MergedDataStoreView(val stores: Seq[DataStore], namespace: Option[String] 
   override def getSchema(name: Name): SimpleFeatureType = getSchema(name.getLocalPart)
 
   override def getSchema(typeName: String): SimpleFeatureType = {
-    val schemas = stores.map(_.getSchema(typeName))
+    val schemas = stores.map(_._1.getSchema(typeName))
 
     if (schemas.contains(null)) {
       return null
@@ -95,13 +96,15 @@ class MergedDataStoreView(val stores: Seq[DataStore], namespace: Option[String] 
 
   override def getFeatureSource(name: Name): SimpleFeatureSource = getFeatureSource(name.getLocalPart)
 
-  override def getFeatureSource(typeName: String): SimpleFeatureSource =
-    new MergedFeatureSourceView(this, stores.map(_.getFeatureSource(typeName)), getSchema(typeName))
+  override def getFeatureSource(typeName: String): SimpleFeatureSource = {
+    val sources = stores.map { case (store, filter) => (store.getFeatureSource(typeName), filter) }
+    new MergedFeatureSourceView(this, sources, getSchema(typeName))
+  }
 
   override def getFeatureReader(query: Query, transaction: Transaction): SimpleFeatureReader =
     GeoMesaFeatureReader(getSchema(query.getTypeName), query, runner, None, None)
 
-  override def dispose(): Unit = stores.foreach(_.dispose())
+  override def dispose(): Unit = stores.foreach(_._1.dispose())
 
   override def getInfo: ServiceInfo = {
     val info = new DefaultServiceInfo()

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/MergedFeatureSourceView.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/MergedFeatureSourceView.scala
@@ -39,26 +39,33 @@ import org.opengis.util.ProgressListener
   * @param sources delegate feature sources
   * @param sft simple feature type
   */
-class MergedFeatureSourceView(ds: MergedDataStoreView, sources: Seq[SimpleFeatureSource], sft: SimpleFeatureType)
-    extends SimpleFeatureSource with LazyLogging {
+class MergedFeatureSourceView(
+    ds: MergedDataStoreView,
+    sources: Seq[(SimpleFeatureSource, Option[Filter])],
+    sft: SimpleFeatureType
+  ) extends SimpleFeatureSource with LazyLogging {
 
   lazy private val hints = Collections.unmodifiableSet(Collections.emptySet[Key])
 
-  lazy private val capabilities = new MergedQueryCapabilities(sources.map(_.getQueryCapabilities))
+  lazy private val capabilities = new MergedQueryCapabilities(sources.map(_._1.getQueryCapabilities))
 
   override def getSchema: SimpleFeatureType = sft
 
-  override def getCount(query: Query): Int = sources.map(_.getCount(query)).sum
+  override def getCount(query: Query): Int =
+    sources.map { case (source, filter) => source.getCount(mergeFilter(query, filter)) }.sum
 
   override def getBounds: ReferencedEnvelope = {
     val bounds = new ReferencedEnvelope(org.locationtech.geomesa.utils.geotools.CRS_EPSG_4326)
-    sources.foreach(s => bounds.expandToInclude(s.getBounds))
+    sources.foreach {
+      case (source, None)    => bounds.expandToInclude(source.getBounds)
+      case (source, Some(f)) => bounds.expandToInclude(source.getBounds(new Query(sft.getTypeName, f)))
+    }
     bounds
   }
 
   override def getBounds(query: Query): ReferencedEnvelope = {
     val bounds = new ReferencedEnvelope(org.locationtech.geomesa.utils.geotools.CRS_EPSG_4326)
-    sources.foreach(s => bounds.expandToInclude(s.getBounds(query)))
+    sources.foreach { case (source, filter) => bounds.expandToInclude(source.getBounds(mergeFilter(query, filter))) }
     bounds
   }
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/package.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/package.scala
@@ -1,0 +1,48 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index
+
+import org.geotools.data.Query
+import org.opengis.filter.Filter
+
+package object view {
+
+  import org.locationtech.geomesa.filter.andFilters
+
+  /**
+    * Helper method to merge a filtered data store query
+    *
+    * @param query query
+    * @param filter data store filter
+    * @return
+    */
+  def mergeFilter(query: Query, filter: Option[Filter]): Query = {
+    filter match {
+      case None => query
+      case Some(f) =>
+        val q = new Query(query)
+        q.setFilter(if (q.getFilter == Filter.INCLUDE) { f } else { andFilters(Seq(q.getFilter, f)) })
+        q
+    }
+  }
+
+  /**
+    * Helper method to merge a filtered data store query
+    *
+    * @param filter filter
+    * @param option data store filter
+    * @return
+    */
+  def mergeFilter(filter: Filter, option: Option[Filter]): Filter = {
+    option match {
+      case None => filter
+      case Some(f) => if (filter == Filter.INCLUDE) { f } else { andFilters(Seq(filter, f)) }
+    }
+  }
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeoMesaParam.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeoMesaParam.scala
@@ -133,7 +133,7 @@ class GeoMesaParam[T <: AnyRef](_key: String, // can't override final 'key' fiel
     * @param params parameter map
     * @return
     */
-  def lookupOpt(params: java.util.Map[String, Serializable]): Option[T] = Option(lookup(params))
+  def lookupOpt(params: java.util.Map[String, _ <: Serializable]): Option[T] = Option(lookup(params))
 
   /**
     * Logs a warning about deprecated parameter keys


### PR DESCRIPTION
* Use `geomesa.merged.store.filter` to apply a filter to each store

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>