### PR TITLE
GEOMESA-2688 Fix heatmap rendering outside [-180,180] longitude

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoLazyDensityIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoLazyDensityIterator.scala
@@ -17,15 +17,14 @@ import org.geotools.factory.Hints
 import org.locationtech.geomesa.accumulo.AccumuloFeatureIndexType
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.index.iterators.DensityScan
-import org.locationtech.geomesa.index.iterators.DensityScan.DensityResult
-import org.locationtech.geomesa.utils.geotools.GeometryUtils
+import org.locationtech.geomesa.utils.geotools.{GeometryUtils, RenderingGrid}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 
 /**
  * Density iterator - only works on kryo-encoded features
  */
-class KryoLazyDensityIterator extends BaseAggregatingIterator[DensityResult] with DensityScan
+class KryoLazyDensityIterator extends BaseAggregatingIterator[RenderingGrid] with DensityScan
 
 object KryoLazyDensityIterator extends LazyLogging {
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z2DensityIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z2DensityIterator.scala
@@ -8,70 +8,19 @@
 
 package org.locationtech.geomesa.accumulo.iterators
 
-import com.google.common.primitives.Longs
 import org.apache.accumulo.core.client.IteratorSetting
 import org.geotools.factory.Hints
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
-import org.locationtech.geomesa.accumulo.index.legacy.z2.Z2IndexV1
-import org.locationtech.geomesa.curve.LegacyZ2SFC
-import org.locationtech.geomesa.index.iterators.DensityScan.DensityResult
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-import org.locationtech.sfcurve.zorder.Z2
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
 /**
- * Density iterator that weights hits based on z2 schema
+ * Note: we don't need to weight hits based on split geometries, as otherwise polygons render
+ * much lighter than points
  */
-class Z2DensityIterator extends KryoLazyDensityIterator {
-
-  // TODO GEOMESA-1164 shares a lot of code with Z3DensityIter
-
-  import Z2DensityIterator.TableSharingKey
-
-  val zBytes = Array.fill[Byte](8)(0)
-
-  override protected def initResult(sft: SimpleFeatureType,
-                                    transform: Option[SimpleFeatureType],
-                                    options: Map[String, String]): DensityResult = {
-    val result = super.initResult(sft, transform, options)
-    if (sft.nonPoints) {
-      // normalize the weight based on how many representations of the geometry are in our index
-      // this is stored in the column qualifier
-      val normalizeWeight: (Double) => Double = (weight) => {
-        val hexCount = topKey.getColumnQualifier.toString
-        val hexSeparator = hexCount.indexOf(",")
-        if (hexSeparator == -1) {
-          weight
-        } else {
-          weight / Integer.parseInt(hexCount.substring(0, hexSeparator), 16)
-        }
-      }
-      val baseWeight = getWeight
-      getWeight = (sf) => normalizeWeight(baseWeight(sf))
-
-      // 1 for split plus optional 1 for table sharing
-      val zPrefix = if (options(TableSharingKey).toBoolean) { 2 } else { 1 }
-      writeGeom = (_, weight, result) => {
-        val row = topKey.getRowData
-        val zOffset = row.offset() + zPrefix
-        var k = 0
-        while (k < Z2IndexV1.GEOM_Z_NUM_BYTES) {
-          zBytes(k) = row.byteAt(zOffset + k)
-          k += 1
-        }
-        val (x, y) = LegacyZ2SFC.invert(Z2(Longs.fromByteArray(zBytes)))
-        val i = gridSnap.i(x)
-        val j = gridSnap.j(y)
-        if (i != -1 && j != -1) {
-          result(i, j) += weight
-        }
-      }
-    }
-
-    result
-  }
-}
+@deprecated
+class Z2DensityIterator extends KryoLazyDensityIterator
 
 object Z2DensityIterator {
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3DensityIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3DensityIterator.scala
@@ -8,69 +8,18 @@
 
 package org.locationtech.geomesa.accumulo.iterators
 
-import com.google.common.primitives.Longs
 import org.apache.accumulo.core.client.IteratorSetting
 import org.geotools.factory.Hints
 import org.locationtech.geomesa.accumulo.index.AccumuloFeatureIndex
-import org.locationtech.geomesa.accumulo.index.legacy.z3.Z3IndexV2
-import org.locationtech.geomesa.accumulo.iterators.Z2DensityIterator.TableSharingKey
-import org.locationtech.geomesa.curve.LegacyZ3SFC
-import org.locationtech.geomesa.index.iterators.DensityScan.DensityResult
-import org.locationtech.sfcurve.zorder.Z3
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
 /**
- * Density iterator that weights hits based on z3 schema
+ * Note: we don't need to weight hits based on split geometries, as otherwise polygons render
+ * much lighter than points
  */
-class Z3DensityIterator extends KryoLazyDensityIterator {
-
-  private val zBytes = Array.fill[Byte](8)(0)
-
-  override protected def initResult(sft: SimpleFeatureType,
-                                    transform: Option[SimpleFeatureType],
-                                    options: Map[String, String]): DensityResult = {
-    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-
-    val result = super.initResult(sft, transform, options)
-    if (sft.nonPoints) {
-      // normalize the weight based on how many representations of the geometry are in our index
-      // this is stored in the column qualifier
-      val normalizeWeight: (Double) => Double = (weight) => {
-        val hexCount = topKey.getColumnQualifier.toString
-        val hexSeparator = hexCount.indexOf(",")
-        if (hexSeparator == -1) {
-          weight
-        } else {
-          weight / Integer.parseInt(hexCount.substring(0, hexSeparator), 16)
-        }
-      }
-      val baseWeight = getWeight
-      getWeight = (sf) => normalizeWeight(baseWeight(sf))
-
-      val sfc = LegacyZ3SFC(sft.getZ3Interval)
-      // 1 for split plus optional 1 for table sharing
-      val zPrefix = if (options(TableSharingKey).toBoolean) { 2 } else { 1 }
-      writeGeom = (_, weight, result) => {
-        val row = topKey.getRowData
-        val zOffset = row.offset() + 3 // two for week and 1 for split
-        var k = 0
-        while (k < Z3IndexV2.GEOM_Z_NUM_BYTES) {
-          zBytes(k) = row.byteAt(zOffset + k)
-          k += 1
-        }
-        val (x, y, _) = sfc.invert(Z3(Longs.fromByteArray(zBytes)))
-        val i = gridSnap.i(x)
-        val j = gridSnap.j(y)
-        if (i != -1 && j != -1) {
-          result(i, j) += weight
-        }
-      }
-    }
-
-    result
-  }
-}
+@deprecated
+class Z3DensityIterator extends KryoLazyDensityIterator
 
 object Z3DensityIterator {
 

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterHelper.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterHelper.scala
@@ -536,6 +536,8 @@ object FilterHelper {
 
   def filterListAsAnd(filters: Seq[Filter]): Option[Filter] = andOption(filters)
 
+  def filterListAsOr(filters: Seq[Filter]): Option[Filter] = orOption(filters)
+
   /**
     * Simplifies filters to make them easier to process.
     *

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/coprocessor/aggregators/HBaseDensityAggregator.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/coprocessor/aggregators/HBaseDensityAggregator.scala
@@ -13,12 +13,11 @@ import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.hbase.HBaseFeatureIndexType
 import org.locationtech.geomesa.hbase.coprocessor.GeoMesaCoprocessor
 import org.locationtech.geomesa.index.iterators.DensityScan
-import org.locationtech.geomesa.index.iterators.DensityScan.DensityResult
-import org.locationtech.geomesa.utils.geotools.GeometryUtils
+import org.locationtech.geomesa.utils.geotools.{GeometryUtils, RenderingGrid}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 
-class HBaseDensityAggregator extends DensityScan with HBaseAggregator[DensityResult]
+class HBaseDensityAggregator extends DensityScan with HBaseAggregator[RenderingGrid]
 
 object HBaseDensityAggregator {
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/iterators/DensityScan.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/iterators/DensityScan.scala
@@ -25,7 +25,7 @@ import org.opengis.filter.expression.Expression
 trait DensityScan extends AggregatingScan[RenderingGrid] {
 
   // we snap each point into a pixel and aggregate based on that
-  protected var renderer: GeometryRenderer = _KafkaQueryRunner
+  protected var renderer: GeometryRenderer = _
 
   override protected def initResult(
       sft: SimpleFeatureType,

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/iterators/DensityScan.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/iterators/DensityScan.scala
@@ -7,8 +7,6 @@
  ***********************************************************************/
 
 package org.locationtech.geomesa.index.iterators
-import java.awt.image.BufferedImage
-
 import com.typesafe.scalalogging.LazyLogging
 import com.vividsolutions.jts.geom._
 import org.geotools.factory.Hints
@@ -17,50 +15,41 @@ import org.geotools.filter.text.ecql.ECQL
 import org.geotools.util.Converters
 import org.locationtech.geomesa.features.kryo.impl.{KryoFeatureDeserialization, KryoFeatureSerialization}
 import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
-import org.locationtech.geomesa.index.iterators.DensityScan.DensityResult
-import org.locationtech.geomesa.utils.geotools.{GeometryUtils, GridSnap}
+import org.locationtech.geomesa.index.iterators.DensityScan.GeometryRenderer
+import org.locationtech.geomesa.utils.geotools.{GridSnap, RenderingGrid}
 import org.locationtech.geomesa.utils.interop.SimpleFeatureTypes
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 import org.opengis.filter.expression.Expression
 
-import scala.annotation.tailrec
-import scala.util.control.NonFatal
-
-trait DensityScan extends AggregatingScan[DensityResult] {
+trait DensityScan extends AggregatingScan[RenderingGrid] {
 
   // we snap each point into a pixel and aggregate based on that
-  protected var gridSnap: GridSnap = _
-  protected var getWeight: (SimpleFeature) => Double = _
-  protected var writeGeom: (SimpleFeature, Double, DensityResult) => Unit = _
+  protected var renderer: GeometryRenderer = _KafkaQueryRunner
 
-  override protected def initResult(sft: SimpleFeatureType,
-                                    transform: Option[SimpleFeatureType],
-                                    options: Map[String, String]): DensityResult = {
-    import DensityScan.Configuration._
-    gridSnap = {
-      val bounds = options(EnvelopeOpt).split(",").map(_.toDouble)
-      val envelope = new Envelope(bounds(0), bounds(1), bounds(2), bounds(3))
-      val Array(width, height) = options(GridOpt).split(",").map(_.toInt)
-      new GridSnap(envelope, width, height)
-    }
-
-    getWeight = DensityScan.getWeight(sft, options.get(WeightOpt))
-    writeGeom = DensityScan.writeGeometry(sft, gridSnap)
-
-    scala.collection.mutable.Map.empty[(Int, Int), Double].withDefaultValue(0d)
+  override protected def initResult(
+      sft: SimpleFeatureType,
+      transform: Option[SimpleFeatureType],
+      options: Map[String, String]): RenderingGrid = {
+    renderer = DensityScan.getRenderer(sft, options.get(DensityScan.Configuration.WeightOpt))
+    val bounds = options(DensityScan.Configuration.EnvelopeOpt).split(",").map(_.toDouble)
+    val envelope = new Envelope(bounds(0), bounds(1), bounds(2), bounds(3))
+    val Array(width, height) = options(DensityScan.Configuration.GridOpt).split(",").map(_.toInt)
+    new RenderingGrid(envelope, width, height)
   }
 
-  override protected def aggregateResult(sf: SimpleFeature, result: DensityResult): Unit =
-    writeGeom(sf, getWeight(sf), result)
+  override protected def aggregateResult(sf: SimpleFeature, result: RenderingGrid): Unit =
+    renderer.render(result, sf)
 
-  override protected def encodeResult(result: DensityResult): Array[Byte] = DensityScan.encodeResult(result)
+  override protected def encodeResult(result: RenderingGrid): Array[Byte] = DensityScan.encodeResult(result)
 }
 
 object DensityScan extends LazyLogging {
 
-  type DensityResult = scala.collection.mutable.Map[(Int, Int), Double]
-  type GridIterator  = (SimpleFeature) => Iterator[(Double, Double, Double)]
+  import org.locationtech.geomesa.index.conf.QueryHints.RichHints
+  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
+  type GridIterator  = SimpleFeature => Iterator[(Double, Double, Double)]
 
   val DensitySft: SimpleFeatureType = SimpleFeatureTypes.createType("density", "*geom:Point:srid=4326")
   val DensityValueKey = new ClassKey(classOf[Array[Byte]])
@@ -72,13 +61,13 @@ object DensityScan extends LazyLogging {
     val WeightOpt   = "weight"
   }
 
-  def configure(sft: SimpleFeatureType,
-                index: GeoMesaFeatureIndex[_, _, _],
-                filter: Option[Filter],
-                hints: Hints): Map[String, String] = {
+  def configure(
+      sft: SimpleFeatureType,
+      index: GeoMesaFeatureIndex[_, _, _],
+      filter: Option[Filter],
+      hints: Hints): Map[String, String] = {
     import AggregatingScan.{OptionToConfig, StringToConfig}
     import Configuration.{EnvelopeOpt, GridOpt, WeightOpt}
-    import org.locationtech.geomesa.index.conf.QueryHints.RichHints
 
     val envelope = hints.getDensityEnvelope.get
     val (width, height) = hints.getDensityBounds.get
@@ -89,12 +78,13 @@ object DensityScan extends LazyLogging {
       WeightOpt   -> hints.getDensityWeight
     )
   }
+
   /**
     * Encodes a sparse matrix into a byte array
     */
-  def encodeResult(result: DensityResult): Array[Byte] = {
+  def encodeResult(result: RenderingGrid): Array[Byte] = {
     val output = KryoFeatureSerialization.getOutput(null)
-    result.toList.groupBy(_._1._1).foreach { case (row, cols) =>
+    result.iterator.toList.groupBy(_._1._1).foreach { case (row, cols) =>
       output.writeInt(row, true)
       output.writeInt(cols.size, true)
       cols.foreach { case (xy, weight) =>
@@ -135,260 +125,142 @@ object DensityScan extends LazyLogging {
     }
   }
 
-  def getWeight(sft: SimpleFeatureType, weight: Option[String]): (SimpleFeature) => Double = {
+  /**
+    * Gets a renderer for the associated geometry binding
+    *
+    * @param sft simple feature type
+    * @return
+    */
+  def getRenderer(sft: SimpleFeatureType, weight: Option[String]): GeometryRenderer = {
     // function to get the weight from the feature - defaults to 1.0 unless an attribute/exp is specified
-    val weightIndex = weight.map(sft.indexOf).getOrElse(-2)
-    if (weightIndex == -2) {
-      (_) => 1.0
-    } else if (weightIndex == -1) {
-      getWeightFromExpression(ECQL.toExpression(weight.get))
-    } else if (classOf[Number].isAssignableFrom(sft.getDescriptor(weightIndex).getType.getBinding)) {
-      getWeightFromNumber(weightIndex)
-    } else {
-      getWeightFromNonNumber(weightIndex)
+    val weigher = weight match {
+      case None => EqualWeight
+      case Some(w) =>
+        val i = sft.indexOf(w)
+        if (i == -1) {
+          new WeightByExpression(ECQL.toExpression(w))
+        } else if (classOf[Number].isAssignableFrom(sft.getDescriptor(i).getType.getBinding)) {
+          new WeightByNumber(i)
+        } else {
+          new WeightByNonNumber(i)
+        }
     }
-  }
 
-  def writeGeometry(sft: SimpleFeatureType, grid: GridSnap): (SimpleFeature, Double, DensityResult) => Unit = {
-    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-    val geomIndex = sft.getGeomIndex
     sft.getGeometryDescriptor.getType.getBinding match {
-      case b if b == classOf[Point]           => writePoint(geomIndex, grid)
-      case b if b == classOf[MultiPoint]      => writeMultiPoint(geomIndex, grid)
-      case b if b == classOf[LineString]      => writeLineString(geomIndex, grid)
-      case b if b == classOf[MultiLineString] => writeMultiLineString(geomIndex, grid)
-      case _                                  => writeGeometry(geomIndex, grid)
+      case b if b == classOf[Point]           => new PointRenderer(sft.getGeomIndex, weigher)
+      case b if b == classOf[MultiPoint]      => new MultiPointRenderer(sft.getGeomIndex, weigher)
+      case b if b == classOf[LineString]      => new LineStringRenderer(sft.getGeomIndex, weigher)
+      case b if b == classOf[MultiLineString] => new MultiLineStringRenderer(sft.getGeomIndex, weigher)
+      case b if b == classOf[Polygon]         => new PolygonRenderer(sft.getGeomIndex, weigher)
+      case b if b == classOf[MultiPolygon]    => new MultiPolygonRenderer(sft.getGeomIndex, weigher)
+      case _                                  => new MultiRenderer(sft.getGeomIndex, weigher)
     }
   }
 
   /**
-    * Gets the weight for a feature from a double attribute
+    * Gets the weight for a simple feature
     */
-  private def getWeightFromNumber(i: Int)(sf: SimpleFeature): Double = {
-    val d = sf.getAttribute(i).asInstanceOf[Number]
-    if (d == null) { 0.0 } else { d.doubleValue }
+  sealed trait Weigher {
+    def weight(sf: SimpleFeature): Double
+  }
+
+  case object EqualWeight extends Weigher {
+    override def weight(sf: SimpleFeature): Double = 1d
+  }
+
+  /**
+    * Gets the weight for a feature from a numeric attribute
+    */
+  class WeightByNumber(i: Int) extends Weigher {
+    override def weight(sf: SimpleFeature): Double = {
+      val d = sf.getAttribute(i).asInstanceOf[Number]
+      if (d == null) { 0.0 } else { d.doubleValue }
+    }
   }
 
   /**
     * Tries to convert a non-double attribute into a double
     */
-  private def getWeightFromNonNumber(i: Int)(sf: SimpleFeature): Double = {
-    val d = sf.getAttribute(i)
-    if (d == null) { 0.0 } else {
-      val converted = Converters.convert(d, classOf[java.lang.Double])
-      if (converted == null) 1.0 else converted
+  class WeightByNonNumber(i: Int) extends Weigher {
+    override def weight(sf: SimpleFeature): Double = {
+      val d = sf.getAttribute(i)
+      if (d == null) { 0.0 } else {
+        val converted = Converters.convert(d, classOf[java.lang.Double])
+        if (converted == null) { 1.0 } else { converted.doubleValue() }
+      }
     }
   }
 
   /**
     * Evaluates an arbitrary expression against the simple feature to return a weight
     */
-  private def getWeightFromExpression(e: Expression)(sf: SimpleFeature): Double = {
-    val d = e.evaluate(sf, classOf[java.lang.Double])
-    if (d == null) 0.0 else d
+  class WeightByExpression(e: Expression) extends Weigher {
+    override def weight(sf: SimpleFeature): Double = {
+      val d = e.evaluate(sf, classOf[java.lang.Double])
+      if (d == null) { 0.0 } else { d }
+    }
+  }
+
+  /**
+    * Renderer for geometries
+    */
+  sealed trait GeometryRenderer {
+    def render(grid: RenderingGrid, sf: SimpleFeature)
   }
 
   /**
     * Writes a density record from a feature that has a point geometry
     */
-  private def writePoint(geomIndex: Int, grid: GridSnap)
-                        (sf: SimpleFeature, weight: Double, result: DensityResult): Unit =
-    writePointToResult(sf.getAttribute(geomIndex).asInstanceOf[Point], weight, grid, result)
+  class PointRenderer(i: Int, weigher: Weigher) extends GeometryRenderer {
+    override def render(grid: RenderingGrid, sf: SimpleFeature): Unit =
+      grid.render(sf.getAttribute(i).asInstanceOf[Point], weigher.weight(sf))
+  }
 
   /**
     * Writes a density record from a feature that has a multi-point geometry
     */
-  private def writeMultiPoint(geomIndex: Int, grid: GridSnap)
-                             (sf: SimpleFeature, weight: Double, result: DensityResult): Unit =
-    writeMultiPointToResult(sf.getAttribute(geomIndex).asInstanceOf[MultiPoint], weight, grid, result)
+  class MultiPointRenderer(i: Int, weigher: Weigher) extends GeometryRenderer {
+    override def render(grid: RenderingGrid, sf: SimpleFeature): Unit =
+      grid.render(sf.getAttribute(i).asInstanceOf[MultiPoint], weigher.weight(sf))
+  }
 
   /**
     * Writes a density record from a feature that has a line geometry
     */
-  private def writeLineString(geomIndex: Int, grid: GridSnap)
-                             (sf: SimpleFeature, weight: Double, result: DensityResult): Unit =
-    writeLineToResult(sf.getAttribute(geomIndex).asInstanceOf[LineString], weight, grid, result)
+  class LineStringRenderer(i: Int, weigher: Weigher) extends GeometryRenderer {
+    override def render(grid: RenderingGrid, sf: SimpleFeature): Unit =
+      grid.render(sf.getAttribute(i).asInstanceOf[LineString], weigher.weight(sf))
+  }
 
   /**
     * Writes a density record from a feature that has a multi-line geometry
     */
-  private def writeMultiLineString(geomIndex: Int, grid: GridSnap)
-                                  (sf: SimpleFeature, weight: Double, result: DensityResult): Unit =
-    writeMultiLineToResult(sf.getAttribute(geomIndex).asInstanceOf[MultiLineString], weight, grid, result)
+  class MultiLineStringRenderer(i: Int, weigher: Weigher) extends GeometryRenderer {
+    override def render(grid: RenderingGrid, sf: SimpleFeature): Unit =
+      grid.render(sf.getAttribute(i).asInstanceOf[MultiLineString], weigher.weight(sf))
+  }
 
   /**
     * Writes a density record from a feature that has a polygon geometry
     */
-  private def writePolygon(geomIndex: Int, grid: GridSnap)
-                          (sf: SimpleFeature, weight: Double, result: DensityResult): Unit =
-    writePolygonToResult(sf.getAttribute(geomIndex).asInstanceOf[Polygon], weight, grid, result)
+  class PolygonRenderer(i: Int, weigher: Weigher) extends GeometryRenderer {
+    override def render(grid: RenderingGrid, sf: SimpleFeature): Unit =
+      grid.render(sf.getAttribute(i).asInstanceOf[Polygon], weigher.weight(sf))
+  }
 
   /**
     * Writes a density record from a feature that has a polygon geometry
     */
-  private def writeMultiPolygon(geomIndex: Int, grid: GridSnap)
-                               (sf: SimpleFeature, weight: Double, result: DensityResult): Unit =
-    writeMultiPolygonToResult(sf.getAttribute(geomIndex).asInstanceOf[MultiPolygon], weight, grid, result)
+  class MultiPolygonRenderer(i: Int, weigher: Weigher) extends GeometryRenderer {
+    override def render(grid: RenderingGrid, sf: SimpleFeature): Unit =
+      grid.render(sf.getAttribute(i).asInstanceOf[MultiPolygon], weigher.weight(sf))
+  }
 
   /**
     * Writes a density record from a feature that has an arbitrary geometry
     */
-  private def writeGeometry(geomIndex: Int, grid: GridSnap)
-                           (sf: SimpleFeature, weight: Double, result: DensityResult): Unit =
-    writeGeometryToResult(sf.getAttribute(geomIndex).asInstanceOf[Geometry], weight, grid, result)
-
-  private def writePointToResult(pt: Point, weight: Double, grid: GridSnap, result: DensityResult): Unit =
-    writeSnappedPoint(grid.i(pt.getX), grid.j(pt.getY), weight, result)
-
-  private def writeMultiPointToResult(pts: MultiPoint, weight: Double, grid: GridSnap, result: DensityResult): Unit = {
-    var i = 0
-    while (i < pts.getNumGeometries) {
-      writePointToResult(pts.getGeometryN(i).asInstanceOf[Point], weight, grid, result)
-      i += 1
-    }
-  }
-
-  private def writeLineToResult(ls: LineString, weight: Double, grid: GridSnap, result: DensityResult): Unit = {
-    if (ls.getNumPoints < 1) {
-      logger.warn(s"Encountered line string with fewer than two points: $ls")
-    } else {
-      var iN, jN = -1 // track the last pixel we've written to avoid double-counting
-      val points = Seq.tabulate(ls.getNumPoints) { i => val p = ls.getCoordinateN(i); (p, grid.i(p.x), grid.j(p.y)) }
-
-      points.sliding(2).foreach { case Seq((p0, i0, j0), (p1, i1, j1)) =>
-        if (i0 == -1 || j0 == -1 || i1 == -1 || j1 == -1) {
-          // line is not entirely contained in the grid region
-          // find the intersection of the line segment with the grid region
-          try {
-            val intersection = GeometryUtils.geoFactory.createLineString(Array(p0, p1)).intersection(grid.envelope)
-            if (!intersection.isEmpty) {
-              writeGeometryToResult(intersection, weight, grid, result)
-            }
-          } catch {
-            case NonFatal(e) => logger.error(s"Error intersecting line string [$p0 $p1] with ${grid.envelope}", e)
-          }
-        } else {
-          val bresenham = grid.bresenhamLine(i0, j0, i1, j1)
-          // check the first point for overlap with last line segment
-          val (iF, jF) = bresenham.next
-          if (iF != iN || jF != jN) {
-            writeSnappedPoint(iF, jF, weight, result)
-          }
-          var next = bresenham.hasNext
-          if (!next) {
-            iN = iF
-            jN = jF
-          } else {
-            @tailrec
-            def writeNext(): Unit = {
-              val (i, j) = bresenham.next
-              writeSnappedPoint(i, j, weight, result)
-              if (bresenham.hasNext) {
-                writeNext()
-              } else {
-                iN = i
-                jN = j
-              }
-            }
-            writeNext()
-          }
-        }
-      }
-    }
-  }
-
-  private def writeMultiLineToResult(lines: MultiLineString, weight: Double, grid: GridSnap, result: DensityResult): Unit = {
-    var i = 0
-    while (i < lines.getNumGeometries) {
-      writeLineToResult(lines.getGeometryN(i).asInstanceOf[LineString], weight, grid, result)
-      i += 1
-    }
-  }
-
-  private def writePolygonToResult(poly: Polygon, weight: Double, grid: GridSnap, result: DensityResult): Unit = {
-    val envelope = poly.getEnvelopeInternal
-    val imin = grid.i(envelope.getMinX)
-    val imax = grid.i(envelope.getMaxX)
-    val jmin = grid.j(envelope.getMinY)
-    val jmax = grid.j(envelope.getMaxY)
-
-    if (imin == -1 || imax == -1 || jmin == -1 || jmax == -1) {
-      // polygon is not entirely contained in the grid region
-      // find the intersection of the polygon with the grid region
-      try {
-        val intersection = poly.intersection(grid.envelope)
-        if (!intersection.isEmpty) {
-          writeGeometryToResult(intersection, weight, grid, result)
-        }
-      } catch {
-        case NonFatal(e) => logger.error(s"Error intersecting polygon [$poly] with ${grid.envelope}", e)
-      }
-    } else {
-      val iLength = imax - imin + 1
-      val jLength = jmax - jmin + 1
-
-      val raster = {
-        // use java awt graphics to draw our polygon on the grid
-        val image = new BufferedImage(iLength, jLength, BufferedImage.TYPE_BYTE_BINARY)
-        val graphics = image.createGraphics()
-
-        val border = poly.getExteriorRing
-        val xPoints = Array.ofDim[Int](border.getNumPoints)
-        val yPoints = Array.ofDim[Int](border.getNumPoints)
-        var i = 0
-        while (i < xPoints.length) {
-          val coord = border.getCoordinateN(i)
-          xPoints(i) = grid.i(coord.x) - imin
-          yPoints(i) = grid.j(coord.y) - jmin
-          i += 1
-        }
-        graphics.fillPolygon(xPoints, yPoints, xPoints.length)
-        image.getRaster
-      }
-
-      var i, j = 0
-      while (i < iLength) {
-        while (j < jLength) {
-          if (raster.getSample(i, j, 0) != 0) {
-            writeSnappedPoint(i + imin, j + jmin, weight, result)
-          }
-          j += 1
-        }
-        j = 0
-        i += 1
-      }
-    }
-  }
-
-  private def writeMultiPolygonToResult(polys: MultiPolygon, weight: Double, grid: GridSnap, result: DensityResult): Unit = {
-    var i = 0
-    while (i < polys.getNumGeometries) {
-      writePolygonToResult(polys.getGeometryN(i).asInstanceOf[Polygon], weight, grid, result)
-      i += 1
-    }
-  }
-
-  private def writeGeometryToResult(geometry: Geometry, weight: Double, grid: GridSnap, result: DensityResult): Unit = {
-    geometry match {
-      case g: Point              => writePointToResult(g, weight, grid, result)
-      case g: LineString         => writeLineToResult(g, weight, grid, result)
-      case g: Polygon            => writePolygonToResult(g, weight, grid, result)
-      case g: MultiPoint         => writeMultiPointToResult(g, weight, grid, result)
-      case g: MultiLineString    => writeMultiLineToResult(g, weight, grid, result)
-      case g: MultiPolygon       => writeMultiPolygonToResult(g, weight, grid, result)
-
-      case g: GeometryCollection =>
-        var i = 0
-        while (i < g.getNumGeometries) {
-          writeGeometryToResult(g.getGeometryN(i), weight, grid, result)
-          i += 1
-        }
-    }
-  }
-
-  private def writeSnappedPoint(i: Int, j: Int, weight: Double, result: DensityResult): Unit = {
-    if (i != -1 && j != -1) {
-      result(i, j) += weight
-    }
+  class MultiRenderer(i: Int, weigher: Weigher) extends GeometryRenderer {
+    override def render(grid: RenderingGrid, sf: SimpleFeature): Unit =
+      grid.render(sf.getAttribute(i).asInstanceOf[Geometry], weigher.weight(sf))
   }
 }

--- a/geomesa-lambda/geomesa-lambda-datastore/src/main/scala/org/locationtech/geomesa/lambda/stream/kafka/KafkaQueryRunner.scala
+++ b/geomesa-lambda/geomesa-lambda-datastore/src/main/scala/org/locationtech/geomesa/lambda/stream/kafka/KafkaQueryRunner.scala
@@ -30,7 +30,7 @@ import org.locationtech.geomesa.security.{AuthorizationsProvider, SecurityUtils,
 import org.locationtech.geomesa.utils.bin.BinaryOutputEncoder
 import org.locationtech.geomesa.utils.bin.BinaryOutputEncoder.EncodingOptions
 import org.locationtech.geomesa.utils.collection.CloseableIterator
-import org.locationtech.geomesa.utils.geotools.{GeometryUtils, GridSnap, SimpleFeatureOrdering}
+import org.locationtech.geomesa.utils.geotools.{GeometryUtils, RenderingGrid, SimpleFeatureOrdering}
 import org.locationtech.geomesa.utils.stats.{Stat, TopK}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.{Filter, Id}
@@ -251,15 +251,13 @@ class KafkaQueryRunner(features: ReadableFeatureCache, stats: GeoMesaStats, auth
                                width: Int,
                                height: Int,
                                weight: Option[String]): Iterator[SimpleFeature] = {
-    val grid = new GridSnap(envelope, width, height)
-    val result = scala.collection.mutable.Map.empty[(Int, Int), Double]
-    val getWeight = DensityScan.getWeight(sft, weight)
-    val writeGeom = DensityScan.writeGeometry(sft, grid)
-    features.foreach(f => writeGeom(f, getWeight(f), result))
+    val grid = new RenderingGrid(envelope, width, height)
+    val renderer = DensityScan.getRenderer(sft, weight)
+    features.foreach(f => renderer.render(grid, f))
 
     val sf = new ScalaSimpleFeature(DensityScan.DensitySft, "", Array(GeometryUtils.zeroPoint))
     // Return value in user data so it's preserved when passed through a RetypingFeatureCollection
-    sf.getUserData.put(DensityScan.DensityValueKey, DensityScan.encodeResult(result))
+    sf.getUserData.put(DensityScan.DensityValueKey, DensityScan.encodeResult(grid))
     Iterator(sf)
   }
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeometryUtils.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeometryUtils.scala
@@ -174,11 +174,11 @@ object GeometryUtils extends LazyLogging {
       }
 
       // if the bbox extends past world bounds, split and wrap it
-      if (translated.getMinX < -180d) {
+      if (translated.getMinX < -180d && translated.getMaxX < 180d) {
         val trimmed = new ReferencedEnvelope(-180d , translated.getMaxX, envelope.getMinY, envelope.getMaxY, crs)
         val wrapped = new ReferencedEnvelope(translated.getMinX + 360d , 180d, envelope.getMinY, envelope.getMaxY, crs)
         Seq(trimmed, wrapped)
-      } else if (translated.getMaxX > 180d) {
+      } else if (translated.getMaxX > 180d && translated.getMinX > -180d) {
         val trimmed = new ReferencedEnvelope(translated.getMinX, 180d, envelope.getMinY, envelope.getMaxY, crs)
         val wrapped = new ReferencedEnvelope(-180d, translated.getMaxX - 360d, envelope.getMinY, envelope.getMaxY, crs)
         Seq(trimmed, wrapped)

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeometryUtils.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GeometryUtils.scala
@@ -8,14 +8,17 @@
 
 package org.locationtech.geomesa.utils.geotools
 
+import com.typesafe.scalalogging.LazyLogging
 import com.vividsolutions.jts.geom._
-import org.geotools.geometry.jts.JTSFactoryFinder
+import org.geotools.geometry.jts.{JTSFactoryFinder, ReferencedEnvelope}
 import org.geotools.referencing.GeodeticCalculator
+
+import scala.util.control.NonFatal
 
 /**
  * The object provides convenience methods for common operations on geometries.
  */
-object GeometryUtils {
+object GeometryUtils extends LazyLogging {
 
   val geoFactory = JTSFactoryFinder.getGeometryFactory
 
@@ -142,5 +145,48 @@ object GeometryUtils {
     val slope = (point1.y - point2.y) / (point1.x - point2.x);
     val intercept = point1.y - (slope * point1.x);
     (slope * crossLon) + intercept;
+  }
+
+  /**
+    * Split a bounding box envelope, which may extend outside [-180,180], into one or more envelopes
+    * that are contained within [-180,180]
+    *
+    * @param envelope envelope of a bounding box
+    * @return
+    */
+  def splitBoundingBox(envelope: ReferencedEnvelope): Seq[ReferencedEnvelope] = {
+    try {
+      val crs = envelope.getCoordinateReferenceSystem
+
+      // if the bbox is completely outside world bounds, translate to bring it back in
+      val translated = if (envelope.getMinX >= 180d) {
+        val multiplier = math.ceil((envelope.getMinX - 180d) / 360d)
+        val left = envelope.getMinX - 360d * multiplier
+        val right = envelope.getMaxX - 360d * multiplier
+        new ReferencedEnvelope(left, right, envelope.getMinY, envelope.getMaxY, crs)
+      } else if (envelope.getMaxX <= -180d) {
+        val multiplier = math.ceil((envelope.getMaxX + 180d) / -360d)
+        val left = envelope.getMinX + 360d * multiplier
+        val right = envelope.getMaxX + 360d * multiplier
+        new ReferencedEnvelope(left, right, envelope.getMinY, envelope.getMaxY, crs)
+      } else {
+        envelope
+      }
+
+      // if the bbox extends past world bounds, split and wrap it
+      if (translated.getMinX < -180d) {
+        val trimmed = new ReferencedEnvelope(-180d , translated.getMaxX, envelope.getMinY, envelope.getMaxY, crs)
+        val wrapped = new ReferencedEnvelope(translated.getMinX + 360d , 180d, envelope.getMinY, envelope.getMaxY, crs)
+        Seq(trimmed, wrapped)
+      } else if (translated.getMaxX > 180d) {
+        val trimmed = new ReferencedEnvelope(translated.getMinX, 180d, envelope.getMinY, envelope.getMaxY, crs)
+        val wrapped = new ReferencedEnvelope(-180d, translated.getMaxX - 360d, envelope.getMinY, envelope.getMaxY, crs)
+        Seq(trimmed, wrapped)
+      } else {
+        Seq(translated)
+      }
+    } catch {
+      case NonFatal(e) => logger.warn(s"Error splitting bounding box envelope '$envelope':", e); Seq(envelope)
+    }
   }
 }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GridSnap.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/GridSnap.scala
@@ -13,6 +13,13 @@ import com.vividsolutions.jts.geom.{Envelope, Geometry}
 
 import scala.math.abs
 
+/**
+  * Snaps points to cells of a defined grid
+  *
+  * @param env bounding envelope
+  * @param xSize number of x cells in the grid
+  * @param ySize number of y cells in the grid
+  */
 class GridSnap(env: Envelope, xSize: Int, ySize: Int) {
 
   lazy val envelope: Geometry = GeometryUtils.geoFactory.toGeometry(env)
@@ -53,8 +60,8 @@ class GridSnap(env: Envelope, xSize: Int, ySize: Int) {
   def i(x: Double): Int = {
     if (x < xMin || x > xMax) { -1 } else {
       val i = math.floor((x - xMin) / dx).toInt
-      // i == length check catches the upper bound
-      if (i < 0 || i > xSize) { -1 } else if (i == xSize) { xSize - 1 } else { i }
+      // i >= size check catches the upper bound
+      if (i >= xSize) { xSize - 1 } else { i }
     }
   }
 
@@ -67,8 +74,8 @@ class GridSnap(env: Envelope, xSize: Int, ySize: Int) {
   def j(y: Double): Int = {
     if (y < yMin || y > yMax) { -1 } else {
       val i = math.floor((y - yMin) / dy).toInt
-      // i == length check catches the upper bound
-      if (i < 0 || i > ySize) { -1 } else if (i == ySize) { ySize - 1 } else { i }
+      // i >= size check catches the upper bound
+      if (i >= ySize) { ySize - 1 } else { i }
     }
   }
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/RenderingGrid.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/RenderingGrid.scala
@@ -1,0 +1,311 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.geotools
+
+import java.awt.image.BufferedImage
+
+import com.typesafe.scalalogging.LazyLogging
+import com.vividsolutions.jts.geom._
+
+import scala.annotation.tailrec
+import scala.util.control.NonFatal
+
+/**
+  * Renders geometries to a fixed-size grid of pixels
+  *
+  * @param env the rendering envelope
+  * @param xSize x pixel count
+  * @param ySize y pixel count
+  */
+class RenderingGrid(env: Envelope, xSize: Int, ySize: Int) extends LazyLogging {
+
+  private val grid = new GridSnap(env, xSize, ySize)
+  private val pixels = scala.collection.mutable.Map.empty[(Int, Int), Double].withDefaultValue(0d)
+
+  private val xMin = env.getMinX
+  private val xMax = env.getMaxX
+
+  private val wide = xMax - xMin > 360d
+
+  /**
+    * Render a point
+    *
+    * @param point geometry
+    * @param weight weight
+    */
+  def render(point: Point, weight: Double): Unit = {
+    val j = grid.j(point.getY)
+    if (j != -1) {
+      translate(point.getX).foreach(i => pixels(i, j) += weight)
+    }
+  }
+
+  /**
+    * Render a multi-point
+    *
+    * @param multiPoint geometry
+    * @param weight weight
+    */
+  def render(multiPoint: MultiPoint, weight: Double): Unit = {
+    var i = 0
+    while (i < multiPoint.getNumGeometries) {
+      render(multiPoint.getGeometryN(i).asInstanceOf[Point], weight)
+      i += 1
+    }
+  }
+
+  /**
+    * Render a line string
+    *
+    * @param lineString geometry
+    * @param weight weight
+    */
+  def render(lineString: LineString, weight: Double): Unit = {
+    if (lineString.getNumPoints > 0) {
+      var iN, jN = -1 // track the last pixel we've written to avoid double-counting
+
+      // our working coordinates
+      var p0: Coordinate = null
+      var i0: Seq[Int] = null
+      var j0: Int = -1
+      var p1 = lineString.getCoordinateN(0)
+      var i1 = translate(p1.x)
+      var j1 = grid.j(p1.y)
+
+      var n = 1
+      while (n < lineString.getNumPoints) {
+        // increment to the next pair of points
+        p0 = p1
+        i0 = i1
+        j0 = j1
+        p1 = lineString.getCoordinateN(n)
+        i1 = translate(p1.x)
+        j1 = grid.j(p1.y)
+
+        if (i0.isEmpty || j0 == -1 || i1.isEmpty || j1 == -1) {
+          // line is not entirely contained in the grid region
+          // find the intersection of the line segment with the grid region
+          try {
+            val intersection = GeometryUtils.geoFactory.createLineString(Array(p0, p1)).intersection(grid.envelope)
+            if (!intersection.isEmpty) {
+              render(intersection, weight)
+            }
+          } catch {
+            case NonFatal(e) => logger.error(s"Error intersecting line string [$p0 $p1] with ${grid.envelope}", e)
+          }
+        } else {
+          val bresenham = grid.bresenhamLine(i0.head, j0, i1.head, j1)
+          // check the first point for overlap with last line segment
+          val (iF, jF) = bresenham.next
+          if (iF != iN || jF != jN) {
+            pixels(iF, jF) += weight
+            i0.tail.foreach { i0N =>
+              pixels(iF - i0.head + i0N, jF) += weight
+            }
+          }
+          if (!bresenham.hasNext) {
+            iN = iF
+            jN = jF
+          } else {
+            @tailrec
+            def writeNext(): Unit = {
+              val (i, j) = bresenham.next
+              pixels(i, j) += weight
+              i0.tail.foreach { i0N =>
+                pixels(i - i0.head + i0N, j) += weight
+              }
+              if (bresenham.hasNext) {
+                writeNext()
+              } else {
+                iN = i
+                jN = j
+              }
+            }
+            writeNext()
+          }
+        }
+
+        n += 1
+      }
+    }
+  }
+
+  /**
+    * Render a multi-line
+    *
+    * @param multiLineString geometry
+    * @param weight weight
+    */
+  def render(multiLineString: MultiLineString, weight: Double): Unit = {
+    var i = 0
+    while (i < multiLineString.getNumGeometries) {
+      render(multiLineString.getGeometryN(i).asInstanceOf[LineString], weight)
+      i += 1
+    }
+  }
+
+  /**
+    * Render a polygon
+    *
+    * @param polygon geometry
+    * @param weight weight
+    */
+  def render(polygon: Polygon, weight: Double): Unit = {
+    val envelope = polygon.getEnvelopeInternal
+    val imins = translate(envelope.getMinX)
+    val imaxes = translate(envelope.getMaxX)
+    val jmin = grid.j(envelope.getMinY)
+    val jmax = grid.j(envelope.getMaxY)
+
+    if (imins.isEmpty || imaxes.isEmpty || jmin == -1 || jmax == -1) {
+      // polygon is not entirely contained in the grid region
+      // find the intersection of the polygon with the grid region
+      try {
+        val intersection = polygon.intersection(grid.envelope)
+        if (!intersection.isEmpty) {
+          render(intersection, weight)
+        }
+      } catch {
+        case NonFatal(e) => logger.error(s"Error intersecting polygon [$polygon] with ${grid.envelope}", e)
+      }
+    } else {
+      val imin = imins.head
+      val iLength = imaxes.head - imin + 1
+      val jLength = jmax - jmin + 1
+
+      val raster = {
+        // use java awt graphics to draw our polygon on the grid
+        val image = new BufferedImage(iLength, jLength, BufferedImage.TYPE_BYTE_BINARY)
+        val graphics = image.createGraphics()
+
+        val border = polygon.getExteriorRing
+        val xPoints = Array.ofDim[Int](border.getNumPoints)
+        val yPoints = Array.ofDim[Int](border.getNumPoints)
+        var i = 0
+        while (i < xPoints.length) {
+          val coord = border.getCoordinateN(i)
+          xPoints(i) = translate(coord.x).head - imin
+          yPoints(i) = grid.j(coord.y) - jmin
+          i += 1
+        }
+        graphics.fillPolygon(xPoints, yPoints, xPoints.length)
+        image.getRaster
+      }
+
+      var i, j = 0
+      while (i < iLength) {
+        while (j < jLength) {
+          if (raster.getSample(i, j, 0) != 0) {
+            imins.foreach(im => pixels(i + im, j + jmin) += weight)
+          }
+          j += 1
+        }
+        j = 0
+        i += 1
+      }
+    }
+  }
+
+  /**
+    * Render a multi-polygon
+    *
+    * @param multiPolygon geometry
+    * @param weight weight
+    */
+  def render(multiPolygon: MultiPolygon, weight: Double): Unit = {
+    var i = 0
+    while (i < multiPolygon.getNumGeometries) {
+      render(multiPolygon.getGeometryN(i).asInstanceOf[Polygon], weight)
+      i += 1
+    }
+  }
+
+  /**
+    * Render an arbitrary geometry
+    *
+    * @param geometry geometry
+    * @param weight weight
+    */
+  def render(geometry: Geometry, weight: Double): Unit = {
+    geometry match {
+      case g: Point              => render(g, weight)
+      case g: LineString         => render(g, weight)
+      case g: Polygon            => render(g, weight)
+      case g: MultiPoint         => render(g, weight)
+      case g: MultiLineString    => render(g, weight)
+      case g: MultiPolygon       => render(g, weight)
+      case g: GeometryCollection =>
+        var i = 0
+        while (i < g.getNumGeometries) {
+          render(g.getGeometryN(i), weight)
+          i += 1
+        }
+      case _ => throw new NotImplementedError(s"Unexpected geometry type: $geometry")
+    }
+  }
+
+  /**
+    * Have any pixels been rendered?
+    *
+    * @return
+    */
+  def isEmpty: Boolean = pixels.isEmpty
+
+  /**
+    * Pixel weights
+    *
+    * @return
+    */
+  def iterator: Iterator[((Int, Int), Double)] = pixels.iterator
+
+  /**
+    * Clear any rendered pixels
+    */
+  def clear(): Unit = pixels.clear()
+
+  /**
+    * Translate a point into the output envelope. If the envelope is larger than 360 degrees, points may
+    * be rendered more than once
+    *
+    * @param x longitude
+    * @return
+    */
+  private def translate(x: Double): Seq[Int] = {
+    if (x < xMin) {
+      val xt = x + (360d * math.ceil((xMin - x) / 360))
+      if (xt > xMax) { Seq.empty } else { widen(xt) }
+    } else if (x > xMax) {
+      val xt = x - (360d * math.ceil((x - xMax) / 360))
+      if (xt < xMin) { Seq.empty } else { widen(xt) }
+    } else {
+      widen(x)
+    }
+  }
+
+  /**
+    * Returns any pixels that should be rendered for the given point
+    *
+    * @param x longitude
+    * @return
+    */
+  private def widen(x: Double): Seq[Int] = {
+    if (wide) {
+      val seq = Seq.newBuilder[Int]
+      // start with the smallest x value greater than xMin
+      var xup = x - 360d * math.floor((x - xMin) / 360)
+      while (xup <= xMax) {
+        seq += grid.i(xup)
+        xup += 360d
+      }
+      seq.result
+    } else {
+      Seq(grid.i(x))
+    }
+  }
+}

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GeometryUtilsTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GeometryUtilsTest.scala
@@ -60,6 +60,9 @@ class GeometryUtilsTest extends Specification {
       translated.head.getMaxX must beCloseTo(-78.44636, 0.0001)
       translated.head.getMinY mustEqual 38.00967
       translated.head.getMaxY mustEqual 38.07052
+
+      val covers = new ReferencedEnvelope(-200, 200, -100, 100, CRS_EPSG_4326)
+      GeometryUtils.splitBoundingBox(covers) mustEqual Seq(covers)
     }
   }
 }

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GeometryUtilsTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/GeometryUtilsTest.scala
@@ -8,6 +8,7 @@
 
 package org.locationtech.geomesa.utils.geotools
 
+import org.geotools.geometry.jts.ReferencedEnvelope
 import com.vividsolutions.jts.geom.Coordinate
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
@@ -30,5 +31,35 @@ class GeometryUtilsTest extends Specification {
       (GeometryUtils.calcCrossLat(p1, p2, 171).toInt, GeometryUtils.calcCrossLat(p2, p1, 171).toInt) mustEqual (6, 6)
     }
 
+    "split bounding box envelopes" >> {
+      val unchanged = Seq(
+        new ReferencedEnvelope(-180, 180, -90, 90, CRS_EPSG_4326),
+        new ReferencedEnvelope(-145, 0, -75, -55, CRS_EPSG_4326),
+        new ReferencedEnvelope(145, 155, -75, 75, CRS_EPSG_4326)
+      )
+      foreach(unchanged) { env =>
+        GeometryUtils.splitBoundingBox(env) mustEqual Seq(env)
+      }
+
+      val high = new ReferencedEnvelope(102.48046875, 237.48046875, -47.63671875, 13.88671875, CRS_EPSG_4326)
+      GeometryUtils.splitBoundingBox(high) mustEqual Seq(
+        new ReferencedEnvelope(102.48046875, 180, -47.63671875, 13.88671875, CRS_EPSG_4326),
+        new ReferencedEnvelope(-180, -122.51953125, -47.63671875, 13.88671875, CRS_EPSG_4326)
+      )
+
+      val low = new ReferencedEnvelope(-291.796875, -21.796875, -41.1328125, 81.9140625, CRS_EPSG_4326)
+      GeometryUtils.splitBoundingBox(low) mustEqual Seq(
+        new ReferencedEnvelope(-180, -21.796875, -41.1328125, 81.9140625, CRS_EPSG_4326),
+        new ReferencedEnvelope(68.203125, 180, -41.1328125, 81.9140625, CRS_EPSG_4326)
+      )
+
+      val outside = new ReferencedEnvelope(-438.52377, -438.44636, 38.00967, 38.07052, CRS_EPSG_4326)
+      val translated = GeometryUtils.splitBoundingBox(outside)
+      translated must haveLength(1)
+      translated.head.getMinX must beCloseTo(-78.52377, 0.0001)
+      translated.head.getMaxX must beCloseTo(-78.44636, 0.0001)
+      translated.head.getMinY mustEqual 38.00967
+      translated.head.getMaxY mustEqual 38.07052
+    }
   }
 }


### PR DESCRIPTION
* Geometries are translated to overlap the rendering envelope
* Filters extracted from the envelope are split for AntiMeridian handling
* Translation logic consolidated in org.locationtech.geomesa.utils.geotools.RenderingGrid

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>