### PR TITLE
GEOMESA-2560 Remove verbose flag from converters

### DIFF
--- a/docs/user/convert/parsing_and_validation.rst
+++ b/docs/user/convert/parsing_and_validation.rst
@@ -135,11 +135,11 @@ To configure the parse mode use add an option to your converter's typesafe confi
 Logging
 ~~~~~~~
 
-To view validation logs you can enable debug level logging on the packages ``org.locationtech.geomesa.convert``
-and ``org.locationtech.geomesa.convert2``.
+To view validation logs you can enable info or debug level logging on the packages
+``org.locationtech.geomesa.convert`` and ``org.locationtech.geomesa.convert2``.
 
-By default, logging will just show the field that failed. To show the entire record, along with the stack trace,
-you can set ``options.verbose = true``.
+When logging is enabled at the info level, it will just show the field that failed. When enabled at the debug
+level, it will show the entire record, along with the stack trace.
 
 Transactional Considerations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/geomesa-convert/geomesa-convert-avro/src/main/scala/org/locationtech/geomesa/convert/avro/AvroConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-avro/src/main/scala/org/locationtech/geomesa/convert/avro/AvroConverterFactory.scala
@@ -173,8 +173,8 @@ class AvroConverterFactory extends AbstractConverterFactory[AvroConverter, AvroC
 
         val converterConfig = AvroConfig(typeToProcess, SchemaEmbedded, Some(id), Map.empty, userData)
 
-        val options = BasicOptions(SimpleFeatureValidator.default, ParseMode.Default, ErrorMode(),
-          StandardCharsets.UTF_8, verbose = true)
+        val options =
+          BasicOptions(SimpleFeatureValidator.default, ParseMode.Default, ErrorMode(), StandardCharsets.UTF_8)
 
         val config = configConvert.to(converterConfig)
             .withFallback(fieldConvert.to(fields))

--- a/geomesa-convert/geomesa-convert-avro/src/test/scala/org/locationtech/geomesa/convert/avro/AvroConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-avro/src/test/scala/org/locationtech/geomesa/convert/avro/AvroConverterTest.scala
@@ -110,7 +110,6 @@ class AvroConverterTest extends Specification with AvroUtils with LazyLogging {
           |   schema-file = "/schema.avsc"
           |   sft         = "testsft"
           |   id-field    = "md5($0)"
-          |   options = { verbose = true }
           |   fields = [
           |     { name = "tobj", transform = "avroPath($1, '/content$type=TObj')" },
           |     { name = "dtg",  transform = "date('yyyy-MM-dd', avroPath($tobj, '/kvmap[$k=dtg]/v'))" },
@@ -147,7 +146,6 @@ class AvroConverterTest extends Specification with AvroUtils with LazyLogging {
           |   sft         = "testsft"
           |   schema      = "embedded"
           |   id-field    = "md5($0)"
-          |   options = { verbose = true }
           |   fields = [
           |     { name = "tobj", transform = "avroPath($1, '/content$type=TObj')" },
           |     { name = "dtg",  transform = "date('yyyy-MM-dd', avroPath($tobj, '/kvmap[$k=dtg]/v'))" },

--- a/geomesa-convert/geomesa-convert-common/src/main/resources/base-converter-defaults.conf
+++ b/geomesa-convert/geomesa-convert-common/src/main/resources/base-converter-defaults.conf
@@ -4,7 +4,6 @@
     "parse-mode" = "incremental"
     "error-mode" = "skip-bad-records"
     "encoding"   = "UTF-8"
-    "verbose"    = false
   }
   "user-data" = {}
   "caches" = {}

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/package.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/package.scala
@@ -35,6 +35,5 @@ package object convert2 {
     def parseMode: ParseMode
     def errorMode: ErrorMode
     def encoding: Charset
-    def verbose: Boolean
   }
 }

--- a/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert/common/EnrichmentCacheTest.scala
+++ b/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert/common/EnrichmentCacheTest.scala
@@ -36,9 +36,6 @@ class EnrichmentCacheTest extends Specification {
           |         }
           |      }
           |   }
-          |   options = {
-          |     verbose = true
-          |   }
           |   fields = [
           |     { name = "id",     transform = "toString($0)"      }
           |     { name = "keytolookup", transform = "cacheLookup('test', $id, 'name')"   }
@@ -82,9 +79,6 @@ class EnrichmentCacheTest extends Specification {
           |         columns = ["id", "name", "age"]
           |         id-field = "id"
           |      }
-          |   }
-          |   options = {
-          |     verbose = true
           |   }
           |   fields = [
           |     { name = "id",     transform = "toString($0)"      }

--- a/geomesa-convert/geomesa-convert-json/src/main/scala/org/locationtech/geomesa/convert/json/JsonConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-json/src/main/scala/org/locationtech/geomesa/convert/json/JsonConverterFactory.scala
@@ -125,8 +125,8 @@ class JsonConverterFactory extends AbstractConverterFactory[JsonConverter, JsonC
 
         val jsonConfig = JsonConfig(typeToProcess, featurePath, idField, Map.empty, Map.empty)
         val fieldConfig = fields :+ geomField
-        val options = BasicOptions(SimpleFeatureValidator.default, ParseMode.Default, ErrorMode(),
-          StandardCharsets.UTF_8, verbose = true)
+        val options =
+          BasicOptions(SimpleFeatureValidator.default, ParseMode.Default, ErrorMode(), StandardCharsets.UTF_8)
 
         val config = configConvert.to(jsonConfig)
             .withFallback(fieldConvert.to(fieldConfig))

--- a/geomesa-convert/geomesa-convert-shp/src/main/scala/org/locationtech/geomesa/convert/shp/ShapefileConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-shp/src/main/scala/org/locationtech/geomesa/convert/shp/ShapefileConverterFactory.scala
@@ -74,8 +74,8 @@ object ShapefileConverterFactory extends LazyLogging {
       }
 
       val shpConfig = BasicConfig(TypeToProcess, Some(Column(0)), Map.empty, Map.empty)
-      val options = BasicOptions(SimpleFeatureValidator.default, ParseMode.Default, ErrorMode(),
-        StandardCharsets.UTF_8, verbose = true)
+      val options =
+        BasicOptions(SimpleFeatureValidator.default, ParseMode.Default, ErrorMode(), StandardCharsets.UTF_8)
 
       val config = BasicConfigConvert.to(shpConfig)
           .withFallback(BasicFieldConvert.to(fields))

--- a/geomesa-convert/geomesa-convert-shp/src/test/scala/org/locationtech/geomesa/convert/shp/ShapefileConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-shp/src/test/scala/org/locationtech/geomesa/convert/shp/ShapefileConverterTest.scala
@@ -50,7 +50,6 @@ class ShapefileConverterTest extends Specification {
           |     { name = "area", transform = "add(shp('ALAND'),shp('AWATER'))" },
           |     { name = "geom", transform = "shp('the_geom')" },
           |   ]
-          |   options = { verbose = true }
           | }
         """.stripMargin)
 

--- a/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
+++ b/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
@@ -175,21 +175,24 @@ object DelimitedTextConverter {
   // check quoted before default - if values are quoted, we don't want the quotes to be captured as part of the value
   private [text] val inferences = Seq(Formats.Tabs, Formats.Quoted, Formats.Default)
 
-  case class DelimitedTextConfig(`type`: String,
-                                 format: String,
-                                 idField: Option[Expression],
-                                 caches: Map[String, Config],
-                                 userData: Map[String, Expression]) extends ConverterConfig
+  case class DelimitedTextConfig(
+      `type`: String,
+      format: String,
+      idField: Option[Expression],
+      caches: Map[String, Config],
+      userData: Map[String, Expression]
+    ) extends ConverterConfig
 
-  case class DelimitedTextOptions(skipLines: Option[Int],
-                                  quote: OptionalChar,
-                                  escape: OptionalChar,
-                                  delimiter: Option[Char],
-                                  validators: SimpleFeatureValidator,
-                                  parseMode: ParseMode,
-                                  errorMode: ErrorMode,
-                                  encoding: Charset,
-                                  verbose: Boolean) extends ConverterOptions
+  case class DelimitedTextOptions(
+      skipLines: Option[Int],
+      quote: OptionalChar,
+      escape: OptionalChar,
+      delimiter: Option[Char],
+      validators: SimpleFeatureValidator,
+      parseMode: ParseMode,
+      errorMode: ErrorMode,
+      encoding: Charset
+    ) extends ConverterOptions
 
   sealed trait OptionalChar {
     def foreach[U](f: Character => U): Unit

--- a/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterFactory.scala
@@ -81,7 +81,7 @@ class DelimitedTextConverterFactory
           }
 
           val options = DelimitedTextOptions(None, CharNotSpecified, CharNotSpecified, None,
-            SimpleFeatureValidator.default, ParseMode.Default, ErrorMode(), StandardCharsets.UTF_8, verbose = true)
+            SimpleFeatureValidator.default, ParseMode.Default, ErrorMode(), StandardCharsets.UTF_8)
 
           val config = configConvert.to(converterConfig)
               .withFallback(fieldConvert.to(fields))
@@ -144,12 +144,12 @@ object DelimitedTextConverterFactory {
   }
 
   object DelimitedTextOptionsConvert extends ConverterOptionsConvert[DelimitedTextOptions] {
-    override protected def decodeOptions(cur: ConfigObjectCursor,
-                                         validators: SimpleFeatureValidator,
-                                         parseMode: ParseMode,
-                                         errorMode: ErrorMode,
-                                         encoding: Charset,
-                                         verbose: Boolean): Either[ConfigReaderFailures, DelimitedTextOptions] = {
+    override protected def decodeOptions(
+        cur: ConfigObjectCursor,
+        validators: SimpleFeatureValidator,
+        parseMode: ParseMode,
+        errorMode: ErrorMode,
+        encoding: Charset): Either[ConfigReaderFailures, DelimitedTextOptions] = {
       def option[T](key: String, reader: ConfigReader[T]): Either[ConfigReaderFailures, Option[T]] = {
         val value = cur.atKeyOrUndefined(key)
         if (value.isUndefined) { Right(None) } else { reader.from(value).right.map(Option.apply) }
@@ -176,7 +176,7 @@ object DelimitedTextConverterFactory {
         escape    <- optionalChar("escape").right
         delimiter <- option("delimiter", PrimitiveConvert.charConfigReader).right
       } yield {
-        DelimitedTextOptions(skipLines, quote, escape, delimiter, validators, parseMode, errorMode, encoding, verbose)
+        DelimitedTextOptions(skipLines, quote, escape, delimiter, validators, parseMode, errorMode, encoding)
       }
     }
 

--- a/geomesa-convert/geomesa-convert-xml/src/main/resources/xml-converter-defaults.conf
+++ b/geomesa-convert/geomesa-convert-xml/src/main/resources/xml-converter-defaults.conf
@@ -7,7 +7,6 @@
     "error-mode" = "skip-bad-records"
     "line-mode"  = "single"
     "encoding"   = "UTF-8"
-    "verbose"    = false
   }
   "user-data" = {}
   "caches" = {}

--- a/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlConverter.scala
+++ b/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlConverter.scala
@@ -168,10 +168,11 @@ object XmlConverter extends StrictLogging {
     }
   }
 
-  case class XmlOptions(validators: SimpleFeatureValidator,
-                        parseMode: ParseMode,
-                        errorMode: ErrorMode,
-                        lineMode: LineMode,
-                        encoding: Charset,
-                        verbose: Boolean) extends ConverterOptions
+  case class XmlOptions(
+      validators: SimpleFeatureValidator,
+      parseMode: ParseMode,
+      errorMode: ErrorMode,
+      lineMode: LineMode,
+      encoding: Charset
+    ) extends ConverterOptions
 }

--- a/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlConverterFactory.scala
@@ -111,12 +111,12 @@ object XmlConverterFactory {
   }
 
   object XmlOptionsConvert extends ConverterOptionsConvert[XmlOptions] {
-    override protected def decodeOptions(cur: ConfigObjectCursor,
-                                         validators: SimpleFeatureValidator,
-                                         parseMode: ParseMode,
-                                         errorMode: ErrorMode,
-                                         encoding: Charset,
-                                         verbose: Boolean): Either[ConfigReaderFailures, XmlOptions] = {
+    override protected def decodeOptions(
+        cur: ConfigObjectCursor,
+        validators: SimpleFeatureValidator,
+        parseMode: ParseMode,
+        errorMode: ErrorMode,
+        encoding: Charset): Either[ConfigReaderFailures, XmlOptions] = {
       def parse[T](key: String, values: Iterable[T]): Either[ConfigReaderFailures, T] = {
         cur.atKey(key).right.flatMap { value =>
           value.asString.right.flatMap { string =>
@@ -133,7 +133,7 @@ object XmlConverterFactory {
       for {
         lineMode <- parse("line-mode", LineMode.values).right
       } yield {
-        XmlOptions(validators, parseMode, errorMode, lineMode, encoding, verbose)
+        XmlOptions(validators, parseMode, errorMode, lineMode, encoding)
       }
     }
 

--- a/geomesa-fs/geomesa-fs-datastore/src/test/resources/reference.conf
+++ b/geomesa-fs/geomesa-fs-datastore/src/test/resources/reference.conf
@@ -13,7 +13,6 @@ geomesa {
       type   = "delimited-text",
       format = "CSV",
       options {
-        verbose = true
         skip-lines = 0
       },
       id-field = "toString($name)",

--- a/geomesa-fs/geomesa-fs-datastore/src/test/scala/org/locationtech/geomesa/fs/converter/ConverterDataStoreTest.scala
+++ b/geomesa-fs/geomesa-fs-datastore/src/test/scala/org/locationtech/geomesa/fs/converter/ConverterDataStoreTest.scala
@@ -110,7 +110,6 @@ class ConverterDataStoreTest extends Specification {
           |      type   = "delimited-text",
           |      format = "CSV",
           |      options {
-          |        verbose = true
           |        skip-lines = 0
           |      },
           |      id-field = "toString($name)",


### PR DESCRIPTION
* Logging configured at 'info' level will just show the field
* Logging configured at the 'debug' level will show the field,
  the inputs, and the stack trace of the underlying exception

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>