### PR TITLE
GEOMESA-2656 Cache writers during local ingest

### DIFF
--- a/docs/user/cli/ingest.rst
+++ b/docs/user/cli/ingest.rst
@@ -126,3 +126,6 @@ disabled in this case, and progress indicators may not be entirely accurate, as 
 For example::
 
     cat foo.csv | geomesa-accumulo ingest ...
+
+For local ingests, feature writers will be pooled and only flushed periodically. The frequency of flushes can be
+controlled via the system property ``geomesa.ingest.local.batch.size``, and defaults to every 20,000 features.

--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -124,6 +124,12 @@ While the following filters both specify a 358-degree globe-spanning polygon:
   // no processing
   "intersects(geom, 'POLYGON((-179 90, 179 90, 179 -90, -179 -90, -179 90))')"
 
+geomesa.ingest.local.batch.size
++++++++++++++++++++++++++++++++
+
+Controls the batch size for local ingests via the command-line tools. By default, feature writers will be
+flushed every 20,000 features.
+
 geomesa.metadata.expiry
 +++++++++++++++++++++++
 

--- a/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/accumulo/tools/ingest/AccumuloIngestCommand.scala
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/accumulo/tools/ingest/AccumuloIngestCommand.scala
@@ -8,19 +8,38 @@
 
 package org.locationtech.geomesa.accumulo.tools.ingest
 
-import com.beust.jcommander.Parameters
+import com.beust.jcommander.{Parameter, Parameters}
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
 import org.locationtech.geomesa.accumulo.tools.AccumuloDataStoreCommand.AccumuloDistributedCommand
 import org.locationtech.geomesa.accumulo.tools.AccumuloDataStoreParams
 import org.locationtech.geomesa.accumulo.tools.ingest.AccumuloIngestCommand.AccumuloIngestParams
