### PR TITLE
Switch to gt-epsg-wkt

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
@@ -110,7 +110,7 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
+            <artifactId>gt-epsg-wkt</artifactId>
         </dependency>
         <dependency>
             <!-- 'works with' due to license issues -->

--- a/geomesa-bigtable/geomesa-bigtable-tools/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-tools/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
+            <artifactId>gt-epsg-wkt</artifactId>
         </dependency>
 
         <!-- test deps -->

--- a/geomesa-cassandra/geomesa-cassandra-tools/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-tools/pom.xml
@@ -86,7 +86,7 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
+            <artifactId>gt-epsg-wkt</artifactId>
         </dependency>
         <dependency>
             <!-- 'works with' due to license issues -->

--- a/geomesa-fs/geomesa-fs-tools/pom.xml
+++ b/geomesa-fs/geomesa-fs-tools/pom.xml
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
+            <artifactId>gt-epsg-wkt</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/geomesa-hbase/geomesa-hbase-tools/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-tools/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
+            <artifactId>gt-epsg-wkt</artifactId>
         </dependency>
 
         <!-- provided deps -->

--- a/geomesa-kafka/geomesa-kafka-tools/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-tools/pom.xml
@@ -59,7 +59,7 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
+            <artifactId>gt-epsg-wkt</artifactId>
         </dependency>
         <dependency>
             <!-- needed in the lib dir -->

--- a/geomesa-kudu/geomesa-kudu-tools/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-tools/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
+            <artifactId>gt-epsg-wkt</artifactId>
         </dependency>
 
         <!-- test deps -->

--- a/geomesa-lambda/geomesa-lambda-tools/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-tools/pom.xml
@@ -106,7 +106,7 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
+            <artifactId>gt-epsg-wkt</artifactId>
         </dependency>
         <dependency>
             <!-- 'works with' due to license issues -->

--- a/geomesa-tools/pom.xml
+++ b/geomesa-tools/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
+            <artifactId>gt-epsg-wkt</artifactId>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -490,7 +490,24 @@
                 <!-- match dependency version used by gt-referencing for convenience -->
                 <version>0.26</version>
             </dependency>
-            <dependency>
+	    <dependency>
+                <groupId>org.geotools</groupId>
+                <artifactId>gt-epsg-wkt</artifactId>
+                <version>${gt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai_core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- excluded due to license issues -->
+                        <groupId>jgridshift</groupId>
+                        <artifactId>jgridshift</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+	    <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-epsg-hsql</artifactId>
                 <version>${gt.version}</version>


### PR DESCRIPTION
All *-tools now use wkt instead of hsql. Tested geomesa-fs cli in both local and distributed run modes with this change.