### PR TITLE
GEOMESA-2589 Cassandra - limit table names to 48 characters

### DIFF
--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -111,6 +111,16 @@ In order to update a schema, or if mutability is desired for some other reason, 
 ``org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.mutable()`` to create a mutable copy. Java users
 can call ``org.locationtech.geomesa.utils.interop.SimpleFeatureTypes.mutable()`` instead.
 
+FileSystem Storage API Changes
+------------------------------
+
+The FileSystem Storage API is still considered beta-level software, and has been updated in this release. The
+DataStore API has not changed, however the internal class interfaces have changed in this release, potentially
+requiring changes in user code.
+
+In addition, the format used to store metadata files has been updated, so older versions of GeoMesa will not be
+able to read metadata created with this version.
+
 Deprecated Modules
 ------------------
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloIndexAdapter.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloIndexAdapter.scala
@@ -54,8 +54,11 @@ class AccumuloIndexAdapter(ds: AccumuloDataStore) extends IndexAdapter[AccumuloD
   private val tableOps = ds.connector.tableOperations()
 
   // noinspection ScalaDeprecation
-  override def createTable(index: GeoMesaFeatureIndex[_, _], table: String, splits: => Seq[Array[Byte]]): Unit = {
-
+  override def createTable(
+      index: GeoMesaFeatureIndex[_, _],
+      partition: Option[String],
+      splits: => Seq[Array[Byte]]): Unit = {
+    val table = index.configureTableName(partition) // writes table name to metadata
     // create table if it doesn't exist
     val created = if (ds.connector.isInstanceOf[org.apache.accumulo.core.client.mock.MockConnector]) {
       // we need to synchronize creation of tables in mock accumulo as it's not thread safe

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraIndexAdapter.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraIndexAdapter.scala
@@ -11,6 +11,7 @@ package org.locationtech.geomesa.cassandra.data
 
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
+import java.util.UUID
 
 import com.datastax.driver.core.Row
 import com.datastax.driver.core.exceptions.AlreadyExistsException
@@ -29,11 +30,37 @@ import org.locationtech.geomesa.index.planning.LocalQueryRunner
 import org.locationtech.geomesa.index.planning.LocalQueryRunner.ArrowDictionaryHook
 import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.locationtech.geomesa.utils.index.ByteArrays
+import org.locationtech.geomesa.utils.text.StringSerialization
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 class CassandraIndexAdapter(ds: CassandraDataStore) extends IndexAdapter[CassandraDataStore] with StrictLogging {
 
-  override def createTable(index: GeoMesaFeatureIndex[_, _], table: String, splits: => Seq[Array[Byte]]): Unit = {
+  override def createTable(
+      index: GeoMesaFeatureIndex[_, _],
+      partition: Option[String],
+      splits: => Seq[Array[Byte]]): Unit = {
+    // cassandra tables have a limit of 48 characters
+    // if we use the attribute names as per usual, we can exceed that, so we use the attribute number instead
+    val table = {
+      val key = index.tableNameKey(partition)
+      ds.metadata.read(index.sft.getTypeName, key).getOrElse {
+        val builder = Seq.newBuilder[String]
+        builder += ds.config.catalog
+        builder ++= Seq(index.sft.getTypeName, index.name).map(StringSerialization.alphaNumericSafeString)
+        builder ++= index.attributes.map(a => s"${index.sft.indexOf(a)}")
+        builder += s"v${index.version}"
+        val base = builder.result.mkString("_")
+        var name = partition.map(p => s"${base}_$p").getOrElse(base)
+        if (name.length > 48) {
+          logger.warn(s"Table name length exceeds Cassandra limit, falling back to UUID: $name")
+          // UUID is 32 chars - prefix with a letter as leading numbers throw errors
+          name = "gm_" + UUID.randomUUID().toString.replaceAllLiterally("-", "")
+        }
+        ds.metadata.insert(index.sft.getTypeName, key, name)
+        name
+      }
+    }
+
     val cluster = ds.session.getCluster
 
     if (cluster.getMetadata.getKeyspace(ds.session.getLoggedKeyspace).getTable(table) == null) {

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
@@ -300,6 +300,15 @@ class CassandraDataStoreTest extends Specification {
 
       ds.getSchema(typeName) must beNull
     }
+
+    "support long attribute names" in {
+      val long = "testsftverylongnaaaaaaaaaaammmmmmmeeeeeeeee"
+      val spec = s"$long:String:index=true,dtg:Date,*geom:Point:srid=4326"
+      foreach(Seq("testnames", long)) { typeName =>
+        ds.getSchema(typeName) must beNull
+        ds.createSchema(SimpleFeatureTypes.createType(typeName, spec)) must not(throwAn[Exception])
+      }
+    }
   }
 
   def testQuery(ds: CassandraDataStore,

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
@@ -56,7 +56,11 @@ class HBaseIndexAdapter(ds: HBaseDataStore) extends IndexAdapter[HBaseDataStore]
 
   import scala.collection.JavaConverters._
 
-  override def createTable(index: GeoMesaFeatureIndex[_, _], table: String, splits: => Seq[Array[Byte]]): Unit = {
+  override def createTable(
+      index: GeoMesaFeatureIndex[_, _],
+      partition: Option[String],
+      splits: => Seq[Array[Byte]]): Unit = {
+    val table = index.configureTableName(partition) // writes table name to metadata
     val name = TableName.valueOf(table)
 
     WithClose(ds.connection.getAdmin) { admin =>

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/IndexAdapter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/IndexAdapter.scala
@@ -29,10 +29,10 @@ trait IndexAdapter[DS <: GeoMesaDataStore[DS]] {
     * Create a table
     *
     * @param index index
-    * @param table table name
+    * @param partition table partition
     * @param splits splits
     */
-  def createTable(index: GeoMesaFeatureIndex[_, _], table: String, splits: => Seq[Array[Byte]]): Unit
+  def createTable(index: GeoMesaFeatureIndex[_, _], partition: Option[String], splits: => Seq[Array[Byte]]): Unit
 
   /**
     * Delete a table

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStore.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStore.scala
@@ -191,7 +191,7 @@ abstract class GeoMesaDataStore[DS <: GeoMesaDataStore[DS]](val config: GeoMesaD
       logger.debug(s"Delaying creation of partitioned indices ${indices.map(_.identifier).mkString(", ")}")
     } else {
       logger.debug(s"Creating indices ${indices.map(_.identifier).mkString(", ")}")
-      indices.foreach(index => adapter.createTable(index, index.configureTableName(None), index.getSplits(None)))
+      indices.foreach(index => adapter.createTable(index, None, index.getSplits(None)))
     }
   }
 
@@ -203,7 +203,7 @@ abstract class GeoMesaDataStore[DS <: GeoMesaDataStore[DS]](val config: GeoMesaD
       logger.debug(s"Delaying creation of partitioned indices ${added.map(_.identifier).mkString(", ")}")
     } else {
       logger.debug(s"Creating indices ${added.map(_.identifier).mkString(", ")}")
-      added.foreach(index => adapter.createTable(index, index.configureTableName(None), index.getSplits(None)))
+      added.foreach(index => adapter.createTable(index, None, index.getSplits(None)))
     }
   }
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureWriter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureWriter.scala
@@ -186,9 +186,7 @@ object GeoMesaFeatureWriter extends LazyLogging {
       if (writer == null) {
         // reconfigure the partition each time - this should be idempotent, and block
         // until it is fully created (which may happen in some other thread)
-        indices.par.foreach { index =>
-          ds.adapter.createTable(index, index.configureTableName(Some(p)), index.getSplits(Some(p)))
-        }
+        indices.par.foreach(index => ds.adapter.createTable(index, Some(p), index.getSplits(Some(p))))
         writer = ds.adapter.createWriter(sft, indices, Some(p))
         cache.put(p, writer)
       }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/TestGeoMesaDataStore.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/TestGeoMesaDataStore.scala
@@ -58,8 +58,13 @@ object TestGeoMesaDataStore {
 
     private val tables = scala.collection.mutable.Map.empty[String, scala.collection.mutable.SortedSet[SingleRowKeyValue[_]]]
 
-    override def createTable(index: GeoMesaFeatureIndex[_, _], table: String, splits: => Seq[Array[Byte]]): Unit =
+    override def createTable(
+        index: GeoMesaFeatureIndex[_, _],
+        partition: Option[String],
+        splits: => Seq[Array[Byte]]): Unit = {
+      val table = index.configureTableName(partition) // writes table name to metadata
       tables.put(table, scala.collection.mutable.SortedSet.empty[SingleRowKeyValue[_]](ordering))
+    }
 
     override def deleteTables(tables: Seq[String]): Unit = tables.foreach(this.tables.remove)
 

--- a/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/data/KuduIndexAdapter.scala
+++ b/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/data/KuduIndexAdapter.scala
@@ -34,7 +34,11 @@ class KuduIndexAdapter(ds: KuduDataStore) extends IndexAdapter[KuduDataStore] {
 
   import scala.collection.JavaConverters._
 
-  override def createTable(index: GeoMesaFeatureIndex[_, _], table: String, splits: => Seq[Array[Byte]]): Unit = {
+  override def createTable(
+      index: GeoMesaFeatureIndex[_, _],
+      partition: Option[String],
+      splits: => Seq[Array[Byte]]): Unit = {
+    val table = index.configureTableName(partition) // writes table name to metadata
     if (!ds.client.tableExists(table)) {
       val mapper = KuduColumnMapper(index)
 

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/index/RedisIndexAdapter.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/index/RedisIndexAdapter.scala
@@ -38,7 +38,10 @@ import scala.util.control.NonFatal
 class RedisIndexAdapter(ds: RedisDataStore) extends IndexAdapter[RedisDataStore] with StrictLogging {
 
   // each 'table' is a sorted set - they are created automatically when you insert values
-  override def createTable(index: GeoMesaFeatureIndex[_, _], table: String, splits: => Seq[Array[Byte]]): Unit = {}
+  override def createTable(
+      index: GeoMesaFeatureIndex[_, _],
+      partition: Option[String],
+      splits: => Seq[Array[Byte]]): Unit = index.configureTableName(partition) // writes table name to metadata
 
   override def deleteTables(tables: Seq[String]): Unit =
     WithClose(ds.connection.getResource)(_.del(tables: _*))

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/data/ManagePartitionsCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/data/ManagePartitionsCommand.scala
@@ -73,7 +73,7 @@ object ManagePartitionsCommand {
     override protected def modify(ds: DS, sft: SimpleFeatureType, partition: TablePartition, p: String): Unit = {
       Command.user.info(s"Adding partition '$p'")
       ds.manager.indices(sft, mode = IndexMode.Write).par.foreach { index =>
-        ds.adapter.createTable(index, index.configureTableName(Some(p)), index.getSplits(Some(p)))
+        ds.adapter.createTable(index, Some(p), index.getSplits(Some(p)))
       }
     }
   }


### PR DESCRIPTION
* Cassandra does not support names longer than 48 chars

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>