### PR TITLE
GEOMESA-2693 HBase - GeoMesa metadata table should be held in memory

### DIFF
--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseBackedMetadata.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseBackedMetadata.scala
@@ -63,6 +63,6 @@ class HBaseBackedMetadata[T](connection: Connection, catalog: TableName, val ser
 
 object HBaseBackedMetadata {
   val ColumnFamily: Array[Byte] = Bytes.toBytes("m")
-  val ColumnFamilyDescriptor = new HColumnDescriptor(ColumnFamily)
+  val ColumnFamilyDescriptor = new HColumnDescriptor(ColumnFamily).setInMemory(true)
   val ColumnQualifier: Array[Byte] = Bytes.toBytes("v")
 }


### PR DESCRIPTION
Signed-off-by: Austin Heyne <aheyne@ccri.com>