### PR TITLE
GEOMESA-2455 Converters - support dropwizard metrics

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -13,8 +13,11 @@ User Manual
    architecture
    datastores/index
    cli/index
+   convert/index
    geoserver
    spark/index
+   nifi
+   process
    hbase/index
    accumulo/index
    bigtable/index
@@ -25,10 +28,7 @@ User Manual
    kudu/index
    lambda/index
    merged_view
-   convert/index
-   process
    geojson
-   nifi
    blobstore
    native_api
    stream

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverter.scala
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverter.scala
@@ -18,16 +18,21 @@ import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
 import io.confluent.kafka.serializers.KafkaAvroDeserializer
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.io.DecoderFactory
+import org.locationtech.geomesa.convert.EvaluationContext
 import org.locationtech.geomesa.convert.avro.registry.AvroSchemaRegistryConverter.{AvroSchemaRegistryConfig, GenericRecordSchemaRegistryIterator}
-import org.locationtech.geomesa.convert.{Counter, EvaluationContext}
 import org.locationtech.geomesa.convert2.AbstractConverter.{BasicField, BasicOptions}
 import org.locationtech.geomesa.convert2.transforms.Expression
 import org.locationtech.geomesa.convert2.{AbstractConverter, ConverterConfig}
 import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.opengis.feature.simple.SimpleFeatureType
 
