### PR TITLE
GEOMESA-2628 Table partitioning indicates if no tables can match a filter

### DIFF
--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
@@ -172,12 +172,10 @@ abstract class GeoMesaFeatureIndex[T, U](val ds: GeoMesaDataStore[_],
     * @return
     */
   def getTablesForQuery(filter: Option[Filter]): Seq[String] = {
-    val partitions = filter.toSeq.flatMap(f => TablePartition(ds, sft).toSeq.flatMap(_.partitions(f)))
-    if (partitions.isEmpty) {
-      getTableNames(None)
-    } else {
+    val partitioned = for { f <- filter; tp <- TablePartition(ds, sft); partitions <- tp.partitions(f) } yield {
       partitions.flatMap(p => getTableNames(Some(p)))
     }
+    partitioned.getOrElse(getTableNames(None))
   }
 
   /**

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/partition/TablePartition.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/partition/TablePartition.scala
@@ -31,12 +31,12 @@ trait TablePartition {
 
   /**
     * Gets the partitions that intersect a given filter. If partitions can't be determined, (e.g. if the filter
-    * doesn't have a predicate on the partition), then an empty seq is returned
+    * doesn't have a predicate on the partition), then an empty option is returned
     *
     * @param filter filter
-    * @return partitions, or an empty seq representing all partitions
+    * @return partitions, or an empty option representing all partitions
     */
-  def partitions(filter: Filter): Seq[String]
+  def partitions(filter: Filter): Option[Seq[String]]
 
   /**
     * Convert from a partition back to a partition-able value

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/conf/partition/TablePartitionTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/conf/partition/TablePartitionTest.scala
@@ -68,7 +68,28 @@ class TablePartitionTest extends Specification {
       val partitionOption = TablePartition(ds, sft)
       partitionOption must beSome
       val partition = partitionOption.get
-      partition.partitions(filter).map(_.toShort) must containTheSameElementsAs(Seq.range(min, max + 1).map(_.toShort))
+      val partitionsOption = partition.partitions(filter)
+      partitionsOption must beSome
+      partitionsOption.get.map(_.toShort) must containTheSameElementsAs(Seq.range(min, max + 1).map(_.toShort))
+    }
+
+    "extract partitions from disjoint filters" in {
+      val filter = ECQL.toFilter("dtg < '2018-01-01T00:00:00.000Z' AND dtg > '2018-02-01T00:00:00.000Z'")
+      val partitionOption = TablePartition(ds, sft)
+      partitionOption must beSome
+      val partition = partitionOption.get
+      val partitionsOption = partition.partitions(filter)
+      partitionsOption must beSome
+      partitionsOption.get must beEmpty
+    }
+
+    "extract nothing from non-selective filters" in {
+      val filter = ECQL.toFilter("bbox(geom,-10,-10,10,10)")
+      val partitionOption = TablePartition(ds, sft)
+      partitionOption must beSome
+      val partition = partitionOption.get
+      val partitionsOption = partition.partitions(filter)
+      partitionsOption must beNone
     }
   }
 }


### PR DESCRIPTION
* TablePartition.partitions changed to return an Option[Seq[String]] to
  indicate disjoint filters

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>