+import org.locationtech.geomesa.tools.Command
 import org.locationtech.geomesa.tools.ingest.IngestCommand
 import org.locationtech.geomesa.tools.ingest.IngestCommand.IngestParams
 
 class AccumuloIngestCommand extends IngestCommand[AccumuloDataStore] with AccumuloDistributedCommand {
   override val params = new AccumuloIngestParams()
+
+  override def execute(): Unit = {
+    super.execute()
+    if (params.compact) {
+      withDataStore { ds =>
+        if (ds.config.generateStats) {
+          Command.user.info("Triggering stat table compaction")
+          ds.stats.compact(wait = false)
+        }
+      }
+    }
+  }
 }
 
 object AccumuloIngestCommand {
   @Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")
-  class AccumuloIngestParams extends IngestParams with AccumuloDataStoreParams
+  class AccumuloIngestParams extends IngestParams with AccumuloDataStoreParams {
+    @Parameter(
+      names = Array("--compact-stats"),
+      description = "Compact stats table after ingest, for improved performance",
+      arity = 1)
+    var compact: Boolean = true
+  }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/CachedLazyMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/CachedLazyMetadata.scala
@@ -156,14 +156,16 @@ trait CachedLazyMetadata[T] extends GeoMesaMetadata[T] with LazyLogging {
     invalidate(metaDataScanCache, typeName)
   }
 
-  override def remove(typeName: String, key: String): Unit = {
+  override def remove(typeName: String, key: String): Unit = remove(typeName, Seq(key))
+
+  override def remove(typeName: String, keys: Seq[String]): Unit = {
     if (tableExists.get) {
-      delete(typeName, Seq(key))
+      delete(typeName, keys)
       // also remove from the cache
-      metaDataCache.invalidate((typeName, key))
+      keys.foreach(k => metaDataCache.invalidate((typeName, k)))
       invalidate(metaDataScanCache, typeName)
     } else {
-      logger.debug(s"Trying to delete '$typeName:$key' but table does not exist")
+      logger.debug(s"Trying to delete '$typeName: ${keys.mkString(", ")}' but table does not exist")
     }
   }
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/GeoMesaMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/GeoMesaMetadata.scala
@@ -49,6 +49,14 @@ trait GeoMesaMetadata[T] extends Closeable {
   def remove(typeName: String, key: String): Unit
 
   /**
+    * Delete multiple keys at once - may be more efficient than single deletes
+    *
+    * @param typeName simple feature type name
+    * @param keys keys
+    */
+  def remove(typeName: String, keys: Seq[String]): Unit
+
+  /**
    * Reads a value
    *
    * @param typeName simple feature type name

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/NoOpMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/NoOpMetadata.scala
@@ -18,6 +18,8 @@ class NoOpMetadata[T] extends GeoMesaMetadata[T] {
 
   override def remove(typeName: String, key: String): Unit = {}
 
+  override def remove(typeName: String, keys: Seq[String]): Unit = {}
+
   override def read(typeName: String, key: String, cache: Boolean): Option[T] = None
 
   override def scan(typeName: String, prefix: String, cache: Boolean): Seq[(String, T)] = Seq.empty

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/stats/MetadataBackedStats.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/stats/MetadataBackedStats.scala
@@ -127,7 +127,7 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
     import org.locationtech.geomesa.utils.geotools.GeoToolsDateFormat
 
     // calculate the stats we'll be gathering based on the simple feature type attributes
-    val statString = buildStatsFor(sft)
+    val statString = buildStatsFor(sft, bounds(sft))
 
     logger.debug(s"Calculating stats for ${sft.getTypeName}: $statString")
 
@@ -174,7 +174,7 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
   }
 
   override def statUpdater(sft: SimpleFeatureType): StatUpdater =
-    if (update) new MetadataStatUpdater(this, sft, Stat(sft, buildStatsFor(sft))) else NoopStatUpdater
+    if (update) { new MetadataStatUpdater(sft) } else { NoopStatUpdater }
 
   override def clearStats(sft: SimpleFeatureType): Unit = metadata.delete(sft.getTypeName)
 
@@ -252,9 +252,10 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
     * For any flagged attributes, we collect min/max and top-k
     *
     * @param sft simple feature type
+    * @param bounds lookup function for histogram bounds
     * @return stat string
     */
-  protected def buildStatsFor(sft: SimpleFeatureType): String = {
+  protected def buildStatsFor(sft: SimpleFeatureType, bounds: String => Option[MinMax[Any]]): String = {
     import GeoMesaStats._
     import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 
@@ -306,13 +307,7 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
       // calculate the endpoints for the histogram
       // the histogram will expand as needed, but this is a starting point
       val (lower, upper, cardinality) = {
-        val mm = try {
-          readStat[MinMax[Any]](sft, minMaxKey(attribute))
-        } catch {
-          case NonFatal(e) =>
-            logger.error("Error reading existing stats - possibly the distributed runtime jar is not available", e)
-            None
-        }
+        val mm = bounds(attribute)
         val (min, max) = mm match {
           case None => defaultBounds(binding)
           // max has to be greater than min for the histogram bounds
@@ -336,6 +331,65 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
     }
 
     Stat.SeqStat(Seq(count) ++ minMax ++ topK ++ histograms ++ frequencies ++ z3Histogram)
+  }
+
+  /**
+    * Default lookup function for histogram bounds
+    *
+    * @param sft simple feature type
+    * @param attribute attribute
+    * @return
+    */
+  private def bounds(sft: SimpleFeatureType)(attribute: String): Option[MinMax[Any]] = {
+    try {
+      readStat[MinMax[Any]](sft, minMaxKey(attribute))
+    } catch {
+      case NonFatal(e) =>
+        logger.error("Error reading existing stats - possibly the distributed runtime jar is not available", e)
+        None
+    }
+  }
+
+  /**
+    * Stores stats as metadata entries
+    *
+    * @param sft simple feature type
+    */
+  class MetadataStatUpdater(sft: SimpleFeatureType) extends StatUpdater with LazyLogging {
+
+    private var stat: Stat = Stat(sft, buildStatsFor(sft, bounds(sft)))
+
+    override def add(sf: SimpleFeature): Unit = stat.observe(sf)
+
+    override def remove(sf: SimpleFeature): Unit = stat.unobserve(sf)
+
+    override def close(): Unit = {
+      if (!stat.isEmpty) {
+        writeStat(stat, sft, merge = true)
+      }
+    }
+
+    override def flush(): Unit = {
+      if (!stat.isEmpty) {
+        writeStat(stat, sft, merge = true)
+      }
+      // reload the tracker - for long-held updaters, this will refresh the histogram ranges
+      stat = Stat(sft, buildStatsFor(sft, localBounds))
+    }
+
+    /**
+      * Get the bounds we've seen so far in this updater, but don't re-load from Accumulo as that
+      * can be slow
+      *
+      * @param attribute attribute
+      * @return
+      */
+    private def localBounds(attribute: String): Option[MinMax[Any]] = {
+      stat match {
+        case s: SeqStat => s.stats.collectFirst { case m: MinMax[Any] if m.property == attribute => m }
+        case _ => logger.error(s"Expected to have a SeqStat but got: $stat"); None
+      }
+    }
   }
 }
 
@@ -430,37 +484,5 @@ object MetadataBackedStats {
 
     override def deserialize(typeName: String, value: Array[Byte]): Stat =
       serializer(typeName).deserialize(value, immutable = true)
-  }
-
-  /**
-    * Stores stats as metadata entries
-    *
-    * @param stats persistence
-    * @param sft simple feature type
-    * @param statFunction creates stats for tracking new features - this will be re-created on flush,
-    *                     so that our bounds are more accurate
-    */
-  class MetadataStatUpdater(stats: MetadataBackedStats, sft: SimpleFeatureType, statFunction: => Stat)
-      extends StatUpdater with LazyLogging {
-
-    private var stat: Stat = statFunction
-
-    override def add(sf: SimpleFeature): Unit = stat.observe(sf)
-
-    override def remove(sf: SimpleFeature): Unit = stat.unobserve(sf)
-
-    override def close(): Unit = {
-      if (!stat.isEmpty) {
-        stats.writeStat(stat, sft, merge = true)
-      }
-    }
-
-    override def flush(): Unit = {
-      if (!stat.isEmpty) {
-        stats.writeStat(stat, sft, merge = true)
-      }
-      // reload the tracker - for long-held updaters, this will refresh the histogram ranges
-      stat = statFunction
-    }
   }
 }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/InMemoryMetadata.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/InMemoryMetadata.scala
@@ -31,6 +31,8 @@ class InMemoryMetadata[T] extends GeoMesaMetadata[T] {
     schemas.get(typeName).foreach(_.remove(key))
   }
 
+  override def remove(typeName: String, keys: Seq[String]): Unit = keys.foreach(remove(typeName, _))
+
   override def read(typeName: String, key: String, cache: Boolean): Option[T] = synchronized {
     schemas.get(typeName).flatMap(_.get(key))
   }

--- a/geomesa-kafka/geomesa-kafka-confluent/src/main/scala/org/locationtech/geomesa/kafka/confluent/ConfluentMetadata.scala
+++ b/geomesa-kafka/geomesa-kafka-confluent/src/main/scala/org/locationtech/geomesa/kafka/confluent/ConfluentMetadata.scala
@@ -81,6 +81,7 @@ class ConfluentMetadata(val schemaRegistry: SchemaRegistryClient) extends GeoMes
   override def insert(typeName: String, key: String, value: String): Unit = {}
   override def insert(typeName: String, kvPairs: Map[String, String]): Unit = {}
   override def remove(typeName: String, key: String): Unit = {}
+  override def remove(typeName: String, keys: Seq[String]): Unit = {}
   override def delete(typeName: String): Unit = {}
 }
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/IngestCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/IngestCommand.scala
@@ -27,6 +27,7 @@ import org.locationtech.geomesa.tools._
 import org.locationtech.geomesa.tools.ingest.IngestCommand.IngestParams
 import org.locationtech.geomesa.tools.utils.{CLArgResolver, Prompt}
 import org.locationtech.geomesa.utils.collection.CloseableIterator
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
 import org.locationtech.geomesa.utils.geotools.{ConfigSftParsing, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.io.fs.LocalDelegate.StdInHandle
 import org.locationtech.geomesa.utils.io.{CloseWithLogging, PathUtils, WithClose}
@@ -127,6 +128,8 @@ trait IngestCommand[DS <: DataStore] extends DataStoreCommand[DS] with Distribut
 }
 
 object IngestCommand extends LazyLogging {
+
+  val LocalBatchSize = SystemProperty("geomesa.ingest.local.batch.size", "20000")
 
   // @Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")
   trait IngestParams extends OptionalTypeNameParam with OptionalFeatureSpecParam with OptionalForceParam

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/CloseablePool.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/CloseablePool.scala
@@ -1,0 +1,75 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.io
+
+import java.io.Closeable
+
+import org.apache.commons.pool2.impl.{DefaultPooledObject, GenericObjectPool, GenericObjectPoolConfig}
+import org.apache.commons.pool2.{BasePooledObjectFactory, PooledObject}
+
+/**
+  * Pool for sharing a finite set of closeable resources
+  *
+  * @tparam T object type
+  */
+trait CloseablePool[T <: Closeable] extends Closeable {
+
+  /**
+    * Borrow an item from the pool. The item will be returned to the pool after execution.
+    *
+    * @param fn function to execute on the borrowed item
+    * @tparam U return type
+    * @return
+    */
+  def borrow[U](fn: T => U): U
+}
+
+object CloseablePool {
+
+  /**
+    * Create a pool
+    *
+    * @param factory method for instantiating pool objects
+    * @param size max size of the pool
+    * @tparam T object type
+    * @return
+    */
+  def apply[T <: Closeable](factory: => T, size: Int = 8): CloseablePool[T] = {
+    val config = new GenericObjectPoolConfig[T]()
+    config.setMaxTotal(size)
+    new CommonsPoolPool(factory, config)
+  }
+
+  /**
+    * Apache commons-pool-backed pool
+    *
+    * @param create factory method for creating new pool objects
+    * @param config pool configuration options
+    * @tparam T object type
+    */
+  class CommonsPoolPool[T <: Closeable](create: => T, config: GenericObjectPoolConfig[T]) extends CloseablePool[T] {
+
+    private val factory: BasePooledObjectFactory[T] = new BasePooledObjectFactory[T] {
+      override def wrap(obj: T) = new DefaultPooledObject[T](obj)
+      override def create(): T = CommonsPoolPool.this.create
+      override def destroyObject(p: PooledObject[T]): Unit = p.getObject.close()
+    }
+
+    private val pool = new GenericObjectPool[T](factory, config)
+
+    override def borrow[U](fn: T => U): U = {
+      val t = pool.borrowObject()
+      try { fn(t) } finally {
+        pool.returnObject(t)
+      }
+    }
+
+    override def close(): Unit = pool.close()
+  }
+}


### PR DESCRIPTION
* Flush each writer every 20k features
* Configurable via `geomesa.ingest.local.batch.size`
* New scala-friendly object pool impl:
  `org.locationtech.geomesa.utils.io.CloseablePool`

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>