### PR TITLE
GEOMESA-2656 Cache writers during local ingest

### DIFF
--- a/docs/user/cli/ingest.rst
+++ b/docs/user/cli/ingest.rst
@@ -126,3 +126,6 @@ disabled in this case, and progress indicators may not be entirely accurate, as 
 For example::
 
     cat foo.csv | geomesa-accumulo ingest ...
+
+For local ingests, feature writers will be pooled and only flushed periodically. The frequency of flushes can be
+controlled via the system property ``geomesa.ingest.local.batch.size``, and defaults to every 20,000 features.

--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -124,6 +124,12 @@ While the following filters both specify a 358-degree globe-spanning polygon:
   // no processing
   "intersects(geom, 'POLYGON((-179 90, 179 90, 179 -90, -179 -90, -179 90))')"
 
+geomesa.ingest.local.batch.size
++++++++++++++++++++++++++++++++
+
+Controls the batch size for local ingests via the command-line tools. By default, feature writers will be
+flushed every 20,000 features.
+
 geomesa.metadata.expiry
 +++++++++++++++++++++++
 

--- a/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/accumulo/tools/ingest/AccumuloIngestCommand.scala
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/accumulo/tools/ingest/AccumuloIngestCommand.scala
@@ -10,10 +10,12 @@ package org.locationtech.geomesa.accumulo.tools.ingest
 
 import java.io.File
 
-import com.beust.jcommander.Parameters
+import com.beust.jcommander.{Parameter, Parameters}
 import org.apache.accumulo.core.client.Connector
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
+import org.locationtech.geomesa.accumulo.tools.ingest.AccumuloIngestCommand.AccumuloIngestParams
 import org.locationtech.geomesa.accumulo.tools.{AccumuloDataStoreCommand, AccumuloDataStoreParams}
+import org.locationtech.geomesa.tools.Command
 import org.locationtech.geomesa.tools.ingest.IngestCommand
 import org.locationtech.geomesa.tools.ingest.IngestCommand.IngestParams
 import org.locationtech.geomesa.utils.classpath.ClassPathUtils
@@ -31,7 +33,27 @@ class AccumuloIngestCommand extends IngestCommand[AccumuloDataStore] with Accumu
     () => ClassPathUtils.getJarsFromClasspath(classOf[AccumuloDataStore]),
     () => ClassPathUtils.getJarsFromClasspath(classOf[Connector])
   )
+
+  override def execute(): Unit = {
+    super.execute()
+    if (params.compact) {
+      withDataStore { ds =>
+        if (ds.config.generateStats) {
+          Command.user.info("Triggering stat table compaction")
+          ds.stats.compact(wait = false)
+        }
+      }
+    }
+  }
 }
 
-@Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")
-class AccumuloIngestParams extends IngestParams with AccumuloDataStoreParams
+object AccumuloIngestCommand {
+  @Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")
+  class AccumuloIngestParams extends IngestParams with AccumuloDataStoreParams {
+    @Parameter(
+      names = Array("--compact-stats"),
+      description = "Compact stats table after ingest, for improved performance",
+      arity = 1)
+    var compact: Boolean = true
+  }
+}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/CachedLazyMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/CachedLazyMetadata.scala
@@ -156,14 +156,16 @@ trait CachedLazyMetadata[T] extends GeoMesaMetadata[T] with LazyLogging {
     invalidate(metaDataScanCache, typeName)
   }
 
