### PR TITLE
GEOMESA-2656 Cache writers during local ingest

### DIFF
--- a/docs/user/cli/ingest.rst
+++ b/docs/user/cli/ingest.rst
@@ -122,3 +122,6 @@ disabled in this case, and progress indicators may not be entirely accurate, as 
 For example::
 
     cat foo.csv | geomesa-accumulo ingest ...
+
+For local ingests, feature writers will be pooled and only flushed periodically. The frequency of flushes can be
+controlled via the system property ``geomesa.ingest.local.batch.size``, and defaults to every 20,000 features.

--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -88,6 +88,12 @@ front, so estimates will cause problems. To force GeoMesa to calculate the exact
 set, you may set this property to ``true``. You may also override this behavior on a per-query basis
 by using the query hint ``org.locationtech.geomesa.accumulo.index.QueryHints.EXACT_COUNT``.
 
+geomesa.ingest.local.batch.size
++++++++++++++++++++++++++++++++
+
+Controls the batch size for local ingests via the command-line tools. By default, feature writers will be
+flushed every 20,000 features.
+
 geomesa.metadata.expiry
 +++++++++++++++++++++++
 

--- a/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/accumulo/tools/ingest/AccumuloIngestCommand.scala
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/accumulo/tools/ingest/AccumuloIngestCommand.scala
@@ -10,10 +10,12 @@ package org.locationtech.geomesa.accumulo.tools.ingest
 
 import java.io.File
 
-import com.beust.jcommander.Parameters
+import com.beust.jcommander.{Parameter, Parameters}
 import org.apache.accumulo.core.client.Connector
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
+import org.locationtech.geomesa.accumulo.tools.ingest.AccumuloIngestCommand.AccumuloIngestParams
 import org.locationtech.geomesa.accumulo.tools.{AccumuloDataStoreCommand, AccumuloDataStoreParams}
+import org.locationtech.geomesa.tools.Command
 import org.locationtech.geomesa.tools.ingest.{IngestCommand, IngestParams}
 import org.locationtech.geomesa.utils.classpath.ClassPathUtils
 
@@ -30,7 +32,27 @@ class AccumuloIngestCommand extends IngestCommand[AccumuloDataStore] with Accumu
     () => ClassPathUtils.getJarsFromClasspath(classOf[AccumuloDataStore]),
     () => ClassPathUtils.getJarsFromClasspath(classOf[Connector])
   )
+
+  override def execute(): Unit = {
+    super.execute()
+    if (params.compact) {
+      withDataStore { ds =>
+        if (ds.config.generateStats) {
+          Command.user.info("Triggering stat table compaction")
+          ds.stats.compact(wait = false)
+        }
+      }
+    }
+  }
 }
 
-@Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")
-class AccumuloIngestParams extends IngestParams with AccumuloDataStoreParams
+object AccumuloIngestCommand {
+  @Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")
+  class AccumuloIngestParams extends IngestParams with AccumuloDataStoreParams {
+    @Parameter(
+      names = Array("--compact-stats"),
+      description = "Compact stats table after ingest, for improved performance",
+      arity = 1)
+    var compact: Boolean = true
+  }
+}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/CachedLazyMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/CachedLazyMetadata.scala
@@ -156,14 +156,16 @@ trait CachedLazyMetadata[T] extends GeoMesaMetadata[T] with LazyLogging {
     invalidate(metaDataScanCache, typeName)
   }
 
