### PR TITLE
GEOMESA-2652 Set explicit EMF dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1303,6 +1303,28 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+
+            <!--
+                `org.eclipse.emf` is a transitive dependency of gt-xsd-wfs, however the version number is
+                specified as `[2.15.0,3.0.0)`, which seems to intermittently trigger a maven bug. As of
+                06/17/19 the latest version is 2.15.0
+            -->
+            <dependency>
+                <groupId>org.eclipse.emf</groupId>
+                <artifactId>org.eclipse.emf.common</artifactId>
+                <version>2.15.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.emf</groupId>
+                <artifactId>org.eclipse.emf.ecore</artifactId>
+                <version>2.15.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.emf</groupId>
+                <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
+                <version>2.15.0</version>
+            </dependency>
+
             <dependency>
                 <groupId>commons-pool</groupId>
                 <artifactId>commons-pool</artifactId>


### PR DESCRIPTION
* Fix intermittent build failures due to version range in geotools poms

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>