-  override def remove(typeName: String, key: String): Unit = {
+  override def remove(typeName: String, key: String): Unit = remove(typeName, Seq(key))
+
+  override def remove(typeName: String, keys: Seq[String]): Unit = {
     if (tableExists.get) {
-      delete(typeName, Seq(key))
+      delete(typeName, keys)
       // also remove from the cache
-      metaDataCache.invalidate((typeName, key))
+      keys.foreach(k => metaDataCache.invalidate((typeName, k)))
       invalidate(metaDataScanCache, typeName)
     } else {
-      logger.debug(s"Trying to delete '$typeName:$key' but table does not exist")
+      logger.debug(s"Trying to delete '$typeName: ${keys.mkString(", ")}' but table does not exist")
     }
   }
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/GeoMesaMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/GeoMesaMetadata.scala
@@ -49,6 +49,14 @@ trait GeoMesaMetadata[T] extends Closeable {
   def remove(typeName: String, key: String): Unit
 
   /**
+    * Delete multiple keys at once - may be more efficient than single deletes
+    *
+    * @param typeName simple feature type name
+    * @param keys keys
+    */
+  def remove(typeName: String, keys: Seq[String]): Unit
+
+  /**
    * Reads a value
    *
    * @param typeName simple feature type name

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/NoOpMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/NoOpMetadata.scala
@@ -18,6 +18,8 @@ class NoOpMetadata[T] extends GeoMesaMetadata[T] {
 
   override def remove(typeName: String, key: String): Unit = {}
 
+  override def remove(typeName: String, keys: Seq[String]): Unit = {}
+
   override def read(typeName: String, key: String, cache: Boolean): Option[T] = None
 
   override def scan(typeName: String, prefix: String, cache: Boolean): Seq[(String, T)] = Seq.empty

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/stats/MetadataBackedStats.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/stats/MetadataBackedStats.scala
@@ -127,7 +127,7 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
     import org.locationtech.geomesa.utils.geotools.GeoToolsDateFormat
 
     // calculate the stats we'll be gathering based on the simple feature type attributes
-    val statString = buildStatsFor(sft)
+    val statString = buildStatsFor(sft, bounds(sft))
 
     logger.debug(s"Calculating stats for ${sft.getTypeName}: $statString")
 
@@ -174,7 +174,7 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
   }
 
   override def statUpdater(sft: SimpleFeatureType): StatUpdater =
-    if (update) new MetadataStatUpdater(this, sft, Stat(sft, buildStatsFor(sft))) else NoopStatUpdater
+    if (update) { new MetadataStatUpdater(sft) } else { NoopStatUpdater }
 
   override def clearStats(sft: SimpleFeatureType): Unit = metadata.delete(sft.getTypeName)
 
@@ -252,9 +252,10 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
     * For any flagged attributes, we collect min/max and top-k
     *
     * @param sft simple feature type
+    * @param bounds lookup function for histogram bounds
     * @return stat string
     */
-  protected def buildStatsFor(sft: SimpleFeatureType): String = {
+  protected def buildStatsFor(sft: SimpleFeatureType, bounds: String => Option[MinMax[Any]]): String = {
     import GeoMesaStats._
     import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 
@@ -306,13 +307,7 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
       // calculate the endpoints for the histogram
       // the histogram will expand as needed, but this is a starting point
       val (lower, upper, cardinality) = {
-        val mm = try {
-          readStat[MinMax[Any]](sft, minMaxKey(attribute))
-        } catch {
-          case NonFatal(e) =>
-            logger.error("Error reading existing stats - possibly the distributed runtime jar is not available", e)
-            None
-        }
+        val mm = bounds(attribute)
         val (min, max) = mm match {
           case None => defaultBounds(binding)
           // max has to be greater than min for the histogram bounds
@@ -336,6 +331,65 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
     }
 
     Stat.SeqStat(Seq(count) ++ minMax ++ topK ++ histograms ++ frequencies ++ z3Histogram)
+  }
+
+  /**
+    * Default lookup function for histogram bounds
+    *
+    * @param sft simple feature type
+    * @param attribute attribute
+    * @return
+    */
+  private def bounds(sft: SimpleFeatureType)(attribute: String): Option[MinMax[Any]] = {
+    try {
+      readStat[MinMax[Any]](sft, minMaxKey(attribute))
+    } catch {
+      case NonFatal(e) =>
+        logger.error("Error reading existing stats - possibly the distributed runtime jar is not available", e)
+        None
+    }
+  }
+
+  /**
+    * Stores stats as metadata entries
+    *
+    * @param sft simple feature type
+    */
+  class MetadataStatUpdater(sft: SimpleFeatureType) extends StatUpdater with LazyLogging {
+
+    private var stat: Stat = Stat(sft, buildStatsFor(sft, bounds(sft)))
+
+    override def add(sf: SimpleFeature): Unit = stat.observe(sf)
+
+    override def remove(sf: SimpleFeature): Unit = stat.unobserve(sf)
+
+    override def close(): Unit = {
+      if (!stat.isEmpty) {
+        writeStat(stat, sft, merge = true)
+      }
+    }
+
+    override def flush(): Unit = {
+      if (!stat.isEmpty) {
+        writeStat(stat, sft, merge = true)
+      }
+      // reload the tracker - for long-held updaters, this will refresh the histogram ranges
+      stat = Stat(sft, buildStatsFor(sft, localBounds))
+    }
+
+    /**
+      * Get the bounds we've seen so far in this updater, but don't re-load from Accumulo as that
+      * can be slow
+      *
+      * @param attribute attribute
+      * @return
+      */
+    private def localBounds(attribute: String): Option[MinMax[Any]] = {
+      stat match {
+        case s: SeqStat => s.stats.collectFirst { case m: MinMax[Any] if m.property == attribute => m }
+        case _ => logger.error(s"Expected to have a SeqStat but got: $stat"); None
+      }
+    }
   }
 }
 
@@ -430,37 +484,5 @@ object MetadataBackedStats {
 
     override def deserialize(typeName: String, value: Array[Byte]): Stat =
       serializer(typeName).deserialize(value, immutable = true)
-  }
-
-  /**
-    * Stores stats as metadata entries
-    *
-    * @param stats persistence
-    * @param sft simple feature type
-    * @param statFunction creates stats for tracking new features - this will be re-created on flush,
-    *                     so that our bounds are more accurate
-    */
-  class MetadataStatUpdater(stats: MetadataBackedStats, sft: SimpleFeatureType, statFunction: => Stat)
-      extends StatUpdater with LazyLogging {
-
-    private var stat: Stat = statFunction
-
-    override def add(sf: SimpleFeature): Unit = stat.observe(sf)
-
-    override def remove(sf: SimpleFeature): Unit = stat.unobserve(sf)
-
-    override def close(): Unit = {
-      if (!stat.isEmpty) {
-        stats.writeStat(stat, sft, merge = true)
-      }
-    }
-
-    override def flush(): Unit = {
-      if (!stat.isEmpty) {
-        stats.writeStat(stat, sft, merge = true)
-      }
-      // reload the tracker - for long-held updaters, this will refresh the histogram ranges
-      stat = statFunction
-    }
   }
 }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/InMemoryMetadata.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/InMemoryMetadata.scala
@@ -31,6 +31,8 @@ class InMemoryMetadata[T] extends GeoMesaMetadata[T] {
     schemas.get(typeName).foreach(_.remove(key))
   }
 
+  override def remove(typeName: String, keys: Seq[String]): Unit = keys.foreach(remove(typeName, _))
+
   override def read(typeName: String, key: String, cache: Boolean): Option[T] = synchronized {
     schemas.get(typeName).flatMap(_.get(key))
   }

--- a/geomesa-kafka/geomesa-kafka-confluent/src/main/scala/org/locationtech/geomesa/kafka/confluent/ConfluentMetadata.scala
+++ b/geomesa-kafka/geomesa-kafka-confluent/src/main/scala/org/locationtech/geomesa/kafka/confluent/ConfluentMetadata.scala
@@ -81,6 +81,7 @@ class ConfluentMetadata(val schemaRegistry: SchemaRegistryClient) extends GeoMes
   override def insert(typeName: String, key: String, value: String): Unit = {}
   override def insert(typeName: String, kvPairs: Map[String, String]): Unit = {}
   override def remove(typeName: String, key: String): Unit = {}
+  override def remove(typeName: String, keys: Seq[String]): Unit = {}
   override def delete(typeName: String): Unit = {}
 }
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/IngestCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/IngestCommand.scala
@@ -27,6 +27,7 @@ import org.locationtech.geomesa.tools._
 import org.locationtech.geomesa.tools.ingest.IngestCommand.IngestParams
 import org.locationtech.geomesa.tools.utils.{CLArgResolver, Prompt}
 import org.locationtech.geomesa.utils.collection.CloseableIterator
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
 import org.locationtech.geomesa.utils.geotools.{ConfigSftParsing, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.io.fs.LocalDelegate.StdInHandle
 import org.locationtech.geomesa.utils.io.{CloseWithLogging, PathUtils, WithClose}
@@ -128,6 +129,8 @@ trait IngestCommand[DS <: DataStore] extends DataStoreCommand[DS] with Interacti
 }
 
 object IngestCommand extends LazyLogging {
+
+  val LocalBatchSize = SystemProperty("geomesa.ingest.local.batch.size", "20000")
 
   // @Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")
   trait IngestParams extends OptionalTypeNameParam with OptionalFeatureSpecParam with OptionalForceParam

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/LocalConverterIngest.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/LocalConverterIngest.scala
@@ -8,13 +8,12 @@
 
 package org.locationtech.geomesa.tools.ingest
 
-import java.util.concurrent.Executors
+import java.io.Flushable
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+import java.util.concurrent.{ConcurrentHashMap, Executors}
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.commons.pool2.impl.{DefaultPooledObject, GenericObjectPool}
-import org.apache.commons.pool2.{BasePooledObjectFactory, PooledObject}
 import org.geotools.data.{DataStore, DataUtilities, FeatureWriter, Transaction}
 import org.locationtech.geomesa.convert.{DefaultCounter, EvaluationContext}
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
@@ -25,7 +24,7 @@ import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.locationtech.geomesa.utils.geotools.FeatureUtils
 import org.locationtech.geomesa.utils.io.fs.FileSystemDelegate.FileHandle
 import org.locationtech.geomesa.utils.io.fs.LocalDelegate.StdInHandle
-import org.locationtech.geomesa.utils.io.{CloseWithLogging, PathUtils, WithClose}
+import org.locationtech.geomesa.utils.io.{CloseWithLogging, CloseablePool, PathUtils, WithClose}
 import org.locationtech.geomesa.utils.text.TextTools
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
@@ -59,13 +58,22 @@ class LocalConverterIngest(
   override protected def runIngest(ds: DataStore, sft: SimpleFeatureType, callback: StatusCallback): Unit = {
     Command.user.info("Running ingestion in local mode")
 
-    val converters = new GenericObjectPool[SimpleFeatureConverter](
-      new BasePooledObjectFactory[SimpleFeatureConverter] {
-        override def wrap(obj: SimpleFeatureConverter) = new DefaultPooledObject[SimpleFeatureConverter](obj)
-        override def create(): SimpleFeatureConverter = SimpleFeatureConverter(sft, converterConfig)
-        override def destroyObject(p: PooledObject[SimpleFeatureConverter]): Unit = p.getObject.close()
-      }
-    )
+    val start = System.currentTimeMillis()
+
+    // if inputs is empty, we've already validated that stdin has data to read
+    val stdin = inputs.isEmpty
+    val files = if (stdin) { StdInHandle.available().toSeq } else { inputs.flatMap(PathUtils.interpretPath) }
+
+    val threads = if (numThreads <= files.length) { numThreads } else {
+      Command.user.warn("Can't use more threads than there are input files - reducing thread count")
+      files.length
+    }
+
+    val batch = IngestCommand.LocalBatchSize.toInt.getOrElse {
+      throw new IllegalArgumentException(
+        s"Invalid batch size for property ${IngestCommand.LocalBatchSize.property}: " +
+            IngestCommand.LocalBatchSize.get)
+    }
 
     // global counts shared among threads
     val written = new AtomicLong(0)
@@ -74,100 +82,103 @@ class LocalConverterIngest(
 
     val bytesRead = new AtomicLong(0L)
 
-    class LocalIngestWorker(file: FileHandle) extends Runnable {
-      override def run(): Unit = {
-        try {
-          val converter = converters.borrowObject()
-          val counter = new LocalIngestCounter(failed)
-          val ec = converter.createEvaluationContext(EvaluationContext.inputFileParam(file.path), counter = counter)
+    val converters = CloseablePool(SimpleFeatureConverter(sft, converterConfig), threads)
+    val writers = CloseablePool(ds.getFeatureWriterAppend(sft.getTypeName, Transaction.AUTO_COMMIT), threads)
+    val batches = new ConcurrentHashMap[FeatureWriter[SimpleFeatureType, SimpleFeature], AtomicInteger](threads)
 
-          var fw: FeatureWriter[SimpleFeatureType, SimpleFeature] = null
-
+    try {
+      class LocalIngestWorker(file: FileHandle) extends Runnable {
+        override def run(): Unit = {
           try {
-            WithClose(file.open) { streams =>
-              streams.foreach { case (name, is) =>
-                ec.setInputFilePath(name.getOrElse(file.path))
-                val features = LocalConverterIngest.this.features(converter.process(is, ec))
-                if (fw == null && features.hasNext) {
-                  fw = ds.getFeatureWriterAppend(sft.getTypeName, Transaction.AUTO_COMMIT)
-                }
-                features.foreach { sf =>
-                  FeatureUtils.copyToWriter(fw, sf, useProvidedFid = true)
-                  try {
-                    fw.write()
-                    written.incrementAndGet()
-                  } catch {
-                    case NonFatal(e) =>
-                      logger.error(s"Failed to write '${DataUtilities.encodeFeature(sf)}'", e)
-                      failed.incrementAndGet()
+            converters.borrow { converter =>
+              val counter = new LocalIngestCounter(failed)
+              val ec = converter.createEvaluationContext(EvaluationContext.inputFileParam(file.path), counter = counter)
+              WithClose(file.open) { streams =>
+                streams.foreach { case (name, is) =>
+                  ec.setInputFilePath(name.getOrElse(file.path))
+                  val features = LocalConverterIngest.this.features(converter.process(is, ec))
+                  writers.borrow { writer =>
+                    var count = batches.get(writer)
+                    if (count == null) {
+                      count = new AtomicInteger(0)
+                      batches.put(writer, count)
+                    }
+                    features.foreach { sf =>
+                      FeatureUtils.copyToWriter(writer, sf, useProvidedFid = true)
+                      try {
+                        writer.write()
+                        written.incrementAndGet()
+                        count.incrementAndGet()
+                      } catch {
+                        case NonFatal(e) =>
+                          logger.error(s"Failed to write '${DataUtilities.encodeFeature(sf)}'", e)
+                          failed.incrementAndGet()
+                      }
+                      if (count.get % batch == 0) {
+                        count.set(0)
+                        writer match {
+                          case f: Flushable => f.flush()
+                          case _ => // no-op
+                        }
+                      }
+                    }
                   }
                 }
               }
             }
-          } finally {
-            converters.returnObject(converter)
-            bytesRead.addAndGet(file.length)
-            if (fw != null) {
-              fw.close() // allow exception to propagate
-            }
-          }
-        } catch {
-          case e @ (_: ClassNotFoundException | _: NoClassDefFoundError) =>
-            // Rethrow exception so it can be caught by getting the future of this runnable in the main thread
-            // which will in turn cause the exception to be handled by org.locationtech.geomesa.tools.Runner
-            // Likely all threads will fail if a dependency is missing so it will terminate quickly
-            throw e
+          } catch {
+            case e @ (_: ClassNotFoundException | _: NoClassDefFoundError) =>
+              // Rethrow exception so it can be caught by getting the future of this runnable in the main thread
+              // which will in turn cause the exception to be handled by org.locationtech.geomesa.tools.Runner
+              // Likely all threads will fail if a dependency is missing so it will terminate quickly
+              throw e
 
-          case NonFatal(e) =>
-            // Don't kill the entire program b/c this thread was bad! use outer try/catch
-            val msg = s"Fatal error running local ingest worker on ${file.path}"
-            Command.user.error(msg)
-            logger.error(msg, e)
-            errors.incrementAndGet()
+            case NonFatal(e) =>
+              // Don't kill the entire program b/c this thread was bad! use outer try/catch
+              val msg = s"Fatal error running local ingest worker on ${file.path}"
+              Command.user.error(msg)
+              logger.error(msg, e)
+              errors.incrementAndGet()
+          } finally {
+            bytesRead.addAndGet(file.length)
+          }
         }
       }
+
+      Command.user.info(s"Ingesting ${if (stdin) { "from stdin" } else { TextTools.getPlural(files.length, "file") }} " +
+          s"with ${TextTools.getPlural(threads, "thread")}")
+
+      val totalLength: () => Float = if (stdin) {
+        () => (bytesRead.get + files.map(_.length).sum).toFloat // re-evaluate each time as bytes are read from stdin
+      } else {
+        val length = files.map(_.length).sum.toFloat // only evaluate once
+        () => length
+      }
+
+      def progress(): Float = bytesRead.get() / totalLength()
+
+      val start = System.currentTimeMillis()
+      val es = Executors.newFixedThreadPool(threads)
+      val futures = files.map(f => es.submit(new LocalIngestWorker(f))).toList
+      es.shutdown()
+
+      def counters = Seq(("ingested", written.get()), ("failed", failed.get()))
+
+      while (!es.isTerminated) {
+        Thread.sleep(500)
+        callback("", progress(), counters, done = false)
+      }
+      callback("", progress(), counters, done = true)
+
+      CloseWithLogging(converters)
+
+      // Get all futures so that we can propagate the logging up to the top level for handling
+      // in org.locationtech.geomesa.tools.Runner to catch missing dependencies
+      futures.foreach(_.get)
+    } finally {
+      CloseWithLogging(converters)
+      CloseWithLogging(writers).foreach(_ => errors.incrementAndGet())
     }
-
-    // if inputs is empty, we've already validated that stdin has data to read
-    val stdin = inputs.isEmpty
-
-    val files = if (stdin) { StdInHandle.available().toSeq } else { inputs.flatMap(PathUtils.interpretPath) }
-
-    val threads = if (numThreads <= files.length) { numThreads } else {
-      Command.user.warn("Can't use more threads than there are input files - reducing thread count")
-      files.length
-    }
-
-    Command.user.info(s"Ingesting ${if (stdin) { "from stdin" } else { TextTools.getPlural(files.length, "file") }} " +
-        s"with ${TextTools.getPlural(threads, "thread")}")
-
-    val totalLength: () => Float = if (stdin) {
-      () => (bytesRead.get + files.map(_.length).sum).toFloat // re-evaluate each time as bytes are read from stdin
-    } else {
-      val length = files.map(_.length).sum.toFloat // only evaluate once
-      () => length
-    }
-
-    def progress(): Float = bytesRead.get() / totalLength()
-
-    val start = System.currentTimeMillis()
-    val es = Executors.newFixedThreadPool(threads)
-    val futures = files.map(f => es.submit(new LocalIngestWorker(f))).toList
-    es.shutdown()
-
-    def counters = Seq(("ingested", written.get()), ("failed", failed.get()))
-
-    while (!es.isTerminated) {
-      Thread.sleep(500)
-      callback("", progress(), counters, done = false)
-    }
-    callback("", progress(), counters, done = true)
-
-    CloseWithLogging(converters)
-
-    // Get all futures so that we can propagate the logging up to the top level for handling
-    // in org.locationtech.geomesa.tools.Runner to catch missing dependencies
-    futures.foreach(_.get)
 
     Command.user.info(s"Local ingestion complete in ${TextTools.getTime(start)}")
     if (files.lengthCompare(1) == 0) {

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/CloseablePool.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/CloseablePool.scala
@@ -1,0 +1,75 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.io
+
+import java.io.Closeable
+
+import org.apache.commons.pool2.impl.{DefaultPooledObject, GenericObjectPool, GenericObjectPoolConfig}
+import org.apache.commons.pool2.{BasePooledObjectFactory, PooledObject}
+
+/**
+  * Pool for sharing a finite set of closeable resources
+  *
+  * @tparam T object type
+  */
+trait CloseablePool[T <: Closeable] extends Closeable {
+
+  /**
+    * Borrow an item from the pool. The item will be returned to the pool after execution.
+    *
+    * @param fn function to execute on the borrowed item
+    * @tparam U return type
+    * @return
+    */
+  def borrow[U](fn: T => U): U
+}
+
+object CloseablePool {
+
+  /**
+    * Create a pool
+    *
+    * @param factory method for instantiating pool objects
+    * @param size max size of the pool
+    * @tparam T object type
+    * @return
+    */
+  def apply[T <: Closeable](factory: => T, size: Int = 8): CloseablePool[T] = {
+    val config = new GenericObjectPoolConfig[T]()
+    config.setMaxTotal(size)
+    new CommonsPoolPool(factory, config)
+  }
+
+  /**
+    * Apache commons-pool-backed pool
+    *
+    * @param create factory method for creating new pool objects
+    * @param config pool configuration options
+    * @tparam T object type
+    */
+  class CommonsPoolPool[T <: Closeable](create: => T, config: GenericObjectPoolConfig[T]) extends CloseablePool[T] {
+
+    private val factory: BasePooledObjectFactory[T] = new BasePooledObjectFactory[T] {
+      override def wrap(obj: T) = new DefaultPooledObject[T](obj)
+      override def create(): T = CommonsPoolPool.this.create
+      override def destroyObject(p: PooledObject[T]): Unit = p.getObject.close()
+    }
+
+    private val pool = new GenericObjectPool[T](factory, config)
+
+    override def borrow[U](fn: T => U): U = {
+      val t = pool.borrowObject()
+      try { fn(t) } finally {
+        pool.returnObject(t)
+      }
+    }
+
+    override def close(): Unit = pool.close()
+  }
+}


### PR DESCRIPTION
* Flush each writer every 20k features
* Configurable via `geomesa.ingest.local.batch.size`
* New scala-friendly object pool impl:
  `org.locationtech.geomesa.utils.io.CloseablePool`

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>