### PR TITLE
GEOMESA-2591: Extend AvroConverter to decode avro using a schema regi…

### DIFF
--- a/docs/user/convert/avro_schema_registry.rst
+++ b/docs/user/convert/avro_schema_registry.rst
@@ -1,7 +1,7 @@
 .. _avro_schema_registry_converter:
 
 Avro Schema Registry Converter
-==============
+==============================
 
 The Avro Schema Registry converter handles data written by `Apache Avro <http://avro.apache.org/>`__
 using a Confluent Schema Registry. The schema registry is a centralized store of versioned Avro schemas.

--- a/docs/user/convert/avro_schema_registry.rst
+++ b/docs/user/convert/avro_schema_registry.rst
@@ -1,0 +1,112 @@
+.. _avro_schema_registry_converter:
+
+Avro Schema Registry Converter
+==============
+
+The Avro Schema Registry converter handles data written by `Apache Avro <http://avro.apache.org/>`__
+using a Confluent Schema Registry. The schema registry is a centralized store of versioned Avro schemas.
+
+To use the Avro converter, specify ``type = "avro-schema-registry"`` in your converter definition.
+
+Note that Confluent requires Avro 1.8 and the Confluent client JARs, which are not bundled with GeoMesa.
+
+
+Configuration
+-------------
+
+The Avro Schema Registry converter supports parsing Avro data using a Confluent schema registry.
+To configure the schema registry set ``schema-registry = "<URL of schema registry>"`` in your converter definition.
+
+The Avro record being parsed is available to field transforms as ``$1``.
+
+The Avro Schema Registry Converter is an extension of the :ref:`avro_converter`, therefore the :ref:`avro_converter_functions`
+can be used to extract fields out of the parsed Avro record.
+
+
+Example Usage
+-------------
+
+For this example we'll assume the following Avro schema is registered in the schema registry as version 1:
+
+::
+
+    {
+      "namespace": "org.locationtech",
+      "type": "record",
+      "name": "SchemaRegistryMessageV1",
+      "fields": [
+        {
+          "name": "lat",
+          "type": "Double"
+        },
+        {
+          "name": "lon",
+          "type": "Double"
+        }
+      ]
+    }
+
+We'll also assume the following Avro schema is registered in the schema registry as version 2:
+
+::
+
+    {
+      "namespace": "org.locationtech",
+      "type": "record",
+      "name": "SchemaRegistryMessageV2",
+      "fields": [
+        {
+          "name": "lat",
+          "type": "Double"
+        },
+        {
+          "name": "lon",
+          "type": "Double"
+        },
+        {
+          "name": "extra",
+          "type": "String"
+        }
+      ]
+    }
+
+Below is a sample Avro record encoded using schema version 1: ::
+
+    {
+      "lat": 45.0,
+      "lon": 45.0
+    }
+
+Here's a sample Avro record encoded using schema version 2: ::
+
+    {
+      "lat": 45.0,
+      "lon": 45.0,
+      "extra": "Extra Test Field"
+    }
+
+Let's say we want to convert our Avro records into simple
+features. We notice that between the two schema versions there are 3 attributes:
+
+-  lat
+-  lon
+-  extra
+
+The following converter config would be sufficient to parse the Avro records that have been encoded
+using multiple schema version defined in the schema registry::
+
+    {
+      type        =     "avro-schema-registry"
+      schema-registry = "http://localhost:8080"
+      sft         =     "testsft"
+      id-field    =     "uuid()"
+      fields = [
+        { name = "lat",    transform = "avroPath($1, '/lat')" },
+        { name = "lon",    transform = "avroPath($1, '/lon')" },
+        { name = "extra",  transform = "avroPath($1, '/extra')",
+        { name = "geom",   transform = "point($lon, $lat)" }
+      ]
+    }
+
+Note that in the simple feature, the ``extra`` field will be null for Avro records encoded using
+schema version 1 and will be populated for records encoded using schema version 2.

--- a/docs/user/convert/index.rst
+++ b/docs/user/convert/index.rst
@@ -23,6 +23,7 @@ details.
     json
     xml
     avro
+    avro_schema_registry
     shp
     fixed_width
     jdbc

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/pom.xml
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>geomesa-convert_2.11</artifactId>
+        <groupId>org.locationtech.geomesa</groupId>
+        <version>2.3.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-convert-avro-schema-registry_2.11</artifactId>
+    <name>GeoMesa Convert Avro Schema Registry</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-convert-avro_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.8.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-main</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-httpclient</groupId>
+            <artifactId>commons-httpclient</artifactId>
+            <version>3.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mortbay.jetty</groupId>
+            <artifactId>jetty</artifactId>
+            <version>6.1.26</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/pom.xml
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/pom.xml
@@ -16,7 +16,6 @@
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-convert-avro_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.avro</groupId>
@@ -30,18 +29,24 @@
             <version>1.8.2</version>
         </dependency>
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry-client</artifactId>
+            <version>${confluent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>${confluent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-main</artifactId>
         </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
@@ -54,7 +59,6 @@
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/resources/META-INF/services/org.locationtech.geomesa.convert2.SimpleFeatureConverterFactory
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/resources/META-INF/services/org.locationtech.geomesa.convert2.SimpleFeatureConverterFactory
@@ -1,0 +1,1 @@
+org.locationtech.geomesa.convert.avro.registry.AvroSchemaRegistryConverterFactory

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverter.scala
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverter.scala
@@ -1,0 +1,138 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert.avro.registry
+
+import java.io.InputStream
+import java.nio.ByteBuffer
+
+import com.github.benmanes.caffeine.cache.{CacheLoader, Caffeine, LoadingCache}
+import com.typesafe.config.Config
+import org.apache.avro.Schema
+import org.apache.avro.Schema.Parser
+import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
+import org.apache.avro.io.DecoderFactory
+import org.apache.commons.httpclient.HttpClient
+import org.apache.commons.httpclient.methods.GetMethod
+import org.json4s.JObject
+import org.json4s.JsonAST.JString
+import org.json4s.native.JsonMethods.parse
+import org.locationtech.geomesa.convert.avro.registry.AvroSchemaRegistryConverter.{GenericRecordSchemaRegistryIterator, SchemaRegistryReader, _}
+import org.locationtech.geomesa.convert.{Counter, EvaluationContext}
+import org.locationtech.geomesa.convert2.AbstractConverter.{BasicField, BasicOptions}
+import org.locationtech.geomesa.convert2.transforms.Expression
+import org.locationtech.geomesa.convert2.{AbstractConverter, ConverterConfig}
+import org.locationtech.geomesa.utils.collection.CloseableIterator
+import org.opengis.feature.simple.SimpleFeatureType
+
+class AvroSchemaRegistryConverter(sft: SimpleFeatureType, config: AvroSchemaRegistryConfig, fields: Seq[BasicField], options: BasicOptions)
+  extends AbstractConverter[GenericRecord, AvroSchemaRegistryConfig, BasicField, BasicOptions](sft, config, fields, options) {
+
+  // Create schema registry reader from URL string and create Avro reader cache
+  private val schemaRegistryConfig: Option[LoadingCache[Integer, GenericDatumReader[GenericRecord]]] = config.schemaRegistry match {
+    case Some(s) => Some(getReaderCache(new SchemaRegistryReader(s)))
+  }
+
+  // Create Avro reader cache to map schema ID to GenericDatumReader
+  def getReaderCache(schemaRegistry: SchemaRegistryReader): LoadingCache[Integer, GenericDatumReader[GenericRecord]] = {
+    Caffeine
+      .newBuilder()
+      .build(
+        new CacheLoader[Integer, GenericDatumReader[GenericRecord]] {
+          override def load(id: Integer): GenericDatumReader[GenericRecord] = {
+            schemaRegistry.getAvroReaderFromId(id)
+          }
+        }
+      )
+  }
+
+  override protected def parse(is: InputStream, ec: EvaluationContext): CloseableIterator[GenericRecord] = {
+    schemaRegistryConfig match {
+      case Some(s)                  => new GenericRecordSchemaRegistryIterator(is, s, ec.counter)
+    }
+  }
+
+  override protected def values(parsed: CloseableIterator[GenericRecord],
+                                ec: EvaluationContext): CloseableIterator[Array[Any]] = {
+    val array = Array.ofDim[Any](2)
+    parsed.map { record => array(1) = record; array }
+  }
+}
+
+object AvroSchemaRegistryConverter {
+
+  private val MAGIC_BYTE_LENGTH = 1
+  private val SCHEMA_ID_LENGTH = 4
+
+  case class AvroSchemaRegistryConfig(`type`: String,
+                        schemaRegistry: Option[String],
+                        idField: Option[Expression],
+                        caches: Map[String, Config],
+                        userData: Map[String, Expression]) extends ConverterConfig
+
+  sealed trait SchemaConfig
+
+  case class SchemaRegistry(url: String) extends SchemaConfig
+
+  /**
+    * Reads avro records using a cached confluent-style schema registry
+    *
+    * @param is input stream
+    * @param readerCache GenericDatumReader cache
+    * @param counter counter
+    */
+  class GenericRecordSchemaRegistryIterator private [AvroSchemaRegistryConverter] (is: InputStream,
+                                                                     readerCache: LoadingCache[Integer, GenericDatumReader[GenericRecord]],
+                                                                     counter: Counter)
+    extends CloseableIterator[GenericRecord] {
+
+    private val decoder = DecoderFactory.get.binaryDecoder(is, null)
+    private var record: GenericRecord = _
+
+    override def hasNext: Boolean = !decoder.isEnd
+
+    override def next(): GenericRecord = {
+      counter.incLineCount()
+      // Read confluent-style bytes
+      decoder.skipFixed(MAGIC_BYTE_LENGTH)
+      val bytes = new Array[Byte](SCHEMA_ID_LENGTH)
+      decoder.readFixed(bytes, 0, SCHEMA_ID_LENGTH)
+
+      val id = ByteBuffer.wrap(bytes).getInt()
+      val reader = readerCache.get(id)
+
+      record = reader.read(record, decoder)
+      record
+    }
+
+    override def close(): Unit = is.close()
+  }
+
+  class SchemaRegistryReader(baseURL: String) {
+
+    private val httpClient = new HttpClient
+
+    private val SCHEMA_PATH = "/schemas/ids/"
+
+
+    def getAvroReaderFromId(id: Int): GenericDatumReader[GenericRecord] = {
+      val schema = getSchemaFromID(id)
+      new GenericDatumReader[GenericRecord](schema)
+    }
+
+    private def getSchemaFromID(id: Int): Schema = {
+      val url = baseURL + SCHEMA_PATH + id
+      val method = new GetMethod(url)
+      val request = httpClient.executeMethod(method)
+      val response = method.getResponseBody
+
+      val JString(schemaString) = parse(new String(response)).asInstanceOf[JObject].obj.head._2
+      new Parser().parse(schemaString)
+    }
+  }
+}

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterFactory.scala
@@ -1,0 +1,52 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert.avro.registry
+
+import com.typesafe.config.Config
+import org.locationtech.geomesa.convert.avro.registry.AvroSchemaRegistryConverter.AvroSchemaRegistryConfig
+import org.locationtech.geomesa.convert.avro.registry.AvroSchemaRegistryConverterFactory.AvroSchemaRegistryConfigConvert
+import org.locationtech.geomesa.convert2.AbstractConverter.{BasicField, BasicOptions}
+import org.locationtech.geomesa.convert2.AbstractConverterFactory.{BasicFieldConvert, BasicOptionsConvert, ConverterConfigConvert, ConverterOptionsConvert, FieldConvert, OptionConvert}
+import org.locationtech.geomesa.convert2.transforms.Expression
+import org.locationtech.geomesa.convert2.AbstractConverterFactory
+import pureconfig.ConfigObjectCursor
+import pureconfig.error.ConfigReaderFailures
+
+class AvroSchemaRegistryConverterFactory extends AbstractConverterFactory[AvroSchemaRegistryConverter, AvroSchemaRegistryConfig, BasicField, BasicOptions] {
+
+  override protected val typeToProcess: String = "avro-schema-registry"
+
+  override protected implicit def configConvert: ConverterConfigConvert[AvroSchemaRegistryConfig] = AvroSchemaRegistryConfigConvert
+  override protected implicit def fieldConvert: FieldConvert[BasicField] = BasicFieldConvert
+  override protected implicit def optsConvert: ConverterOptionsConvert[BasicOptions] = BasicOptionsConvert
+
+}
+
+object AvroSchemaRegistryConverterFactory {
+
+  object AvroSchemaRegistryConfigConvert extends ConverterConfigConvert[AvroSchemaRegistryConfig] with OptionConvert {
+
+    override protected def decodeConfig(cur: ConfigObjectCursor,
+                                        `type`: String,
+                                        idField: Option[Expression],
+                                        caches: Map[String, Config],
+                                        userData: Map[String, Expression]): Either[ConfigReaderFailures, AvroSchemaRegistryConfig] = {
+
+      for {
+        schemaRegistry <- optional(cur, "schema-registry").right
+      } yield {
+        AvroSchemaRegistryConfig(`type`, schemaRegistry, idField, caches, userData)
+      }
+    }
+
+    override protected def encodeConfig(config: AvroSchemaRegistryConfig, base: java.util.Map[String, AnyRef]): Unit = {
+      base.put("schema-registry", config.schemaRegistry)
+    }
+  }
+}

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterFactory.scala
@@ -39,7 +39,7 @@ object AvroSchemaRegistryConverterFactory {
                                         userData: Map[String, Expression]): Either[ConfigReaderFailures, AvroSchemaRegistryConfig] = {
 
       for {
-        schemaRegistry <- optional(cur, "schema-registry").right
+        schemaRegistry <- cur.atKey("schema-registry").right.flatMap(_.asString).right
       } yield {
         AvroSchemaRegistryConfig(`type`, schemaRegistry, idField, caches, userData)
       }

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/resources/log4j.xml
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/resources/log4j.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.EnhancedPatternLayout">
+            <param name="ConversionPattern" value="[%d] %5p %c{1}: %m%n"/>
+        </layout>
+    </appender>
+
+    <category name="org.apache.zookeeper">
+        <priority value="warn"/>
+    </category>
+    <category name="org.apache.accumulo">
+        <priority value="warn"/>
+    </category>
+    <category name="org.apache.hadoop">
+        <priority value="warn"/>
+    </category>
+    <category name="hsqldb">
+        <priority value="warn"/>
+    </category>
+    <category name="org.locationtech.geomesa.convert">
+        <priority value="error"/>
+    </category>
+    <category name="org.locationtech.geomesa.convert2">
+        <priority value="error"/>
+    </category>
+
+    <root>
+        <priority value="info"/>
+        <appender-ref ref="CONSOLE" />
+    </root>
+</log4j:configuration>
+

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/resources/schema.avsc
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/resources/schema.avsc
@@ -1,0 +1,36 @@
+{
+  "namespace": "org.locationtech",
+  "type": "record",
+  "name": "CompositeMessage",
+  "fields": [
+    { "name": "content",
+      "type": [
+         {
+           "name": "TObj",
+           "type": "record",
+           "fields": [
+             {
+               "name": "kvmap",
+               "type": {
+                  "type": "array",
+                  "items": {
+                    "name": "kvpair",
+                    "type": "record",
+                    "fields": [
+                      { "name": "k", "type": "string" },
+                      { "name": "v", "type": ["string", "double", "int", "null"] }
+                    ]
+                  }
+               }
+             }
+           ]
+         },
+         {
+            "name": "OtherObject",
+            "type": "record",
+            "fields": [{ "name": "id", "type": "int"}]
+         }
+      ]
+   }
+  ]
+}

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/resources/schema2.avsc
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/resources/schema2.avsc
@@ -1,0 +1,43 @@
+{
+  "namespace": "org.locationtech2",
+  "type": "record",
+  "name": "CompositeMessage",
+  "fields": [
+    { "name": "content",
+      "type": [
+         {
+           "name": "TObj",
+           "type": "record",
+           "fields": [
+             {
+               "name": "kvmap",
+               "type": {
+                  "type": "array",
+                  "items": {
+                    "name": "kvpair",
+                    "type": "record",
+                    "fields": [
+                      { "name": "k", "type": "string" },
+                      { "name": "v", "type": ["string", "double", "int", "null"] },
+                      { "name": "extra", "type": ["null", "string"], "default": null }
+
+                    ]
+                  }
+               }
+             }
+           ]
+         },
+         {
+            "name": "OtherObject",
+            "type": "record",
+            "fields": [
+                {
+                    "name": "id",
+                    "type": "int"
+                }
+            ]
+         }
+      ]
+    }
+  ]
+}

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/resources/sft_testsft.conf
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/resources/sft_testsft.conf
@@ -1,0 +1,8 @@
+{
+  type-name = "testsft2"
+  attributes = [
+    { name = "dtg", type = "Date",  index = "true", default = true  }
+    { name = "geom", type = "Point",  index = "true", srid = 4326, default = true  }
+    { name = "extra", type = "String",  index = "true" }
+  ]
+}

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterTest.scala
@@ -1,0 +1,197 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert.avro.registry
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+import com.google.common.hash.Hashing
+import com.typesafe.config.{ConfigFactory, ConfigRenderOptions}
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.avro.file.DataFileWriter
+import org.apache.avro.generic.{GenericData, GenericDatumWriter, GenericRecord}
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.convert2.SimpleFeatureConverter
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.features.avro.AvroDataFileWriter
+import org.locationtech.geomesa.utils.collection.SelfClosingIterator
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.io.WithClose
+import org.mortbay.jetty.{Handler, Request, Server}
+import org.mortbay.jetty.handler.{AbstractHandler, ContextHandler}
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class AvroSchemaRegistryConverterTest extends Specification with AvroSchemaRegistryUtils with LazyLogging {
+
+  sequential
+
+  val sft = SimpleFeatureTypes.createType(ConfigFactory.load("sft_testsft.conf"))
+
+  "AvroSchemaRegistryConverter should" should {
+    class SchemaRegistryHandlerv1 extends AbstractHandler {
+
+      override def handle(target: String, request: HttpServletRequest, response: HttpServletResponse, i: Int): Unit = {
+        response.setContentType("application/json")
+        response.setStatus(HttpServletResponse.SC_OK)
+        request.asInstanceOf[Request].setHandled(true)
+        response.getWriter.write(
+          """
+            |{
+            |"schema":
+            |"{
+            |  \"namespace\": \"org.locationtech\",
+            |  \"type\": \"record\",
+            |  \"name\": \"CompositeMessage\",
+            |  \"fields\": [
+            |    { \"name\": \"content\",
+            |      \"type\": [
+            |         {
+            |           \"name\": \"TObj\",
+            |           \"type\": \"record\",
+            |           \"fields\": [
+            |             {
+            |               \"name\": \"kvmap\",
+            |               \"type\": {
+            |                  \"type\": \"array\",
+            |                  \"items\": {
+            |                    \"name\": \"kvpair\",
+            |                    \"type\": \"record\",
+            |                    \"fields\": [
+            |                      { \"name\": \"k\", \"type\": \"string\" },
+            |                      { \"name\": \"v\", \"type\": [\"string\", \"double\", \"int\", \"null\"] }
+            |                    ]
+            |                  }
+            |               }
+            |             }
+            |           ]
+            |         },
+            |         {
+            |            \"name\": \"OtherObject\",
+            |            \"type\": \"record\",
+            |            \"fields\": [{ \"name\": \"id\", \"type\": \"int\"}]
+            |         }
+            |      ]
+            |   }
+            |  ]
+            |}"}
+          """.stripMargin
+        )
+      }
+    }
+
+    class SchemaRegistryHandlerv2 extends AbstractHandler {
+      override def handle(target: String, request: HttpServletRequest, response: HttpServletResponse, i: Int): Unit = {
+        response.setContentType("application/json")
+        response.setStatus(HttpServletResponse.SC_OK)
+        request.asInstanceOf[Request].setHandled(true)
+        response.getWriter.write(
+          """
+            |{
+            |"schema":
+            |"{
+            |  \"namespace\": \"org.locationtech2\",
+            |  \"type\": \"record\",
+            |  \"name\": \"CompositeMessage\",
+            |  \"fields\": [
+            |    { \"name\": \"content\",
+            |      \"type\": [
+            |         {
+            |           \"name\": \"TObj\",
+            |           \"type\": \"record\",
+            |           \"fields\": [
+            |             {
+            |               \"name\": \"kvmap\",
+            |               \"type\": {
+            |                  \"type\": \"array\",
+            |                  \"items\": {
+            |                    \"name\": \"kvpair\",
+            |                    \"type\": \"record\",
+            |                    \"fields\": [
+            |                      { \"name\": \"k\", \"type\": \"string\" },
+            |                      { \"name\": \"v\", \"type\": [\"string\", \"double\", \"int\", \"null\"] },
+            |                      { \"name\": \"extra\", \"type\": [\"null\", \"string\"], \"default\": null }
+            |
+            |                    ]
+            |                  }
+            |               }
+            |             }
+            |           ]
+            |         },
+            |         {
+            |            \"name\": \"OtherObject\",
+            |            \"type\": \"record\",
+            |            \"fields\": [{ \"name\": \"id\", \"type\": \"int\"}]
+            |         }
+            |      ]
+            |    }
+            |  ]
+            |}"}
+          """.stripMargin
+        )
+      }
+    }
+
+    val jetty = new Server(8089)
+    val context1 = new ContextHandler()
+    context1.setContextPath("/schemas/ids/1")
+    jetty.setHandler(context1)
+    context1.setHandler(new SchemaRegistryHandlerv1())
+    val context2 = new ContextHandler()
+    context2.setContextPath("/schemas/ids/2")
+    jetty.setHandler(context2)
+    context2.setHandler(new SchemaRegistryHandlerv2())
+    jetty.setHandlers(Array[Handler](context1, context2))
+
+
+    "properly convert a GenericRecord to a SimpleFeature with Schema Registry" >> {
+
+      val conf = ConfigFactory.parseString(
+        """
+          | {
+          |   type        = "avro-schema-registry"
+          |   schema-registry = "http://localhost:8089"
+          |   sft         = "testsft"
+          |   id-field    = "uuid()"
+          |   fields = [
+          |     { name = "tobj", transform = "avroPath($1, '/content$type=TObj')" },
+          |     { name = "dtg",  transform = "date('yyyy-MM-dd', avroPath($tobj, '/kvmap[$k=dtg]/v'))" },
+          |     { name = "lat",  transform = "avroPath($tobj, '/kvmap[$k=lat]/v')" },
+          |     { name = "lon",  transform = "avroPath($tobj, '/kvmap[$k=lon]/v')" },
+          |     { name = "geom", transform = "point($lon, $lat)" }
+          |     { name = "extra", transform = "avroPath($tobj, '/kvmap[$k=extra]/extra')" }
+          |   ]
+          | }
+        """.stripMargin)
+
+      try {
+        jetty.start()
+
+        WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
+          val ec = converter.createEvaluationContext()
+          val res = WithClose(converter.process(new ByteArrayInputStream(bytes), ec))(_.toList)
+          res must haveLength(3)
+          val sf = res(0)
+          val sf1 = res(1)
+          sf.getAttributeCount must be equalTo 3
+          sf.getAttribute("dtg") must not(beNull)
+          sf.getAttribute("extra") must beNull
+          sf1.getAttribute("extra") must be equalTo "TEST"
+
+          ec.counter.getFailure mustEqual 0L
+          ec.counter.getSuccess mustEqual 3L
+          ec.counter.getLineCount mustEqual 3L
+        }
+      } finally {
+        jetty.stop()
+      }
+    }
+  }
+}

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterTest.scala
@@ -8,19 +8,13 @@
 
 package org.locationtech.geomesa.convert.avro.registry
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.io.ByteArrayInputStream
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.google.common.hash.Hashing
-import com.typesafe.config.{ConfigFactory, ConfigRenderOptions}
+import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.avro.file.DataFileWriter
-import org.apache.avro.generic.{GenericData, GenericDatumWriter, GenericRecord}
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
-import org.locationtech.geomesa.features.ScalaSimpleFeature
-import org.locationtech.geomesa.features.avro.AvroDataFileWriter
-import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.io.WithClose
 import org.mortbay.jetty.{Handler, Request, Server}
@@ -44,44 +38,7 @@ class AvroSchemaRegistryConverterTest extends Specification with AvroSchemaRegis
         request.asInstanceOf[Request].setHandled(true)
         response.getWriter.write(
           """
-            |{
-            |"schema":
-            |"{
-            |  \"namespace\": \"org.locationtech\",
-            |  \"type\": \"record\",
-            |  \"name\": \"CompositeMessage\",
-            |  \"fields\": [
-            |    { \"name\": \"content\",
-            |      \"type\": [
-            |         {
-            |           \"name\": \"TObj\",
-            |           \"type\": \"record\",
-            |           \"fields\": [
-            |             {
-            |               \"name\": \"kvmap\",
-            |               \"type\": {
-            |                  \"type\": \"array\",
-            |                  \"items\": {
-            |                    \"name\": \"kvpair\",
-            |                    \"type\": \"record\",
-            |                    \"fields\": [
-            |                      { \"name\": \"k\", \"type\": \"string\" },
-            |                      { \"name\": \"v\", \"type\": [\"string\", \"double\", \"int\", \"null\"] }
-            |                    ]
-            |                  }
-            |               }
-            |             }
-            |           ]
-            |         },
-            |         {
-            |            \"name\": \"OtherObject\",
-            |            \"type\": \"record\",
-            |            \"fields\": [{ \"name\": \"id\", \"type\": \"int\"}]
-            |         }
-            |      ]
-            |   }
-            |  ]
-            |}"}
+            |{"schema":"{\"namespace\": \"org.locationtech\",\"type\": \"record\",\"name\": \"CompositeMessage\",\"fields\": [{ \"name\": \"content\",\"type\": [{\"name\": \"TObj\",\"type\": \"record\",\"fields\": [{\"name\": \"kvmap\",\"type\": {\"type\": \"array\",\"items\": {\"name\": \"kvpair\",\"type\": \"record\",\"fields\": [{ \"name\": \"k\", \"type\": \"string\" },{ \"name\": \"v\", \"type\": [\"string\", \"double\", \"int\", \"null\"] }]}}}]},{\"name\": \"OtherObject\",\"type\": \"record\",\"fields\": [{ \"name\": \"id\", \"type\": \"int\"}]}]}]}"}
           """.stripMargin
         )
       }
@@ -94,46 +51,7 @@ class AvroSchemaRegistryConverterTest extends Specification with AvroSchemaRegis
         request.asInstanceOf[Request].setHandled(true)
         response.getWriter.write(
           """
-            |{
-            |"schema":
-            |"{
-            |  \"namespace\": \"org.locationtech2\",
-            |  \"type\": \"record\",
-            |  \"name\": \"CompositeMessage\",
-            |  \"fields\": [
-            |    { \"name\": \"content\",
-            |      \"type\": [
-            |         {
-            |           \"name\": \"TObj\",
-            |           \"type\": \"record\",
-            |           \"fields\": [
-            |             {
-            |               \"name\": \"kvmap\",
-            |               \"type\": {
-            |                  \"type\": \"array\",
-            |                  \"items\": {
-            |                    \"name\": \"kvpair\",
-            |                    \"type\": \"record\",
-            |                    \"fields\": [
-            |                      { \"name\": \"k\", \"type\": \"string\" },
-            |                      { \"name\": \"v\", \"type\": [\"string\", \"double\", \"int\", \"null\"] },
-            |                      { \"name\": \"extra\", \"type\": [\"null\", \"string\"], \"default\": null }
-            |
-            |                    ]
-            |                  }
-            |               }
-            |             }
-            |           ]
-            |         },
-            |         {
-            |            \"name\": \"OtherObject\",
-            |            \"type\": \"record\",
-            |            \"fields\": [{ \"name\": \"id\", \"type\": \"int\"}]
-            |         }
-            |      ]
-            |    }
-            |  ]
-            |}"}
+            |{"schema":"{\"namespace\": \"org.locationtech2\",\"type\": \"record\",\"name\": \"CompositeMessage\",\"fields\": [{ \"name\": \"content\",\"type\": [{\"name\": \"TObj\",\"type\": \"record\",\"fields\": [{\"name\": \"kvmap\",\"type\": {\"type\": \"array\",\"items\": {\"name\": \"kvpair\",\"type\": \"record\",\"fields\": [{ \"name\": \"k\", \"type\": \"string\" },{ \"name\": \"v\", \"type\": [\"string\", \"double\", \"int\", \"null\"] },{ \"name\": \"extra\", \"type\": [\"null\", \"string\"], \"default\": null }]}}}]},{\"name\": \"OtherObject\",\"type\": \"record\",\"fields\": [{ \"name\": \"id\", \"type\": \"int\"}]}]}]}"}
           """.stripMargin
         )
       }

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryUtils.scala
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryUtils.scala
@@ -85,8 +85,4 @@ trait AvroSchemaRegistryUtils {
   baos.close()
   val bytes = baos.toByteArray
 
-//  val datumReader = new GenericDatumReader[GenericRecord](schema)
-//  val decoder = DecoderFactory.get().binaryDecoder(bytes, null)
-//  val gr = datumReader.read(null, decoder)
-
 }

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryUtils.scala
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryUtils.scala
@@ -1,0 +1,92 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert.avro.registry
+
+import java.io.ByteArrayOutputStream
+
+import org.apache.avro.Schema.Parser
+import org.apache.avro.generic.{GenericDatumReader, GenericDatumWriter, GenericRecord, GenericRecordBuilder}
+import org.apache.avro.io.{DecoderFactory, EncoderFactory}
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+trait AvroSchemaRegistryUtils {
+  val spec = getClass.getResourceAsStream("/schema.avsc")
+  val spec2 = getClass.getResourceAsStream("/schema2.avsc")
+
+  val parser = new Parser
+  val schema = parser.parse(spec)
+  val schema2 = parser.parse(spec2)
+
+  val contentSchema = schema.getField("content").schema()
+  val types = contentSchema.getTypes.toList
+  val tObjSchema = types(0)
+  val otherObjSchema = types(1)
+
+  val contentSchema2 = schema2.getField("content").schema()
+  val types2 = contentSchema2.getTypes.toList
+  val tObjSchema2 = types2(0)
+  val otherObjSchema2 = types2(1)
+
+  val innerBuilder = new GenericRecordBuilder(tObjSchema.getField("kvmap").schema.getElementType)
+  val rec1 = innerBuilder.set("k", "lat").set("v", 45.0).build
+  val rec2 = innerBuilder.set("k", "lon").set("v", 45.0).build
+  val rec3 = innerBuilder.set("k", "prop3").set("v", " foo ").build
+  val rec4 = innerBuilder.set("k", "prop4").set("v", 1.0).build
+  val rec5 = innerBuilder.set("k", "dtg").set("v", "2015-01-02").build
+
+  val outerBuilder = new GenericRecordBuilder(tObjSchema)
+  val tObj = outerBuilder.set("kvmap", List(rec1, rec2, rec3, rec4, rec5).asJava).build()
+
+  val compositeBuilder = new GenericRecordBuilder(schema)
+  val obj = compositeBuilder.set("content", tObj).build()
+
+  val innerBuilder2 = new GenericRecordBuilder(tObjSchema2.getField("kvmap").schema.getElementType)
+  val rec2_1 = innerBuilder2.set("k", "lat").set("v", 45.0).build
+  val rec2_2 = innerBuilder2.set("k", "lon").set("v", 45.0).build
+  val rec2_3 = innerBuilder2.set("k", "prop3").set("v", " foo ").build
+  val rec2_4 = innerBuilder2.set("k", "prop4").set("v", 1.0).build
+  val rec2_5 = innerBuilder2.set("k", "dtg").set("v", "2015-01-02").build
+  val rec2_6 = innerBuilder2.set("k", "extra").set("v", null).set("extra", "TEST").build
+
+  val outerBuilder2 = new GenericRecordBuilder(tObjSchema2)
+  val tObj2 = outerBuilder2.set("kvmap", List(rec2_1, rec2_2, rec2_3, rec2_4, rec2_5, rec2_6).asJava).build()
+
+  val compositeBuilder2 = new GenericRecordBuilder(schema2)
+
+  val obj2 = compositeBuilder2.set("content", tObj2).build()
+
+  val baos = new ByteArrayOutputStream()
+  val writer2_1 = new GenericDatumWriter[GenericRecord](schema)
+  val writer2_2 = new GenericDatumWriter[GenericRecord](schema2)
+  var enc3 = EncoderFactory.get().binaryEncoder(baos, null)
+  val header1 = Array[Byte](0,0,0,0,1)
+  val header2 = Array[Byte](0,0,0,0,2)
+
+  baos.write(header1)
+  writer2_1.write(obj, enc3)
+  enc3.flush()
+
+  baos.write(header2)
+  writer2_2.write(obj2, enc3)
+  enc3.flush()
+
+  baos.write(header2)
+  writer2_2.write(obj2, enc3)
+  enc3.flush()
+
+  baos.close()
+  val bytes = baos.toByteArray
+
+//  val datumReader = new GenericDatumReader[GenericRecord](schema)
+//  val decoder = DecoderFactory.get().binaryDecoder(bytes, null)
+//  val gr = datumReader.read(null, decoder)
+
+}

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryUtils.scala
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryUtils.scala
@@ -11,8 +11,8 @@ package org.locationtech.geomesa.convert.avro.registry
 import java.io.ByteArrayOutputStream
 
 import org.apache.avro.Schema.Parser
-import org.apache.avro.generic.{GenericDatumReader, GenericDatumWriter, GenericRecord, GenericRecordBuilder}
-import org.apache.avro.io.{DecoderFactory, EncoderFactory}
+import org.apache.avro.generic.{GenericDatumWriter, GenericRecord, GenericRecordBuilder}
+import org.apache.avro.io.EncoderFactory
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -84,5 +84,4 @@ trait AvroSchemaRegistryUtils {
 
   baos.close()
   val bytes = baos.toByteArray
-
 }

--- a/geomesa-convert/pom.xml
+++ b/geomesa-convert/pom.xml
@@ -15,6 +15,7 @@
     <modules>
         <module>geomesa-convert-all</module>
         <module>geomesa-convert-avro</module>
+        <module>geomesa-convert-avro-schema-registry</module>
         <module>geomesa-convert-common</module>
         <module>geomesa-convert-fixedwidth</module>
         <module>geomesa-convert-jdbc</module>


### PR DESCRIPTION
…stry

* Add module geomesa-convert-avro-schema-registry
* Module uses avro version 1.8
* Add avro-schema-registry converter with schema-registry config
* Make rest call to schema-registry url based on confluent-style bytes
* Decode avro using GenericDatumReader configured with schema from registry

Signed-off-by: Rebecca Pledger <rebeccapledger14@gmail.com>