### PR TITLE
GEOMESA-2689 Reduce memory footprint of deserialized simple features

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoVisibilityRowEncoder.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoVisibilityRowEncoder.scala
@@ -14,9 +14,10 @@ import org.apache.accumulo.core.data.{Key, Value}
 import org.apache.accumulo.core.iterators.user.RowEncodingIterator
 import org.apache.accumulo.core.iterators.{IteratorEnvironment, SortedKeyValueIterator}
 import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
-import org.locationtech.geomesa.features.kryo.impl.{KryoFeatureDeserialization, KryoFeatureSerialization}
+import org.locationtech.geomesa.features.kryo.impl.KryoFeatureDeserialization
+import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.index.iterators.IteratorCache
-import org.locationtech.geomesa.utils.cache.CacheKeyGenerator
+import org.locationtech.geomesa.utils.collection.IntBitSet
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.SimpleFeatureType
 
@@ -26,52 +27,117 @@ import org.opengis.feature.simple.SimpleFeatureType
 class KryoVisibilityRowEncoder extends RowEncodingIterator {
 
   private var sft: SimpleFeatureType = _
-  private var nullBytes: Array[Array[Byte]] = _
-  private var offsets: Array[Int] = _
+  private var count: Int = -1
+  private var attributes: Array[(Array[Byte], Int, Int)] = _ // (bytes, offset, length)
+
+  private var nullBytesV2: Array[Array[Byte]] = _
+  private var offsetsV2: Array[Int] = _
   private var offsetStart: Int = -1
 
   private val output: Output = new Output(128, -1)
 
-  override def init(source: SortedKeyValueIterator[Key, Value],
-                    options: java.util.Map[String, String],
-                    env: IteratorEnvironment): Unit = {
+  override def init(
+      source: SortedKeyValueIterator[Key, Value],
+      options: java.util.Map[String, String],
+      env: IteratorEnvironment): Unit = {
     super.init(source, options, env)
-
     sft = IteratorCache.sft(options.get(KryoVisibilityRowEncoder.SftOpt))
-    if (offsets == null || offsets.length != sft.getAttributeCount) {
-      offsets = Array.ofDim[Int](sft.getAttributeCount)
+    count = sft.getAttributeCount
+    if (attributes == null || attributes.length < count) {
+      attributes = Array.ofDim[(Array[Byte], Int, Int)](count)
     }
-    val cacheKey = CacheKeyGenerator.cacheKey(sft)
-    nullBytes = KryoFeatureSerialization.getWriters(cacheKey, sft).map { writer =>
-      output.clear()
-      writer(output, null)
-      output.toBytes
-    }
+    nullBytesV2 = null // lazily initialized when we hit v2 encoded data
   }
 
   override def rowEncoder(keys: java.util.List[Key], values: java.util.List[Value]): Value = {
     if (values.size() == 1) {
       return values.get(0)
     }
+    // TODO if we don't have a geometry, skip the record?
+    values.get(0).get.head match {
+      case KryoFeatureSerializer.Version  => encodeV3(keys, values)
+      case KryoFeatureSerializer.Version2 => encodeV2(keys, values)
+    }
+  }
 
+  private def encodeV3(keys: java.util.List[Key], values: java.util.List[Value]): Value = {
+    // 1 byte for version + 2 bytes for count + metadata
+    var length = 3 + org.locationtech.geomesa.features.kryo.metadataSize(count)
+    var valueCursor = length
+
+    var i = 0
+    while (i < keys.size) {
+      val bytes = values.get(i).get
+      val input = KryoFeatureDeserialization.getInput(bytes, 0, bytes.length)
+
+      keys.get(i).getColumnQualifier.getBytes.foreach { unsigned =>
+        val index = java.lang.Byte.toUnsignedInt(unsigned)
+        input.setPosition(3 + (2 * index))
+        val pos = input.readShort()
+        val len = input.readShort() - pos
+        attributes(index) = (bytes, 3 + pos, len)
+        length += len
+      }
+      i += 1
+    }
+
+    val value = Array.ofDim[Byte](length)
+    val output = new Output(value)
+    output.writeByte(KryoFeatureSerializer.Version)
+    output.writeShort(count)
+
+    val nulls = IntBitSet(count)
+
+    i = 0
+    while (i < count) {
+      output.writeShort(valueCursor - 3) // offset relative to version + count
+      val attribute = attributes(i)
+      if (attribute == null) { nulls.add(i) } else {
+        val (bytes, offset, len) = attribute
+        System.arraycopy(bytes, offset, value, valueCursor, len)
+        valueCursor += len
+        attributes(i) = null // reset for next time through
+      }
+      i += 1
+    }
+    output.writeShort(valueCursor) // user-data position
+
+    // write nulls - we should already be in the right position
+    nulls.serialize(output)
+
+    new Value(value)
+  }
+
+  private def encodeV2(keys: java.util.List[Key], values: java.util.List[Value]): Value = {
+    setupV2()
     val allValues = Array.ofDim[Array[Byte]](sft.getAttributeCount)
     var i = 0
     while (i < keys.size) {
       val cq = keys.get(i).getColumnQualifier
       val comma = cq.find(",")
-      val indices = if (comma == -1) cq.getBytes.map(_.toInt) else cq.getBytes.drop(comma + 1).map(_.toInt)
+      // convert unsigned bytes to int
+      val indices = if (comma == -1) { cq.getBytes.map(java.lang.Byte.toUnsignedInt) } else { cq.getBytes.drop(comma + 1).map(java.lang.Byte.toUnsignedInt) }
 
       val bytes = values.get(i).get
 
-      readOffsets(bytes)
+      val input = KryoFeatureDeserialization.getInput(bytes, 0, bytes.length)
+      // reset our offsets
+      input.setPosition(1) // skip version
+      offsetStart = input.readInt()
+      input.setPosition(offsetStart) // set to offsets start
+      var j = 0
+      while (j < offsetsV2.length) {
+        offsetsV2(j) = if (input.position < input.limit) { input.readInt(true) } else { -1 }
+        j += 1
+      }
 
       // set the non-null values
       indices.foreach { index =>
-        val endIndex = offsets.indexWhere(_ != -1, index + 1)
-        val end = if (endIndex == -1) offsetStart else offsets(endIndex)
-        val length = end - offsets(index)
+        val endIndex = offsetsV2.indexWhere(_ != -1, index + 1)
+        val end = if (endIndex == -1) offsetStart else offsetsV2(endIndex)
+        val length = end - offsetsV2(index)
         val values = Array.ofDim[Byte](length)
-        System.arraycopy(bytes, offsets(index), values, 0, length)
+        System.arraycopy(bytes, offsetsV2(index), values, 0, length)
         allValues(index) = values
       }
 
@@ -81,31 +147,30 @@ class KryoVisibilityRowEncoder extends RowEncodingIterator {
     i = 0
     while (i < allValues.length) {
       if (allValues(i) == null) {
-        allValues(i) = nullBytes(i)
+        allValues(i) = nullBytesV2(i)
       }
       i += 1
     }
 
-    // TODO if we don't have a geometry, skip the record?
-    KryoVisibilityRowEncoder.encode(allValues, output, offsets)
+    KryoVisibilityRowEncoder.encodeV2(allValues, output, offsetsV2)
   }
 
-  /**
-    * Reads offsets in the 'offsets' array and sets the start of the offset block
-    *
-    * @param bytes kryo feature bytes
-    * @return
-    */
-  private def readOffsets(bytes: Array[Byte]): Unit = {
-    val input = KryoFeatureDeserialization.getInput(bytes, 0, bytes.length)
-    // reset our offsets
-    input.setPosition(1) // skip version
-    offsetStart = input.readInt()
-    input.setPosition(offsetStart) // set to offsets start
-    var i = 0
-    while (i < offsets.length) {
-      offsets(i) = if (input.position < input.limit) input.readInt(true) else -1
-      i += 1
+  private def setupV2(): Unit = {
+    if (nullBytesV2 == null) {
+      if (offsetsV2 == null || offsetsV2.length != sft.getAttributeCount) {
+        offsetsV2 = Array.ofDim[Int](sft.getAttributeCount)
+      }
+      nullBytesV2 = Array.tabulate(sft.getAttributeCount) { i =>
+        val descriptor = sft.getDescriptor(i)
+        val bindings = ObjectType.selectType(descriptor)
+        output.clear()
+        bindings.head match {
+          case ObjectType.STRING if bindings.last != ObjectType.JSON => output.writeString(null) // write string supports nulls
+          case ObjectType.LIST | ObjectType.MAP | ObjectType.BYTES   => output.writeInt(-1, true)
+          case _ => output.write(KryoFeatureSerializer.NullByte)
+        }
+        output.toBytes
+      }
     }
   }
 
@@ -118,8 +183,8 @@ class KryoVisibilityRowEncoder extends RowEncodingIterator {
       iterator.sourceIter = sourceIter.deepCopy(env)
     }
     iterator.sft = sft
-    iterator.offsets = Array.ofDim[Int](sft.getAttributeCount)
-    iterator.nullBytes = nullBytes
+    iterator.offsetsV2 = Array.ofDim[Int](sft.getAttributeCount)
+    iterator.nullBytesV2 = nullBytesV2
     iterator
   }
 }
@@ -136,9 +201,9 @@ object KryoVisibilityRowEncoder {
     is
   }
 
-  private def encode(values: Array[Array[Byte]], output: Output, offsets: Array[Int]): Value = {
+  private def encodeV2(values: Array[Array[Byte]], output: Output, offsets: Array[Int]): Value = {
     output.clear()
-    output.writeInt(KryoFeatureSerializer.VERSION, true)
+    output.writeInt(KryoFeatureSerializer.Version2, true)
     output.setPosition(5) // leave 4 bytes to write the offsets
     // note: we don't write ID - tables are assumed to be using serialization without IDs
     // write attributes and keep track off offset into byte array

--- a/geomesa-features/geomesa-feature-avro/src/main/scala/org/locationtech/geomesa/features/avro/serialization/AvroUserDataSerialization.scala
+++ b/geomesa-features/geomesa-feature-avro/src/main/scala/org/locationtech/geomesa/features/avro/serialization/AvroUserDataSerialization.scala
@@ -17,7 +17,7 @@ object AvroUserDataSerialization extends GenericMapSerialization[Encoder, Decode
 
   val NullMarkerString = "<null>"
 
-  override def serialize(out: Encoder, map: java.util.Map[AnyRef, AnyRef]): Unit = {
+  override def serialize(out: Encoder, map: java.util.Map[_ <: AnyRef, _ <: AnyRef]): Unit = {
     // may not be able to write all entries - must pre-filter to know correct count
     val filtered = map.asScala.filter { case (key, value) =>
       if (canSerialize(key)) {

--- a/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/serialization/GenericMapSerialization.scala
+++ b/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/serialization/GenericMapSerialization.scala
@@ -18,7 +18,7 @@ import org.locationtech.jts.geom.Geometry
 // noinspection LanguageFeature
 trait GenericMapSerialization[T <: PrimitiveWriter, V <: PrimitiveReader] extends LazyLogging {
 
-  def serialize(out: T, map: java.util.Map[AnyRef, AnyRef]): Unit
+  def serialize(out: T, map: java.util.Map[_ <: AnyRef, _ <: AnyRef]): Unit
 
   def deserialize(in: V): java.util.Map[AnyRef, AnyRef]
 

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/KryoBufferSimpleFeature.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/KryoBufferSimpleFeature.scala
@@ -8,14 +8,17 @@
 
 package org.locationtech.geomesa.features.kryo
 
-import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.{Input, Output}
 import org.geotools.geometry.jts.ReferencedEnvelope
 import org.geotools.process.vector.TransformProcess
+import org.geotools.process.vector.TransformProcess.Definition
 import org.locationtech.geomesa.features.ScalaSimpleFeature
-import org.locationtech.geomesa.features.SerializationOption._
-import org.locationtech.geomesa.features.kryo.KryoBufferSimpleFeature.{IdParser, WithIdParser}
-import org.locationtech.geomesa.features.kryo.impl.KryoFeatureDeserialization
-import org.locationtech.geomesa.features.serialization.ObjectType
+import org.locationtech.geomesa.features.SerializationOption.SerializationOption
+import org.locationtech.geomesa.features.kryo.KryoBufferSimpleFeature.{KryoBufferV3, _}
+import org.locationtech.geomesa.features.kryo.impl.KryoFeatureDeserialization.KryoLongReader
+import org.locationtech.geomesa.features.kryo.impl.{KryoFeatureDeserialization, KryoFeatureDeserializationV2}
+import org.locationtech.geomesa.features.kryo.serialization.KryoUserDataSerialization
+import org.locationtech.geomesa.utils.collection.IntBitSet
 import org.locationtech.geomesa.utils.geotools.ImmutableFeatureId
 import org.locationtech.jts.geom.Geometry
 import org.opengis.feature.`type`.{AttributeDescriptor, Name}
@@ -25,34 +28,35 @@ import org.opengis.filter.expression.PropertyName
 import org.opengis.filter.identity.FeatureId
 import org.opengis.geometry.BoundingBox
 
-import scala.collection.JavaConversions._
+class KryoBufferSimpleFeature(serializer: KryoFeatureDeserialization) extends SimpleFeature {
 
-object LazySimpleFeature {
-  val NULL_BYTE: Byte = 0
-}
-
-class KryoBufferSimpleFeature(sft: SimpleFeatureType,
-                              readers: Array[Input => AnyRef],
-                              readUserData: Input => java.util.Map[AnyRef, AnyRef],
-                              options: Set[SerializationOption]) extends SimpleFeature {
-  private var offset: Int = _
-  private var length: Int = _
+  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
   private val input = new Input()
-  private val offsets = Array.ofDim[Int](sft.getAttributeCount)
-  private var startOfOffsets: Int = -1
-  private var missingAttributes: Boolean = false
-  private lazy val geomIndex = sft.indexOf(sft.getGeometryDescriptor.getLocalName)
-  private var userData: java.util.Map[AnyRef, AnyRef] = _
-  private var userDataOffset: Int = -1
 
-  private val idParser = if (options.withoutId) { new IdParser() } else { new WithIdParser(input) }
+  private val idParser = if (serializer.withoutId) { new IdParser() } else { new WithIdParser() }
+  private val delegateV3 = new KryoBufferV3(serializer, input)
+
+  @volatile
+  private var seenV2 = false
+  private lazy val delegateV2 = {
+    seenV2 = true
+    val buf = new KryoBufferV2(serializer, input)
+    if (transforms != null) {
+      buf.setTransforms(transformSchema, transformDefinitions)
+    }
+    buf
+  }
+
+  private lazy val geomIndex = serializer.out.getGeomIndex
+
+  private var delegate: KryoBufferDelegate = _
 
   private var transforms: String = _
   private var transformSchema: SimpleFeatureType = _
+  private var transformDefinitions: java.util.List[Definition] = _
 
-  private var binaryTransform: () => Array[Byte] = input.getBuffer
-  private var reserializeTransform: () => Array[Byte] = input.getBuffer
+  private var userData: java.util.Map[AnyRef, AnyRef] = _
 
   /**
     * Creates a new feature for later use - does not copy attribute bytes
@@ -60,7 +64,8 @@ class KryoBufferSimpleFeature(sft: SimpleFeatureType,
     * @return
     */
   def copy(): KryoBufferSimpleFeature = {
-    val sf = new KryoBufferSimpleFeature(sft, readers, readUserData, options)
+    val sf = new KryoBufferSimpleFeature(serializer)
+    sf.setIdParser(idParser.parse)
     if (transforms != null) {
       sf.setTransforms(transforms, transformSchema)
     }
@@ -68,13 +73,35 @@ class KryoBufferSimpleFeature(sft: SimpleFeatureType,
   }
 
   /**
-    * Transform the feature into a serialized byte array
+    * Sets the parser for reading feature ids out of the id buffer
+    *
+    * @param parse parse method
+    */
+  def setIdParser(parse: (Array[Byte], Int, Int) => String): Unit = idParser.parse = parse
+
+  /**
+    * Sets the transform to be applied to this feature when calling `transform`
+    *
+    * @param transforms transform definition, per geotools format
+    * @param transformSchema schema that results from applying the transform
+    */
+  def setTransforms(transforms: String, transformSchema: SimpleFeatureType): Unit = {
+    this.transforms = transforms
+    this.transformSchema = transformSchema
+    this.transformDefinitions = TransformProcess.toDefinition(transforms)
+    delegateV3.setTransforms(transformSchema, transformDefinitions)
+    if (seenV2) {
+      delegateV2.setTransforms(transformSchema, transformDefinitions)
+    }
+  }
+
+  /**
+    * Gets any transforms applied to this feature
     *
     * @return
     */
-  def transform(): Array[Byte] =
-    // if attributes have been added to the sft, we have to reserialize to get the null serialized values
-    if (missingAttributes) { reserializeTransform() } else { binaryTransform() }
+  def getTransform: Option[(String, SimpleFeatureType)] =
+    for { t <- Option(transforms); s <- Option(transformSchema) } yield { (t, s) }
 
   /**
     * Set the serialized bytes to use for reading attributes
@@ -91,27 +118,14 @@ class KryoBufferSimpleFeature(sft: SimpleFeatureType,
     * @param length number of valid bytes to read from the byte array
     */
   def setBuffer(bytes: Array[Byte], offset: Int, length: Int): Unit = {
-    this.offset = offset
-    this.length = length
     input.setBuffer(bytes, offset, length)
-    // reset our offsets
-    input.setPosition(offset + 1) // skip version
-    startOfOffsets = offset + input.readInt()
-    input.setPosition(startOfOffsets) // set to offsets start
-    var i = 0
-    while (i < offsets.length && input.position < input.limit) {
-      offsets(i) = offset + input.readInt(true)
-      i += 1
+    delegate = input.readByte() match {
+      case KryoFeatureSerializer.Version  => delegateV3
+      case KryoFeatureSerializer.Version2 => delegateV2
+      case b => throw new IllegalArgumentException(s"Can't process features serialized with version: $b")
     }
-    if (i < offsets.length) {
-      // attributes have been added to the sft since this feature was serialized
-      missingAttributes = true
-      do { offsets(i) = -1; i += 1 } while (i < offsets.length)
-    } else {
-      missingAttributes = false
-    }
+    delegate.reset()
     userData = null
-    userDataOffset = input.position()
   }
 
   /**
@@ -135,143 +149,55 @@ class KryoBufferSimpleFeature(sft: SimpleFeatureType,
   }
 
   /**
-    * Sets the parser for reading feature ids out of the id buffer
+    * Transform the feature into a serialized byte array
     *
-    * @param parse parse method
+    * @return
     */
-  def setIdParser(parse: (Array[Byte], Int, Int) => String): Unit = idParser.parse = parse
+  def transform(): Array[Byte] = delegate.transform(this)
 
   /**
-    * Sets the transform to be applied to this feature
+    * Get a date attribute as a raw long
     *
-    * @param transforms transform definition, per geotools format
-    * @param transformSchema schema that results from applying the transform
+    * @param index attribute index
+    * @return
     */
-  def setTransforms(transforms: String, transformSchema: SimpleFeatureType): Unit = {
-    this.transforms = transforms
-    this.transformSchema = transformSchema
+  def getDateAsLong(index: Int): Long = delegate.getDateAsLong(index)
 
-    val tdefs = TransformProcess.toDefinition(transforms)
+  /**
+    * Get the underlying kryo input, positioned to read the attribute at the given index
+    *
+    * @param index attribute index
+    * @return input, if the attribute is not null
+    */
+  def getInput(index: Int): Option[Input] = delegate.getInput(index)
 
-    // transforms by evaluating the transform expressions and then serializing the resulting feature
-    // we use this for transform expressions and for data that was written using an old schema
-    reserializeTransform = {
-      val serializer = KryoFeatureSerializer(transformSchema, options)
-      val sf = new ScalaSimpleFeature(transformSchema, "")
-      () => {
-        sf.setId(getID)
-        var i = 0
-        while (i < tdefs.size) {
-          sf.setAttribute(i, tdefs.get(i).expression.evaluate(this))
-          i += 1
-        }
-        serializer.serialize(sf)
-      }
-    }
+  override def getAttribute(index: Int): AnyRef = delegate.getAttribute(index)
 
-    val indices = tdefs.map { t =>
-      t.expression match {
-        case p: PropertyName => sft.indexOf(p.getPropertyName)
-        case _ => -1
-      }
-    }
-
-    val shouldReserialize = indices.contains(-1)
-
-    // if we are just returning a subset of attributes, we can copy the bytes directly and avoid creating
-    // new objects, reserializing, etc
-    binaryTransform = if (!shouldReserialize) {
-      val mutableOffsetsAndLength = Array.ofDim[(Int,Int)](indices.length)
-
-      () => {
-        // NOTE: the input buffer is the raw buffer. we need to ensure that we use the
-        // offset into the raw buffer rather than the raw buffer directly
-        val buf = input.getBuffer
-        var length = offsets(0) - this.offset // space for version, offset block and ID
-        var idx = 0
-        while(idx < mutableOffsetsAndLength.length) {
-          val i = indices(idx)
-          val l = (if (i < offsets.length - 1) offsets(i + 1) else startOfOffsets) - offsets(i)
-          length += l
-          mutableOffsetsAndLength(idx) = (offsets(i), l)
-          idx += 1
-        }
-
-        val dst = Array.ofDim[Byte](length)
-        // copy the version, offset block and id
-        var dstPos = offsets(0) - this.offset
-        System.arraycopy(buf, this.offset, dst, 0, dstPos)
-        mutableOffsetsAndLength.foreach { case (o, l) =>
-          System.arraycopy(buf, o, dst, dstPos, l)
-          dstPos += l
-        }
-        // note that the offset block is incorrect - we couldn't use this in another lazy feature
-        // but the normal serializer doesn't care
-        dst
-      }
-    } else {
-      reserializeTransform
-    }
-  }
-
-  def getTransform: Option[(String, SimpleFeatureType)] =
-    for { t <- Option(transforms); s <- Option(transformSchema) } yield { (t, s) }
-
-  def getDateAsLong(index: Int): Long = {
-    val offset = offsets(index)
-    if (offset == -1) {
-      0L
-    } else {
-      input.setPosition(offset)
-      KryoBufferSimpleFeature.longReader(input).asInstanceOf[Long]
-    }
-  }
-
-  override def getAttribute(index: Int): AnyRef = {
-    val offset = offsets(index)
-    if (offset == -1) {
-      null
-    } else {
-      input.setPosition(offset)
-      readers(index)(input)
-    }
-  }
-
-  def getInput(index: Int): Input = {
-    val offset = offsets(index)
-    if (offset == -1) {
-      null
-    } else {
-      input.setPosition(offset)
-      input
-    }
-  }
-
-  override def getType: SimpleFeatureType = sft
-  override def getFeatureType: SimpleFeatureType = sft
-  override def getName: Name = sft.getName
+  override def getType: SimpleFeatureType = serializer.out
+  override def getFeatureType: SimpleFeatureType = serializer.out
+  override def getName: Name = serializer.out.getName
 
   override def getID: String = idParser.id()
   override def getIdentifier: FeatureId = new ImmutableFeatureId(idParser.id())
 
   override def getAttribute(name: Name): AnyRef = getAttribute(name.getLocalPart)
   override def getAttribute(name: String): Object = {
-    val index = sft.indexOf(name)
-    if (index == -1) null else getAttribute(index)
+    val index = serializer.out.indexOf(name)
+    if (index == -1) { null } else { getAttribute(index) }
   }
 
-  override def getDefaultGeometry: AnyRef = getAttribute(geomIndex)
-  override def getAttributeCount: Int = sft.getAttributeCount
+  override def getDefaultGeometry: AnyRef = if (geomIndex == -1) { null } else { getAttribute(geomIndex) }
+  override def getAttributeCount: Int = serializer.out.getAttributeCount
 
   override def getBounds: BoundingBox = getDefaultGeometry match {
-    case g: Geometry => new ReferencedEnvelope(g.getEnvelopeInternal, sft.getCoordinateReferenceSystem)
-    case _           => new ReferencedEnvelope(sft.getCoordinateReferenceSystem)
+    case g: Geometry => new ReferencedEnvelope(g.getEnvelopeInternal, serializer.out.getCoordinateReferenceSystem)
+    case _           => new ReferencedEnvelope(serializer.out.getCoordinateReferenceSystem)
   }
 
   override def getAttributes: java.util.List[AnyRef] = {
-    val attributes = new java.util.ArrayList[AnyRef](offsets.length)
+    val attributes = new java.util.ArrayList[AnyRef](serializer.out.getAttributeCount)
     var i = 0
-    while (i < offsets.length) {
+    while (i < serializer.out.getAttributeCount) {
       attributes.add(getAttribute(i))
       i += 1
     }
@@ -280,8 +206,7 @@ class KryoBufferSimpleFeature(sft: SimpleFeatureType,
 
   override def getUserData: java.util.Map[AnyRef, AnyRef] = {
     if (userData == null) {
-      input.setPosition(userDataOffset)
-      userData = readUserData(input)
+      userData = if (serializer.withoutUserData) { new java.util.HashMap(1) } else { delegate.getUserData }
     }
     userData
   }
@@ -309,11 +234,13 @@ class KryoBufferSimpleFeature(sft: SimpleFeatureType,
   override def validate(): Unit = throw new NotImplementedError
 
   override def toString: String = s"KryoBufferSimpleFeature:$getID"
+
+  private class WithIdParser extends IdParser {
+    override def id(): String = delegate.id()
+  }
 }
 
 object KryoBufferSimpleFeature {
-
-  val longReader: Input => AnyRef = KryoFeatureDeserialization.matchReader(Seq(ObjectType.LONG))
 
   private class IdParser {
     var parse: (Array[Byte], Int, Int) => String = _
@@ -324,10 +251,384 @@ object KryoBufferSimpleFeature {
     def id(): String = parse(buffer, offset, length)
   }
 
-  private class WithIdParser(input: Input) extends IdParser {
+  /**
+    * Common interface for handling serialization versions
+    */
+  private sealed trait KryoBufferDelegate {
+
+    /**
+      * Invoked after the underlying kryo buffer has been updated with a new serialized feature
+      */
+    def reset(): Unit
+
+    /**
+      * Sets the transform to be applied to the feature
+      *
+      * @param schema schema that results from applying the transform
+      * @param transforms transform definitions
+      */
+    def setTransforms(schema: SimpleFeatureType, transforms: java.util.List[Definition]): Unit
+
+    /**
+      * Deserialize the feature ID (assuming options.withId)
+      *
+      * @return
+      */
+    def id(): String
+
+    /**
+      * Deserialize an attribute
+      *
+      * @param index attribute number
+      * @return
+      */
+    def getAttribute(index: Int): AnyRef
+
+    /**
+      * Deserialize user data
+      *
+      * @return
+      */
+    def getUserData: java.util.Map[AnyRef, AnyRef]
+
+    /**
+      * Optimized method to get a date attribute as millis without creating a new Date object
+      *
+      * @param index attribute number
+      * @return
+      */
+    def getDateAsLong(index: Int): Long
+
+    /**
+      * Gets the input, positioned to read the given attribute
+      *
+      * @param index attribute index
+      * @return
+      */
+    def getInput(index: Int): Option[Input]
+
+    /**
+      * Transform a feature, based on previously set transform schema
+      *
+      * @param original original feature being transformed
+      * @return
+      */
+    def transform(original: SimpleFeature): Array[Byte]
+  }
+
+  /**
+    * Abstraction over transformer impls
+    */
+  private sealed trait Transformer {
+    def transform(original: SimpleFeature): Array[Byte]
+  }
+
+  /**
+    * Serialization version 3 delegate
+    *
+    * @param serializer serializer
+    * @param input input
+    */
+  private class KryoBufferV3(serializer: KryoFeatureDeserialization, input: Input) extends KryoBufferDelegate {
+
+    private var count: Int = -1
+    private var offset: Int = -1
+    private var nulls: IntBitSet = _
+
+    private var transformer: Transformer = _
+
+    override def reset(): Unit = {
+      count = input.readShort()
+      offset = input.position()
+      // read our null mask
+      input.setPosition(offset + (2 * count) + 2)
+      nulls = IntBitSet.deserialize(input, count)
+    }
+
+    override def setTransforms(schema: SimpleFeatureType, transforms: java.util.List[Definition]): Unit = {
+      val indices = Array.tabulate(transforms.size()) { i =>
+        transforms.get(i).expression match {
+          case p: PropertyName => serializer.out.indexOf(p.getPropertyName)
+          case _ => -1
+        }
+      }
+      if (indices.contains(-1)) {
+        transformer = new ReserializeTransformer(schema, transforms, serializer.options)
+      } else {
+        transformer = new BinaryTransformer(indices)
+      }
+    }
+
+    override def id(): String = {
+      input.setPosition(offset + metadataSize(count))
+      input.readString()
+    }
+
+    override def getAttribute(index: Int): AnyRef = {
+      if (index >= count || nulls.contains(index)) { null } else {
+        // read the offset and go to the position for reading
+        input.setPosition(offset + (2 * index))
+        input.setPosition(offset + input.readShort())
+        serializer.readers(index).apply(input)
+      }
+    }
+
+    override def getUserData: java.util.Map[AnyRef, AnyRef] = {
+      // read the offset and go to the position for reading
+      input.setPosition(offset + (2 * count))
+      input.setPosition(offset + input.readShort())
+      KryoUserDataSerialization.deserialize(input)
+    }
+
+    override def getDateAsLong(index: Int): Long = {
+      if (index >= count || nulls.contains(index)) { 0L } else {
+        // read the offset and go to the position for reading
+        input.setPosition(offset + (2 * index))
+        input.setPosition(offset + input.readShort())
+        KryoLongReader.apply(input)
+      }
+    }
+
+    override def getInput(index: Int): Option[Input] = {
+      if (index >= count || nulls.contains(index)) { None } else {
+        // read the offset and go to the position for reading
+        input.setPosition(offset + (2 * index))
+        input.setPosition(offset + input.readShort())
+        Some(input)
+      }
+    }
+
+    override def transform(original: SimpleFeature): Array[Byte] = transformer.transform(original)
+
+    // if we are just returning a subset of attributes, we can copy the bytes directly
+    private class BinaryTransformer(indices: Array[Int]) extends Transformer {
+
+      private val positionsAndLengths = Array.ofDim[(Int, Int)](indices.length)
+
+      override def transform(original: SimpleFeature): Array[Byte] = {
+        var length = metadataSize(indices.length) + 3 // +1 for version and +2 for count
+        val id = if (serializer.withoutId) { null } else {
+          val pos = offset + metadataSize(count)
+          input.setPosition(pos)
+          val id = input.readString()
+          length += input.position() - pos
+          id
+        }
+
+        val nulls = IntBitSet(indices.length)
+
+        // track the write position for copying attributes in the transformed array
+        var resultCursor = length
+
+        var i = 0
+        while (i < indices.length) {
+          val index = indices(i) // the index of the attribute in the original feature
+          if (index >= count || KryoBufferV3.this.nulls.contains(index)) { nulls.add(i) } else {
+            // read the offset and the subsequent offset to get the length
+            input.setPosition(offset + (2 * index))
+            val pos = input.readShort()
+            val len = input.readShort() - pos
+            length += len
+            positionsAndLengths(i) = (pos, len)
+          }
+          i += 1
+        }
+
+        // note: the input buffer is the raw buffer. we need to ensure that we use the
+        // offset into the raw buffer rather than the raw buffer directly
+        val buf = input.getBuffer
+
+        val result = Array.ofDim[Byte](length)
+        val output = new Output(result, length)
+        output.writeByte(KryoFeatureSerializer.Version)
+        output.writeShort(indices.length) // track the number of attributes
+        i = 0
+        while (i < positionsAndLengths.length) {
+          output.writeShort(resultCursor)
+          if (!nulls.contains(i)) {
+            val (pos, len) = positionsAndLengths(i)
+            System.arraycopy(buf, offset + pos, result, resultCursor, len)
+            resultCursor += len
+          }
+          i += 1
+        }
+        output.writeShort(resultCursor) // user data offset
+
+        // TODO user data?
+        // TODO handle overflow if offsets don't fit in shorts
+
+        // write out nulls
+        nulls.serialize(output)
+
+        // we're already positioned to write out the feature id
+        if (id != null) {
+          output.writeString(id)
+        }
+
+        result
+      }
+    }
+  }
+
+  /**
+    * Serialiation version 2 delegate
+    *
+    * @param serializer serializer
+    * @param input input
+    */
+  private class KryoBufferV2(serializer: KryoFeatureDeserialization, input: Input) extends KryoBufferDelegate {
+
+    private val offsets = Array.ofDim[Int](serializer.out.getAttributeCount)
+    private var offset: Int = -1
+    private var startOfOffsets: Int = -1
+    private var missingAttributes: Boolean = false
+    private var userDataOffset: Int = -1
+
+    private var reserializeTransform: Transformer = _
+    private var binaryTransform: Transformer = _
+
+    override def reset(): Unit = {
+      // reset our offsets
+      offset = input.position() - 1 // we've already read the version byte
+      startOfOffsets = offset + input.readInt()
+      input.setPosition(startOfOffsets) // set to offsets start
+      var i = 0
+      while (i < offsets.length && input.position < input.limit) {
+        offsets(i) = offset + input.readInt(true)
+        i += 1
+      }
+      if (i < offsets.length) {
+        // attributes have been added to the sft since this feature was serialized
+        missingAttributes = true
+        do { offsets(i) = -1; i += 1 } while (i < offsets.length)
+      } else {
+        missingAttributes = false
+      }
+      userDataOffset = input.position()
+    }
+
+    override def setTransforms(schema: SimpleFeatureType, transforms: java.util.List[Definition]): Unit = {
+      val indices = Array.tabulate(transforms.size()) { i =>
+        transforms.get(i).expression match {
+          case p: PropertyName => serializer.out.indexOf(p.getPropertyName)
+          case _ => -1
+        }
+      }
+
+      // transforms by evaluating the transform expressions and then serializing the resulting feature
+      // we use this for transform expressions and for data that was written using an old schema
+      reserializeTransform = new ReserializeTransformer(schema, transforms, serializer.options)
+      // if we are just returning a subset of attributes, we can copy the bytes directly
+      // and avoid creating new objects, reserializing, etc
+      binaryTransform =
+          if (indices.contains(-1)) { reserializeTransform } else { new BinaryTransformerV2(input, indices, offsets) }
+    }
+
     override def id(): String = {
       input.setPosition(5)
       input.readString()
+    }
+
+    override def getAttribute(index: Int): AnyRef = {
+      val offset = offsets(index)
+      if (offset == -1) { null } else {
+        input.setPosition(offset)
+        serializer.readersV2(index)(input)
+      }
+    }
+
+    override def getUserData: java.util.Map[AnyRef, AnyRef] = {
+      input.setPosition(userDataOffset)
+      KryoUserDataSerialization.deserialize(input)
+    }
+
+    override def getDateAsLong(index: Int): Long = {
+      val offset = offsets(index)
+      if (offset == -1) { 0L } else {
+        input.setPosition(offset)
+        KryoFeatureDeserializationV2.LongReader.apply(input)
+      }
+    }
+
+    override def getInput(index: Int): Option[Input] = {
+      val offset = offsets(index)
+      if (offset == -1) { None } else {
+        input.setPosition(offset)
+        Some(input)
+      }
+    }
+
+    override def transform(original: SimpleFeature): Array[Byte] = {
+      // if attributes have been added to the sft, we have to reserialize to get the null serialized values
+      val transformer = if (missingAttributes) { reserializeTransform } else { binaryTransform }
+      transformer.transform(original)
+    }
+
+    /**
+      * Serialization version 2 binary transformer. Copies serialized attribute bytes directly without
+      * deserializing them
+      *
+      * @param input input
+      * @param indices transform indices
+      * @param offsets attribute offsets
+      */
+    private class BinaryTransformerV2(input: Input, indices: Array[Int], offsets: Array[Int]) extends Transformer {
+
+      private val mutableOffsetsAndLength = Array.ofDim[(Int,Int)](indices.length)
+
+      override def transform(original: SimpleFeature): Array[Byte] = {
+        // NOTE: the input buffer is the raw buffer. we need to ensure that we use the
+        // offset into the raw buffer rather than the raw buffer directly
+        val buf = input.getBuffer
+        var length = offsets(0) - offset // space for version, offset block and ID
+        var idx = 0
+        while (idx < mutableOffsetsAndLength.length) {
+          val i = indices(idx)
+          val el = (if (i < offsets.length - 1) { offsets(i + 1) } else { startOfOffsets }) - offsets(i)
+          length += el
+          mutableOffsetsAndLength(idx) = (offsets(i), el)
+          idx += 1
+        }
+
+        val dst = Array.ofDim[Byte](length)
+        // copy the version, offset block and id
+        var dstPos = offsets(0) - offset
+        System.arraycopy(buf, offset, dst, 0, dstPos)
+        mutableOffsetsAndLength.foreach { case (o, l) =>
+          System.arraycopy(buf, o, dst, dstPos, l)
+          dstPos += l
+        }
+        // note that the offset block is incorrect - we couldn't use this in another lazy feature
+        // but the normal serializer doesn't care
+        dst
+      }
+    }
+  }
+
+  /**
+    * For non-attribute expressions, we have evaluate them, then serialize the resulting feature
+    *
+    * @param schema transform schema
+    * @param transforms transform definitions
+    * @param options serialization options
+    */
+  private class ReserializeTransformer(
+      schema: SimpleFeatureType,
+      transforms: java.util.List[Definition],
+      options: Set[SerializationOption]
+  ) extends Transformer {
+
+    private val serializer = KryoFeatureSerializer(schema, options)
+    private val sf = new ScalaSimpleFeature(schema, "")
+
+    override def transform(original: SimpleFeature): Array[Byte] = {
+      sf.setId(original.getID)
+      var i = 0
+      while (i < transforms.size) {
+        sf.setAttribute(i, transforms.get(i).expression.evaluate(original))
+        i += 1
+      }
+      serializer.serialize(sf)
     }
   }
 }

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/KryoFeatureSerializer.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/KryoFeatureSerializer.scala
@@ -19,11 +19,14 @@ trait KryoFeatureSerializer extends KryoFeatureSerialization with KryoFeatureDes
 
 object KryoFeatureSerializer {
 
-  val VERSION = 2
-  assert(VERSION < Byte.MaxValue, "Serialization expects version to be in one byte")
+  val Version : Byte = 3
+  val Version2: Byte = 2
 
-  val NULL_BYTE: Byte     = 0.asInstanceOf[Byte]
-  val NON_NULL_BYTE: Byte = 1.asInstanceOf[Byte]
+  @deprecated("Version")
+  lazy val VERSION: Int = Version
+
+  val NullByte: Byte    = 0.asInstanceOf[Byte]
+  val NonNullByte: Byte = 1.asInstanceOf[Byte]
 
   def apply(sft: SimpleFeatureType, options: Set[SerializationOption] = Set.empty): KryoFeatureSerializer = {
     (options.immutable, options.isLazy) match {
@@ -38,26 +41,26 @@ object KryoFeatureSerializer {
 
   class ImmutableActiveSerializer(sft: SimpleFeatureType, val options: Set[SerializationOption])
       extends KryoFeatureSerializer with ImmutableActiveDeserialization {
-    override private [kryo] def serializeSft = sft
-    override private [kryo] def deserializeSft = sft
+    override protected [kryo] def in: SimpleFeatureType = sft
+    override protected [kryo] def out: SimpleFeatureType = sft
   }
 
   class ImmutableLazySerializer(sft: SimpleFeatureType, val options: Set[SerializationOption])
       extends KryoFeatureSerializer with ImmutableLazyDeserialization {
-    override private [kryo] def serializeSft = sft
-    override private [kryo] def deserializeSft = sft
+    override protected [kryo] def in: SimpleFeatureType = sft
+    override protected [kryo] def out: SimpleFeatureType = sft
   }
 
   class MutableActiveSerializer(sft: SimpleFeatureType, val options: Set[SerializationOption])
       extends KryoFeatureSerializer with MutableActiveDeserialization {
-    override private [kryo] def serializeSft = sft
-    override private [kryo] def deserializeSft = sft
+    override protected [kryo] def in: SimpleFeatureType = sft
+    override protected [kryo] def out: SimpleFeatureType = sft
   }
 
   class MutableLazySerializer(sft: SimpleFeatureType, val options: Set[SerializationOption])
       extends KryoFeatureSerializer with MutableLazyDeserialization {
-    override private [kryo] def serializeSft = sft
-    override private [kryo] def deserializeSft = sft
+    override protected [kryo] def in: SimpleFeatureType = sft
+    override protected [kryo] def out: SimpleFeatureType = sft
   }
 
   class Builder private [KryoFeatureSerializer] (sft: SimpleFeatureType)

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserialization.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserialization.scala
@@ -9,20 +9,19 @@
 package org.locationtech.geomesa.features.kryo.impl
 
 import java.io.InputStream
-import java.util
 import java.util.{Date, UUID}
 
 import com.esotericsoftware.kryo.io.Input
 import com.typesafe.scalalogging.LazyLogging
 import org.locationtech.geomesa.features.SimpleFeatureSerializer
 import org.locationtech.geomesa.features.kryo.KryoBufferSimpleFeature
-import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer.NULL_BYTE
-import org.locationtech.geomesa.features.kryo.impl.KryoFeatureDeserialization.getReaders
+import org.locationtech.geomesa.features.kryo.impl.KryoFeatureDeserialization.KryoAttributeReader
 import org.locationtech.geomesa.features.kryo.json.KryoJsonSerialization
-import org.locationtech.geomesa.features.kryo.serialization.{KryoGeometrySerialization, KryoUserDataSerialization}
+import org.locationtech.geomesa.features.kryo.serialization.KryoGeometrySerialization
 import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.cache.{CacheKeyGenerator, SoftThreadLocal, SoftThreadLocalCache}
+import org.locationtech.jts.geom.Geometry
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType
 
@@ -33,44 +32,23 @@ import scala.util.control.NonFatal
   */
 trait KryoFeatureDeserialization extends SimpleFeatureSerializer with LazyLogging {
 
-  private [kryo] def deserializeSft: SimpleFeatureType
+  private val key = CacheKeyGenerator.cacheKey(out)
 
-  private val withoutUserData = !options.withUserData
-  protected val withoutId: Boolean = options.withoutId
+  protected [kryo] val withoutUserData: Boolean = !options.withUserData
+  protected [kryo] val withoutId: Boolean = options.withoutId
 
-  protected val readers: Array[Input => AnyRef] =
-    getReaders(CacheKeyGenerator.cacheKey(deserializeSft), deserializeSft)
+  protected [kryo] val readers: Array[KryoAttributeReader] = KryoFeatureDeserialization.getReaders(key, out)
+  protected [kryo] lazy val readersV2: Array[Input => AnyRef] = KryoFeatureDeserializationV2.getReaders(key, out)
 
-  protected def readUserData(input: Input, skipOffsets: Boolean): java.util.Map[AnyRef, AnyRef] = {
-    if (withoutUserData) {
-      new java.util.HashMap[AnyRef, AnyRef]
-    } else {
-      if (skipOffsets) {
-        // skip offset data
-        try {
-          var i = 0
-          while (i < readers.length) {
-            input.readInt(true)
-            i += 1
-          }
-        } catch {
-          case NonFatal(e) =>
-            logger.error("Error reading serialized kryo user data:", e)
-            return new java.util.HashMap[AnyRef, AnyRef]()
-        }
-      }
-      KryoUserDataSerialization.deserialize(input)
-    }
-  }
+  protected [kryo] def out: SimpleFeatureType
 
-  def getReusableFeature: KryoBufferSimpleFeature =
-    new KryoBufferSimpleFeature(deserializeSft, readers, readUserData(_, skipOffsets = false), options)
+  def getReusableFeature: KryoBufferSimpleFeature = new KryoBufferSimpleFeature(this)
 }
 
 object KryoFeatureDeserialization extends LazyLogging {
 
-  private[this] val inputs  = new SoftThreadLocal[Input]()
-  private[this] val readers = new SoftThreadLocalCache[String, Array[Input => AnyRef]]()
+  private val inputs  = new SoftThreadLocal[Input]()
+  private val readers = new SoftThreadLocalCache[String, Array[KryoAttributeReader]]()
 
   def getInput(bytes: Array[Byte], offset: Int, count: Int): Input = {
     val in = inputs.getOrElseUpdate(new Input)
@@ -85,134 +63,126 @@ object KryoFeatureDeserialization extends LazyLogging {
     in
   }
 
-  private [geomesa] def getReaders(key: String, sft: SimpleFeatureType): Array[Input => AnyRef] = {
+  def getReaders(key: String, sft: SimpleFeatureType): Array[KryoAttributeReader] = {
     readers.getOrElseUpdate(key, sft.getAttributeDescriptors.toArray.map {
-      case ad: AttributeDescriptor => matchReader(ObjectType.selectType(ad))
+      case ad: AttributeDescriptor => reader(ObjectType.selectType(ad))
     })
   }
 
-  private [geomesa] def matchReader(bindings: Seq[ObjectType]): Input => AnyRef = {
+  private [geomesa] def reader(bindings: Seq[ObjectType]): KryoAttributeReader = {
     bindings.head match {
-      case ObjectType.STRING   => if (bindings.last == ObjectType.JSON) KryoJsonSerialization.deserializeAndRender else StringReader
-      case ObjectType.INT      => IntReader
-      case ObjectType.LONG     => LongReader
-      case ObjectType.FLOAT    => FloatReader
-      case ObjectType.DOUBLE   => DoubleReader
-      case ObjectType.DATE     => DateReader
-      case ObjectType.UUID     => UuidReader
-      case ObjectType.GEOMETRY => KryoGeometrySerialization.deserialize
-      case ObjectType.BYTES    => BytesReader
-      case ObjectType.BOOLEAN  => BooleanReader
-      case ObjectType.LIST     => new ListReader(matchReader(bindings.drop(1)))
-      case ObjectType.MAP      => new MapReader(matchReader(bindings.slice(1, 2)), matchReader(bindings.drop(2)))
+      case ObjectType.STRING   => if (bindings.last == ObjectType.JSON) { KryoJsonReader } else { KryoStringReader }
+      case ObjectType.INT      => KryoIntReader
+      case ObjectType.LONG     => KryoLongReader
+      case ObjectType.FLOAT    => KryoFloatReader
+      case ObjectType.DOUBLE   => KryoDoubleReader
+      case ObjectType.DATE     => KryoDateReader
+      case ObjectType.GEOMETRY => KryoGeometryReader
+      case ObjectType.BYTES    => KryoBytesReader
+      case ObjectType.UUID     => KryoUuidReader
+      case ObjectType.BOOLEAN  => KryoBooleanReader
+      case ObjectType.LIST     => KryoListReader(reader(bindings.drop(1)))
+      case ObjectType.MAP      => KryoMapReader(reader(bindings.slice(1, 2)), reader(bindings.drop(2)))
+
+      case b => throw new NotImplementedError(s"Unexpected attribute type binding: $b")
     }
   }
 
-  private object StringReader extends (Input => String) {
+  sealed trait KryoAttributeReader {
+    def apply(input: Input): AnyRef
+  }
+
+  case object KryoStringReader extends KryoAttributeReader {
     override def apply(input: Input): String = try { input.readString() } catch {
       case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
     }
   }
 
-  private object IntReader extends (Input => Integer) {
-    override def apply(input: Input): Integer = try {
-      if (input.read() == NULL_BYTE) { null } else { input.readInt() }
-    } catch {
+  case object KryoIntReader extends KryoAttributeReader {
+    override def apply(input: Input): Integer = try { input.readInt() } catch {
       case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
     }
   }
 
-  private object LongReader extends (Input => java.lang.Long) {
-    override def apply(input: Input): java.lang.Long = try {
-      if (input.read() == NULL_BYTE) { null } else { input.readLong() }
-    } catch {
+  case object KryoLongReader extends KryoAttributeReader {
+    override def apply(input: Input): java.lang.Long = try { input.readLong() } catch {
       case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
     }
   }
 
-  private object FloatReader extends (Input => java.lang.Float) {
-    override def apply(input: Input): java.lang.Float = try {
-      if (input.read() == NULL_BYTE) { null } else { input.readFloat() }
-    } catch {
+  case object KryoFloatReader extends KryoAttributeReader {
+    override def apply(input: Input): java.lang.Float = try { input.readFloat() } catch {
       case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
     }
   }
 
-  private object DoubleReader extends (Input => java.lang.Double) {
-    override def apply(input: Input): java.lang.Double = try {
-      if (input.read() == NULL_BYTE) { null } else { input.readDouble() }
-    } catch {
+  case object KryoDoubleReader extends KryoAttributeReader {
+    override def apply(input: Input): java.lang.Double = try { input.readDouble() } catch {
       case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
     }
   }
 
-  private object BooleanReader extends (Input => java.lang.Boolean) {
-    override def apply(input: Input): java.lang.Boolean = try {
-      if (input.read() == NULL_BYTE) { null } else { input.readBoolean() }
-    } catch {
+  case object KryoBooleanReader extends KryoAttributeReader {
+    override def apply(input: Input): java.lang.Boolean = try { input.readBoolean() } catch {
       case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
     }
   }
 
-  private object DateReader extends (Input => Date) {
-    override def apply(input: Input): Date = try {
-      if (input.read() == NULL_BYTE) { null } else { new Date(input.readLong()) }
-    } catch {
+  case object KryoDateReader extends KryoAttributeReader {
+    override def apply(input: Input): Date = try { new Date(input.readLong()) } catch {
       case NonFatal(e) => logger.error("Error reading serialized kryo bytes", e); null
     }
   }
 
-  private object UuidReader extends (Input => UUID) {
-    override def apply(input: Input): UUID = try {
-      if (input.read() == NULL_BYTE) { null } else { new UUID(input.readLong(), input.readLong()) }
-    } catch {
+  case object KryoUuidReader extends KryoAttributeReader {
+    override def apply(input: Input): UUID = try { new UUID(input.readLong(), input.readLong()) } catch {
       case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
     }
   }
 
-  private object BytesReader extends (Input => Array[Byte]) {
+  case object KryoBytesReader extends KryoAttributeReader {
     override def apply(input: Input): Array[Byte] = try {
-      val size = input.readInt(true)
-      if (size == -1) { null } else {
-        val array = new Array[Byte](size)
-        input.read(array)
-        array
-      }
+      val array = new Array[Byte](input.readInt(true))
+      input.read(array)
+      array
     } catch {
       case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
     }
   }
 
-  private class ListReader(valueReader: Input => AnyRef) extends (Input => java.util.List[AnyRef]) {
-    override def apply(input: Input): util.List[AnyRef] = try {
+  case object KryoJsonReader extends KryoAttributeReader {
+    override def apply(input: Input): String = KryoJsonSerialization.deserializeAndRender(input)
+  }
+
+  case object KryoGeometryReader extends KryoAttributeReader {
+    override def apply(input: Input): Geometry = KryoGeometrySerialization.deserialize(input)
+  }
+
+  case class KryoListReader(elements: KryoAttributeReader) extends KryoAttributeReader {
+    override def apply(input: Input): java.util.List[AnyRef] = try {
       val size = input.readInt(true)
-      if (size == -1) { null } else {
-        val list = new java.util.ArrayList[AnyRef](size)
-        var index = 0
-        while (index < size) {
-          list.add(valueReader.apply(input))
-          index += 1
-        }
-        list
+      val list = new java.util.ArrayList[AnyRef](size)
+      var index = 0
+      while (index < size) {
+        list.add(elements.apply(input))
+        index += 1
       }
+      list
     } catch {
       case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
     }
   }
 
-  private class MapReader(keyReader: Input => AnyRef, valueReader: Input => AnyRef)
-      extends (Input => java.util.Map[AnyRef, AnyRef]) {
-    override def apply(input: Input): util.Map[AnyRef, AnyRef] = try {
+  case class KryoMapReader(keys: KryoAttributeReader, values: KryoAttributeReader) extends KryoAttributeReader {
+    override def apply(input: Input): java.util.Map[AnyRef, AnyRef] = try {
       val size = input.readInt(true)
-      if (size == -1) { null } else {
-        val map = new java.util.HashMap[AnyRef, AnyRef](size)
-        var index = 0
-        while (index < size) {
-          map.put(keyReader.apply(input), valueReader.apply(input))
-          index += 1
-        }
-        map
+      val map = new java.util.HashMap[AnyRef, AnyRef](size)
+      var index = 0
+      while (index < size) {
+        map.put(keys.apply(input), values.apply(input))
+        index += 1
       }
+      map
     } catch {
       case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
     }

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserializationV2.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserializationV2.scala
@@ -1,0 +1,163 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.features.kryo.impl
+
+import java.util
+import java.util.{Date, UUID}
+
+import com.esotericsoftware.kryo.io.Input
+import com.typesafe.scalalogging.LazyLogging
+import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer.NullByte
+import org.locationtech.geomesa.features.kryo.json.KryoJsonSerialization
+import org.locationtech.geomesa.features.kryo.serialization.KryoGeometrySerialization
+import org.locationtech.geomesa.features.serialization.ObjectType
+import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
+import org.locationtech.geomesa.utils.cache.SoftThreadLocalCache
+import org.opengis.feature.`type`.AttributeDescriptor
+import org.opengis.feature.simple.SimpleFeatureType
+
+import scala.util.control.NonFatal
+
+object KryoFeatureDeserializationV2 extends LazyLogging {
+
+  private val readers = new SoftThreadLocalCache[String, Array[Input => AnyRef]]()
+
+  private [geomesa] def getReaders(key: String, sft: SimpleFeatureType): Array[Input => AnyRef] = {
+    readers.getOrElseUpdate(key, sft.getAttributeDescriptors.toArray.map {
+      case ad: AttributeDescriptor => matchReader(ObjectType.selectType(ad))
+    })
+  }
+
+  private [geomesa] def matchReader(bindings: Seq[ObjectType]): Input => AnyRef = {
+    bindings.head match {
+      case ObjectType.STRING   => if (bindings.last == ObjectType.JSON) KryoJsonSerialization.deserializeAndRender else StringReader
+      case ObjectType.INT      => IntReader
+      case ObjectType.LONG     => LongReader
+      case ObjectType.FLOAT    => FloatReader
+      case ObjectType.DOUBLE   => DoubleReader
+      case ObjectType.DATE     => DateReader
+      case ObjectType.UUID     => UuidReader
+      case ObjectType.GEOMETRY => KryoGeometrySerialization.deserialize
+      case ObjectType.BYTES    => BytesReader
+      case ObjectType.BOOLEAN  => BooleanReader
+      case ObjectType.LIST     => new ListReader(matchReader(bindings.drop(1)))
+      case ObjectType.MAP      => new MapReader(matchReader(bindings.slice(1, 2)), matchReader(bindings.drop(2)))
+    }
+  }
+
+  object StringReader extends (Input => String) {
+    override def apply(input: Input): String = try { input.readString() } catch {
+      case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
+    }
+  }
+
+  object IntReader extends (Input => Integer) {
+    override def apply(input: Input): Integer = try {
+      if (input.read() == NullByte) { null } else { input.readInt() }
+    } catch {
+      case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
+    }
+  }
+
+  object LongReader extends (Input => java.lang.Long) {
+    override def apply(input: Input): java.lang.Long = try {
+      if (input.read() == NullByte) { null } else { input.readLong() }
+    } catch {
+      case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
+    }
+  }
+
+  object FloatReader extends (Input => java.lang.Float) {
+    override def apply(input: Input): java.lang.Float = try {
+      if (input.read() == NullByte) { null } else { input.readFloat() }
+    } catch {
+      case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
+    }
+  }
+
+  object DoubleReader extends (Input => java.lang.Double) {
+    override def apply(input: Input): java.lang.Double = try {
+      if (input.read() == NullByte) { null } else { input.readDouble() }
+    } catch {
+      case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
+    }
+  }
+
+  object BooleanReader extends (Input => java.lang.Boolean) {
+    override def apply(input: Input): java.lang.Boolean = try {
+      if (input.read() == NullByte) { null } else { input.readBoolean() }
+    } catch {
+      case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
+    }
+  }
+
+  object DateReader extends (Input => Date) {
+    override def apply(input: Input): Date = try {
+      if (input.read() == NullByte) { null } else { new Date(input.readLong()) }
+    } catch {
+      case NonFatal(e) => logger.error("Error reading serialized kryo bytes", e); null
+    }
+  }
+
+  object UuidReader extends (Input => UUID) {
+    override def apply(input: Input): UUID = try {
+      if (input.read() == NullByte) { null } else { new UUID(input.readLong(), input.readLong()) }
+    } catch {
+      case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
+    }
+  }
+
+  object BytesReader extends (Input => Array[Byte]) {
+    override def apply(input: Input): Array[Byte] = try {
+      val size = input.readInt(true)
+      if (size == -1) { null } else {
+        val array = new Array[Byte](size)
+        input.read(array)
+        array
+      }
+    } catch {
+      case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
+    }
+  }
+
+  class ListReader(valueReader: Input => AnyRef) extends (Input => java.util.List[AnyRef]) {
+    override def apply(input: Input): util.List[AnyRef] = try {
+      val size = input.readInt(true)
+      if (size == -1) { null } else {
+        val list = new java.util.ArrayList[AnyRef](size)
+        var index = 0
+        while (index < size) {
+          list.add(valueReader.apply(input))
+          index += 1
+        }
+        list
+      }
+    } catch {
+      case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
+    }
+  }
+
+  class MapReader(keyReader: Input => AnyRef, valueReader: Input => AnyRef)
+      extends (Input => java.util.Map[AnyRef, AnyRef]) {
+    override def apply(input: Input): util.Map[AnyRef, AnyRef] = try {
+      val size = input.readInt(true)
+      if (size == -1) { null } else {
+        val map = new java.util.HashMap[AnyRef, AnyRef](size)
+        var index = 0
+        while (index < size) {
+          map.put(keyReader.apply(input), valueReader.apply(input))
+          index += 1
+        }
+        map
+      }
+    } catch {
+      case NonFatal(e) => logger.error("Error reading serialized kryo bytes:", e); null
+    }
+  }
+}

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureSerialization.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureSerialization.scala
@@ -6,33 +6,35 @@
  * http://www.opensource.org/licenses/apache2.0.php.
  ***********************************************************************/
 
-package org.locationtech.geomesa.features.kryo.impl
+package org.locationtech.geomesa.features.kryo
+package impl
 
 import java.io.OutputStream
 import java.util.{Date, UUID}
 
 import com.esotericsoftware.kryo.io.Output
-import org.locationtech.jts.geom.Geometry
 import org.locationtech.geomesa.features.SimpleFeatureSerializer
-import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer.{NON_NULL_BYTE, NULL_BYTE, VERSION}
 import org.locationtech.geomesa.features.kryo.json.KryoJsonSerialization
 import org.locationtech.geomesa.features.kryo.serialization.{KryoGeometrySerialization, KryoUserDataSerialization}
 import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.cache.{CacheKeyGenerator, SoftThreadLocal, SoftThreadLocalCache}
+import org.locationtech.geomesa.utils.collection.IntBitSet
 import org.locationtech.geomesa.utils.geometry.GeometryPrecision
+import org.locationtech.jts.geom.Geometry
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 trait KryoFeatureSerialization extends SimpleFeatureSerializer {
 
-  private [kryo] def serializeSft: SimpleFeatureType
+  protected [kryo] def in: SimpleFeatureType
 
-  private val cacheKey = CacheKeyGenerator.cacheKey(serializeSft)
-  private val writers = KryoFeatureSerialization.getWriters(cacheKey, serializeSft)
+  private val writers = KryoFeatureSerialization.getWriters(CacheKeyGenerator.cacheKey(in), in)
 
   private val withId = !options.withoutId
   private val withUserData = options.withUserData
+
+  private val count = in.getAttributeCount
 
   override def serialize(sf: SimpleFeature): Array[Byte] = {
     val output = KryoFeatureSerialization.getOutput(null)
@@ -47,155 +49,191 @@ trait KryoFeatureSerialization extends SimpleFeatureSerializer {
   }
 
   private def writeFeature(sf: SimpleFeature, output: Output): Unit = {
-    val offsets = KryoFeatureSerialization.getOffsets(cacheKey, writers.length)
+    output.writeByte(KryoFeatureSerializer.Version)
+    output.writeShort(count) // track the number of attributes
     val offset = output.position()
-    output.writeInt(VERSION, true)
-    output.setPosition(offset + 5) // leave 4 bytes to write the offsets
+    output.setPosition(offset + metadataSize(count))
     if (withId) {
-      // TODO optimize for uuids?
-      output.writeString(sf.getID)
+      output.writeString(sf.getID) // TODO optimize for uuids?
     }
     // write attributes and keep track off offset into byte array
+    val nulls = IntBitSet(count)
     var i = 0
-    while (i < writers.length) {
-      offsets(i) = output.position() - offset
-      writers(i)(output, sf.getAttribute(i))
+    while (i < count) {
+      val position = output.position()
+      output.setPosition(offset + (i * 2))
+      output.writeShort(position - offset)
+      output.setPosition(position)
+      val attribute = sf.getAttribute(i)
+      if (attribute == null) {
+        nulls.add(i)
+      } else {
+        writers(i).apply(output, attribute)
+      }
       i += 1
     }
-    // write the offsets - variable width
-    i = 0
-    val offsetStart = output.position() - offset
-    while (i < writers.length) {
-      output.writeInt(offsets(i), true)
-      i += 1
-    }
-    // got back and write the start position for the offsets
-    val end = output.position()
-    output.setPosition(offset + 1)
-    output.writeInt(offsetStart)
-    // reset the position back to the end of the buffer so the bytes aren't lost, and we can keep writing user data
-    output.setPosition(end)
-
+    val userDataPosition = output.position()
+    output.setPosition(offset + (i * 2))
+    output.writeShort(userDataPosition - offset)
+    output.setPosition(userDataPosition)
     if (withUserData) {
       KryoUserDataSerialization.serialize(output, sf.getUserData)
     }
+    val end = output.position()
+    if (end - offset > Short.MaxValue.toInt) {
+      // TODO handle overflow
+      throw new NotImplementedError(s"Serialized feature exceeds max byte size (${Short.MaxValue}): ${end - offset}")
+    }
+    // go back and write the nulls
+    output.setPosition(offset + (2 * count) + 2)
+    nulls.serialize(output)
+    // reset the position back to the end of the buffer so the bytes aren't lost
+    output.setPosition(end)
   }
 }
 
 object KryoFeatureSerialization {
 
-  private [this] val outputs = new SoftThreadLocal[Output]()
-  private [this] val writers = new SoftThreadLocalCache[String, Array[(Output, AnyRef) => Unit]]()
-  private [this] val offsets = new SoftThreadLocalCache[String, Array[Int]]()
+  import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 
+  import scala.collection.JavaConverters._
+
+  private [this] val outputs = new SoftThreadLocal[Output]()
+  private [this] val writers = new SoftThreadLocalCache[String, Array[KryoAttributeWriter]]()
+
+  /**
+    * Gets a reusable, thread-local output. Don't hold on to the result, as it may be re-used on a per-thread basis
+    *
+    * @param stream output stream, may be null
+    * @return
+    */
   def getOutput(stream: OutputStream): Output = {
     val out = outputs.getOrElseUpdate(new Output(1024, -1))
     out.setOutputStream(stream)
     out
   }
 
-  private [kryo] def getOffsets(sft: String, size: Int): Array[Int] =
-    offsets.getOrElseUpdate(sft, Array.ofDim[Int](size))
+  /**
+    * Get attribute writes for a feature type
+    *
+    * @param key cache key for the feature type
+    * @param sft simple feature type
+    * @return
+    */
+  def getWriters(key: String, sft: SimpleFeatureType): Array[KryoAttributeWriter] =
+    writers.getOrElseUpdate(key, sft.getAttributeDescriptors.asScala.map(writer).toArray)
 
-  private [geomesa] def getWriters(key: String, sft: SimpleFeatureType): Array[(Output, AnyRef) => Unit] = {
-    import scala.collection.JavaConversions._
-    writers.getOrElseUpdate(key,
-      sft.getAttributeDescriptors.map(ad => matchWriter(ObjectType.selectType(ad), ad)).toArray)
-  }
+  private [geomesa] def writer(descriptor: AttributeDescriptor): KryoAttributeWriter =
+    writer(ObjectType.selectType(descriptor), descriptor)
 
-  private [geomesa] def matchWriter(bindings: Seq[ObjectType], descriptor: AttributeDescriptor): (Output, AnyRef) => Unit = {
-    import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
+  private [geomesa] def writer(bindings: Seq[ObjectType], ad: AttributeDescriptor): KryoAttributeWriter = {
     bindings.head match {
-      case ObjectType.STRING =>
-        if (bindings.last == ObjectType.JSON) {
-          (o: Output, v: AnyRef) => KryoJsonSerialization.serialize(o, v.asInstanceOf[String])
-        } else {
-          (o: Output, v: AnyRef) => o.writeString(v.asInstanceOf[String]) // write string supports nulls
-        }
-      case ObjectType.INT =>
-        val w = (o: Output, v: AnyRef) => o.writeInt(v.asInstanceOf[Int])
-        writeNullable(w)
-      case ObjectType.LONG =>
-        val w = (o: Output, v: AnyRef) => o.writeLong(v.asInstanceOf[Long])
-        writeNullable(w)
-      case ObjectType.FLOAT =>
-        val w = (o: Output, v: AnyRef) => o.writeFloat(v.asInstanceOf[Float])
-        writeNullable(w)
-      case ObjectType.DOUBLE =>
-        val w = (o: Output, v: AnyRef) => o.writeDouble(v.asInstanceOf[Double])
-        writeNullable(w)
-      case ObjectType.BOOLEAN =>
-        val w = (o: Output, v: AnyRef) => o.writeBoolean(v.asInstanceOf[Boolean])
-        writeNullable(w)
-      case ObjectType.DATE =>
-        val w = (o: Output, v: AnyRef) => o.writeLong(v.asInstanceOf[Date].getTime)
-        writeNullable(w)
-      case ObjectType.UUID =>
-        val w = (o: Output, v: AnyRef) => {
-          val uuid = v.asInstanceOf[UUID]
-          o.writeLong(uuid.getMostSignificantBits)
-          o.writeLong(uuid.getLeastSignificantBits)
-        }
-        writeNullable(w)
+      case ObjectType.STRING   => if (bindings.last == ObjectType.JSON) { KryoJsonWriter } else { KryoStringWriter }
+      case ObjectType.INT      => KryoIntWriter
+      case ObjectType.LONG     => KryoLongWriter
+      case ObjectType.FLOAT    => KryoFloatWriter
+      case ObjectType.DOUBLE   => KryoDoubleWriter
+      case ObjectType.DATE     => KryoDateWriter
       case ObjectType.GEOMETRY =>
-        // null checks are handled by geometry serializer
-        descriptor.getPrecision match {
-          case GeometryPrecision.FullPrecision =>
-            (o: Output, v: AnyRef) => KryoGeometrySerialization.serializeWkb(o, v.asInstanceOf[Geometry])
-          case precision: GeometryPrecision.TwkbPrecision =>
-            (o: Output, v: AnyRef) => KryoGeometrySerialization.serialize(o, v.asInstanceOf[Geometry], precision)
+        ad.getPrecision match {
+          case GeometryPrecision.FullPrecision => KryoGeometryWkbWriter
+          case precision: GeometryPrecision.TwkbPrecision => KryoGeometryTwkbWriter(precision)
         }
-      case ObjectType.LIST =>
-        val valueWriter = matchWriter(bindings.drop(1), descriptor)
-        (o: Output, v: AnyRef) => {
-          val list = v.asInstanceOf[java.util.List[AnyRef]]
-          if (list == null) {
-            o.writeInt(-1, true)
-          } else {
-            o.writeInt(list.size(), true)
-            val iter = list.iterator()
-            while (iter.hasNext) {
-              valueWriter(o, iter.next())
-            }
-          }
-        }
-      case ObjectType.MAP =>
-        val keyWriter = matchWriter(bindings.slice(1, 2), descriptor)
-        val valueWriter = matchWriter(bindings.drop(2), descriptor)
-        (o: Output, v: AnyRef) => {
-          val map = v.asInstanceOf[java.util.Map[AnyRef, AnyRef]]
-          if (map == null) {
-            o.writeInt(-1, true)
-          } else {
-            o.writeInt(map.size(), true)
-            val iter = map.entrySet.iterator()
-            while (iter.hasNext) {
-              val entry = iter.next()
-              keyWriter(o, entry.getKey)
-              valueWriter(o, entry.getValue)
-            }
-          }
-        }
-      case ObjectType.BYTES =>
-        (o: Output, v: AnyRef) => {
-          val arr = v.asInstanceOf[Array[Byte]]
-          if (arr == null) {
-            o.writeInt(-1, true)
-          } else {
-            o.writeInt(arr.length, true)
-            o.writeBytes(arr)
-          }
-        }
+      case ObjectType.UUID     => KryoUuidWriter
+      case ObjectType.BYTES    => KryoBytesWriter
+      case ObjectType.BOOLEAN  => KryoBooleanWriter
+      case ObjectType.LIST     => KryoListWriter(writer(bindings.drop(1), ad))
+      case ObjectType.MAP      => KryoMapWriter(writer(bindings.slice(1, 2), ad), writer(bindings.drop(2), ad))
+
+      case b => throw new NotImplementedError(s"Unexpected attribute type binding: $b")
     }
   }
 
-  private def writeNullable(wrapped: (Output, AnyRef) => Unit): (Output, AnyRef) => Unit = {
-    (o: Output, v: AnyRef) => {
-      if (v == null) {
-        o.write(NULL_BYTE)
-      } else {
-        o.write(NON_NULL_BYTE)
-        wrapped(o, v)
+  sealed trait KryoAttributeWriter {
+    def apply(output: Output, value: AnyRef): Unit
+  }
+
+  case object KryoStringWriter extends KryoAttributeWriter {
+    override def apply(output: Output, value: AnyRef): Unit = output.writeString(value.asInstanceOf[String])
+  }
+
+  case object KryoIntWriter extends KryoAttributeWriter {
+    override def apply(output: Output, value: AnyRef): Unit = output.writeInt(value.asInstanceOf[Int])
+  }
+
+  case object KryoLongWriter extends KryoAttributeWriter {
+    override def apply(output: Output, value: AnyRef): Unit = output.writeLong(value.asInstanceOf[Long])
+  }
+
+  case object KryoFloatWriter extends KryoAttributeWriter {
+    override def apply(output: Output, value: AnyRef): Unit = output.writeFloat(value.asInstanceOf[Float])
+  }
+
+  case object KryoDoubleWriter extends KryoAttributeWriter {
+    override def apply(output: Output, value: AnyRef): Unit = output.writeDouble(value.asInstanceOf[Double])
+  }
+
+  case object KryoBooleanWriter extends KryoAttributeWriter {
+    override def apply(output: Output, value: AnyRef): Unit = output.writeBoolean(value.asInstanceOf[Boolean])
+  }
+
+  case object KryoDateWriter extends KryoAttributeWriter {
+    override def apply(output: Output, value: AnyRef): Unit = output.writeLong(value.asInstanceOf[Date].getTime)
+  }
+
+  case object KryoUuidWriter extends KryoAttributeWriter {
+    override def apply(output: Output, value: AnyRef): Unit = {
+      val uuid = value.asInstanceOf[UUID]
+      output.writeLong(uuid.getMostSignificantBits)
+      output.writeLong(uuid.getLeastSignificantBits)
+    }
+  }
+
+  case object KryoJsonWriter extends KryoAttributeWriter {
+    override def apply(output: Output, value: AnyRef): Unit =
+      KryoJsonSerialization.serialize(output, value.asInstanceOf[String])
+  }
+
+  case object KryoBytesWriter extends KryoAttributeWriter {
+    override def apply(output: Output, value: AnyRef): Unit = {
+      val array = value.asInstanceOf[Array[Byte]]
+      output.writeInt(array.length, true)
+      output.writeBytes(array)
+    }
+  }
+
+  case object KryoGeometryWkbWriter extends KryoAttributeWriter {
+    override def apply(output: Output, value: AnyRef): Unit =
+      KryoGeometrySerialization.serializeWkb(output, value.asInstanceOf[Geometry])
+  }
+
+  case class KryoGeometryTwkbWriter(precision: GeometryPrecision.TwkbPrecision) extends KryoAttributeWriter {
+    override def apply(output: Output, value: AnyRef): Unit =
+      KryoGeometrySerialization.serialize(output, value.asInstanceOf[Geometry], precision)
+  }
+
+  case class KryoListWriter(elements: KryoAttributeWriter) extends KryoAttributeWriter {
+    // TODO handle null elements?
+    override def apply(output: Output, value: AnyRef): Unit = {
+      val list = value.asInstanceOf[java.util.List[AnyRef]]
+      output.writeInt(list.size(), true)
+      val iter = list.iterator()
+      while (iter.hasNext) {
+        elements(output, iter.next())
+      }
+    }
+  }
+
+  case class KryoMapWriter(keys: KryoAttributeWriter, values: KryoAttributeWriter) extends KryoAttributeWriter {
+    // TODO handle null keys/values?
+    override def apply(output: Output, value: AnyRef): Unit = {
+      val map = value.asInstanceOf[java.util.Map[AnyRef, AnyRef]]
+      output.writeInt(map.size(), true)
+      val iter = map.entrySet.iterator()
+      while (iter.hasNext) {
+        val entry = iter.next()
+        keys(output, entry.getKey)
+        values(output, entry.getValue)
       }
     }
   }

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/LazyDeserialization.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/LazyDeserialization.scala
@@ -6,13 +6,15 @@
  * http://www.opensource.org/licenses/apache2.0.php.
  ***********************************************************************/
 
-package org.locationtech.geomesa.features.kryo.impl
+package org.locationtech.geomesa.features.kryo
+package impl
 
 import java.io.InputStream
 
 import com.esotericsoftware.kryo.io.Input
 import org.locationtech.geomesa.features.ScalaSimpleFeature.{LazyImmutableSimpleFeature, LazyMutableSimpleFeature}
-import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
+import org.locationtech.geomesa.features.kryo.serialization.KryoUserDataSerialization
+import org.locationtech.geomesa.utils.collection.IntBitSet
 import org.opengis.feature.simple.SimpleFeature
 
 object LazyDeserialization {
@@ -21,12 +23,11 @@ object LazyDeserialization {
     * Creates mutable features, lazily evaluated
     */
   trait MutableLazyDeserialization extends LazyDeserialization {
-    override protected def createFeature(id: String,
-                                         offsets: Array[Int],
-                                         userDataOffset: Int,
-                                         input: Input): SimpleFeature = {
-      new LazyMutableSimpleFeature(deserializeSft, id, readAttribute(_, offsets, input),
-        readUserData(userDataOffset, input))
+    override protected def createFeature(
+        id: String,
+        readAttribute: Int => AnyRef,
+        readUserData: () => java.util.Map[AnyRef, AnyRef]): SimpleFeature = {
+      new LazyMutableSimpleFeature(out, id, readAttribute, readUserData)
     }
   }
 
@@ -34,12 +35,11 @@ object LazyDeserialization {
     * Creates immutable features, lazily evaluated
     */
   trait ImmutableLazyDeserialization extends LazyDeserialization {
-    override protected def createFeature(id: String,
-                                         offsets: Array[Int],
-                                         userDataOffset: Int,
-                                         input: Input): SimpleFeature = {
-      new LazyImmutableSimpleFeature(deserializeSft, id, readAttribute(_, offsets, input),
-        readUserData(userDataOffset, input))
+    override protected def createFeature(
+        id: String,
+        readAttribute: Int => AnyRef,
+        readUserData: () => java.util.Map[AnyRef, AnyRef]): SimpleFeature = {
+      new LazyImmutableSimpleFeature(out, id, readAttribute, readUserData)
     }
   }
 }
@@ -49,28 +49,73 @@ object LazyDeserialization {
   */
 trait LazyDeserialization extends KryoFeatureDeserialization {
 
-  protected def createFeature(id: String, offsets: Array[Int], userDataOffset: Int, input: Input): SimpleFeature
-
-  override def deserialize(bytes: Array[Byte]): SimpleFeature = deserialize("", bytes, 0, bytes.length)
+  override def deserialize(bytes: Array[Byte]): SimpleFeature =
+    readFeature("", new Input(bytes, 0, bytes.length))
 
   override def deserialize(id: String, bytes: Array[Byte]): SimpleFeature =
-    deserialize(id, bytes, 0, bytes.length)
+    readFeature(id, new Input(bytes, 0, bytes.length))
+
+  override def deserialize(bytes: Array[Byte], offset: Int, length: Int): SimpleFeature =
+    readFeature("", new Input(bytes, offset, length))
+
+  override def deserialize(id: String, bytes: Array[Byte], offset: Int, length: Int): SimpleFeature =
+    readFeature(id, new Input(bytes, offset, length))
 
   // TODO read into a byte array so we can lazily evaluate it
   // user data is tricky here as we don't know the length...
   override def deserialize(in: InputStream): SimpleFeature = throw new NotImplementedError
   override def deserialize(id: String, in: InputStream): SimpleFeature = throw new NotImplementedError
 
-  override def deserialize(bytes: Array[Byte], offset: Int, length: Int): SimpleFeature =
-    deserialize("", bytes, offset, length)
+  protected def createFeature(
+      id: String,
+      readAttribute: Int => AnyRef,
+      readUserData: () => java.util.Map[AnyRef, AnyRef]): SimpleFeature
 
-  override def deserialize(id: String, bytes: Array[Byte], offset: Int, length: Int): SimpleFeature = {
-    val input = new Input(bytes, offset, offset + length)
-    if (input.readInt(true) != KryoFeatureSerializer.VERSION) {
-      throw new IllegalArgumentException("Can't process features serialized with wrong version")
+  private def readFeature(id: String, input: Input): SimpleFeature = {
+    input.readByte() match {
+      case KryoFeatureSerializer.Version  => readFeatureV3(id, input)
+      case KryoFeatureSerializer.Version2 => readFeatureV2(id, input)
+      case b => throw new IllegalArgumentException(s"Can't process features serialized with version: $b")
     }
+  }
+
+  private def readFeatureV3(id: String, input: Input): SimpleFeature = {
+    val count = input.readShort()
+    val offset = input.position()
+
+    // read our null mask
+    input.setPosition(offset + (2 * count) + 2)
+    val nulls = IntBitSet.deserialize(input, count)
+
+    // we should now be positioned to read the feature id
+    val finalId = if (withoutId) { id } else { input.readString() }
+    val toAttribute: Int => AnyRef = readAttributeV3(input, offset, count, nulls)
+    val toUserData: () => java.util.Map[AnyRef, AnyRef] = readUserDataV3(input, offset, count)
+    createFeature(finalId, toAttribute, toUserData)
+  }
+
+  private def readAttributeV3(input: Input, offset: Int, count: Int, nulls: IntBitSet)(i: Int): AnyRef = {
+    if (i >= count || nulls.contains(i)) { null } else {
+      // read the offset and go to the position for reading
+      input.setPosition(offset + (2 * i))
+      input.setPosition(offset + input.readShort())
+      readers(i).apply(input)
+    }
+  }
+
+  private def readUserDataV3(input: Input, offset: Int, count: Int)(): java.util.Map[AnyRef, AnyRef] = {
+    if (withoutUserData) { new java.util.HashMap[AnyRef, AnyRef](1) } else {
+      // read the offset and go to the position for reading
+      input.setPosition(offset + (2 * count))
+      input.setPosition(offset + input.readShort())
+      KryoUserDataSerialization.deserialize(input)
+    }
+  }
+
+  private def readFeatureV2(id: String, input: Input): SimpleFeature = {
+    val offset = input.position() - 1 // we've already read our version byte
     // read the start of the offsets, then the feature id
-    val offsets = Array.ofDim[Int](readers.length)
+    val offsets = Array.ofDim[Int](readersV2.length)
     val offsetStarts = offset + input.readInt()
     val finalId = if (withoutId) { id } else { input.readString() }
     // now read our offsets
@@ -86,20 +131,24 @@ trait LazyDeserialization extends KryoFeatureDeserialization {
     }
     val userDataOffset = input.position()
 
-    createFeature(finalId, offsets, userDataOffset, input)
+    val toAttribute: Int => AnyRef = readAttributeV2(offsets, input)
+    val toUserData: () => java.util.Map[AnyRef, AnyRef]  = readUserDataV2(userDataOffset, input)
+
+    createFeature(finalId, toAttribute, toUserData)
   }
 
-
-  protected def readAttribute(index: Int, offsets: Array[Int], input: Input): AnyRef = {
+  protected def readAttributeV2(offsets: Array[Int], input: Input)(index: Int): AnyRef = {
     val offset = offsets(index)
     if (offset == -1) { null } else {
       input.setPosition(offset)
-      readers(index)(input)
+      readersV2(index)(input)
     }
   }
 
-  protected def readUserData(offset: Int, input: Input): java.util.Map[AnyRef, AnyRef] = {
-    input.setPosition(offset)
-    readUserData(input, skipOffsets = false)
+  protected def readUserDataV2(offset: Int, input: Input)(): java.util.Map[AnyRef, AnyRef] = {
+    if (withoutUserData) { new java.util.HashMap[AnyRef, AnyRef] } else {
+      input.setPosition(offset)
+      KryoUserDataSerialization.deserialize(input)
+    }
   }
 }

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessor.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/json/JsonPathPropertyAccessor.scala
@@ -12,9 +12,9 @@ import java.lang.ref.SoftReference
 
 import com.jayway.jsonpath.Option.{ALWAYS_RETURN_LIST, DEFAULT_PATH_LEAF_TO_NULL, SUPPRESS_EXCEPTIONS}
 import com.jayway.jsonpath.{Configuration, JsonPath}
-import org.geotools.util.factory.Hints
 import org.geotools.feature.AttributeTypeBuilder
 import org.geotools.filter.expression.{PropertyAccessor, PropertyAccessorFactory}
+import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.features.kryo.KryoBufferSimpleFeature
 import org.locationtech.geomesa.features.kryo.json.JsonPathParser.{PathAttribute, PathAttributeWildCard, PathDeepScan, PathElement}
 import org.locationtech.geomesa.features.kryo.json.JsonPathPropertyAccessor.pathFor
@@ -120,13 +120,14 @@ object JsonPathPropertyAccessor {
     override protected def getFeatureType(obj: AnyRef): SimpleFeatureType =
       obj.asInstanceOf[SimpleFeature].getFeatureType
 
-    override protected def getValue(descriptor: AttributeDescriptor,
-                                    attribute: Int,
-                                    path: Seq[PathElement],
-                                    obj: AnyRef): Any = {
+    override protected def getValue(
+        descriptor: AttributeDescriptor,
+        attribute: Int,
+        path: Seq[PathElement],
+        obj: AnyRef): Any = {
       obj match {
         case s: KryoBufferSimpleFeature if descriptor.isJson() =>
-          KryoJsonSerialization.deserialize(s.getInput(attribute), path)
+          s.getInput(attribute).map(KryoJsonSerialization.deserialize(_, path)).orNull
 
         case s: SimpleFeature =>
           val json = s.getAttribute(attribute).asInstanceOf[String]

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/package.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/package.scala
@@ -1,0 +1,26 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.features
+
+import org.locationtech.geomesa.utils.collection.IntBitSet
+
+package object kryo {
+
+  /**
+    * Calculates the size (in bytes) required to store metadata for each feature, which currently consists
+    * of offsets for each attribute value and user data, and a bit mask for holding nulls
+    *
+    * Size required is:
+    *   2 bytes per attribute for relative offset + 2 bytes for user data offset + 4 bytes per bit mask for nulls
+    *
+    * @param count number of attributes
+    * @return
+    */
+  def metadataSize(count: Int): Int = (2 * count) + 2 + (IntBitSet.size(count) * 4)
+}

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/serialization/GeometrySerializer.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/serialization/GeometrySerializer.scala
@@ -19,12 +19,12 @@ import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
 class GeometrySerializer extends Serializer[Geometry] {
 
   override def write(kryo: Kryo, output: Output, geom: Geometry): Unit = {
-    output.writeInt(KryoFeatureSerializer.VERSION, true)
+    output.writeByte(KryoFeatureSerializer.Version)
     KryoGeometrySerialization.serialize(output, geom)
   }
 
   override def read(kryo: Kryo, input: Input, typ: Class[Geometry]): Geometry = {
-    input.readInt(true) // not used
+    input.readByte() // version - not used
     KryoGeometrySerialization.deserialize(input)
   }
 }

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/serialization/KryoUserDataSerialization.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/serialization/KryoUserDataSerialization.scala
@@ -47,7 +47,7 @@ object KryoUserDataSerialization extends GenericMapSerialization[Output, Input] 
 
   private implicit val ordering: Ordering[(AnyRef, AnyRef)] = Ordering.by(_._1.toString)
 
-  override def serialize(out: Output, javaMap: java.util.Map[AnyRef, AnyRef]): Unit = {
+  override def serialize(out: Output, javaMap: java.util.Map[_ <: AnyRef, _ <: AnyRef]): Unit = {
     import scala.collection.JavaConverters._
 
     // write in sorted order to keep consistent output

--- a/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/KryoBufferSimpleFeatureTest.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/KryoBufferSimpleFeatureTest.scala
@@ -19,8 +19,6 @@ import org.specs2.runner.JUnitRunner
 
 import scala.collection.JavaConversions._
 
-//import scala.languageFeature.postfixOps
-
 @RunWith(classOf[JUnitRunner])
 class KryoBufferSimpleFeatureTest extends Specification {
 

--- a/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/KryoFeatureSerializerTest.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/test/scala/org/locationtech/geomesa/features/kryo/KryoFeatureSerializerTest.scala
@@ -378,7 +378,7 @@ class KryoFeatureSerializerTest extends Specification with LazyLogging {
       foreach(options) { opts =>
         val serialized = KryoFeatureSerializer(sft, opts).serialize(sf)
         // mess up the bytes for 'geom' - this change was picked semi-randomly but works to fail the deserializer
-        serialized(32) = Byte.MaxValue
+        serialized(40) = Byte.MaxValue
 
         val deserialized = KryoFeatureSerializer(sft, opts).deserialize(serialized)
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/WritableFeature.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/WritableFeature.scala
@@ -177,10 +177,15 @@ object WritableFeature {
       visibilities
     }
 
-    lazy val indexGroups: Seq[(Array[Byte], Array[Byte])] =
-      visibilities.zipWithIndex.groupBy(_._1).map { case (vis, indices) =>
-        (vis.getBytes(StandardCharsets.UTF_8), indices.map(_._2.toByte).sorted)
-      }.toSeq
+    lazy val indexGroups: Seq[(Array[Byte], Array[Byte])] = {
+      val grouped = scala.collection.mutable.Map.empty[String, scala.collection.mutable.ArrayBuilder[Byte]]
+      var i = 0
+      while (i < visibilities.length) {
+        grouped.getOrElseUpdate(visibilities(i), Array.newBuilder[Byte]) += i.toByte
+        i += 1
+      }
+      grouped.map { case (vis, indices) => (vis.getBytes(StandardCharsets.UTF_8), indices.result) }.toSeq
+    }
 
     override lazy val values: Seq[KeyValue] = indexGroups.map { case (vis, indices) =>
       val sf = new ScalaSimpleFeature(feature.getFeatureType, "")

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/collection/AtomicBitSet.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/collection/AtomicBitSet.scala
@@ -28,7 +28,7 @@ class AtomicBitSet(array: AtomicIntegerArray) {
     * @param value value to check
     * @return true if contains, false otherwise
     */
-  def contains(value: Int): Boolean = (array.get(value >> Divisor) & (1 << value)) != 0L
+  def contains(value: Int): Boolean = (array.get(value >> Divisor) & (1 << value)) != 0
 
   /**
     * Adds the value to the set, if it is not present

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/collection/IntBitSet.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/collection/IntBitSet.scala
@@ -1,0 +1,247 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.collection
+
+import com.esotericsoftware.kryo.io.{Input, Output}
+
+/**
+  * A bit set backed by ints (to reduce memory footprint for small sizes).
+  *
+  * Provides access to the underlying mask, for serialization. Not thread safe.
+  */
+sealed abstract class IntBitSet {
+
+  /**
+    * Checks whether the value is contained in the set or not
+    *
+    * @param value value to check
+    * @return true if contains, false otherwise
+    */
+  def contains(value: Int): Boolean
+
+  /**
+    * Adds the value to the set, if it is not present. Note that implementations may be constructed with
+    * a fixed capacity - attempting to add a value outside the capacity will result in undefined behavior
+    *
+    * @param value value to add
+    * @return true if value was added, false if value was already present
+    */
+  def add(value: Int): Boolean
+
+  /**
+    * Removes the value from the set, if it is present
+    *
+    * @param value value to remove
+    * @return true if value was removed, false if value was not present
+    */
+  def remove(value: Int): Boolean
+
+  /**
+    * Resets all values
+    */
+  def clear(): Unit
+
+  /**
+    * Serialize to a kryo output stream
+    *
+    * @param output output
+    */
+  def serialize(output: Output): Unit
+}
+
+object IntBitSet {
+
+  // use `>> 5` instead of `/ 32`
+  private final val Divisor = 5
+
+  /**
+    * Create a bit set capable of holding numbers up to `length`
+    *
+    * @param length max int to be stored in the bit set
+    * @return
+    */
+  def apply(length: Int): IntBitSet = {
+    val words = size(length)
+    if (words == 1) {
+      new BitSet32(0)
+    } else if (words == 2) {
+      new BitSet64(0, 0)
+    } else {
+      new BitSetN(Array.fill(words)(0))
+    }
+  }
+
+  /**
+    * Deserialize from a kryo input stream
+    *
+    * @param input input
+    * @param length max int that the serialized bit set was capabable of storing
+    * @return
+    */
+  def deserialize(input: Input, length: Int): IntBitSet = {
+    val words = size(length)
+    if (words == 1) {
+      new BitSet32(input.readInt())
+    } else if (words == 2) {
+      new BitSet64(input.readInt(), input.readInt())
+    } else {
+      new BitSetN(Array.fill(words)(input.readInt()))
+    }
+  }
+
+  /**
+    * Gets the number of ints (words) required to hold numbers up to `length`
+    *
+    * @param length max int to be stored in the bit set
+    * @return
+    */
+  def size(length: Int): Int = ((length - 1) >> Divisor) + 1
+
+  /**
+    * Bit set for tracking values < 32
+    *
+    * @param mask underlying masked int
+    */
+  class BitSet32(private var mask: Int) extends IntBitSet {
+
+    override def contains(value: Int): Boolean = (mask & (1 << value)) != 0
+
+    override def add(value: Int): Boolean = {
+      val updated = mask | (1 << value)
+      if (updated == mask) {
+        false
+      } else {
+        mask = updated
+        true
+      }
+    }
+
+    override def remove(value: Int): Boolean = {
+      val updated = mask & ~(1 << value)
+      if (updated == mask) {
+        false
+      } else {
+        mask = updated
+        true
+      }
+    }
+
+    override def clear(): Unit = mask = 0
+
+    override def serialize(output: Output): Unit = output.writeInt(mask)
+  }
+
+  /**
+    * Bit set for tracking values < 64
+    *
+    * @param mask0 underlying masked int for 0-31
+    * @param mask1 underlying masked int for 31-63
+    */
+  class BitSet64(private var mask0: Int, private var mask1: Int) extends IntBitSet {
+
+    override def contains(value: Int): Boolean = {
+      val mask = if (value >> Divisor == 0) { mask0 } else { mask1 }
+      (mask & (1 << value)) != 0
+    }
+
+    override def add(value: Int): Boolean = {
+      if (value >> Divisor == 0) {
+        val updated = mask0 | (1 << value)
+        if (updated == mask0) {
+          false
+        } else {
+          mask0 = updated
+          true
+        }
+      } else {
+        val updated = mask1 | (1 << value)
+        if (updated == mask1) {
+          false
+        } else {
+          mask1 = updated
+          true
+        }
+      }
+    }
+
+    override def remove(value: Int): Boolean = {
+      if (value >> Divisor == 0) {
+        val updated = mask0 & ~(1 << value)
+        if (updated == mask0) {
+          false
+        } else {
+          mask0 = updated
+          true
+        }
+      } else {
+        val updated = mask1 & ~(1 << value)
+        if (updated == mask1) {
+          false
+        } else {
+          mask1 = updated
+          true
+        }
+      }
+    }
+
+    override def clear(): Unit = {
+      mask0 = 0
+      mask1 = 0
+    }
+
+    override def serialize(output: Output): Unit = {
+      output.writeInt(mask0)
+      output.writeInt(mask1)
+    }
+  }
+
+  /**
+    * Bit set for tracking values >= 64
+    *
+    * @param masks underlying mask values
+    */
+  class BitSetN(masks: Array[Int]) extends IntBitSet {
+
+    override def contains(value: Int): Boolean = (masks(value >> Divisor) & (1 << value)) != 0
+
+    override def add(value: Int): Boolean = {
+      val word = value >> Divisor
+      val current = masks(word)
+      val updated = current | (1 << value)
+      if (updated == current) {
+        false
+      } else {
+        masks(word) = updated
+        true
+      }
+    }
+
+    override def remove(value: Int): Boolean = {
+      val word = value >> Divisor
+      val current = masks(word)
+      val updated = current & ~(1 << value)
+      if (updated == current) {
+        false
+      } else {
+        masks(word) = updated
+        true
+      }
+    }
+
+    override def clear(): Unit = {
+      var i = 0
+      while (i < masks.length) {
+        masks(i) = 0
+        i += 1
+      }
+    }
+
+    override def serialize(output: Output): Unit = masks.foreach(output.writeInt)
+  }
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/ByteArrays.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/ByteArrays.scala
@@ -27,6 +27,10 @@ object ByteArrays {
   implicit val ByteOrdering: Ordering[Array[Byte]] =
     Ordering.comparatorToOrdering(UnsignedBytes.lexicographicalComparator)
 
+  implicit val UnsignedByteOrdering: Ordering[Byte] = new Ordering[Byte] {
+    override def compare(x: Byte, y: Byte): Int = UnsignedBytes.compare(x, y)
+  }
+
   /**
     * Writes the short as 2 bytes in the provided array, starting at offset
     *

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/collection/IntBitSetTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/collection/IntBitSetTest.scala
@@ -1,0 +1,95 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.collection
+
+import com.esotericsoftware.kryo.io.{Input, Output}
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.utils.collection.IntBitSet.{BitSet32, BitSet64, BitSetN}
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.util.Random
+
+@RunWith(classOf[JUnitRunner])
+class IntBitSetTest extends Specification {
+
+  val sizes = Seq(32, 64, 96) // gets each of the 3 bit set impls
+
+  val rands = new ThreadLocal[Random]() {
+    override def initialValue: Random = new Random(-7)
+  }
+
+  def shuffle(count: Int): Seq[Int] = rands.get.shuffle((0 until count).toList)
+
+  "IntBitSet" should {
+    "set and get values" >> {
+      foreach(sizes) { size =>
+        val bs = IntBitSet(size)
+        foreach(shuffle(size)) { i =>
+          bs.contains(i) must beFalse
+          bs.add(i) must beTrue
+          bs.contains(i) must beTrue
+          bs.add(i) must beFalse
+        }
+        foreach(shuffle(size)) { i =>
+          bs.remove(i) must beTrue
+          bs.contains(i) must beFalse
+          bs.remove(i) must beFalse
+          bs.contains(i) must beFalse
+        }
+      }
+    }
+    "clear values" >> {
+      foreach(sizes) { size =>
+        val bs = IntBitSet(size)
+        foreach(shuffle(size)) { i =>
+          bs.add(i) must beTrue
+        }
+        foreach(shuffle(size)) { i =>
+          bs.contains(i) must beTrue
+        }
+        bs.clear()
+        foreach(shuffle(size)) { i =>
+          bs.contains(i) must beFalse
+        }
+      }
+    }
+    "have the correct size" >> {
+      foreach(sizes) { size =>
+        val bs = IntBitSet(size)
+        size match {
+          case 32 => bs must beAnInstanceOf[BitSet32]
+          case 64 => bs must beAnInstanceOf[BitSet64]
+          case 96 => bs must beAnInstanceOf[BitSetN]
+        }
+        bs.add(size - 1) must beTrue
+        bs.contains(size - 1) must beTrue
+        bs.remove(size - 1) must beTrue
+        bs.contains(size - 1) must beFalse
+      }
+    }
+    "be serializable" >> {
+      val indices = Seq(rands.get.nextInt(32), rands.get.nextInt(32) + 32, rands.get.nextInt(32) + 64)
+      foreach(sizes) { size =>
+        val bs = IntBitSet(size)
+        indices.foreach { i =>
+          if (i < size) {
+            bs.add(i)
+          }
+        }
+        val output = new Output(32)
+        bs.serialize(output)
+        val recreated = IntBitSet.deserialize(new Input(output.toBytes), size)
+        foreach(0 until size) { i =>
+          recreated.contains(i) mustEqual indices.contains(i)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
* New V3 serialization format
* Doesn't require tracking offsets into serialized bytes
* De-references backing array when all attributes are read
* Stores nulls in a bitmask to save space

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>