-class AvroSchemaRegistryConverter(sft: SimpleFeatureType, config: AvroSchemaRegistryConfig, fields: Seq[BasicField], options: BasicOptions)
-  extends AbstractConverter[GenericRecord, AvroSchemaRegistryConfig, BasicField, BasicOptions](sft, config, fields, options) {
+class AvroSchemaRegistryConverter(
+    sft: SimpleFeatureType,
+    config: AvroSchemaRegistryConfig,
+    fields: Seq[BasicField],
+    options: BasicOptions
+  ) extends AbstractConverter[GenericRecord, AvroSchemaRegistryConfig, BasicField, BasicOptions](
+    sft, config, fields, options) {
 
   private val schemaRegistryClient = new CachedSchemaRegistryClient(config.schemaRegistry, 100)
 
@@ -41,23 +46,21 @@ class AvroSchemaRegistryConverter(sft: SimpleFeatureType, config: AvroSchemaRegi
 
   // Create Avro reader cache to map schema ID to GenericDatumReader
   def getReaderCache(deserializer: ThreadLocal[KafkaAvroDeserializer]): LoadingCache[Integer, GenericDatumReader[GenericRecord]] = {
-    Caffeine
-      .newBuilder()
-      .build(
-        new CacheLoader[Integer, GenericDatumReader[GenericRecord]] {
-          override def load(id: Integer): GenericDatumReader[GenericRecord] = {
-            new GenericDatumReader[GenericRecord](deserializer.get.getById(id))
-          }
+    Caffeine.newBuilder().build(
+      new CacheLoader[Integer, GenericDatumReader[GenericRecord]] {
+        override def load(id: Integer): GenericDatumReader[GenericRecord] = {
+          new GenericDatumReader[GenericRecord](deserializer.get.getById(id))
         }
-      )
+      }
+    )
   }
 
-  override protected def parse(is: InputStream, ec: EvaluationContext): CloseableIterator[GenericRecord] = {
-    new GenericRecordSchemaRegistryIterator(is, schemaRegistryConfig, ec.counter)
-  }
+  override protected def parse(is: InputStream, ec: EvaluationContext): CloseableIterator[GenericRecord] =
+    new GenericRecordSchemaRegistryIterator(is, schemaRegistryConfig, ec)
 
-  override protected def values(parsed: CloseableIterator[GenericRecord],
-                                ec: EvaluationContext): CloseableIterator[Array[Any]] = {
+  override protected def values(
+      parsed: CloseableIterator[GenericRecord],
+      ec: EvaluationContext): CloseableIterator[Array[Any]] = {
     val array = Array.ofDim[Any](2)
     parsed.map { record => array(1) = record; array }
   }
@@ -68,11 +71,13 @@ object AvroSchemaRegistryConverter {
   private val MAGIC_BYTE_LENGTH = 1
   private val SCHEMA_ID_LENGTH = 4
 
-  case class AvroSchemaRegistryConfig(`type`: String,
-                        schemaRegistry: String,
-                        idField: Option[Expression],
-                        caches: Map[String, Config],
-                        userData: Map[String, Expression]) extends ConverterConfig
+  case class AvroSchemaRegistryConfig(
+      `type`: String,
+      schemaRegistry: String,
+      idField: Option[Expression],
+      caches: Map[String, Config],
+      userData: Map[String, Expression]
+    ) extends ConverterConfig
 
   sealed trait SchemaConfig
 
@@ -83,12 +88,13 @@ object AvroSchemaRegistryConverter {
     *
     * @param is input stream
     * @param readerCache GenericDatumReader cache
-    * @param counter counter
+    * @param ec evaluation context
     */
-  class GenericRecordSchemaRegistryIterator private [AvroSchemaRegistryConverter] (is: InputStream,
-                                                                     readerCache: LoadingCache[Integer, GenericDatumReader[GenericRecord]],
-                                                                     counter: Counter)
-    extends CloseableIterator[GenericRecord] with LazyLogging{
+  class GenericRecordSchemaRegistryIterator private [AvroSchemaRegistryConverter] (
+      is: InputStream,
+      readerCache: LoadingCache[Integer, GenericDatumReader[GenericRecord]],
+      ec: EvaluationContext
+    ) extends CloseableIterator[GenericRecord] with LazyLogging{
 
     private val decoder = DecoderFactory.get.binaryDecoder(is, null)
     private var record: GenericRecord = _
@@ -96,7 +102,7 @@ object AvroSchemaRegistryConverter {
     override def hasNext: Boolean = !decoder.isEnd
 
     override def next(): GenericRecord = {
-      counter.incLineCount()
+      ec.line += 1
       // Read confluent-style bytes
       decoder.skipFixed(MAGIC_BYTE_LENGTH)
       val bytes = new Array[Byte](SCHEMA_ID_LENGTH)

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterFactory.scala
@@ -12,13 +12,14 @@ import com.typesafe.config.Config
 import org.locationtech.geomesa.convert.avro.registry.AvroSchemaRegistryConverter.AvroSchemaRegistryConfig
 import org.locationtech.geomesa.convert.avro.registry.AvroSchemaRegistryConverterFactory.AvroSchemaRegistryConfigConvert
 import org.locationtech.geomesa.convert2.AbstractConverter.{BasicField, BasicOptions}
+import org.locationtech.geomesa.convert2.AbstractConverterFactory
 import org.locationtech.geomesa.convert2.AbstractConverterFactory.{BasicFieldConvert, BasicOptionsConvert, ConverterConfigConvert, ConverterOptionsConvert, FieldConvert, OptionConvert}
 import org.locationtech.geomesa.convert2.transforms.Expression
-import org.locationtech.geomesa.convert2.AbstractConverterFactory
 import pureconfig.ConfigObjectCursor
 import pureconfig.error.ConfigReaderFailures
 
-class AvroSchemaRegistryConverterFactory extends AbstractConverterFactory[AvroSchemaRegistryConverter, AvroSchemaRegistryConfig, BasicField, BasicOptions] {
+class AvroSchemaRegistryConverterFactory
+    extends AbstractConverterFactory[AvroSchemaRegistryConverter, AvroSchemaRegistryConfig, BasicField, BasicOptions] {
 
   override protected val typeToProcess: String = "avro-schema-registry"
 
@@ -32,21 +33,18 @@ object AvroSchemaRegistryConverterFactory {
 
   object AvroSchemaRegistryConfigConvert extends ConverterConfigConvert[AvroSchemaRegistryConfig] with OptionConvert {
 
-    override protected def decodeConfig(cur: ConfigObjectCursor,
-                                        `type`: String,
-                                        idField: Option[Expression],
-                                        caches: Map[String, Config],
-                                        userData: Map[String, Expression]): Either[ConfigReaderFailures, AvroSchemaRegistryConfig] = {
-
-      for {
-        schemaRegistry <- cur.atKey("schema-registry").right.flatMap(_.asString).right
-      } yield {
+    override protected def decodeConfig(
+        cur: ConfigObjectCursor,
+        `type`: String,
+        idField: Option[Expression],
+        caches: Map[String, Config],
+        userData: Map[String, Expression]): Either[ConfigReaderFailures, AvroSchemaRegistryConfig] = {
+      for { schemaRegistry <- cur.atKey("schema-registry").right.flatMap(_.asString).right } yield {
         AvroSchemaRegistryConfig(`type`, schemaRegistry, idField, caches, userData)
       }
     }
 
-    override protected def encodeConfig(config: AvroSchemaRegistryConfig, base: java.util.Map[String, AnyRef]): Unit = {
+    override protected def encodeConfig(config: AvroSchemaRegistryConfig, base: java.util.Map[String, AnyRef]): Unit =
       base.put("schema-registry", config.schemaRegistry)
-    }
   }
 }

--- a/geomesa-convert/geomesa-convert-common/pom.xml
+++ b/geomesa-convert/geomesa-convert-common/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>pureconfig_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/geomesa-convert/geomesa-convert-common/src/main/resources/META-INF/services/org.locationtech.geomesa.convert2.metrics.ReporterFactory
+++ b/geomesa-convert/geomesa-convert-common/src/main/resources/META-INF/services/org.locationtech.geomesa.convert2.metrics.ReporterFactory
@@ -1,0 +1,2 @@
+org.locationtech.geomesa.convert2.metrics.ConsoleReporterFactory
+org.locationtech.geomesa.convert2.metrics.Slf4jReporterFactory

--- a/geomesa-convert/geomesa-convert-common/src/main/resources/META-INF/services/org.locationtech.geomesa.convert2.validators.SimpleFeatureValidatorFactory
+++ b/geomesa-convert/geomesa-convert-common/src/main/resources/META-INF/services/org.locationtech.geomesa.convert2.validators.SimpleFeatureValidatorFactory
@@ -1,5 +1,5 @@
-org.locationtech.geomesa.convert2.validators.SimpleFeatureValidator$HasDtgValidatorFactory
-org.locationtech.geomesa.convert2.validators.SimpleFeatureValidator$HasGeoValidatorFactory
-org.locationtech.geomesa.convert2.validators.SimpleFeatureValidator$IndexValidatorFactory
-org.locationtech.geomesa.convert2.validators.SimpleFeatureValidator$NoneValidatorFactory
-org.locationtech.geomesa.convert2.validators.SimpleFeatureValidator$ZIndexValidatorFactory
+org.locationtech.geomesa.convert2.validators.HasDtgValidatorFactory
+org.locationtech.geomesa.convert2.validators.HasGeoValidatorFactory
+org.locationtech.geomesa.convert2.validators.IndexValidatorFactory
+org.locationtech.geomesa.convert2.validators.NoneValidatorFactory
+org.locationtech.geomesa.convert2.validators.IndexValidatorFactory$ZIndexValidatorFactory

--- a/geomesa-convert/geomesa-convert-common/src/main/resources/base-converter-defaults.conf
+++ b/geomesa-convert/geomesa-convert-common/src/main/resources/base-converter-defaults.conf
@@ -1,10 +1,11 @@
 {
   "options" = {
     "validators" = [ "index" ]
+    "reporters" = {}
     "parse-mode" = "incremental"
     "error-mode" = "skip-bad-records"
     "encoding"   = "UTF-8"
   }
-  "user-data" = {}
   "caches" = {}
+  "user-data" = {}
 }

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureConverterFactory.scala
@@ -15,10 +15,10 @@ import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.io.IOUtils
 import org.geotools.factory.Hints
-import org.locationtech.geomesa.convert.Modes.ErrorMode
-import org.locationtech.geomesa.convert.Modes.ParseMode
+import org.locationtech.geomesa.convert.Modes.{ErrorMode, ParseMode}
 import org.locationtech.geomesa.convert.Transformers._
 import org.locationtech.geomesa.convert.ValidationMode.ValidationMode
+import org.locationtech.geomesa.convert2.metrics.ConverterMetrics
 import org.locationtech.geomesa.convert2.transforms.Expression
 import org.locationtech.geomesa.convert2.transforms.Expression.LiteralNull
 import org.locationtech.geomesa.features.ScalaSimpleFeature
@@ -311,11 +311,12 @@ trait ToSimpleFeatureConverter[I] extends SimpleFeatureConverter[I] with LazyLog
   def parseOpts: ConvertParseOpts
 
   protected lazy val validate: (SimpleFeature, EvaluationContext) => SimpleFeature = {
-    val validators = org.locationtech.geomesa.convert2.validators.SimpleFeatureValidator(targetSFT, parseOpts.validators)
+    val validators =
+      org.locationtech.geomesa.convert2.validators.SimpleFeatureValidator(targetSFT, parseOpts.validators, ConverterMetrics.empty)
     (sf: SimpleFeature, ec: EvaluationContext) => {
       val error = validators.validate(sf)
       if (error == null) { sf } else {
-        val msg = s"Invalid SimpleFeature on line ${ec.counter.getLineCount}: $error"
+        val msg = s"Invalid SimpleFeature on line ${ec.line}: $error"
         if (parseOpts.validationMode == ValidationMode.RaiseErrors) {
           throw new IOException(msg)
         } else {
@@ -363,10 +364,10 @@ trait ToSimpleFeatureConverter[I] extends SimpleFeatureConverter[I] with LazyLog
           val msg = if (parseOpts.verbose) {
             val valuesStr = if (t.length > 0) t.tail.mkString(", ") else ""
             s"Failed to evaluate field '${requiredFields(i).name}' " +
-              s"on line ${ec.counter.getLineCount} using values:\n" +
+              s"on line ${ec.line} using values:\n" +
               s"${t.headOption.orNull}\n[$valuesStr]"  // head is the whole record
           } else {
-            s"Failed to evaluate field '${requiredFields(i).name}' on line ${ec.counter.getLineCount}"
+            s"Failed to evaluate field '${requiredFields(i).name}' on line ${ec.line}"
           }
           if (parseOpts.validationMode == ValidationMode.SkipBadRecords) {
             if (parseOpts.verbose) { logger.debug(msg, e) } else { logger.debug(msg) }
@@ -405,19 +406,19 @@ trait ToSimpleFeatureConverter[I] extends SimpleFeatureConverter[I] with LazyLog
    */
   override def processSingleInput(i: I, ec: EvaluationContext): Iterator[SimpleFeature] = {
     ec.clear()
-    ec.counter.incLineCount()
+    ec.line += 1
 
     val attributes = try { fromInputType(i, ec) } catch {
       case e: Exception =>
         logger.warn(s"Failed to parse input '$i'", e)
-        ec.counter.incFailure()
+        ec.failure.inc()
         Iterator.empty
     }
 
     attributes.flatMap { a =>
       convert(a, ec) match {
-        case null => ec.counter.incFailure(); Iterator.empty
-        case sf   => ec.counter.incSuccess(); Iterator.single(sf)
+        case null => ec.failure.inc(); Iterator.empty
+        case sf   => ec.success.inc(); Iterator.single(sf)
       }
     }
   }
@@ -428,7 +429,7 @@ trait ToSimpleFeatureConverter[I] extends SimpleFeatureConverter[I] with LazyLog
     val values = Array.ofDim[Any](names.length)
     // note, globalKeys are maintained even through EvaluationContext.clear()
     globalKeys.zipWithIndex.foreach { case (k, i) => values(requiredFields.length + i) = globalParams(k) }
-    new EvaluationContextImpl(names, values, counter, caches)
+    EvaluationContext(names, values, counter, caches)
   }
 
   override def processInput(is: Iterator[I], ec: EvaluationContext): Iterator[SimpleFeature] = {

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureValidator.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/SimpleFeatureValidator.scala
@@ -199,11 +199,12 @@ object SimpleFeatureValidator extends LazyLogging {
     * @param geom geom index
     */
   private class Z2Validator(geom: Int) extends Validator {
+    private val envelope = wholeWorldEnvelope
     override def validate(sf: SimpleFeature): String = {
       val g = sf.getAttribute(geom).asInstanceOf[Geometry]
       if (g == null) {
         Errors.GeomNull
-      } else if (!wholeWorldEnvelope.contains(g.getEnvelopeInternal)) {
+      } else if (!envelope.contains(g.getEnvelopeInternal)) {
         Errors.GeomBounds
       } else {
         null
@@ -220,6 +221,7 @@ object SimpleFeatureValidator extends LazyLogging {
     * @param maxDate max z3 date
     */
   private class Z3Validator(geom: Int, dtg: Int, minDate: Date, maxDate: Date) extends Validator {
+    private val envelope = wholeWorldEnvelope
     private val dateBefore = s"date is before minimum indexable date ($minDate)"
     private val dateAfter = s"date is after maximum indexable date ($maxDate)"
 
@@ -236,7 +238,7 @@ object SimpleFeatureValidator extends LazyLogging {
         } else {
           Errors.GeomNull
         }
-      } else if (!wholeWorldEnvelope.contains(g.getEnvelopeInternal)) {
+      } else if (!envelope.contains(g.getEnvelopeInternal)) {
         if (d == null) {
           s"${Errors.GeomBounds}, ${Errors.DateNull}"
         } else if (d.before(minDate)) {

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/package.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/package.scala
@@ -1,0 +1,44 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa
+
+package object convert {
+
+  @deprecated("Use evaluation context metrics")
+  trait Counter {
+    def incSuccess(i: Long = 1): Unit
+    def getSuccess: Long
+
+    def incFailure(i: Long = 1): Unit
+    def getFailure: Long
+
+    // For things like Avro think of this as a recordCount as well
+    def incLineCount(i: Long = 1): Unit
+    def getLineCount: Long
+    def setLineCount(i: Long)
+  }
+
+  // noinspection ScalaDeprecation
+  @deprecated("Use evaluation context metrics")
+  class DefaultCounter extends Counter {
+    private var s: Long = 0
+    private var f: Long = 0
+    private var c: Long = 0
+
+    override def incSuccess(i: Long = 1): Unit = s += i
+    override def getSuccess: Long = s
+
+    override def incFailure(i: Long = 1): Unit = f += i
+    override def getFailure: Long = f
+
+    override def incLineCount(i: Long = 1): Unit = c += i
+    override def getLineCount: Long = c
+    override def setLineCount(i: Long): Unit = c = i
+  }
+}

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/AbstractCompositeConverter.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/AbstractCompositeConverter.scala
@@ -10,10 +10,12 @@ package org.locationtech.geomesa.convert2
 
 import java.io.InputStream
 
+import com.codahale.metrics.Counter
 import com.typesafe.scalalogging.LazyLogging
 import org.locationtech.geomesa.convert.Modes.ErrorMode
-import org.locationtech.geomesa.convert.{Counter, EnrichmentCache, EvaluationContext}
+import org.locationtech.geomesa.convert.{EnrichmentCache, EvaluationContext}
 import org.locationtech.geomesa.convert2.AbstractCompositeConverter.CompositeEvaluationContext
+import org.locationtech.geomesa.convert2.metrics.ConverterMetrics
 import org.locationtech.geomesa.convert2.transforms.Predicate
 import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.locationtech.geomesa.utils.io.CloseWithLogging
@@ -34,11 +36,15 @@ abstract class AbstractCompositeConverter[T](
 
   override def targetSft: SimpleFeatureType = sft
 
-  override def createEvaluationContext(globalParams: Map[String, Any],
+  override def createEvaluationContext(globalParams: Map[String, Any]): EvaluationContext =
+    new CompositeEvaluationContext(converters.map(_.createEvaluationContext(globalParams)))
+
+  // noinspection ScalaDeprecation
+  override def createEvaluationContext(
+      globalParams: Map[String, Any],
       caches: Map[String, EnrichmentCache],
-      counter: Counter): EvaluationContext = {
-    val contexts = converters.map(_.createEvaluationContext(globalParams, caches, counter))
-    new CompositeEvaluationContext(contexts.toIndexedSeq)
+      counter: org.locationtech.geomesa.convert.Counter): EvaluationContext = {
+    new CompositeEvaluationContext(converters.map(_.createEvaluationContext(globalParams, caches, counter)))
   }
 
   override def process(is: InputStream, ec: EvaluationContext): CloseableIterator[SimpleFeature] = {
@@ -62,11 +68,11 @@ abstract class AbstractCompositeConverter[T](
         }
         i += 1
       }
-      ec.counter.incFailure()
+      ec.failure.inc()
       CloseableIterator.empty
     }
 
-    new ErrorHandlingIterator(parse(is, ec), errorMode, ec.counter).flatMap(eval)
+    new ErrorHandlingIterator(parse(is, ec), errorMode, ec.failure).flatMap(eval)
   }
 
   override def close(): Unit = converters.foreach(CloseWithLogging.apply)
@@ -83,8 +89,12 @@ object AbstractCompositeConverter {
     override def get(i: Int): Any = current.get(i)
     override def set(i: Int, v: Any): Unit = current.set(i, v)
     override def indexOf(n: String): Int = current.indexOf(n)
-    override def counter: Counter = current.counter
-    override def getCache(k: String): EnrichmentCache = current.getCache(k)
     override def clear(): Unit = contexts.foreach(_.clear())
+    override def cache: Map[String, EnrichmentCache] = current.cache
+    override def metrics: ConverterMetrics = current.metrics
+    override def success: Counter = current.success
+    override def failure: Counter = current.failure
+    // noinspection ScalaDeprecation
+    override def counter: org.locationtech.geomesa.convert.Counter = current.counter
   }
 }

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/metrics/ConsoleReporterFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/metrics/ConsoleReporterFactory.scala
@@ -1,0 +1,37 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert2.metrics
+
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics.Slf4jReporter.LoggingLevel
+import com.codahale.metrics.{ConsoleReporter, MetricRegistry, ScheduledReporter, Slf4jReporter}
+import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
+
+class ConsoleReporterFactory extends ReporterFactory {
+
+  override def apply(
+      conf: Config,
+      registry: MetricRegistry,
+      rates: TimeUnit,
+      durations: TimeUnit): Option[ScheduledReporter] = {
+    if (!conf.hasPath("type") || !conf.getString("type").equalsIgnoreCase("console")) { None } else {
+      val reporter =
+        ConsoleReporter.forRegistry(registry)
+          .convertRatesTo(rates)
+          .convertDurationsTo(durations)
+          .build()
+      Some(reporter)
+    }
+  }
+}
+
+

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/metrics/ConverterMetrics.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/metrics/ConverterMetrics.scala
@@ -1,0 +1,104 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert2.metrics
+
+import java.io.Closeable
+
+import com.codahale.metrics._
+import com.typesafe.config.Config
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
+import org.locationtech.geomesa.utils.io.CloseWithLogging
+import org.opengis.feature.simple.SimpleFeatureType
+
+/**
+  * Provides namespaced access to reporting metrics
+  *
+  * @param registry metric registry
+  * @param prefix namespace prefix
+  * @param typeName simple feature type name being processed
+  * @param reporters metric reporters
+  */
+class ConverterMetrics(
+    val registry: MetricRegistry,
+    prefix: Option[String],
+    typeName: String,
+    reporters: Seq[ScheduledReporter]
+  ) extends Closeable {
+
+  private val pre = s"${prefix.map(_ + ".").getOrElse("")}geomesa.convert.${typeName.replaceAll("[^A-Za-z0-9]", ".")}."
+
+  /**
+    * Creates a prefixed counter
+    *
+    * @param id short identifier for the metric being counted
+    * @return
+    */
+  def counter(id: String): Counter = registry.counter(s"$pre$id")
+
+  /**
+    * Creates a prefixed histogram
+    *
+    * @param id short identifier for the metric being histogramed
+    * @return
+    */
+  def histogram(id: String): Histogram = registry.histogram(s"$pre$id")
+
+  /**
+    * Creates a prefixed meter
+    *
+    * @param id short identifier for the metric being metered
+    * @return
+    */
+  def meter(id: String): Meter = registry.meter(s"$pre$id")
+
+  /**
+    * Creates a prefixed timer
+    *
+    * @param id short identifier for the metric being timed
+    * @return
+    */
+  def timer(id: String): Timer = registry.timer(s"$pre$id")
+
+  /**
+    * Register a metric
+    *
+    * @param id short identifier for the metric
+    * @param metric metric to register
+    * @tparam T metric type
+    * @return
+    */
+  def register[T <: Metric](id: String, metric: T): T = registry.register(s"$pre$id", metric)
+
+  override def close(): Unit = CloseWithLogging(reporters)
+}
+
+object ConverterMetrics {
+
+  val MetricsPrefix = SystemProperty("geomesa.convert.validators.prefix")
+
+  /**
+    * Creates an empty registry with no namespace or reporters
+    *
+    * @return
+    */
+  def empty: ConverterMetrics = new ConverterMetrics(new MetricRegistry(), None, "", Seq.empty)
+
+  /**
+    * Create a registry for the provided feature type
+    *
+    * @param sft simple feature type
+    * @param reporters configs for metric reporters
+    * @return
+    */
+  def apply(sft: SimpleFeatureType, reporters: Map[String, Config]): ConverterMetrics = {
+    val registry = new MetricRegistry()
+    val reps = reporters.values.map(ReporterFactory.apply(_, registry)).toList
+    new ConverterMetrics(registry, MetricsPrefix.option, sft.getTypeName, reps)
+  }
+}

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/metrics/ReporterFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/metrics/ReporterFactory.scala
@@ -1,0 +1,90 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert2.metrics
+
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics.{MetricRegistry, ScheduledReporter}
+import com.typesafe.config.Config
+import org.locationtech.geomesa.utils.classpath.ServiceLoader
+import pureconfig.error.{CannotConvert, ConfigReaderFailures}
+import pureconfig.{ConfigCursor, ConfigObjectCursor, ConfigReader}
+
+import scala.concurrent.duration.Duration
+import scala.util.control.NonFatal
+
+/**
+  * Factory for SPI loading reporters at runtime
+  */
+trait ReporterFactory {
+  def apply(conf: Config, registry: MetricRegistry, rates: TimeUnit, durations: TimeUnit): Option[ScheduledReporter]
+}
+
+object ReporterFactory {
+
+  private lazy val factories = ServiceLoader.load[ReporterFactory]()
+
+  private implicit val reader: ConfigReader[ReporterConfig] = ReporterReader
+
+  /**
+    * Load a reporter from the available factories
+    *
+    * @param config config
+    * @param registry registry
+    * @return
+    */
+  def apply(config: Config, registry: MetricRegistry): ScheduledReporter = {
+    val ReporterConfig(rates, durations, interval) = pureconfig.loadConfigOrThrow[ReporterConfig](config)
+    val reporter = factories.toStream.flatMap(_.apply(config, registry, rates, durations)).headOption.getOrElse {
+      throw new IllegalArgumentException(s"Could not load reporter factory using provided config:\n" +
+          config.root().render())
+    }
+    if (interval > 0) {
+      reporter.start(interval, TimeUnit.MILLISECONDS)
+    }
+    reporter
+  }
+
+  case class ReporterConfig(rates: TimeUnit, durations: TimeUnit, interval: Long)
+
+  object ReporterReader extends ConfigReader[ReporterConfig] {
+    override def from(cur: ConfigCursor): Either[ConfigReaderFailures, ReporterConfig] = {
+      for {
+        obj      <- cur.asObjectCursor.right
+        rate     <- timeUnit(obj, "rate-units", "units").right
+        duration <- timeUnit(obj, "duration-units", "units").right
+        interval <- durationMillis(obj.atKeyOrUndefined("interval")).right
+      } yield {
+        ReporterConfig(rate, duration, interval)
+      }
+    }
+
+    private def timeUnit(cur: ConfigObjectCursor, key: String, fallback: String): Either[ConfigReaderFailures, TimeUnit] = {
+      val primary = cur.atKey(key).right.flatMap(_.asString).right.flatMap { unit =>
+        TimeUnit.values().find(_.toString.equalsIgnoreCase(unit)).toRight[ConfigReaderFailures](
+          ConfigReaderFailures(cur.failureFor(CannotConvert(cur.value.toString, "TimeUnit", "Does not match a TimeUnit")))
+        )
+      }
+      if (primary.isRight || fallback == null) { primary } else {
+        // use the fallback if it's a right, otherwise use the primary as a left
+        timeUnit(cur, fallback, null).left.flatMap(_ => primary)
+      }
+    }
+
+    private def durationMillis(cur: ConfigCursor): Either[ConfigReaderFailures, Long] = {
+      if (cur.isUndefined) { Right(-1L) } else {
+        cur.asString.right.flatMap { d =>
+          try { Right(Duration(d).toMillis) } catch {
+            case NonFatal(e) => cur.failed(CannotConvert(cur.value.toString, "Duration", e.getMessage))
+          }
+        }
+      }
+    }
+  }
+}

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/metrics/Slf4jReporterFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/metrics/Slf4jReporterFactory.scala
@@ -1,0 +1,49 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert2.metrics
+
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics.Slf4jReporter.LoggingLevel
+import com.codahale.metrics.{MetricRegistry, ScheduledReporter, Slf4jReporter}
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import org.slf4j.LoggerFactory
+
+class Slf4jReporterFactory extends ReporterFactory {
+
+  import Slf4jReporterFactory.{Slf4jConfig, Slf4jDefaults}
+
+  override def apply(
+      conf: Config,
+      registry: MetricRegistry,
+      rates: TimeUnit,
+      durations: TimeUnit): Option[ScheduledReporter] = {
+    if (!conf.hasPath("type") || !conf.getString("type").equalsIgnoreCase("slf4j")) { None } else {
+      val slf4j = pureconfig.loadConfigOrThrow[Slf4jConfig](conf.withFallback(Slf4jDefaults))
+      val logger = LoggerFactory.getLogger(slf4j.logger)
+      val level = LoggingLevel.valueOf(slf4j.level.toUpperCase(Locale.US))
+      val reporter =
+        Slf4jReporter.forRegistry(registry)
+          .outputTo(logger)
+          .convertRatesTo(rates)
+          .convertDurationsTo(durations)
+          .withLoggingLevel(level)
+          .build()
+      Some(reporter)
+    }
+  }
+}
+
+object Slf4jReporterFactory {
+
+  case class Slf4jConfig(logger: String, level: String)
+
+  val Slf4jDefaults: Config = ConfigFactory.empty.withValue("level", ConfigValueFactory.fromAnyRef("DEBUG"))
+}

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/package.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/package.scala
@@ -10,10 +10,11 @@ package org.locationtech.geomesa
 
 import java.nio.charset.Charset
 
+import com.codahale.metrics.Counter
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import org.locationtech.geomesa.convert.Modes.{ErrorMode, ParseMode}
-import org.locationtech.geomesa.convert.{Counter, EvaluationContext, SimpleFeatureValidator}
+import org.locationtech.geomesa.convert.EvaluationContext
 import org.locationtech.geomesa.convert2.transforms.Expression
 import org.locationtech.geomesa.utils.collection.CloseableIterator
 
@@ -36,6 +37,7 @@ package object convert2 {
 
   trait ConverterOptions {
     def validators: Seq[String]
+    def reporters: Map[String, Config]
     def parseMode: ParseMode
     def errorMode: ErrorMode
     def encoding: Charset
@@ -67,7 +69,7 @@ package object convert2 {
           }
         } catch {
           case NonFatal(e) =>
-            counter.incFailure()
+            counter.inc()
             mode match {
               case ErrorMode.SkipBadRecords => logger.warn("Failed parsing input: ", e)
               case ErrorMode.RaiseErrors => throw e

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/transforms/EnrichmentCacheFunctionFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/transforms/EnrichmentCacheFunctionFactory.scala
@@ -17,7 +17,7 @@ class EnrichmentCacheFunctionFactory extends TransformerFunctionFactory {
 
   private val cacheLookup = new NamedTransformerFunction(Seq("cacheLookup")) {
     override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = {
-      val cache = ctx.getCache(args(0).asInstanceOf[String])
+      val cache = ctx.cache(args(0).asInstanceOf[String])
       cache.get(Array(args(1).asInstanceOf[String], args(2).asInstanceOf[String]))
     }
   }

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/transforms/MiscFunctionFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/transforms/MiscFunctionFactory.scala
@@ -20,6 +20,6 @@ class MiscFunctionFactory extends TransformerFunctionFactory {
   }
 
   private val lineNumber = new NamedTransformerFunction(Seq("lineNo", "lineNumber")) {
-    def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = ctx.counter.getLineCount
+    def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = ctx.line
   }
 }

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/HasDtgValidatorFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/HasDtgValidatorFactory.scala
@@ -1,0 +1,31 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert2.validators
+
+import org.locationtech.geomesa.convert2.metrics.ConverterMetrics
+import org.opengis.feature.simple.SimpleFeatureType
+
+class HasDtgValidatorFactory extends SimpleFeatureValidatorFactory {
+
+  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
+  override val name: String = HasDtgValidatorFactory.Name
+
+  override def apply(
+      sft: SimpleFeatureType,
+      metrics: ConverterMetrics,
+      config: Option[String]): SimpleFeatureValidator = {
+    val i = sft.getDtgIndex.getOrElse(-1)
+    if (i == -1) { NoValidator } else { new NullValidator(i, Errors.DateNull, metrics.counter("validators.dtg.null")) }
+  }
+}
+
+object HasDtgValidatorFactory {
+  val Name = "has-dtg"
+}

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/HasGeoValidatorFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/HasGeoValidatorFactory.scala
@@ -1,0 +1,31 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert2.validators
+
+import org.locationtech.geomesa.convert2.metrics.ConverterMetrics
+import org.opengis.feature.simple.SimpleFeatureType
+
+class HasGeoValidatorFactory extends SimpleFeatureValidatorFactory {
+
+  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
+  override val name: String = HasGeoValidatorFactory.Name
+
+  override def apply(
+      sft: SimpleFeatureType,
+      metrics: ConverterMetrics,
+      config: Option[String]): SimpleFeatureValidator = {
+    val i = sft.getGeomIndex
+    if (i == -1) { NoValidator } else { new NullValidator(i, Errors.GeomNull, metrics.counter("validators.geom.null")) }
+  }
+}
+
+object HasGeoValidatorFactory {
+  val Name = "has-geo"
+}

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/IndexValidatorFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/IndexValidatorFactory.scala
@@ -1,0 +1,154 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert2.validators
+
+import java.util.{Date, Locale}
+
+import com.codahale.metrics.Counter
+import com.typesafe.scalalogging.LazyLogging
+import org.locationtech.geomesa.convert2.metrics.ConverterMetrics
+import org.locationtech.geomesa.curve.BinnedTime
+import org.locationtech.jts.geom.Geometry
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+
+/**
+  * Validator based on the indices used by the feature type. Currently only the x/z2 and x/z3 indices have
+  * input requirements. In addition, features that validate against the x/z3 index will also validate against
+  * the x/z2 index
+  */
+class IndexValidatorFactory extends SimpleFeatureValidatorFactory {
+
+  import IndexValidatorFactory._
+  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
+  override val name: String = IndexValidatorFactory.Name
+  override def apply(
+      sft: SimpleFeatureType,
+      metrics: ConverterMetrics,
+      config: Option[String]): SimpleFeatureValidator = {
+    val geom = sft.getGeomIndex
+    val dtg = sft.getDtgIndex.getOrElse(-1)
+    val enabled = sft.getIndices.collect { case id if id.mode.write => id.name.toLowerCase(Locale.US) }
+    if (enabled.contains("z3") || enabled.contains("xz3") || (enabled.isEmpty && geom != -1 && dtg != -1)) {
+      val minDate = Date.from(BinnedTime.ZMinDate.toInstant)
+      val maxDate = Date.from(BinnedTime.maxDate(sft.getZ3Interval).toInstant)
+      val counters = {
+        val geom = ErrorCounters(metrics.counter(GeomNullCounter), metrics.counter(GeomBoundsCounter))
+        val dtg = ErrorCounters(metrics.counter(DtgNullCounter), metrics.counter(DtgBoundsCounter))
+        Z3Counters(geom, dtg, metrics.counter(Z3TotalCounter))
+      }
+      new Z3Validator(geom, dtg, minDate, maxDate, counters)
+    } else if (enabled.contains("z2") || enabled.contains("xz2") || (enabled.isEmpty && geom != -1)) {
+      val counters = {
+        val geom = ErrorCounters(metrics.counter(GeomNullCounter), metrics.counter(GeomBoundsCounter))
+        Z2Counters(geom, metrics.counter(Z2TotalCounter))
+      }
+      new Z2Validator(geom, counters)
+    } else {
+      NoValidator
+    }
+  }
+}
+
+object IndexValidatorFactory extends LazyLogging {
+
+  val Name = "index"
+
+  val GeomNullCounter = "validators.geom.null"
+  val GeomBoundsCounter = "validators.geom.bounds"
+
+  val DtgNullCounter = "validators.dtg.null"
+  val DtgBoundsCounter = "validators.dtg.bounds"
+
+  val Z2TotalCounter = "validators.z2.failed"
+  val Z3TotalCounter = "validators.z3.failed"
+
+  // load a mutable envelope once - we don't modify it
+  private val WholeWorldEnvelope = org.locationtech.geomesa.utils.geotools.wholeWorldEnvelope
+
+  private case class ErrorCounters(missing: Counter, bounds: Counter)
+
+  private case class Z2Counters(geom: ErrorCounters, total: Counter)
+  private case class Z3Counters(geom: ErrorCounters, dtg: ErrorCounters, total: Counter)
+
+  /**
+    * Z2 validator
+    *
+    * @param geom geom index
+    */
+  private class Z2Validator(geom: Int, counters: Z2Counters) extends SimpleFeatureValidator {
+    override def validate(sf: SimpleFeature): String = {
+      val g = sf.getAttribute(geom).asInstanceOf[Geometry]
+      if (g == null) {
+        counters.geom.missing.inc()
+        counters.total.inc()
+        Errors.GeomNull
+      } else if (!WholeWorldEnvelope.contains(g.getEnvelopeInternal)) {
+        counters.geom.bounds.inc()
+        counters.total.inc()
+        Errors.GeomBounds
+      } else {
+        null
+      }
+    }
+  }
+
+  /**
+    * Z3 validator
+    *
+    * @param geom geom index
+    * @param dtg dtg index
+    * @param minDate min z3 date
+    * @param maxDate max z3 date
+    */
+  private class Z3Validator(geom: Int, dtg: Int, minDate: Date, maxDate: Date, counters: Z3Counters)
+      extends SimpleFeatureValidator {
+
+    private val dateBefore = s"date is before minimum indexable date ($minDate)"
+    private val dateAfter = s"date is after maximum indexable date ($maxDate)"
+
+    override def validate(sf: SimpleFeature): String = {
+      val d = sf.getAttribute(dtg).asInstanceOf[Date]
+      val g = sf.getAttribute(geom).asInstanceOf[Geometry]
+      var error: String = null
+      if (g == null) {
+        counters.geom.missing.inc()
+        error =  s"$error, ${Errors.GeomNull}"
+      } else if (!WholeWorldEnvelope.contains(g.getEnvelopeInternal)) {
+        counters.geom.bounds.inc()
+        error =  s"$error, ${Errors.GeomBounds}"
+      }
+      if (d == null) {
+        counters.dtg.missing.inc()
+        error = s"$error, ${Errors.DateNull}"
+      } else if (d.before(minDate)) {
+        counters.dtg.bounds.inc()
+        error = s"$error, $dateBefore"
+      } else if (d.after(maxDate)) {
+        counters.dtg.bounds.inc()
+        error = s"$error, $dateAfter"
+      }
+      if (error == null) { null } else {
+        counters.total.inc()
+        error.substring(6) // trim off leading 'null, '
+      }
+    }
+  }
+
+  class ZIndexValidatorFactory extends IndexValidatorFactory {
+    override val name = "z-index"
+    override def apply(
+        sft: SimpleFeatureType,
+        metrics: ConverterMetrics,
+        config: Option[String]): SimpleFeatureValidator = {
+      logger.warn("'z-index' validator is deprecated, using 'index' instead")
+      super.apply(sft, metrics, config)
+    }
+  }
+}

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/NoneValidatorFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/NoneValidatorFactory.scala
@@ -1,0 +1,20 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert2.validators
+
+import org.locationtech.geomesa.convert2.metrics.ConverterMetrics
+import org.opengis.feature.simple.SimpleFeatureType
+
+class NoneValidatorFactory extends SimpleFeatureValidatorFactory {
+  override val name: String = "none"
+  override def apply(
+      sft: SimpleFeatureType,
+      metrics: ConverterMetrics,
+      config: Option[String]): SimpleFeatureValidator = NoValidator
+}

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/SimpleFeatureValidator.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/SimpleFeatureValidator.scala
@@ -8,14 +8,10 @@
 
 package org.locationtech.geomesa.convert2.validators
 
-import java.util.{Date, Locale}
-
 import com.typesafe.scalalogging.LazyLogging
-import org.locationtech.geomesa.curve.BinnedTime
+import org.locationtech.geomesa.convert2.metrics.ConverterMetrics
 import org.locationtech.geomesa.utils.classpath.ServiceLoader
 import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
-import org.locationtech.geomesa.utils.geotools.wholeWorldEnvelope
-import org.locationtech.jts.geom.Geometry
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 trait SimpleFeatureValidator {
@@ -30,8 +26,6 @@ trait SimpleFeatureValidator {
 }
 
 object SimpleFeatureValidator extends LazyLogging {
-
-  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
   private lazy val factories = ServiceLoader.load[SimpleFeatureValidatorFactory]()
 
@@ -53,9 +47,10 @@ object SimpleFeatureValidator extends LazyLogging {
     *
     * @param sft simple feature type
     * @param names validator names and options
+    * @param metrics optional metrics registry for tracking validation results
     * @return
     */
-  def apply(sft: SimpleFeatureType, names: Seq[String]): SimpleFeatureValidator = {
+  def apply(sft: SimpleFeatureType, names: Seq[String], metrics: ConverterMetrics): SimpleFeatureValidator = {
     val validators = names.map { full =>
       val i = full.indexOf('(')
       val (name, options) = if (i == -1) { (full, None) } else {
@@ -66,7 +61,7 @@ object SimpleFeatureValidator extends LazyLogging {
         throw new IllegalArgumentException(s"No factory found for name '$name'. " +
             s"Available factories: ${(factories.map(_.name) ++ factoriesV1.map(_.name)).mkString(", ")}")
       }
-      factory.apply(sft, options)
+      factory.apply(sft, metrics, options)
     }
 
     if (validators.lengthCompare(2) < 0) {
@@ -88,7 +83,10 @@ object SimpleFeatureValidator extends LazyLogging {
           s"Please migrate to org.locationtech.geomesa.convert2.validators.SimpleFeatureValidatorFactory")
       new SimpleFeatureValidatorFactory() {
         override def name: String = factory.name
-        override def apply(sft: SimpleFeatureType, config: Option[String]): SimpleFeatureValidator = {
+        override def apply(
+            sft: SimpleFeatureType,
+            metrics: ConverterMetrics,
+            config: Option[String]): SimpleFeatureValidator = {
           new SimpleFeatureValidator() {
             private val validator = factory.validator(sft, config)
             override def validate(sf: SimpleFeature): String = validator.validate(sf)
@@ -114,154 +112,5 @@ object SimpleFeatureValidator extends LazyLogging {
       }
       error
     }
-  }
-
-  /**
-    * Validator based on the indices used by the feature type. Currently only the x/z2 and x/z3 indices have
-    * input requirements. In addition, features that validate against the x/z3 index will also validate against
-    * the x/z2 index
-    */
-  class IndexValidatorFactory extends SimpleFeatureValidatorFactory {
-    override val name: String = IndexValidatorFactory.Name
-    override def apply(sft: SimpleFeatureType, config: Option[String]): SimpleFeatureValidator = {
-      val geom = sft.getGeomIndex
-      val dtg = sft.getDtgIndex.getOrElse(-1)
-      val enabled = sft.getIndices.collect { case id if id.mode.write => id.name.toLowerCase(Locale.US) }
-      if (enabled.contains("z3") || enabled.contains("xz3") || (enabled.isEmpty && geom != -1 && dtg != -1)) {
-        val minDate = Date.from(BinnedTime.ZMinDate.toInstant)
-        val maxDate = Date.from(BinnedTime.maxDate(sft.getZ3Interval).toInstant)
-        new Z3Validator(geom, dtg, minDate, maxDate)
-      } else if (enabled.contains("z2") || enabled.contains("xz2") || (enabled.isEmpty && geom != -1)) {
-        new Z2Validator(geom)
-      } else {
-        NoValidator
-      }
-    }
-  }
-
-  object IndexValidatorFactory {
-    val Name = "index"
-  }
-
-  class ZIndexValidatorFactory extends IndexValidatorFactory {
-    override val name = "z-index"
-    override def apply(sft: SimpleFeatureType, config: Option[String]): SimpleFeatureValidator = {
-      logger.warn("'z-index' validator is deprecated, using 'index' instead")
-      super.apply(sft, config)
-    }
-  }
-
-  class HasGeoValidatorFactory extends SimpleFeatureValidatorFactory {
-    override val name: String = HasGeoValidatorFactory.Name
-    override def apply(sft: SimpleFeatureType, config: Option[String]): SimpleFeatureValidator = {
-      val i = sft.getGeomIndex
-      if (i == -1) { NoValidator } else { new NullValidator(i, Errors.GeomNull) }
-    }
-  }
-
-  object HasGeoValidatorFactory {
-    val Name = "has-geo"
-  }
-
-  class HasDtgValidatorFactory extends SimpleFeatureValidatorFactory {
-    override val name: String = HasDtgValidatorFactory.Name
-    override def apply(sft: SimpleFeatureType, config: Option[String]): SimpleFeatureValidator = {
-      val i = sft.getDtgIndex.getOrElse(-1)
-      if (i == -1) { NoValidator } else { new NullValidator(i, Errors.DateNull) }
-    }
-  }
-
-  object HasDtgValidatorFactory {
-    val Name = "has-dtg"
-  }
-
-  class NoneValidatorFactory extends SimpleFeatureValidatorFactory {
-    override val name: String = "none"
-    override def apply(sft: SimpleFeatureType, config: Option[String]): SimpleFeatureValidator = NoValidator
-  }
-
-  /**
-    * Validates an attribute is not null
-    *
-    * @param i attribute index
-    * @param error error message
-    */
-  private class NullValidator(i: Int, error: String) extends SimpleFeatureValidator {
-    override def validate(sf: SimpleFeature): String = if (sf.getAttribute(i) == null) { error } else { null }
-  }
-
-  /**
-    * Z2 validator
-    *
-    * @param geom geom index
-    */
-  private class Z2Validator(geom: Int) extends SimpleFeatureValidator {
-    override def validate(sf: SimpleFeature): String = {
-      val g = sf.getAttribute(geom).asInstanceOf[Geometry]
-      if (g == null) {
-        Errors.GeomNull
-      } else if (!wholeWorldEnvelope.contains(g.getEnvelopeInternal)) {
-        Errors.GeomBounds
-      } else {
-        null
-      }
-    }
-  }
-
-  /**
-    * Z3 validator
-    *
-    * @param geom geom index
-    * @param dtg dtg index
-    * @param minDate min z3 date
-    * @param maxDate max z3 date
-    */
-  private class Z3Validator(geom: Int, dtg: Int, minDate: Date, maxDate: Date) extends SimpleFeatureValidator {
-    private val dateBefore = s"date is before minimum indexable date ($minDate)"
-    private val dateAfter = s"date is after maximum indexable date ($maxDate)"
-
-    override def validate(sf: SimpleFeature): String = {
-      val d = sf.getAttribute(dtg).asInstanceOf[Date]
-      val g = sf.getAttribute(geom).asInstanceOf[Geometry]
-      if (g == null) {
-        if (d == null) {
-          s"${Errors.GeomNull}, ${Errors.DateNull}"
-        } else if (d.before(minDate)) {
-          s"${Errors.GeomNull}, $dateBefore"
-        } else if (d.after(maxDate)) {
-          s"${Errors.GeomNull}, $dateAfter"
-        } else {
-          Errors.GeomNull
-        }
-      } else if (!wholeWorldEnvelope.contains(g.getEnvelopeInternal)) {
-        if (d == null) {
-          s"${Errors.GeomBounds}, ${Errors.DateNull}"
-        } else if (d.before(minDate)) {
-          s"${Errors.GeomBounds}, $dateBefore"
-        } else if (d.after(maxDate)) {
-          s"${Errors.GeomBounds}, $dateAfter"
-        } else {
-          Errors.GeomBounds
-        }
-      } else if (d == null) {
-        Errors.DateNull
-      } else if (d.before(minDate)) {
-        dateBefore
-      } else if (d.after(maxDate)) {
-        dateAfter
-      } else {
-        null
-      }
-    }
-  }
-
-  private object NoValidator extends SimpleFeatureValidator {
-    override def validate(sf: SimpleFeature): String = null
-  }
-
-  private object Errors {
-    val GeomNull   = "geometry is null"
-    val DateNull   = "date is null"
-    val GeomBounds = s"geometry exceeds world bounds ($wholeWorldEnvelope)"
   }
 }

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/SimpleFeatureValidatorFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/SimpleFeatureValidatorFactory.scala
@@ -8,6 +8,7 @@
 
 package org.locationtech.geomesa.convert2.validators
 
+import org.locationtech.geomesa.convert2.metrics.ConverterMetrics
 import org.opengis.feature.simple.SimpleFeatureType
 
 trait SimpleFeatureValidatorFactory {
@@ -23,6 +24,8 @@ trait SimpleFeatureValidatorFactory {
     * Create a validator for the given feature typ
     *
     * @param sft simple feature type
+    * @param metrics metrics registry for reporting validation
+    * @param config optional configuration string
     */
-  def apply(sft: SimpleFeatureType, config: Option[String]): SimpleFeatureValidator
+  def apply(sft: SimpleFeatureType, metrics: ConverterMetrics, config: Option[String]): SimpleFeatureValidator
 }

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/package.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/validators/package.scala
@@ -1,0 +1,42 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert2
+
+import com.codahale.metrics.Counter
+import org.locationtech.geomesa.utils.geotools.wholeWorldEnvelope
+import org.opengis.feature.simple.SimpleFeature
+
+package object validators {
+
+  /**
+    * Validates an attribute is not null
+    *
+    * @param i attribute index
+    * @param error error message
+    * @param counter optional counter for validation failures
+    */
+  class NullValidator(i: Int, error: String, counter: Counter) extends SimpleFeatureValidator {
+    override def validate(sf: SimpleFeature): String = {
+      if (sf.getAttribute(i) != null) { null } else {
+        counter.inc()
+        error
+      }
+    }
+  }
+
+  object NoValidator extends SimpleFeatureValidator {
+    override def validate(sf: SimpleFeature): String = null
+  }
+
+  object Errors {
+    val GeomNull   = "geometry is null"
+    val DateNull   = "date is null"
+    val GeomBounds = s"geometry exceeds world bounds ($wholeWorldEnvelope)"
+  }
+}

--- a/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert/common/TransformersTest.scala
+++ b/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert/common/TransformersTest.scala
@@ -8,17 +8,17 @@
 
 package org.locationtech.geomesa.convert.common
 
-import java.time.{LocalDateTime, ZoneOffset}
 import java.time.format.DateTimeFormatter
+import java.time.{LocalDateTime, ZoneOffset}
 import java.util.Date
 
 import com.google.common.hash.Hashing
-import org.locationtech.jts.geom._
 import org.apache.commons.codec.binary.Base64
 import org.geotools.util.Converters
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.convert.{EvaluationContext, EvaluationContextImpl, Transformers}
+import org.locationtech.geomesa.convert.{Counter, EnrichmentCache, EvaluationContext, Transformers}
 import org.locationtech.geomesa.utils.text.WKTUtils
+import org.locationtech.jts.geom._
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -478,7 +478,7 @@ class TransformersTest extends Specification {
       }
 
       "handle named values" >> {
-        val ctx = EvaluationContext(IndexedSeq(null, "foo", null), Array[Any](null, "bar", null), null, Map.empty)
+        val ctx = EvaluationContext(IndexedSeq[String](null, "foo", null), Array[Any](null, "bar", null), null: Counter, Map.empty[String, EnrichmentCache])
         val exp = Transformers.parseTransform("capitalize($foo)")
         exp.eval(Array(null))(ctx) must be equalTo "Bar"
       }
@@ -799,7 +799,7 @@ class TransformersTest extends Specification {
     }
 
     "return null for non-existing fields" >> {
-      val fieldsCtx = new EvaluationContextImpl(IndexedSeq("foo", "bar"), Array("5", "10"), null, Map.empty)
+      val fieldsCtx = EvaluationContext(IndexedSeq("foo", "bar"), Array[Any]("5", "10"), null: Counter, Map.empty[String, EnrichmentCache])
       Transformers.parseTransform("$b").eval(Array())(fieldsCtx) mustEqual null
       Transformers.parseTransform("$bar").eval(Array())(fieldsCtx) mustEqual "10"
     }

--- a/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert2/metrics/ReporterFactoryTest.scala
+++ b/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert2/metrics/ReporterFactoryTest.scala
@@ -1,0 +1,61 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert2.metrics
+
+import com.codahale.metrics.{ConsoleReporter, MetricRegistry, Slf4jReporter}
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.LazyLogging
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ReporterFactoryTest extends Specification with LazyLogging {
+
+  "ReporterFactory" should {
+    "load console configs" in {
+      val conf = ConfigFactory.parseString(
+        """
+          |{
+          |  type = "console"
+          |  units = "MILLISECONDS"
+          |}
+        """.stripMargin
+      )
+      val registry = new MetricRegistry()
+      val reporter = ReporterFactory(conf, registry)
+      try {
+        reporter must beAnInstanceOf[ConsoleReporter]
+      } finally {
+        reporter.close()
+      }
+    }
+    "load slf configs" in {
+      val conf = ConfigFactory.parseString(
+        """
+          |{
+          |  type           = "slf4j"
+          |  logger         = "org.locationtech.geomesa.convert2.metrics.ReporterFactoryTest"
+          |  level          = "INFO"
+          |  rate-units     = "SECONDS"
+          |  duration-units = "MILLISECONDS"
+          |  interval       = "10 seconds"
+          |}
+        """.stripMargin
+      )
+      val registry = new MetricRegistry()
+      val reporter = ReporterFactory(conf, registry)
+      try {
+        reporter must beAnInstanceOf[Slf4jReporter]
+      } finally {
+        reporter.close()
+      }
+    }
+  }
+}

--- a/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert2/transforms/ExpressionTest.scala
+++ b/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert2/transforms/ExpressionTest.scala
@@ -16,7 +16,7 @@ import com.google.common.hash.Hashing
 import org.apache.commons.codec.binary.Base64
 import org.geotools.util.Converters
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.convert.{EvaluationContext, EvaluationContextImpl}
+import org.locationtech.geomesa.convert.EvaluationContext
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.locationtech.jts.geom._
 import org.specs2.mutable.Specification
@@ -442,7 +442,8 @@ class ExpressionTest extends Specification {
       }
     }
     "handle named values" >> {
-      val ctx = EvaluationContext(IndexedSeq(null, "foo", null), Array[Any](null, "bar", null), null, Map.empty)
+      val ctx = EvaluationContext(Seq(null, "foo", null))
+      ctx.set(1, "bar")
       val exp = Expression("capitalize($foo)")
       exp.eval(Array(null))(ctx) must be equalTo "Bar"
     }
@@ -629,7 +630,9 @@ class ExpressionTest extends Specification {
       exp.eval(Array("", "18", null)) mustEqual null
     }
     "return null for non-existing fields" >> {
-      val fieldsCtx = new EvaluationContextImpl(IndexedSeq("foo", "bar"), Array("5", "10"), null, Map.empty)
+      val fieldsCtx = EvaluationContext(Seq("foo", "bar"))
+      fieldsCtx.set(0, "5")
+      fieldsCtx.set(1, "10")
       Expression("$b").eval(Array())(fieldsCtx) mustEqual null
       Expression("$bar").eval(Array())(fieldsCtx) mustEqual "10"
     }

--- a/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert2/validators/SimpleFeatureValidatorTest.scala
+++ b/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert2/validators/SimpleFeatureValidatorTest.scala
@@ -9,6 +9,7 @@
 package org.locationtech.geomesa.convert2.validators
 
 import org.junit.runner.RunWith
+import org.locationtech.geomesa.convert2.metrics.ConverterMetrics
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.specs2.mutable.Specification
@@ -21,7 +22,7 @@ class SimpleFeatureValidatorTest extends Specification {
 
   "SimpleFeatureValidator" should {
     "allow custom SPI loading" in {
-      val custom = SimpleFeatureValidator(sft, Seq("custom"))
+      val custom = SimpleFeatureValidator(sft, Seq("custom"), ConverterMetrics.empty)
       custom must not(beNull)
       custom.validate(null) must beNull
       SimpleFeatureValidatorTest.errors.set("foo")
@@ -32,7 +33,7 @@ class SimpleFeatureValidatorTest extends Specification {
       }
     }
     "allow custom SPI loading with options" in {
-      val custom = SimpleFeatureValidator(sft, Seq("custom(foo,bar,baz)"))
+      val custom = SimpleFeatureValidator(sft, Seq("custom(foo,bar,baz)"), ConverterMetrics.empty)
       custom must not(beNull)
       custom.validate(null) mustEqual "foo,bar,baz"
       SimpleFeatureValidatorTest.errors.set("foo")
@@ -43,7 +44,7 @@ class SimpleFeatureValidatorTest extends Specification {
       }
     }
     "allow custom SPI loading of deprecated v1 validators" in {
-      val custom = SimpleFeatureValidator(sft, Seq("custom-v1"))
+      val custom = SimpleFeatureValidator(sft, Seq("custom-v1"), ConverterMetrics.empty)
       custom must not(beNull)
       custom.validate(null) must beNull
       SimpleFeatureValidatorTest.errors.set("foo")
@@ -54,7 +55,7 @@ class SimpleFeatureValidatorTest extends Specification {
       }
     }
     "allow custom SPI loading of deprecated v1 validators with options" in {
-      val custom = SimpleFeatureValidator(sft, Seq("custom-v1(foo,bar,baz)"))
+      val custom = SimpleFeatureValidator(sft, Seq("custom-v1(foo,bar,baz)"), ConverterMetrics.empty)
       custom must not(beNull)
       custom.validate(null) mustEqual "foo,bar,baz"
       SimpleFeatureValidatorTest.errors.set("foo")
@@ -79,8 +80,10 @@ object SimpleFeatureValidatorTest {
   // src/test/resources/META-INF/services/org.locationtech.geomesa.convert2.validators.SimpleFeatureValidatorFactory
   class CustomValidatorFactory extends SimpleFeatureValidatorFactory {
     override def name: String = "custom"
-    override def apply(sft: SimpleFeatureType, config: Option[String]): SimpleFeatureValidator =
-      new CustomValidator(config)
+    override def apply(
+        sft: SimpleFeatureType,
+        metrics: ConverterMetrics,
+        config: Option[String]): SimpleFeatureValidator = new CustomValidator(config)
   }
 
   // v1 deprecated validators for back compatibility tests

--- a/geomesa-convert/geomesa-convert-fixedwidth/src/main/scala/org/locationtech/geomesa/convert/fixedwidth/FixedWidthConverter.scala
+++ b/geomesa-convert/geomesa-convert-fixedwidth/src/main/scala/org/locationtech/geomesa/convert/fixedwidth/FixedWidthConverter.scala
@@ -32,7 +32,7 @@ class FixedWidthConverter(sft: SimpleFeatureType,
       override def hasNext: Boolean = lines.hasNext
 
       override def next(): String = {
-        ec.counter.incLineCount()
+        ec.line += 1
         lines.next
       }
 

--- a/geomesa-convert/geomesa-convert-jdbc/src/main/scala/org/locationtech/geomesa/convert/jdbc/JdbcConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-jdbc/src/main/scala/org/locationtech/geomesa/convert/jdbc/JdbcConverterFactory.scala
@@ -33,11 +33,12 @@ object JdbcConverterFactory {
 
   object JdbcConfigConvert extends ConverterConfigConvert[JdbcConfig] {
 
-    override protected def decodeConfig(cur: ConfigObjectCursor,
-                                        `type`: String,
-                                        idField: Option[Expression],
-                                        caches: Map[String, Config],
-                                        userData: Map[String, Expression]): Either[ConfigReaderFailures, JdbcConfig] = {
+    override protected def decodeConfig(
+        cur: ConfigObjectCursor,
+        `type`: String,
+        idField: Option[Expression],
+        caches: Map[String, Config],
+        userData: Map[String, Expression]): Either[ConfigReaderFailures, JdbcConfig] = {
       for { conn <- cur.atKey("connection").right.flatMap(_.asString).right } yield {
         JdbcConfig(`type`, conn, idField, caches, userData)
       }

--- a/geomesa-convert/geomesa-convert-json/src/main/scala/org/locationtech/geomesa/convert/json/JsonCompositeConverter.scala
+++ b/geomesa-convert/geomesa-convert-json/src/main/scala/org/locationtech/geomesa/convert/json/JsonCompositeConverter.scala
@@ -27,5 +27,5 @@ class JsonCompositeConverter(
   ) extends AbstractCompositeConverter(sft, errorMode, delegates) {
 
   override protected def parse(is: InputStream, ec: EvaluationContext): CloseableIterator[JsonElement] =
-    new JsonConverter.JsonIterator(is, encoding, ec.counter)
+    new JsonConverter.JsonIterator(is, encoding, ec)
 }

--- a/geomesa-convert/geomesa-convert-metrics-ganglia/pom.xml
+++ b/geomesa-convert/geomesa-convert-metrics-ganglia/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>geomesa-convert_2.11</artifactId>
+        <groupId>org.locationtech.geomesa</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-convert-metrics-ganglia_2.11</artifactId>
+    <name>GeoMesa Convert Metrics - Ganglia</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- excluded due to licensing -->
+                <groupId>info.ganglia.gmetric4j</groupId>
+                <artifactId>gmetric4j</artifactId>
+                <version>1.0.7</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-ganglia</artifactId>
+            <version>${metrics.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/geomesa-convert/geomesa-convert-metrics-ganglia/src/main/resources/META-INF/services/org.locationtech.geomesa.convert2.metrics.ReporterFactory
+++ b/geomesa-convert/geomesa-convert-metrics-ganglia/src/main/resources/META-INF/services/org.locationtech.geomesa.convert2.metrics.ReporterFactory
@@ -1,0 +1,1 @@
+org.locationtech.geomesa.convert.metrics.ganglia.GangliaReporterFactory

--- a/geomesa-convert/geomesa-convert-metrics-ganglia/src/main/scala/org/locationtech/geomesa/convert/metrics/ganglia/GangliaReporterFactory.scala
+++ b/geomesa-convert/geomesa-convert-metrics-ganglia/src/main/scala/org/locationtech/geomesa/convert/metrics/ganglia/GangliaReporterFactory.scala
@@ -1,0 +1,57 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert.metrics.ganglia
+
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics.ganglia.GangliaReporter
+import com.codahale.metrics.{MetricRegistry, ScheduledReporter}
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import info.ganglia.gmetric4j.gmetric.GMetric
+import info.ganglia.gmetric4j.gmetric.GMetric.UDPAddressingMode
+import org.locationtech.geomesa.convert2.metrics.ReporterFactory
+
+class GangliaReporterFactory extends ReporterFactory {
+
+  import GangliaReporterFactory.{GangliaConfig, GangliaDefaults}
+
+  override def apply(
+      conf: Config,
+      registry: MetricRegistry,
+      rates: TimeUnit,
+      durations: TimeUnit): Option[ScheduledReporter] = {
+    if (!conf.hasPath("type") || !conf.getString("type").equalsIgnoreCase("ganglia")) { None } else {
+      val ganglia = pureconfig.loadConfigOrThrow[GangliaConfig](conf.withFallback(GangliaDefaults))
+      val mode = ganglia.addressingMode.toLowerCase(Locale.US) match {
+        case "unicast" => UDPAddressingMode.UNICAST
+        case "multicast" => UDPAddressingMode.MULTICAST
+        case m => throw new IllegalArgumentException(s"Invalid addressing mode: $m")
+      }
+
+      val reporter =
+        GangliaReporter.forRegistry(registry)
+          .convertRatesTo(rates)
+          .convertDurationsTo(durations)
+          .build(new GMetric(ganglia.group, ganglia.port, mode, ganglia.ttl, ganglia.ganglia311))
+
+      Some(reporter)
+    }
+  }
+}
+
+object GangliaReporterFactory {
+
+  case class GangliaConfig(group: String, port: Int, addressingMode: String, ttl: Int, ganglia311: Boolean)
+
+  val GangliaDefaults: Config =
+    ConfigFactory.empty
+        .withValue("addressing-mode", ConfigValueFactory.fromAnyRef("unicast"))
+        .withValue("ganglia311", ConfigValueFactory.fromAnyRef("true"))
+}

--- a/geomesa-convert/geomesa-convert-metrics-graphite/pom.xml
+++ b/geomesa-convert/geomesa-convert-metrics-graphite/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>geomesa-convert_2.11</artifactId>
+        <groupId>org.locationtech.geomesa</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-convert-metrics-graphite_2.11</artifactId>
+    <name>GeoMesa Convert Metrics - Graphite</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-convert-common_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-graphite</artifactId>
+            <version>${metrics.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/geomesa-convert/geomesa-convert-metrics-graphite/src/main/resources/META-INF/services/org.locationtech.geomesa.convert2.metrics.ReporterFactory
+++ b/geomesa-convert/geomesa-convert-metrics-graphite/src/main/resources/META-INF/services/org.locationtech.geomesa.convert2.metrics.ReporterFactory
@@ -1,0 +1,1 @@
+org.locationtech.geomesa.convert.metrics.graphite.GraphiteReporterFactory

--- a/geomesa-convert/geomesa-convert-metrics-graphite/src/main/scala/org/locationtech/geomesa/convert/metrics/graphite/GraphiteReporterFactory.scala
+++ b/geomesa-convert/geomesa-convert-metrics-graphite/src/main/scala/org/locationtech/geomesa/convert/metrics/graphite/GraphiteReporterFactory.scala
@@ -1,0 +1,50 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.convert.metrics.graphite
+
+import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics.graphite.{Graphite, GraphiteReporter}
+import com.codahale.metrics.{MetricRegistry, ScheduledReporter}
+import com.typesafe.config.Config
+import org.locationtech.geomesa.convert2.metrics.ReporterFactory
+
+import scala.util.control.NonFatal
+
+class GraphiteReporterFactory extends ReporterFactory {
+
+  import GraphiteReporterFactory.GraphiteConfig
+
+  override def apply(
+      conf: Config,
+      registry: MetricRegistry,
+      rates: TimeUnit,
+      durations: TimeUnit): Option[ScheduledReporter] = {
+    if (!conf.hasPath("type") || !conf.getString("type").equalsIgnoreCase("graphite")) { None } else {
+      val graphite = pureconfig.loadConfigOrThrow[GraphiteConfig](conf)
+      val url +: Nil :+ port = try { graphite.url.split(":").toList } catch {
+        case NonFatal(_) => throw new IllegalArgumentException(s"Invalid url: ${graphite.url}")
+      }
+
+      val reporter =
+        GraphiteReporter.forRegistry(registry)
+          .prefixedWith(graphite.prefix.orNull)
+          .convertRatesTo(rates)
+          .convertDurationsTo(durations)
+          .build(new Graphite(new InetSocketAddress(url, port.toInt)))
+
+      Some(reporter)
+    }
+  }
+}
+
+object GraphiteReporterFactory {
+  case class GraphiteConfig(url: String, prefix: Option[String])
+}

--- a/geomesa-convert/geomesa-convert-scripting/src/test/scala/org/locationtech/geomesa/convert/scripting/ScriptingFunctionFactoryTest.scala
+++ b/geomesa-convert/geomesa-convert-scripting/src/test/scala/org/locationtech/geomesa/convert/scripting/ScriptingFunctionFactoryTest.scala
@@ -12,7 +12,7 @@ import java.io.File
 
 import com.typesafe.config.ConfigFactory
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.convert.{DefaultCounter, EvaluationContextImpl, SimpleFeatureConverters}
+import org.locationtech.geomesa.convert.{EvaluationContext, SimpleFeatureConverters}
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -43,7 +43,7 @@ class ScriptingFunctionFactoryTest extends Specification {
     }
 
     "execute functions" >> {
-      implicit val ec = new EvaluationContextImpl(IndexedSeq.empty[String], Array.empty[Any], new DefaultCounter, Map.empty)
+      implicit val ec = EvaluationContext.empty
       val fn = sff.functions.find(_.names.contains("js:hello")).head
       val res = fn.eval(Array("geomesa"))
       res must beEqualTo("hello: geomesa")

--- a/geomesa-convert/geomesa-convert-shp/src/main/scala/org/locationtech/geomesa/convert/shp/ShapefileConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-shp/src/main/scala/org/locationtech/geomesa/convert/shp/ShapefileConverterFactory.scala
@@ -8,17 +8,13 @@
 
 package org.locationtech.geomesa.convert.shp
 
-import java.nio.charset.StandardCharsets
-
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.data.shapefile.ShapefileDataStore
-import org.locationtech.geomesa.convert.Modes.{ErrorMode, ParseMode}
 import org.locationtech.geomesa.convert2.AbstractConverter.{BasicConfig, BasicField, BasicOptions}
 import org.locationtech.geomesa.convert2.AbstractConverterFactory
 import org.locationtech.geomesa.convert2.AbstractConverterFactory._
 import org.locationtech.geomesa.convert2.transforms.Expression.Column
-import org.locationtech.geomesa.convert2.validators.SimpleFeatureValidator
 import org.opengis.feature.simple.SimpleFeatureType
 
 import scala.util.control.NonFatal
@@ -74,12 +70,10 @@ object ShapefileConverterFactory extends LazyLogging {
       }
 
       val shpConfig = BasicConfig(TypeToProcess, Some(Column(0)), Map.empty, Map.empty)
-      val options =
-        BasicOptions(SimpleFeatureValidator.default, ParseMode.Default, ErrorMode(), StandardCharsets.UTF_8)
 
       val config = BasicConfigConvert.to(shpConfig)
           .withFallback(BasicFieldConvert.to(fields))
-          .withFallback(BasicOptionsConvert.to(options))
+          .withFallback(BasicOptionsConvert.to(BasicOptions.default))
           .toConfig
 
       Some((sft.getOrElse(ds.getSchema), config))

--- a/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert2/simplefeature/FeatureToFeatureConverter.scala
+++ b/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert2/simplefeature/FeatureToFeatureConverter.scala
@@ -28,11 +28,13 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
   * @param fields converter fields
   * @param options converter options
   */
-class FeatureToFeatureConverter(sft: SimpleFeatureType,
-                                config: FeatureToFeatureConfig,
-                                fields: Seq[BasicField],
-                                options: BasicOptions)
-    extends AbstractConverter[SimpleFeature, FeatureToFeatureConfig, BasicField, BasicOptions](sft, config, fields, options)  {
+class FeatureToFeatureConverter(
+    sft: SimpleFeatureType,
+    config: FeatureToFeatureConfig,
+    fields: Seq[BasicField],
+    options: BasicOptions
+  ) extends AbstractConverter[SimpleFeature, FeatureToFeatureConfig, BasicField, BasicOptions](
+    sft, config, fields, options)  {
 
   override protected def parse(is: InputStream, ec: EvaluationContext): CloseableIterator[SimpleFeature] =
     throw new NotImplementedError()
@@ -41,7 +43,7 @@ class FeatureToFeatureConverter(sft: SimpleFeatureType,
                                 ec: EvaluationContext): CloseableIterator[Array[Any]] = {
     var array = Array.empty[Any]
     parsed.map { feature =>
-      ec.counter.incLineCount()
+      ec.line += 1
       if (feature.getAttributeCount + 1 != array.length) {
         array = Array.ofDim(feature.getAttributeCount + 1)
       }

--- a/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert2/simplefeature/FeatureToFeatureConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert2/simplefeature/FeatureToFeatureConverterFactory.scala
@@ -89,19 +89,22 @@ object FeatureToFeatureConverterFactory {
 
   private val InputSftPath = "input-sft"
 
-  case class FeatureToFeatureConfig(`type`: String,
-                                    inputSft: String,
-                                    idField: Option[Expression],
-                                    caches: Map[String, Config],
-                                    userData: Map[String, Expression]) extends ConverterConfig
+  case class FeatureToFeatureConfig(
+      `type`: String,
+      inputSft: String,
+      idField: Option[Expression],
+      caches: Map[String, Config],
+      userData: Map[String, Expression]
+    ) extends ConverterConfig
 
   object FeatureToFeatureConfigConvert extends ConverterConfigConvert[FeatureToFeatureConfig] with StrictLogging {
 
-    override protected def decodeConfig(cur: ConfigObjectCursor,
-                                        `type`: String,
-                                        idField: Option[Expression],
-                                        caches: Map[String, Config],
-                                        userData: Map[String, Expression]): Either[ConfigReaderFailures, FeatureToFeatureConfig] = {
+    override protected def decodeConfig(
+        cur: ConfigObjectCursor,
+        `type`: String,
+        idField: Option[Expression],
+        caches: Map[String, Config],
+        userData: Map[String, Expression]): Either[ConfigReaderFailures, FeatureToFeatureConfig] = {
       for { sftName <- cur.atKey(InputSftPath).right.flatMap(_.asString).right } yield {
         FeatureToFeatureConfig(`type`, sftName, idField, caches, userData)
       }

--- a/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
+++ b/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
@@ -16,9 +16,9 @@ import com.typesafe.config.Config
 import org.apache.commons.csv.{CSVFormat, CSVRecord, QuoteMode}
 import org.geotools.factory.GeoTools
 import org.geotools.util.Converters
+import org.locationtech.geomesa.convert.EvaluationContext
 import org.locationtech.geomesa.convert.Modes.{ErrorMode, ParseMode}
 import org.locationtech.geomesa.convert.text.DelimitedTextConverter.{DelimitedTextConfig, DelimitedTextOptions}
-import org.locationtech.geomesa.convert.{Counter, EvaluationContext}
 import org.locationtech.geomesa.convert2.AbstractConverter.BasicField
 import org.locationtech.geomesa.convert2._
 import org.locationtech.geomesa.convert2.transforms.Expression
@@ -30,16 +30,18 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.annotation.tailrec
 
-class DelimitedTextConverter(sft: SimpleFeatureType,
-                             config: DelimitedTextConfig,
-                             fields: Seq[BasicField],
-                             options: DelimitedTextOptions)
-    extends AbstractConverter[CSVRecord, DelimitedTextConfig, BasicField, DelimitedTextOptions](sft, config, fields, options) {
+class DelimitedTextConverter(
+    sft: SimpleFeatureType,
+    config: DelimitedTextConfig,
+    fields: Seq[BasicField],
+    options: DelimitedTextOptions
+  ) extends AbstractConverter[CSVRecord, DelimitedTextConfig, BasicField, DelimitedTextOptions](
+    sft, config, fields, options) {
 
   private val format = DelimitedTextConverter.createFormat(config.format, options)
 
   override protected def parse(is: InputStream, ec: EvaluationContext): CloseableIterator[CSVRecord] =
-    DelimitedTextConverter.iterator(format, is, options.encoding, options.skipLines.getOrElse(0), ec.counter)
+    DelimitedTextConverter.iterator(format, is, options.encoding, options.skipLines.getOrElse(0), ec)
 
   override protected def values(parsed: CloseableIterator[CSVRecord],
                                 ec: EvaluationContext): CloseableIterator[Array[Any]] = {
@@ -109,7 +111,7 @@ object DelimitedTextConverter {
     * @param is input stream
     * @param encoding charset
     * @param skip number of header lines to skip
-    * @param counter counter
+    * @param ec evalution context
     * @return
     */
   def iterator(
@@ -117,8 +119,8 @@ object DelimitedTextConverter {
       is: InputStream,
       encoding: Charset,
       skip: Int,
-      counter: Counter): CloseableIterator[CSVRecord] = {
-    new CsvIterator(format, is, encoding, skip, counter)
+      ec: EvaluationContext): CloseableIterator[CSVRecord] = {
+    new CsvIterator(format, is, encoding, skip, ec)
   }
 
   /**
@@ -218,6 +220,7 @@ object DelimitedTextConverter {
       escape: OptionalChar,
       delimiter: Option[Char],
       validators: Seq[String],
+      reporters: Map[String, Config],
       parseMode: ParseMode,
       errorMode: ErrorMode,
       encoding: Charset
@@ -244,9 +247,9 @@ object DelimitedTextConverter {
     * @param is input
     * @param encoding encoding
     * @param skip skip lines up front, used for e.g. headers
-    * @param counter counter
+    * @param ec evaluation context
     */
-  private class CsvIterator(format: CSVFormat, is: InputStream, encoding: Charset, skip: Int, counter: Counter)
+  private class CsvIterator(format: CSVFormat, is: InputStream, encoding: Charset, skip: Int, ec: EvaluationContext)
       extends CloseableIterator[CSVRecord] {
 
     private val parser = format.parse(new InputStreamReader(is, encoding))
@@ -263,10 +266,10 @@ object DelimitedTextConverter {
         val line = parser.getCurrentLineNumber
         if (line == lastLine) {
           // commons-csv doesn't always increment the line count for the final line in a file...
-          counter.incLineCount()
+          ec.line += 1
           lastLine = line + 1
         } else {
-          counter.incLineCount(line - lastLine)
+          ec.line += (line - lastLine)
           lastLine = line
         }
         if (lastLine <= skip) {

--- a/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterFactory.scala
@@ -82,7 +82,7 @@ class DelimitedTextConverterFactory
           }
 
           val options = DelimitedTextOptions(None, CharNotSpecified, CharNotSpecified, None,
-            SimpleFeatureValidator.default, ParseMode.Default, ErrorMode(), StandardCharsets.UTF_8)
+            SimpleFeatureValidator.default, Map.empty, ParseMode.Default, ErrorMode(), StandardCharsets.UTF_8)
 
           val config = configConvert.to(converterConfig)
               .withFallback(fieldConvert.to(fields))
@@ -131,27 +131,29 @@ object DelimitedTextConverterFactory {
 
   object DelimitedTextConfigConvert extends ConverterConfigConvert[DelimitedTextConfig] {
 
-    override protected def decodeConfig(cur: ConfigObjectCursor,
-                                        typ: String,
-                                        idField: Option[Expression],
-                                        caches: Map[String, Config],
-                                        userData: Map[String, Expression]): Either[ConfigReaderFailures, DelimitedTextConfig] = {
+    override protected def decodeConfig(
+        cur: ConfigObjectCursor,
+        typ: String,
+        idField: Option[Expression],
+        caches: Map[String, Config],
+        userData: Map[String, Expression]): Either[ConfigReaderFailures, DelimitedTextConfig] = {
       for { format <- cur.atKey("format").right.flatMap(_.asString).right } yield {
         DelimitedTextConfig(typ, format, idField, caches, userData)
       }
     }
 
-    override protected def encodeConfig(config: DelimitedTextConfig,
-                                        base: java.util.Map[String, AnyRef]): Unit = {
+    override protected def encodeConfig(
+        config: DelimitedTextConfig,
+        base: java.util.Map[String, AnyRef]): Unit = {
       base.put("format", config.format)
     }
-
   }
 
   object DelimitedTextOptionsConvert extends ConverterOptionsConvert[DelimitedTextOptions] {
     override protected def decodeOptions(
         cur: ConfigObjectCursor,
         validators: Seq[String],
+        reporters: Map[String, Config],
         parseMode: ParseMode,
         errorMode: ErrorMode,
         encoding: Charset): Either[ConfigReaderFailures, DelimitedTextOptions] = {
@@ -181,7 +183,7 @@ object DelimitedTextConverterFactory {
         escape    <- optionalChar("escape").right
         delimiter <- option("delimiter", PrimitiveConvert.charConfigReader).right
       } yield {
-        DelimitedTextOptions(skipLines, quote, escape, delimiter, validators, parseMode, errorMode, encoding)
+        DelimitedTextOptions(skipLines, quote, escape, delimiter, validators, reporters, parseMode, errorMode, encoding)
       }
     }
 

--- a/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterTest.scala
@@ -15,15 +15,15 @@ import java.util.Collections
 import com.google.common.hash.Hashing
 import com.google.common.io.Resources
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
-import org.locationtech.jts.geom.{Coordinate, GeometryFactory, Point}
 import org.apache.commons.csv.CSVFormat
 import org.geotools.factory.Hints
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.convert.{DefaultCounter, SimpleFeatureConverters}
+import org.locationtech.geomesa.convert.SimpleFeatureConverters
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.io.WithClose
 import org.locationtech.geomesa.utils.text.WKTUtils
+import org.locationtech.jts.geom.{Coordinate, GeometryFactory, Point}
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -345,15 +345,14 @@ class DelimitedTextConverterTest extends Specification {
         WithClose(SimpleFeatureConverter(wktSft, trueConf)) { converter =>
           converter must not(beNull)
 
-          val counter = new DefaultCounter
-          val ec = converter.createEvaluationContext(counter = counter)
+          val ec = converter.createEvaluationContext()
           val stream = new ByteArrayInputStream(trueData.getBytes(StandardCharsets.UTF_8))
           val res = WithClose(converter.process(stream, ec))(_.toList)
           res.length mustEqual 2
 
-          counter.getLineCount mustEqual 3
-          counter.getSuccess mustEqual 2
-          counter.getFailure mustEqual 0
+          ec.line mustEqual 3
+          ec.success.getCount mustEqual 2
+          ec.failure.getCount mustEqual 0
 
           val geoFac = new GeometryFactory()
           res(0).getDefaultGeometry mustEqual geoFac.createPoint(new Coordinate(46, 45))
@@ -369,14 +368,13 @@ class DelimitedTextConverterTest extends Specification {
         WithClose(SimpleFeatureConverter(wktSft, falseConf)) { converter =>
           converter must not(beNull)
 
-          val counter = new DefaultCounter
-          val ec = converter.createEvaluationContext(counter = counter)
+          val ec = converter.createEvaluationContext()
           val res = WithClose(converter.process(new ByteArrayInputStream(falseData.getBytes(StandardCharsets.UTF_8)), ec))(_.toList)
           res.length mustEqual 2
 
-          counter.getLineCount mustEqual 2
-          counter.getSuccess mustEqual 2
-          counter.getFailure mustEqual 0
+          ec.line mustEqual 2
+          ec.success.getCount mustEqual 2
+          ec.failure.getCount mustEqual 0
 
           val geoFac = new GeometryFactory()
           res(0).getDefaultGeometry mustEqual geoFac.createPoint(new Coordinate(46, 45))
@@ -394,14 +392,13 @@ class DelimitedTextConverterTest extends Specification {
         WithClose(SimpleFeatureConverter(wktSft, falseConf)) { converter =>
           converter must not(beNull)
 
-          val counter = new DefaultCounter
-          val ec = converter.createEvaluationContext(counter = counter)
+          val ec = converter.createEvaluationContext()
           val res = WithClose(converter.process(new ByteArrayInputStream(falseData.getBytes(StandardCharsets.UTF_8)), ec))(_.toList)
           res.length mustEqual 2
 
-          counter.getLineCount mustEqual 5
-          counter.getSuccess mustEqual 2
-          counter.getFailure mustEqual 0
+          ec.line mustEqual 5
+          ec.success.getCount mustEqual 2
+          ec.failure.getCount mustEqual 0
 
           val geoFac = new GeometryFactory()
           res(0).getDefaultGeometry mustEqual geoFac.createPoint(new Coordinate(46, 45))

--- a/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlCompositeConverter.scala
+++ b/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlCompositeConverter.scala
@@ -32,5 +32,5 @@ class XmlCompositeConverter(
   private val parser = new DocParser(xsd)
 
   override protected def parse(is: InputStream, ec: EvaluationContext): CloseableIterator[Element] =
-    XmlConverter.iterator(parser, is, encoding, lineMode, ec.counter)
+    XmlConverter.iterator(parser, is, encoding, lineMode, ec)
 }

--- a/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlConverterFactory.scala
@@ -70,11 +70,12 @@ object XmlConverterFactory {
 
     import scala.collection.JavaConverters._
 
-    override protected def decodeConfig(cur: ConfigObjectCursor,
-                                        `type`: String,
-                                        idField: Option[Expression],
-                                        caches: Map[String, Config],
-                                        userData: Map[String, Expression]): Either[ConfigReaderFailures, XmlConfig] = {
+    override protected def decodeConfig(
+        cur: ConfigObjectCursor,
+        `type`: String,
+        idField: Option[Expression],
+        caches: Map[String, Config],
+        userData: Map[String, Expression]): Either[ConfigReaderFailures, XmlConfig] = {
       for {
         provider   <- cur.atKey("xpath-factory").right.flatMap(_.asString).right
         namespace  <- cur.atKey("xml-namespaces").right.flatMap(_.asObjectCursor).right
@@ -118,6 +119,7 @@ object XmlConverterFactory {
     override protected def decodeOptions(
         cur: ConfigObjectCursor,
         validators: Seq[String],
+        reporters: Map[String, Config],
         parseMode: ParseMode,
         errorMode: ErrorMode,
         encoding: Charset): Either[ConfigReaderFailures, XmlOptions] = {
@@ -137,7 +139,7 @@ object XmlConverterFactory {
       for {
         lineMode <- parse("line-mode", LineMode.values).right
       } yield {
-        XmlOptions(validators, parseMode, errorMode, lineMode, encoding)
+        XmlOptions(validators, reporters, parseMode, errorMode, lineMode, encoding)
       }
     }
 

--- a/geomesa-convert/pom.xml
+++ b/geomesa-convert/pom.xml
@@ -20,6 +20,8 @@
         <module>geomesa-convert-fixedwidth</module>
         <module>geomesa-convert-jdbc</module>
         <module>geomesa-convert-json</module>
+        <module>geomesa-convert-metrics-ganglia</module>
+        <module>geomesa-convert-metrics-graphite</module>
         <module>geomesa-convert-osm</module>
         <module>geomesa-convert-redis-cache</module>
         <module>geomesa-convert-scripting</module>

--- a/geomesa-metrics/pom.xml
+++ b/geomesa-metrics/pom.xml
@@ -13,7 +13,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <metrics.version>3.1.2</metrics.version>
     </properties>
 
     <dependencyManagement>

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ConvertCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ConvertCommand.scala
@@ -75,10 +75,10 @@ class ConvertCommand extends Command with MethodProfiling with LazyLogging {
         WithClose(ConvertCommand.getExporter(params, output, query.getHints)) { exporter =>
           exporter.start(query.getHints.getReturnSft)
           val count = WithClose(ConvertCommand.convertFeatures(files, converter, ec, query))(exporter.export)
-          val records = ec.counter.getLineCount - (if (params.noHeader) { 0 } else { params.files.size })
+          val records = ec.line - (if (params.noHeader) { 0 } else { params.files.size })
           Command.user.info(s"Converted ${getPlural(records, "line")} "
-              + s"with ${getPlural(ec.counter.getSuccess, "success", "successes")} "
-              + s"and ${getPlural(ec.counter.getFailure, "failure")}")
+              + s"with ${getPlural(ec.success.getCount, "success", "successes")} "
+              + s"and ${getPlural(ec.failure.getCount, "failure")}")
           count
         }
       }

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <kryo.version>3.0.3</kryo.version>
         <arrow.version>0.10.0</arrow.version>
         <netty.version>4.1.17.Final</netty.version>
+        <metrics.version>3.1.2</metrics.version>
 
         <!-- environment-dependent versions -->
         <!-- These are compiled and pass CQs and should be compatible with recommended versions -->
@@ -1864,6 +1865,11 @@
                 <groupId>org.parboiled</groupId>
                 <artifactId>parboiled-core</artifactId>
                 <version>1.1.7</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>${metrics.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hsqldb</groupId>


### PR DESCRIPTION
* Metrics are exposed through the EvaluationContext or configurable reporters
* Validators publish success/failed metrics
* API change - AbstractConverter.ConverterOptions requires a `reporters` field

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>