### PR TITLE
 GEOMESA-2573 Add ejml core to ingest libjars

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-tools/src/main/resources/org/locationtech/geomesa/accumulo/tools/ingest-libjars.list
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/main/resources/org/locationtech/geomesa/accumulo/tools/ingest-libjars.list
@@ -9,6 +9,7 @@ commons-lang3
 commons-pool
 commons-text
 config
+core
 curator-client
 curator-framework
 curator-recipes

--- a/geomesa-bigtable/geomesa-bigtable-tools/src/main/resources/org/locationtech/geomesa/bigtable/tools/ingest-libjars.list
+++ b/geomesa-bigtable/geomesa-bigtable-tools/src/main/resources/org/locationtech/geomesa/bigtable/tools/ingest-libjars.list
@@ -6,6 +6,7 @@ commons-lang3
 commons-pool
 commons-text
 config
+core
 geomesa
 gson
 gt

--- a/geomesa-fs/geomesa-fs-tools/src/main/resources/org/locationtech/geomesa/fs/tools/ingest-libjars.list
+++ b/geomesa-fs/geomesa-fs-tools/src/main/resources/org/locationtech/geomesa/fs/tools/ingest-libjars.list
@@ -14,7 +14,6 @@ geomesa
 gson
 gt
 hive
-hsqldb
 joda
 json4s-ast
 json4s-core

--- a/geomesa-fs/geomesa-fs-tools/src/main/resources/org/locationtech/geomesa/fs/tools/ingest-libjars.list
+++ b/geomesa-fs/geomesa-fs-tools/src/main/resources/org/locationtech/geomesa/fs/tools/ingest-libjars.list
@@ -6,6 +6,7 @@ commons-lang3
 commons-pool
 commons-text
 config
+core
 curator-client
 curator-framework
 curator-recipes
@@ -13,6 +14,7 @@ geomesa
 gson
 gt
 hive
+hsqldb
 joda
 json4s-ast
 json4s-core

--- a/geomesa-hbase/geomesa-hbase-tools/src/main/resources/org/locationtech/geomesa/hbase/tools/ingest-libjars.list
+++ b/geomesa-hbase/geomesa-hbase-tools/src/main/resources/org/locationtech/geomesa/hbase/tools/ingest-libjars.list
@@ -5,6 +5,7 @@ commons-lang3
 commons-pool
 commons-text
 config
+core
 geomesa
 gson
 gt

--- a/geomesa-kafka/geomesa-kafka-tools/src/main/resources/org/locationtech/geomesa/kafka/tools/ingest-libjars.list
+++ b/geomesa-kafka/geomesa-kafka-tools/src/main/resources/org/locationtech/geomesa/kafka/tools/ingest-libjars.list
@@ -5,6 +5,7 @@ commons-lang3
 commons-pool
 commons-text
 config
+core
 curator-client
 curator-framework
 curator-recipes

--- a/geomesa-kudu/geomesa-kudu-tools/src/main/resources/org/locationtech/geomesa/kudu/tools/ingest-libjars.list
+++ b/geomesa-kudu/geomesa-kudu-tools/src/main/resources/org/locationtech/geomesa/kudu/tools/ingest-libjars.list
@@ -7,6 +7,7 @@ commons-lang3
 commons-pool
 commons-text
 config
+core
 geomesa
 gson
 gt


### PR DESCRIPTION
Per https://geomesa.atlassian.net/browse/GEOMESA-2573

Added 'core' to all ingest-libjars.list occurrences. First commit incorrectly added hsqldb.