-  override def remove(typeName: String, key: String): Unit = {
+  override def remove(typeName: String, key: String): Unit = remove(typeName, Seq(key))
+
+  override def remove(typeName: String, keys: Seq[String]): Unit = {
     if (tableExists.get) {
-      delete(typeName, Seq(key))
+      delete(typeName, keys)
       // also remove from the cache
-      metaDataCache.invalidate((typeName, key))
+      keys.foreach(k => metaDataCache.invalidate((typeName, k)))
       invalidate(metaDataScanCache, typeName)
     } else {
-      logger.debug(s"Trying to delete '$typeName:$key' but table does not exist")
+      logger.debug(s"Trying to delete '$typeName: ${keys.mkString(", ")}' but table does not exist")
     }
   }
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/GeoMesaMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/GeoMesaMetadata.scala
@@ -49,6 +49,14 @@ trait GeoMesaMetadata[T] extends Closeable {
   def remove(typeName: String, key: String): Unit
 
   /**
+    * Delete multiple keys at once - may be more efficient than single deletes
+    *
+    * @param typeName simple feature type name
+    * @param keys keys
+    */
+  def remove(typeName: String, keys: Seq[String]): Unit
+
+  /**
    * Reads a value
    *
    * @param typeName simple feature type name

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/NoOpMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/NoOpMetadata.scala
@@ -18,6 +18,8 @@ class NoOpMetadata[T] extends GeoMesaMetadata[T] {
 
   override def remove(typeName: String, key: String): Unit = {}
 
+  override def remove(typeName: String, keys: Seq[String]): Unit = {}
+
   override def read(typeName: String, key: String, cache: Boolean): Option[T] = None
 
   override def scan(typeName: String, prefix: String, cache: Boolean): Seq[(String, T)] = Seq.empty

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/InMemoryMetadata.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/InMemoryMetadata.scala
@@ -31,6 +31,8 @@ class InMemoryMetadata[T] extends GeoMesaMetadata[T] {
     schemas.get(typeName).foreach(_.remove(key))
   }
 
+  override def remove(typeName: String, keys: Seq[String]): Unit = keys.foreach(remove(typeName, _))
+
   override def read(typeName: String, key: String, cache: Boolean): Option[T] = synchronized {
     schemas.get(typeName).flatMap(_.get(key))
   }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/IngestCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/IngestCommand.scala
@@ -23,6 +23,7 @@ import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.tools.DistributedRunParam.RunModes
 import org.locationtech.geomesa.tools._
 import org.locationtech.geomesa.tools.utils.{CLArgResolver, DataFormats, Prompt}
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
 import org.locationtech.geomesa.utils.geotools.{ConfigSftParsing, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.io.{PathUtils, WithClose}
 import org.opengis.feature.simple.SimpleFeatureType
@@ -191,6 +192,10 @@ trait IngestCommand[DS <: DataStore] extends DataStoreCommand[DS] with Interacti
         Command.user.error(s"Error trying to persist inferred schema: $e")
     }
   }
+}
+
+object IngestCommand {
+  val LocalBatchSize = SystemProperty("geomesa.ingest.local.batch.size", "20000")
 }
 
 // @Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/CloseablePool.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/CloseablePool.scala
@@ -1,0 +1,75 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.io
+
+import java.io.Closeable
+
+import org.apache.commons.pool2.impl.{DefaultPooledObject, GenericObjectPool, GenericObjectPoolConfig}
+import org.apache.commons.pool2.{BasePooledObjectFactory, PooledObject}
+
+/**
+  * Pool for sharing a finite set of closeable resources
+  *
+  * @tparam T object type
+  */
+trait CloseablePool[T <: Closeable] extends Closeable {
+
+  /**
+    * Borrow an item from the pool. The item will be returned to the pool after execution.
+    *
+    * @param fn function to execute on the borrowed item
+    * @tparam U return type
+    * @return
+    */
+  def borrow[U](fn: T => U): U
+}
+
+object CloseablePool {
+
+  /**
+    * Create a pool
+    *
+    * @param factory method for instantiating pool objects
+    * @param size max size of the pool
+    * @tparam T object type
+    * @return
+    */
+  def apply[T <: Closeable](factory: => T, size: Int = 8): CloseablePool[T] = {
+    val config = new GenericObjectPoolConfig()
+    config.setMaxTotal(size)
+    new CommonsPoolPool(factory, config)
+  }
+
+  /**
+    * Apache commons-pool-backed pool
+    *
+    * @param create factory method for creating new pool objects
+    * @param config pool configuration options
+    * @tparam T object type
+    */
+  class CommonsPoolPool[T <: Closeable](create: => T, config: GenericObjectPoolConfig) extends CloseablePool[T] {
+
+    private val factory: BasePooledObjectFactory[T] = new BasePooledObjectFactory[T] {
+      override def wrap(obj: T) = new DefaultPooledObject[T](obj)
+      override def create(): T = CommonsPoolPool.this.create
+      override def destroyObject(p: PooledObject[T]): Unit = p.getObject.close()
+    }
+
+    private val pool = new GenericObjectPool[T](factory, config)
+
+    override def borrow[U](fn: T => U): U = {
+      val t = pool.borrowObject()
+      try { fn(t) } finally {
+        pool.returnObject(t)
+      }
+    }
+
+    override def close(): Unit = pool.close()
+  }
+}


### PR DESCRIPTION
* Flush each writer every 20k features
* Configurable via `geomesa.ingest.local.batch.size`
* New scala-friendly object pool impl:
  `org.locationtech.geomesa.utils.io.CloseablePool`

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>