### PR TITLE
GEOMESA-2542 Kafka - provide option to clear topic on startup

### DIFF
--- a/docs/user/kafka/usage.rst
+++ b/docs/user/kafka/usage.rst
@@ -50,6 +50,8 @@ Parameter                            Type    Description
                                              all existing messages are processed. However, feature listeners will still be invoked as normal.
                                              See :ref:`kafka_initial_load`
 ``kafka.consumer.count``             Integer Number of kafka consumers used per feature type. Set to 0 to disable consuming (i.e. producer only)
+``kafka.producer.clear``             Boolean Send a 'clear' message on startup. This will cause clients to ignore any data that was in the
+                                             topic prior to startup
 ``kafka.topic.partitions``           Integer Number of partitions to use in new kafka topics
 ``kafka.topic.replication``          Integer Replication factor to use in new kafka topics
 ``kafka.serialization.type``         String  Internal serialization format to use for kafka messages. Must be one of ``kryo`` or ``avro``

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaDataStore.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaDataStore.scala
@@ -71,6 +71,8 @@ class KafkaDataStore(val config: KafkaDataStoreConfig)
     KafkaDataStore.producer(config)
   }
 
+  private val cleared = Collections.newSetFromMap(new ConcurrentHashMap[String, java.lang.Boolean]())
+
   private val caches = Caffeine.newBuilder().build(new CacheLoader[String, KafkaCacheLoader] {
     override def load(key: String): KafkaCacheLoader = {
       if (config.consumers.count < 1) {
@@ -190,7 +192,11 @@ class KafkaDataStore(val config: KafkaDataStoreConfig)
     if (sft == null) {
       throw new IOException(s"Schema '$typeName' has not been initialized. Please call 'createSchema' first.")
     }
-    new ModifyKafkaFeatureWriter(sft, producer, config.serialization, filter)
+    val writer = new ModifyKafkaFeatureWriter(sft, producer, config.serialization, filter)
+    if (config.clearOnStart && cleared.add(typeName)) {
+      writer.clear()
+    }
+    writer
   }
 
   override def getFeatureWriterAppend(typeName: String, transaction: Transaction): KafkaFeatureWriter = {
@@ -198,7 +204,11 @@ class KafkaDataStore(val config: KafkaDataStoreConfig)
     if (sft == null) {
       throw new IOException(s"Schema '$typeName' has not been initialized. Please call 'createSchema' first.")
     }
-    new AppendKafkaFeatureWriter(sft, producer, config.serialization)
+    val writer = new AppendKafkaFeatureWriter(sft, producer, config.serialization)
+    if (config.clearOnStart && cleared.add(typeName)) {
+      writer.clear()
+    }
+    writer
   }
 
   override def dispose(): Unit = {
@@ -339,18 +349,20 @@ object KafkaDataStore extends LazyLogging {
     }
   }
 
-  case class KafkaDataStoreConfig(catalog: String,
-                                  brokers: String,
-                                  zookeepers: String,
-                                  consumers: ConsumerConfig,
-                                  producers: ProducerConfig,
-                                  topics: TopicConfig,
-                                  serialization: SerializationType,
-                                  indices: IndexConfig,
-                                  looseBBox: Boolean,
-                                  authProvider: AuthorizationsProvider,
-                                  audit: Option[(AuditWriter, AuditProvider, String)],
-                                  namespace: Option[String]) extends NamespaceConfig
+  case class KafkaDataStoreConfig(
+      catalog: String,
+      brokers: String,
+      zookeepers: String,
+      consumers: ConsumerConfig,
+      producers: ProducerConfig,
+      clearOnStart: Boolean,
+      topics: TopicConfig,
+      serialization: SerializationType,
+      indices: IndexConfig,
+      looseBBox: Boolean,
+      authProvider: AuthorizationsProvider,
+      audit: Option[(AuditWriter, AuditProvider, String)],
+      namespace: Option[String]) extends NamespaceConfig
 
   case class ConsumerConfig(count: Int, properties: Map[String, String], readBack: Option[Duration])
 

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreFactory.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreFactory.scala
@@ -112,6 +112,7 @@ object KafkaDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
       val props = ProducerConfig.lookupOpt(params).map(_.asScala.toMap).getOrElse(Map.empty[String, String])
       KafkaDataStore.ProducerConfig(props)
     }
+    val clearOnStart = ClearOnStart.lookup(params)
 
     val serialization = org.locationtech.geomesa.features.SerializationType.withName(SerializationType.lookup(params))
 
@@ -168,7 +169,7 @@ object KafkaDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
       }
     }
 
-    KafkaDataStoreConfig(catalog, brokers, zookeepers, consumers, producers, topics, serialization,
+    KafkaDataStoreConfig(catalog, brokers, zookeepers, consumers, producers, clearOnStart, topics, serialization,
       indices, looseBBox, authProvider, audit, ns)
   }
 
@@ -251,6 +252,7 @@ object KafkaDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
     val ZkPath            = new GeoMesaParam[String]("kafka.zk.path", "Zookeeper discoverable path (namespace)", default = DefaultZkPath, deprecatedKeys = Seq("zkPath"))
     val ProducerConfig    = new GeoMesaParam[Properties]("kafka.producer.config", "Configuration options for kafka producer, in Java properties format. See http://kafka.apache.org/documentation.html#producerconfigs", largeText = true, deprecatedKeys = Seq("producerConfig"))
     val ConsumerConfig    = new GeoMesaParam[Properties]("kafka.consumer.config", "Configuration options for kafka consumer, in Java properties format. See http://kafka.apache.org/documentation.html#newconsumerconfigs", largeText = true, deprecatedKeys = Seq("consumerConfig"))
+    val ClearOnStart      = new GeoMesaParam[java.lang.Boolean]("kafka.producer.clear", "Send a 'clear' message on startup. This will cause clients to ignore any data that was in the topic prior to startup", default = Boolean.box(false))
     val ConsumerReadBack  = new GeoMesaParam[Duration]("kafka.consumer.read-back", "On start up, read messages that were written within this time frame (vs ignore old messages), e.g. '1 hour'. Use 'Inf' to read all messages", deprecatedParams = Seq(DeprecatedOffset, DeprecatedEarliest))
     val TopicPartitions   = new GeoMesaParam[Integer]("kafka.topic.partitions", "Number of partitions to use in new kafka topics", default = 1, deprecatedKeys = Seq("partitions"))
     val TopicReplication  = new GeoMesaParam[Integer]("kafka.topic.replication", "Replication factor to use in new kafka topics", default = 1, deprecatedKeys = Seq("replication"))


### PR DESCRIPTION
* Use `kafka.producer.clear` set to `true`

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>