### PR TITLE
GEOMESA-1643 Move SimpleFeatureType loading to SpatialRDDProvider

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
@@ -99,7 +99,7 @@ object AccumuloDataStoreFactory extends GeoMesaDataStoreInfo {
   @deprecated("Use Description")
   val DESCRIPTION: String = Description
 
-  override def canProcess(params: java.util.Map[String, Serializable]): Boolean = {
+  override def canProcess(params: java.util.Map[String, _ <: Serializable]): Boolean = {
     val hasConnector = ConnectorParam.lookupOpt(params).isDefined
     def hasConnection = InstanceIdParam.exists(params) && ZookeepersParam.exists(params) && UserParam.exists(params)
     def hasMock = InstanceIdParam.exists(params) && UserParam.exists(params) && MockParam.lookupOpt(params).contains(java.lang.Boolean.TRUE)

--- a/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
+++ b/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
@@ -39,10 +39,9 @@ import org.locationtech.geomesa.utils.io.{WithClose, WithStore}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 
-import scala.collection.JavaConversions._
-
 class AccumuloSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
-  import org.locationtech.geomesa.spark.CaseInsensitiveMapFix._
+
+  import scala.collection.JavaConverters._
 
   override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean =
     AccumuloDataStoreFactory.canProcess(params)
@@ -51,7 +50,8 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
                    sc: SparkContext,
                    params: Map[String, String],
                    query: Query): SpatialRDD = {
-    val ds = DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
+    val paramsAsJava = params.asJava
+    val ds = DataStoreFinder.getDataStore(paramsAsJava).asInstanceOf[AccumuloDataStore]
 
     lazy val transform = query.getHints.getTransformSchema
 
@@ -61,7 +61,7 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
       } else {
         // note: we've ensured there is only one table per query plan, below
         InputConfigurator.setInputTableName(classOf[AccumuloInputFormat], conf, qp.tables.head)
-        InputConfigurator.setRanges(classOf[AccumuloInputFormat], conf, qp.ranges)
+        InputConfigurator.setRanges(classOf[AccumuloInputFormat], conf, qp.ranges.asJava)
         InputConfigurator.setBatchScan(classOf[AccumuloInputFormat], conf, true)
 
         qp.iterators.foreach(InputConfigurator.addIterator(classOf[AccumuloInputFormat], conf, _))
@@ -79,7 +79,7 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
         }
 
         // Configure Auths from DS
-        val auths = AccumuloDataStoreParams.AuthsParam.lookupOpt(params)
+        val auths = AccumuloDataStoreParams.AuthsParam.lookupOpt(paramsAsJava)
         auths.foreach { a =>
           val authorizations = new Authorizations(a.split(","): _*)
           InputConfigurator.setScanAuthorizations(classOf[AccumuloInputFormat], conf, authorizations)
@@ -98,11 +98,11 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
         SparkHadoopUtil.get.addCredentials(jconf)
 
         // Get username from params
-        val username = AccumuloDataStoreParams.UserParam.lookup(params)
+        val username = AccumuloDataStoreParams.UserParam.lookup(paramsAsJava)
 
         // Get password or keytabPath from params. Precisely one of these should be set due to prior validation
-        val password = AccumuloDataStoreParams.PasswordParam.lookup(params)
-        val keytabPath = AccumuloDataStoreParams.KeytabPathParam.lookup(params)
+        val password = AccumuloDataStoreParams.PasswordParam.lookup(paramsAsJava)
+        val keytabPath = AccumuloDataStoreParams.KeytabPathParam.lookup(paramsAsJava)
 
         // Create authentication token according to password or Kerberos
         val authToken = if (password != null) {
@@ -113,9 +113,9 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
         }
 
         // Get params and set instance
-        val instance = AccumuloDataStoreParams.InstanceIdParam.lookup(params)
-        val zookeepers = AccumuloDataStoreParams.ZookeepersParam.lookup(params)
-        if (AccumuloDataStoreParams.MockParam.lookup(params)) {
+        val instance = AccumuloDataStoreParams.InstanceIdParam.lookup(paramsAsJava)
+        val zookeepers = AccumuloDataStoreParams.ZookeepersParam.lookup(paramsAsJava)
+        if (AccumuloDataStoreParams.MockParam.lookup(paramsAsJava)) {
           AbstractInputFormat.setMockInstance(jconf, instance)
         } else {
           AbstractInputFormat.setZooKeeperInstance(jconf, new ClientConfiguration()
@@ -123,21 +123,27 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
         }
 
         // Set connectorInfo. If needed, this will add a DelegationToken to jconf.getCredentials
-        val user = AccumuloDataStoreParams.UserParam.lookup(params)
+        val user = AccumuloDataStoreParams.UserParam.lookup(paramsAsJava)
         AbstractInputFormat.setConnectorInfo(jconf, user, authToken)
 
         // Iterate over tokens in credentials and add the Accumulo one to the configuration directly
         // This is because the credentials seem to disappear between here and the YARN executor
         // See https://stackoverflow.com/questions/44525351/delegation-tokens-with-accumulo-spark
-        for (tok <- jconf.getCredentials.getAllTokens) {
-          if (tok.getKind.toString=="ACCUMULO_AUTH_TOKEN") {
+        val tokens = jconf.getCredentials.getAllTokens.iterator()
+        var hasNext = tokens.hasNext
+        while (hasNext) {
+          val token = tokens.next()
+          if (token.getKind.toString == "ACCUMULO_AUTH_TOKEN") {
             logger.info("Adding ACCUMULO_AUTH_TOKEN to configuration")
-            jconf.set("org.locationtech.geomesa.token", tok.encodeToUrlString())
+            jconf.set("org.locationtech.geomesa.token", token.encodeToUrlString())
+            hasNext = false
+          } else {
+            hasNext = tokens.hasNext
           }
         }
 
         // From sc.newAPIHadoopRDD
-        new NewHadoopRDD(sc, classOf[GeoMesaAccumuloInputFormat], classOf[Text], classOf[SimpleFeature], jconf).map(U => U._2)
+        new NewHadoopRDD(sc, classOf[GeoMesaAccumuloInputFormat], classOf[Text], classOf[SimpleFeature], jconf).map(_._2)
       }
     }
 

--- a/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
+++ b/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
@@ -44,7 +44,7 @@ import scala.collection.JavaConversions._
 class AccumuloSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
   import org.locationtech.geomesa.spark.CaseInsensitiveMapFix._
 
-  override def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean =
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean =
     AccumuloDataStoreFactory.canProcess(params)
 
   override def rdd(conf: Configuration,

--- a/geomesa-bigtable/geomesa-bigtable-datastore/src/main/scala/org/locationtech/geomesa/bigtable/data/BigtableDataStoreFactory.scala
+++ b/geomesa-bigtable/geomesa-bigtable-datastore/src/main/scala/org/locationtech/geomesa/bigtable/data/BigtableDataStoreFactory.scala
@@ -62,7 +62,7 @@ object BigtableDataStoreFactory extends GeoMesaDataStoreInfo with NamespaceParam
     )
 
   // verify that the hbase-site.xml exists and contains the appropriate bigtable keys
-  override def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean = {
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean = {
     BigtableCatalogParam.exists(params) &&
         Option(HBaseConfiguration.create().get(HBaseDataStoreFactory.BigTableParamCheck)).exists(_.trim.nonEmpty)
   }

--- a/geomesa-bigtable/geomesa-bigtable-spark/src/main/scala/org/locationtech/geomesa/bigtable/spark/BigtableSparkRDDProvider.scala
+++ b/geomesa-bigtable/geomesa-bigtable-spark/src/main/scala/org/locationtech/geomesa/bigtable/spark/BigtableSparkRDDProvider.scala
@@ -31,7 +31,7 @@ class BigtableSparkRDDProvider extends HBaseSpatialRDDProvider {
 
   import org.locationtech.geomesa.index.conf.QueryHints.RichHints
 
-  override def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean =
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean =
     BigtableDataStoreFactory.canProcess(params)
 
   override def rdd(

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreFactory.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreFactory.scala
@@ -133,7 +133,8 @@ object CassandraDataStoreFactory extends GeoMesaDataStoreInfo {
       Params.QueryTimeoutParam
     )
 
-  override def canProcess(params: java.util.Map[String,Serializable]): Boolean = Params.KeySpaceParam.exists(params)
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean =
+    Params.KeySpaceParam.exists(params)
 
   object Params extends GeoMesaDataStoreParams {
 

--- a/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/data/FileSystemDataStoreFactory.scala
+++ b/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/data/FileSystemDataStoreFactory.scala
@@ -92,7 +92,7 @@ object FileSystemDataStoreFactory extends GeoMesaDataStoreInfo {
       FileSystemDataStoreParams.ConfParam
     )
 
-  override def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean =
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean =
     FileSystemDataStoreParams.PathParam.exists(params)
 
   private val configuration = new Configuration()

--- a/geomesa-gt/geomesa-gt-spark/src/main/scala/org/locationtech/geomesa/geotools/spark/GeoToolsSpatialRDDProvider.scala
+++ b/geomesa-gt/geomesa-gt-spark/src/main/scala/org/locationtech/geomesa/geotools/spark/GeoToolsSpatialRDDProvider.scala
@@ -30,9 +30,10 @@ class GeoToolsSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
 
   import scala.collection.JavaConverters._
 
-  override def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean = {
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean = {
+    val parameters = params.asInstanceOf[java.util.Map[String, java.io.Serializable]]
     Option(params.get("geotools")).exists(FastConverter.convert(_, classOf[java.lang.Boolean])) &&
-        DataStoreFinder.getAllDataStores.asScala.exists(_.canProcess(params))
+        DataStoreFinder.getAllDataStores.asScala.exists(_.canProcess(parameters))
   }
 
   override def rdd(

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreFactory.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreFactory.scala
@@ -134,7 +134,7 @@ object HBaseDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
   private [geomesa] val BigTableParamCheck = "google.bigtable.instance.id"
 
   // check that the hbase-site.xml does not have bigtable keys
-  override def canProcess(params: java.util.Map[java.lang.String,Serializable]): Boolean = {
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean = {
     HBaseCatalogParam.exists(params) &&
         Option(HBaseConfiguration.create().get(BigTableParamCheck)).forall(_.trim.isEmpty)
   }

--- a/geomesa-hbase/geomesa-hbase-spark/src/main/scala/org/locationtech/geomesa/spark/hbase/HBaseSpatialRDDProvider.scala
+++ b/geomesa-hbase/geomesa-hbase-spark/src/main/scala/org/locationtech/geomesa/spark/hbase/HBaseSpatialRDDProvider.scala
@@ -26,7 +26,7 @@ class HBaseSpatialRDDProvider extends SpatialRDDProvider {
 
   import org.locationtech.geomesa.index.conf.QueryHints._
 
-  override def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean =
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean =
     HBaseDataStoreFactory.canProcess(params)
 
   def rdd(
@@ -99,5 +99,4 @@ class HBaseSpatialRDDProvider extends SpatialRDDProvider {
       }
     }
   }
-
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreFactory.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreFactory.scala
@@ -73,6 +73,6 @@ object GeoMesaDataStoreFactory {
     def DisplayName: String
     def Description: String
     def ParameterInfo: Array[GeoMesaParam[_]]
-    def canProcess(params: java.util.Map[String,Serializable]): Boolean
+    def canProcess(params: java.util.Map[String, _ <: Serializable]): Boolean
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/MergedDataStoreViewFactory.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/MergedDataStoreViewFactory.scala
@@ -112,6 +112,6 @@ object MergedDataStoreViewFactory extends GeoMesaDataStoreInfo with NamespacePar
 
   override val ParameterInfo: Array[GeoMesaParam[_]] = ConfigLoaderParam.toArray :+ ConfigParam
 
-  override def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean =
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean =
     params.containsKey(ConfigParam.key) || ConfigLoaderParam.exists(p => params.containsKey(p.key))
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/RouteSelector.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/RouteSelector.scala
@@ -21,7 +21,7 @@ trait RouteSelector {
     *
     * @param stores stores and configuration maps
     */
-  def init(stores: Seq[(DataStore, java.util.Map[String, AnyRef])]): Unit
+  def init(stores: Seq[(DataStore, java.util.Map[String, _ <: AnyRef])]): Unit
 
   /**
     * Route a query to a particular store. If no store is selected, query will return empty

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/RouteSelectorByAttribute.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/RouteSelectorByAttribute.scala
@@ -27,7 +27,7 @@ class RouteSelectorByAttribute extends RouteSelector {
   private var id: Option[DataStore] = None
   private var include: Option[DataStore] = None
 
-  override def init(stores: Seq[(DataStore, java.util.Map[String, AnyRef])]): Unit = {
+  override def init(stores: Seq[(DataStore, java.util.Map[String, _ <: AnyRef])]): Unit = {
     val builder = Seq.newBuilder[(Set[String], DataStore)]
 
     stores.foreach { case (ds, config) =>

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/RoutedDataStoreViewFactory.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/RoutedDataStoreViewFactory.scala
@@ -45,7 +45,7 @@ class RoutedDataStoreViewFactory extends DataStoreFactorySpi {
     val namespace = NamespaceParam.lookupOpt(params)
     val nsConfig = namespace.map(ConfigValueFactory.fromAnyRef)
 
-    val stores = Seq.newBuilder[(DataStore, java.util.Map[String, AnyRef])]
+    val stores = Seq.newBuilder[(DataStore, java.util.Map[String, _ <: AnyRef])]
     stores.sizeHint(configs.length)
 
     try {
@@ -56,7 +56,7 @@ class RoutedDataStoreViewFactory extends DataStoreFactorySpi {
         val storeParams = nsConfig.map(config.withValue(NamespaceParam.key, _)).getOrElse(config).root().unwrapped()
         Try(DataStoreFinder.getDataStore(storeParams)) match {
           case Success(null)  => throw error
-          case Success(store) => stores += store -> storeParams
+          case Success(store) => stores += store -> storeParams.asInstanceOf[java.util.Map[String, AnyRef]]
           case Failure(e)     => throw error.initCause(e)
         }
       }
@@ -113,6 +113,6 @@ object RoutedDataStoreViewFactory extends GeoMesaDataStoreInfo with NamespacePar
 
   override val ParameterInfo: Array[GeoMesaParam[_]] = Array(ConfigParam, RouterParam)
 
-  override def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean =
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean =
     params.containsKey(ConfigParam.key)
 }

--- a/geomesa-kafka/geomesa-kafka-confluent/src/main/scala/org/locationtech/geomesa/kafka/confluent/ConfluentKafkaDataStoreFactory.scala
+++ b/geomesa-kafka/geomesa-kafka-confluent/src/main/scala/org/locationtech/geomesa/kafka/confluent/ConfluentKafkaDataStoreFactory.scala
@@ -58,7 +58,7 @@ object ConfluentKafkaDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogg
 
   override val ParameterInfo: Array[GeoMesaParam[_]] = KafkaDataStoreFactory.ParameterInfo.+:(SchemaRegistryUrl)
 
-  override def canProcess(params: java.util.Map[String, Serializable]): Boolean = {
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean = {
     KafkaDataStoreFactoryParams.Brokers.exists(params) &&
         KafkaDataStoreFactoryParams.Zookeepers.exists(params) &&
         SchemaRegistryUrl.exists(params)

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreFactory.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreFactory.scala
@@ -100,7 +100,7 @@ object KafkaDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
       KafkaDataStoreFactoryParams.Authorizations
     )
 
-  override def canProcess(params: java.util.Map[String, Serializable]): Boolean = {
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean = {
     KafkaDataStoreFactoryParams.Brokers.exists(params) &&
         KafkaDataStoreFactoryParams.Zookeepers.exists(params) &&
         !params.containsKey("kafka.schema.registry.url") // defer to confluent data store

--- a/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/data/KuduDataStoreFactory.scala
+++ b/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/data/KuduDataStoreFactory.scala
@@ -99,7 +99,8 @@ object KuduDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
       Params.CachingParam
     )
 
-  override def canProcess(params: java.util.Map[String,Serializable]): Boolean = Params.KuduMasterParam.exists(params)
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean =
+    Params.KuduMasterParam.exists(params)
 
   // noinspection TypeAnnotation
   object Params extends GeoMesaDataStoreParams {

--- a/geomesa-kudu/geomesa-kudu-spark/src/main/scala/org/locationtech/geomesa/kudu/spark/KuduSpatialRDDProvider.scala
+++ b/geomesa-kudu/geomesa-kudu-spark/src/main/scala/org/locationtech/geomesa/kudu/spark/KuduSpatialRDDProvider.scala
@@ -24,7 +24,7 @@ import org.opengis.feature.simple.SimpleFeature
 
 class KuduSpatialRDDProvider extends SpatialRDDProvider {
 
-  override def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean =
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean =
     KuduDataStoreFactory.canProcess(params)
 
   override def rdd(conf: Configuration, sc: SparkContext, params: Map[String, String], query: Query): SpatialRDD = {

--- a/geomesa-lambda/geomesa-lambda-datastore/src/main/scala/org/locationtech/geomesa/lambda/data/LambdaDataStoreFactory.scala
+++ b/geomesa-lambda/geomesa-lambda-datastore/src/main/scala/org/locationtech/geomesa/lambda/data/LambdaDataStoreFactory.scala
@@ -112,7 +112,7 @@ object LambdaDataStoreFactory extends GeoMesaDataStoreInfo {
       Params.AuditQueriesParam
     )
 
-  override def canProcess(params: java.util.Map[String, Serializable]): Boolean =
+  override def canProcess(params: java.util.Map[String, _ <: Serializable]): Boolean =
     AccumuloDataStoreFactory.canProcess(LambdaDataStoreFactory.filter(params)) &&
         Seq(Params.ExpiryParam, Params.Kafka.BrokersParam, Params.Kafka.ZookeepersParam).forall(_.exists(params))
 
@@ -154,7 +154,7 @@ object LambdaDataStoreFactory extends GeoMesaDataStoreInfo {
       deprecatedParams = p.deprecatedParams, systemProperty = p.systemProperty)
   }
 
-  private def filter(params: java.util.Map[String, Serializable]): java.util.Map[String, Serializable] = {
+  private def filter(params: java.util.Map[String, _ <: Serializable]): java.util.Map[String, Serializable] = {
     // note: includes a bit of redirection to allow us to pass non-serializable values in to tests
     import scala.collection.JavaConverters._
     Map[String, Any](params.asScala.toSeq: _ *)

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/RedisDataStoreFactory.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/RedisDataStoreFactory.scala
@@ -81,7 +81,7 @@ object RedisDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
       ForceEmptyAuthsParam
     )
 
-  override def canProcess(params: java.util.Map[java.lang.String,Serializable]): Boolean =
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean =
     RedisCatalogParam.exists(params)
 
   /**

--- a/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/DataStoreConnector.scala
+++ b/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/DataStoreConnector.scala
@@ -16,13 +16,13 @@ import org.geotools.data.{DataStore, DataStoreFinder}
   */
 object DataStoreConnector {
 
-  import org.locationtech.geomesa.spark.CaseInsensitiveMapFix._
+  import scala.collection.JavaConverters._
 
   def apply[T <: DataStore](params: Map[String, String]): T = loadingMap.get(params).asInstanceOf[T]
 
   private val loadingMap = Caffeine.newBuilder().build[Map[String, String], DataStore](
     new CacheLoader[Map[String, String], DataStore] {
-      override def load(key: Map[String, String]): DataStore = DataStoreFinder.getDataStore(key)
+      override def load(key: Map[String, String]): DataStore = DataStoreFinder.getDataStore(key.asJava)
     }
   )
 }

--- a/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/GeoMesaSpark.scala
+++ b/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/GeoMesaSpark.scala
@@ -8,19 +8,7 @@
 
 package org.locationtech.geomesa.spark
 
-import java.io.{BufferedWriter, StringWriter}
 import java.util.ServiceLoader
-
-import org.apache.hadoop.conf.Configuration
-import org.apache.spark.geomesa.GeoMesaSparkKryoRegistratorEndpoint
-import org.apache.spark.{Partition, SparkContext, TaskContext}
-import org.apache.spark.rdd.RDD
-import org.geotools.data.Query
-import org.geotools.geojson.feature.FeatureJSON
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
-import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
-
-import scala.collection.JavaConversions._
 
 object GeoMesaSpark {
 

--- a/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/GeoMesaSpark.scala
+++ b/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/GeoMesaSpark.scala
@@ -22,103 +22,13 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.JavaConversions._
 
-
 object GeoMesaSpark {
 
   import scala.collection.JavaConversions._
 
   lazy val providers: ServiceLoader[SpatialRDDProvider] = ServiceLoader.load(classOf[SpatialRDDProvider])
 
-  def apply(params: java.util.Map[String, java.io.Serializable]): SpatialRDDProvider =
+  def apply(params: java.util.Map[String, _ <: java.io.Serializable]): SpatialRDDProvider =
     providers.find(_.canProcess(params)).getOrElse(throw new RuntimeException("Could not find a SpatialRDDProvider"))
 }
 
-trait SpatialRDDProvider {
-
-  def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean
-
-  def rdd(conf: Configuration, sc: SparkContext, params: Map[String, String], query: Query) : SpatialRDD
-
-  /**
-    * Writes this RDD to a GeoMesa table.
-    * The type must exist in the data store, and all of the features in the RDD must be of this type.
-    *
-    * @param rdd
-    * @param params
-    * @param typeName
-    */
-  def save(rdd: RDD[SimpleFeature], params: Map[String, String], typeName: String): Unit
-
-}
-
-trait Schema {
-  def schema: SimpleFeatureType
-}
-
-class SpatialRDD(rdd: RDD[SimpleFeature], sft: SimpleFeatureType) extends RDD[SimpleFeature](rdd) with Schema {
-
-  GeoMesaSparkKryoRegistrator.register(sft)
-
-  private val sft_name = sft.getTypeName
-  private val sft_spec = SimpleFeatureTypes.encodeType(sft, true)
-
-  @transient lazy val schema = SimpleFeatureTypes.createType(sft_name, sft_spec)
-
-  def compute(split: Partition, context: TaskContext): Iterator[SimpleFeature] = firstParent.compute(split, context)
-  def getPartitions: Array[Partition] = firstParent.partitions
-}
-
-object SpatialRDD {
-
-  GeoMesaSparkKryoRegistratorEndpoint.init()
-
-  def apply(rdd: RDD[SimpleFeature], schema: SimpleFeatureType) = new SpatialRDD(rdd, schema)
-
-  implicit def toValueSeq(in: RDD[SimpleFeature] with Schema): RDD[Seq[AnyRef]] =
-    in.map(sf => Seq(sf.getAttributes: _*))
-
-  implicit def toKeyValueSeq(in: RDD[SimpleFeature] with Schema): RDD[Seq[(String, AnyRef)]] =
-    in.map(_.getProperties.map(p => (p.getName.getLocalPart, p.getValue)).toSeq)
-
-  implicit def toKeyValueMap(in: RDD[SimpleFeature] with Schema): RDD[Map[String, AnyRef]] =
-    in.map(_.getProperties.map(p => (p.getName.getLocalPart, p.getValue)).toMap)
-
-  implicit def toGeoJSONString(in: RDD[SimpleFeature] with Schema): RDD[String] = {
-    in.mapPartitions(features => {
-      val json = new FeatureJSON
-      val sw = new StringWriter
-      val bw = new BufferedWriter(sw)
-      features.map(f => try {
-        json.writeFeature(f, bw); sw.toString
-      } finally {
-        sw.getBuffer.setLength(0)
-      })
-    })
-  }
-
-  implicit class SpatialRDDConversions(in: RDD[SimpleFeature] with Schema) {
-    def asGeoJSONString = toGeoJSONString(in)
-    def asKeyValueMap = toKeyValueMap(in)
-    def asKeyValueSeq = toKeyValueSeq(in)
-    def asValueSeq = toValueSeq(in)
-  }
-}
-
-// Resolve issue with wrapped instance of org.apache.spark.sql.execution.datasources.CaseInsensitiveMap in Scala 2.10
-object CaseInsensitiveMapFix {
-  import scala.collection.convert.Wrappers._
-
-  trait MapWrapperFix[A,B] {
-    this: MapWrapper[A,B] =>
-    override def containsKey(key: AnyRef): Boolean = try {
-      get(key) != null
-    } catch {
-      case ex: ClassCastException => false
-    }
-  }
-
-  implicit def mapAsJavaMap[A <: String, B](m: scala.collection.Map[A, B]): java.util.Map[A, B] = m match {
-    case JMapWrapper(wrapped) => wrapped.asInstanceOf[java.util.Map[A, B]]
-    case _ => new MapWrapper[A,B](m) with MapWrapperFix[A, B]
-  }
-}

--- a/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/SpatialRDD.scala
+++ b/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/SpatialRDD.scala
@@ -1,0 +1,79 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.spark
+
+import java.io.{BufferedWriter, StringWriter}
+
+import org.apache.spark.geomesa.GeoMesaSparkKryoRegistratorEndpoint
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, TaskContext}
+import org.geotools.geojson.feature.FeatureJSON
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+
+/**
+  * RDD with a known schema
+  *
+  * @param rdd simple feature RDD
+  * @param sft simple feature type schema
+  */
+class SpatialRDD(rdd: RDD[SimpleFeature], sft: SimpleFeatureType) extends RDD[SimpleFeature](rdd) with Schema {
+
+  GeoMesaSparkKryoRegistrator.register(sft)
+
+  private val typeName = sft.getTypeName
+  private val spec = SimpleFeatureTypes.encodeType(sft, includeUserData = true)
+
+  @transient
+  override lazy val schema: SimpleFeatureType = SimpleFeatureTypes.createType(typeName, spec)
+
+  override def compute(split: Partition, context: TaskContext): Iterator[SimpleFeature] =
+    firstParent.compute(split, context)
+
+  override def getPartitions: Array[Partition] = firstParent.partitions
+}
+
+object SpatialRDD {
+
+  import scala.collection.JavaConverters._
+
+  GeoMesaSparkKryoRegistratorEndpoint.init()
+
+  def apply(rdd: RDD[SimpleFeature], schema: SimpleFeatureType) = new SpatialRDD(rdd, schema)
+
+  implicit def toValueSeq(in: RDD[SimpleFeature] with Schema): RDD[Seq[AnyRef]] =
+    in.map(_.getAttributes.asScala)
+
+  implicit def toKeyValueSeq(in: RDD[SimpleFeature] with Schema): RDD[Seq[(String, AnyRef)]] =
+    in.map(_.getProperties.asScala.map(p => (p.getName.getLocalPart, p.getValue)).toSeq)
+
+  implicit def toKeyValueMap(in: RDD[SimpleFeature] with Schema): RDD[Map[String, AnyRef]] =
+    in.map(_.getProperties.asScala.map(p => (p.getName.getLocalPart, p.getValue)).toMap)
+
+  implicit def toGeoJSONString(in: RDD[SimpleFeature] with Schema): RDD[String] = {
+    in.mapPartitions { features =>
+      val json = new FeatureJSON
+      val sw = new StringWriter
+      val bw = new BufferedWriter(sw)
+      features.map { f =>
+        sw.getBuffer.setLength(0)
+        json.writeFeature(f, bw)
+        bw.flush()
+        sw.toString
+      }
+    }
+  }
+
+  implicit class SpatialRDDConversions(in: RDD[SimpleFeature] with Schema) {
+    def asGeoJSONString: RDD[String] = toGeoJSONString(in)
+    def asKeyValueMap: RDD[Map[String, AnyRef]] = toKeyValueMap(in)
+    def asKeyValueSeq: RDD[Seq[(String, AnyRef)]] = toKeyValueSeq(in)
+    def asValueSeq: RDD[Seq[AnyRef]] = toValueSeq(in)
+  }
+}

--- a/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/SpatialRDDProvider.scala
+++ b/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/SpatialRDDProvider.scala
@@ -1,0 +1,65 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.spark
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.geotools.data.{DataStore, Query}
+import org.locationtech.geomesa.utils.io.WithStore
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+
+/**
+  * Provider trait for loading spatial RDDs, generally backed by GeoTools data store implementations
+  */
+trait SpatialRDDProvider {
+
+  /**
+    * Indicates if the provider can process the given parameters
+    *
+    * @param params data store parameters
+    * @return
+    */
+  def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean
+
+  /**
+    * Load an RDD for the given query.
+    *
+    * This method is implicitly guarded by `canProcess`; it is an error to try to load an RDD if `canProcess`
+    * returns false for the given parameters.
+    *
+    * @param conf conf
+    * @param sc spark context
+    * @param params data store parameters
+    * @param query query for features to load
+    * @return
+    */
+  def rdd(conf: Configuration, sc: SparkContext, params: Map[String, String], query: Query) : SpatialRDD
+
+  /**
+    * Persist an RDD to long-term storage.
+    *
+    * The type must exist in the data store, and all of the features in the RDD must be of this type.
+    *
+    * @param rdd rdd to save
+    * @param params data store parameters
+    * @param typeName simple feature type name
+    */
+  def save(rdd: RDD[SimpleFeature], params: Map[String, String], typeName: String): Unit
+
+  /**
+    * Load an existing simple feature type
+    *
+    * @param params data store parameters
+    * @param typeName simple feature type name
+    * @return
+    */
+  def sft(params: Map[String, String], typeName: String): Option[SimpleFeatureType] =
+    Option(WithStore[DataStore](params)(_.getSchema(typeName)))
+}

--- a/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/package.scala
+++ b/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/package.scala
@@ -11,27 +11,7 @@ package org.locationtech.geomesa
 import org.opengis.feature.simple.SimpleFeatureType
 
 package object spark {
-
   trait Schema {
     def schema: SimpleFeatureType
-  }
-
-  // Resolve issue with wrapped instance of org.apache.spark.sql.execution.datasources.CaseInsensitiveMap in Scala 2.10
-  object CaseInsensitiveMapFix {
-    import scala.collection.convert.Wrappers._
-
-    trait MapWrapperFix[A,B] {
-      this: MapWrapper[A,B] =>
-      override def containsKey(key: AnyRef): Boolean = try {
-        get(key) != null
-      } catch {
-        case ex: ClassCastException => false
-      }
-    }
-
-    implicit def mapAsJavaMap[A <: String, B](m: scala.collection.Map[A, B]): java.util.Map[A, B] = m match {
-      case JMapWrapper(wrapped) => wrapped.asInstanceOf[java.util.Map[A, B]]
-      case _ => new MapWrapper[A,B](m) with MapWrapperFix[A, B]
-    }
   }
 }

--- a/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/package.scala
+++ b/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/package.scala
@@ -1,0 +1,37 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa
+
+import org.opengis.feature.simple.SimpleFeatureType
+
+package object spark {
+
+  trait Schema {
+    def schema: SimpleFeatureType
+  }
+
+  // Resolve issue with wrapped instance of org.apache.spark.sql.execution.datasources.CaseInsensitiveMap in Scala 2.10
+  object CaseInsensitiveMapFix {
+    import scala.collection.convert.Wrappers._
+
+    trait MapWrapperFix[A,B] {
+      this: MapWrapper[A,B] =>
+      override def containsKey(key: AnyRef): Boolean = try {
+        get(key) != null
+      } catch {
+        case ex: ClassCastException => false
+      }
+    }
+
+    implicit def mapAsJavaMap[A <: String, B](m: scala.collection.Map[A, B]): java.util.Map[A, B] = m match {
+      case JMapWrapper(wrapped) => wrapped.asInstanceOf[java.util.Map[A, B]]
+      case _ => new MapWrapper[A,B](m) with MapWrapperFix[A, B]
+    }
+  }
+}

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/GeoMesaDataSource.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/GeoMesaDataSource.scala
@@ -37,8 +37,6 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 class GeoMesaDataSource extends DataSourceRegister
     with RelationProvider with SchemaRelationProvider with CreatableRelationProvider with LazyLogging {
 
-  import CaseInsensitiveMapFix._
-
   import scala.collection.JavaConverters._
 
   override def shortName(): String = "geomesa"
@@ -96,7 +94,7 @@ class GeoMesaDataSource extends DataSourceRegister
       }
     }
 
-    GeoMesaSpark(parameters).save(rddToSave, parameters, newFeatureName)
+    GeoMesaSpark(parameters.asJava).save(rddToSave, parameters, newFeatureName)
 
     GeoMesaRelation(sqlContext, parameters, data.schema, sft)
   }

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/GeoMesaRelation.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/GeoMesaRelation.scala
@@ -8,125 +8,317 @@
 
 package org.locationtech.geomesa.spark
 
-import java.util.Collections
+import java.util.{Collections, Locale}
 
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.storage.StorageLevel
-import org.geotools.data.{DataStoreFactorySpi, DataStoreFinder, Query}
+import org.geotools.data.{DataStoreFinder, Query, Transaction}
 import org.geotools.filter.text.ecql.ECQL
+import org.locationtech.geomesa.filter.FilterHelper
 import org.locationtech.geomesa.memory.cqengine.datastore.GeoCQEngineDataStore
+import org.locationtech.geomesa.spark.GeoMesaRelation.{CachedRDD, IndexedRDD, PartitionedIndexedRDD, PartitionedRDD}
 import org.locationtech.geomesa.spark.GeoMesaSparkSQL.GEOMESA_SQL_FEATURE
 import org.locationtech.geomesa.spark.jts.util.WKTUtils
+import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.jts.geom.Envelope
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
-import scala.util.Try
+import scala.collection.Iterator
+import scala.util.control.NonFatal
 
-// the Spark Relation that builds the scan over the GeoMesa table
-// used by the SQL optimization rules to push spatio-temporal predicates into the `filt` variable
+/**
+  * The Spark Relation that builds the scan over the GeoMesa table
+  *
+  * @param sqlContext spark sql context
+  * @param sft simple feature type associated with the rows in the relation
+  * @param schema spark sql schema (must correspond to the sft)
+  * @param params user parameters, generally for configured the underlying data store and/or caching/partitioning
+  * @param filter a push-down geotools filter applied to the relation
+  * @param cached an optional cached RDD, used to speed up queries when enabled
+  * @param partitioned an optional spatially partitioned RDD, used to speed up spatial joins when enabled
+  */
 case class GeoMesaRelation(
     sqlContext: SQLContext,
     sft: SimpleFeatureType,
     schema: StructType,
     params: Map[String, String],
-    filt: org.opengis.filter.Filter = org.opengis.filter.Filter.INCLUDE,
-    props: Option[Seq[String]] = None,
-    var partitionHints : Seq[Int] = null,
-    var indexRDD: RDD[GeoCQEngineDataStore] = null,
-    var partitionedRDD: RDD[(Int, Iterable[SimpleFeature])] = null,
-    var indexPartRDD: RDD[(Int, GeoCQEngineDataStore)] = null)
-    extends BaseRelation with PrunedFilteredScan {
+    filter: Option[org.opengis.filter.Filter],
+    cached: Option[CachedRDD],
+    partitioned: Option[PartitionedRDD]
+  ) extends BaseRelation with PrunedFilteredScan with LazyLogging {
 
   import scala.collection.JavaConverters._
 
-  val cache: Boolean = Try(params("cache").toBoolean).getOrElse(false)
-  val indexId: Boolean = Try(params("indexId").toBoolean).getOrElse(false)
-  val indexGeom: Boolean  = Try(params("indexGeom").toBoolean).getOrElse(false)
-  val numPartitions: Int = Try(params("partitions").toInt).getOrElse(sqlContext.sparkContext.defaultParallelism)
-  val spatiallyPartition: Boolean = Try(params("spatial").toBoolean).getOrElse(false)
-  val partitionStrategy: String = Try(params("strategy").toString).getOrElse("EQUAL")
-  var partitionEnvelopes: List[Envelope] = _
-  val providedBounds: String = Try(params("bounds").toString).getOrElse(null)
-  val coverPartition: Boolean = Try(params("cover").toBoolean).getOrElse(false)
-  // Control partitioning strategies that require a sample of the data
-  val sampleSize: Int = Try(params("sampleSize").toInt).getOrElse(100)
-  val thresholdMultiplier: Double = Try(params("threshold").toDouble).getOrElse(0.3)
-
-  val initialQuery: String = Try(params("query").toString).getOrElse("INCLUDE")
-  val geometryOrdinal: Int = sft.indexOf(sft.getGeometryDescriptor.getLocalName)
-
-  lazy val rawRDD: SpatialRDD = buildRawRDD
-
-  def buildRawRDD: SpatialRDD = {
-    val spark = GeoMesaSpark(params.asJava.asInstanceOf[java.util.Map[String, java.io.Serializable]])
-    val query = new Query(params(GEOMESA_SQL_FEATURE), ECQL.toFilter(initialQuery))
-    val raw = spark.rdd(new Configuration(), sqlContext.sparkContext, params, query)
-
-    if (raw.getNumPartitions != numPartitions && params.contains("partitions")) {
-      SpatialRDD(raw.repartition(numPartitions), raw.schema)
-    } else {
-      raw
-    }
-  }
-
-  val encodedSFT: String = SimpleFeatureTypes.encodeType(sft, includeUserData = true)
-
-  if (partitionedRDD == null && spatiallyPartition) {
-    if (partitionEnvelopes == null) {
-      val bounds: Envelope = if (providedBounds == null) {
-        RelationUtils.getBound(rawRDD)
+  /**
+    * Attempts to do an optimized join between two relations.
+    *
+    * Currently this method uses grid partitioning on both relations so that the join comparisons
+    * only need to be applied on each pair of partitions, instead of globally. This only works
+    * if both relations have already been grid partitioned.
+    *
+    * @param other relation to join
+    * @param condition join condition
+    * @return an optimized join, if possible to do so
+    */
+  def join(other: GeoMesaRelation, condition: Expression): Option[GeoMesaJoinRelation] = {
+    val opt = for { p <- partitioned; o <- other.partitioned } yield {
+      val toJoin = if (p.envelopes == o.envelopes) {
+        Some(other)
+      } else if (p.cover) {
+        val repartitioned: SpatialRDD = p.partitions match {
+          case None => p.raw
+          case Some(partitions) => SpatialRDD(p.raw.repartition(partitions), p.raw.schema)
+        }
+        val parallelism = p.partitions.getOrElse(sqlContext.sparkContext.defaultParallelism)
+        val rdd = RelationUtils.grid(repartitioned, p.envelopes, parallelism)
+        val partitioned = Some(PartitionedRDD(rdd, p.raw, p.envelopes, p.partitions, p.cover))
+        Some(other.copy(partitioned = partitioned))
       } else {
-        WKTUtils.read(providedBounds).getEnvelopeInternal
+        logger.warn("Joining across two relations that are not partitioned by the same scheme - unable to optimize")
+        None
       }
-      partitionEnvelopes = partitionStrategy match {
-        case "EARTH" => RelationUtils.wholeEarthPartitioning(numPartitions)
-        case "EQUAL" => RelationUtils.equalPartitioning(bounds, numPartitions)
-        case "WEIGHTED" => RelationUtils.weightedPartitioning(rawRDD, bounds, numPartitions, sampleSize)
-        case "RTREE" => RelationUtils.rtreePartitioning(rawRDD, numPartitions, sampleSize, thresholdMultiplier)
-        case _ => throw new IllegalArgumentException(s"Invalid partitioning strategy specified: $partitionStrategy")
+      toJoin.map { rel =>
+        GeoMesaJoinRelation(sqlContext, this, rel, StructType(schema.fields ++ rel.schema.fields), condition)
       }
     }
-    partitionedRDD = RelationUtils.spatiallyPartition(partitionEnvelopes, rawRDD, numPartitions, geometryOrdinal)
-    partitionedRDD.persist(StorageLevel.MEMORY_ONLY)
+    opt.flatten
   }
 
-  if (cache) {
-    def isCqStore(spi: DataStoreFactorySpi): Boolean = spi.canProcess(Collections.singletonMap("cqengine", "true"))
-    if (!DataStoreFinder.getAvailableDataStores.asScala.exists(isCqStore)) {
-      throw new IllegalArgumentException("Cache argument set to true but GeoCQEngineDataStore is not on the classpath")
-    }
-    if (spatiallyPartition && indexPartRDD == null) {
-      indexPartRDD = RelationUtils.indexPartitioned(encodedSFT, sft.getTypeName, partitionedRDD, indexId, indexGeom)
-      partitionedRDD.unpersist() // make this call blocking?
-      indexPartRDD.persist(StorageLevel.MEMORY_ONLY)
-    } else if (indexRDD == null) {
-      indexRDD = RelationUtils.index(encodedSFT, sft.getTypeName, rawRDD, indexId, indexGeom)
-      indexRDD.persist(StorageLevel.MEMORY_ONLY)
-    }
-  }
+  override def buildScan(
+      requiredColumns: Array[String],
+      filters: Array[org.apache.spark.sql.sources.Filter]): RDD[Row] = {
+    lazy val debug =
+      s"filt = $filter, filters = ${filters.mkString(",")}, requiredColumns = ${requiredColumns.mkString(",")}"
 
-  override def buildScan(requiredColumns: Array[String], filters: Array[org.apache.spark.sql.sources.Filter]): RDD[Row] = {
-    if (cache) {
-      if (spatiallyPartition) {
-        RelationUtils.buildScanInMemoryPartScan(requiredColumns, filters, filt,
-          sqlContext.sparkContext, schema, params, partitionHints, indexPartRDD)
-      } else {
-        RelationUtils.buildScanInMemoryScan(requiredColumns, filters, filt, sqlContext.sparkContext, schema, params, indexRDD)
-      }
-    } else {
-      RelationUtils.buildScan(requiredColumns, filters, filt, sqlContext.sparkContext, schema, params)
+    val filt = {
+      val sum = Seq.newBuilder[org.opengis.filter.Filter]
+      filter.foreach(sum += _)
+      filters.foreach(f => SparkUtils.sparkFilterToCQLFilter(f).foreach(sum += _))
+      FilterHelper.filterListAsAnd(sum.result).getOrElse(org.opengis.filter.Filter.INCLUDE)
     }
+    val requiredAttributes = requiredColumns.filterNot(_ == "__fid__")
+
+    // avoid closures on complex objects
+    val schema = this.schema // note: referencing case class members evidently serializes the whole class??
+    val typeName = sft.getTypeName
+
+    val result: RDD[SimpleFeature] = cached match {
+      case None =>
+        logger.debug(s"Building scan, $debug")
+        val conf = new Configuration(sqlContext.sparkContext.hadoopConfiguration)
+        val query = new Query(typeName, filt, requiredAttributes)
+        GeoMesaSpark(params.asJava).rdd(conf, sqlContext.sparkContext, params, query)
+
+      case Some(IndexedRDD(rdd)) =>
+        logger.debug(s"Building in-memory scan, $debug")
+        val cql = ECQL.toCQL(filt)
+        rdd.flatMap { engine =>
+          val query = new Query(typeName, ECQL.toFilter(cql), requiredAttributes)
+          SelfClosingIterator(engine.getFeatureReader(query, Transaction.AUTO_COMMIT))
+        }
+
+      case Some(PartitionedIndexedRDD(rdd, _)) =>
+        logger.debug(s"Building partitioned in-memory scan, $debug")
+        val cql = ECQL.toCQL(filt)
+        rdd.flatMap { case (_, engine) =>
+          val query = new Query(typeName, ECQL.toFilter(cql), requiredAttributes)
+          SelfClosingIterator(engine.getFeatureReader(query, Transaction.AUTO_COMMIT))
+        }
+    }
+
+    val extractors = SparkUtils.getExtractors(requiredColumns, schema)
+
+    result.map(SparkUtils.sf2row(schema, _, extractors))
   }
 
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = {
     filters.filter {
-      case t @ (_:IsNotNull | _:IsNull) => true
+      case _ @ (_:IsNotNull | _:IsNull) => true
       case _ => false
     }
   }
+}
+
+object GeoMesaRelation extends LazyLogging {
+
+  import scala.collection.JavaConverters._
+
+  /**
+    * Create a new relation based on the input parameters
+    *
+    * @param sqlContext sql context
+    * @param params parameters
+    * @return
+    */
+  def apply(sqlContext: SQLContext, params: Map[String, String]): GeoMesaRelation = {
+    val name = params.getOrElse(GEOMESA_SQL_FEATURE,
+      throw new IllegalArgumentException(s"Feature type must be specified with '$GEOMESA_SQL_FEATURE'"))
+    val sft = GeoMesaSpark(params.asJava).sft(params, name).getOrElse {
+      throw new IllegalArgumentException(s"Could not load feature type with name '$name'")
+    }
+    apply(sqlContext, params, SparkUtils.createStructType(sft), sft)
+  }
+
+  /**
+    * Create a new relation based on the input parameters, with the given schema
+    *
+    * @param sqlContext sql context
+    * @param params parameters
+    * @param schema schema
+    * @return
+    */
+  def apply(sqlContext: SQLContext, params: Map[String, String], schema: StructType): GeoMesaRelation = {
+    val name = params.getOrElse(GEOMESA_SQL_FEATURE,
+      throw new IllegalArgumentException(s"Feature type must be specified with '$GEOMESA_SQL_FEATURE'"))
+    val sft = GeoMesaSpark(params.asJava).sft(params, name).getOrElse {
+      throw new IllegalArgumentException(s"Could not load feature type with name '$name'")
+    }
+    apply(sqlContext, params, schema, sft)
+  }
+
+  /**
+    * Create a new relation based on the input parameters, with the given schema and underlying feature type
+    *
+    * @param sqlContext sql context
+    * @param params parameters
+    * @param schema schema
+    * @param sft simple feature type
+    * @return
+    */
+  def apply(
+      sqlContext: SQLContext,
+      params: Map[String, String],
+      schema: StructType,
+      sft: SimpleFeatureType): GeoMesaRelation = {
+
+    logger.trace(s"Creating GeoMesaRelation with sft: $sft")
+
+    def get[T](key: String, transform: String => T, default: => T): T = {
+      params.get(key) match {
+        case None => default
+        case Some(v) =>
+          try { transform(v) } catch {
+            case NonFatal(e) => logger.error(s"Error evaluating param '$key' with value '$v':", e); default
+          }
+      }
+    }
+
+    def rawRDD: SpatialRDD = {
+      val query = new Query(sft.getTypeName, ECQL.toFilter(params.getOrElse("query", "INCLUDE")))
+      GeoMesaSpark(params.asJava).rdd(new Configuration(), sqlContext.sparkContext, params, query)
+    }
+
+    val partitioned = if (!get[Boolean]("spatial", _.toBoolean, false)) { None } else {
+      val raw = rawRDD
+      val bounds: Envelope = params.get("bounds") match {
+        case None => RelationUtils.getBound(raw)
+        case Some(b) =>
+          try { WKTUtils.read(b).getEnvelopeInternal } catch {
+            case NonFatal(e) => throw new IllegalArgumentException(s"Error reading provided bounds '$b':", e)
+          }
+      }
+
+      val partitions = Option(get[Int]("partitions", _.toInt, -1)).filter(_ > 0)
+      val parallelism = partitions.getOrElse(sqlContext.sparkContext.defaultParallelism)
+      // control partitioning strategies that require a sample of the data
+      lazy val sampleSize = get[Int]("sampleSize", _.toInt, 100)
+      lazy val threshold = get[Double]("threshold", _.toDouble, 0.3)
+
+      val envelopes = params.getOrElse("strategy", "equal").toLowerCase(Locale.US) match {
+        case "equal"    => RelationUtils.equalPartitioning(bounds, parallelism)
+        case "earth"    => RelationUtils.wholeEarthPartitioning(parallelism)
+        case "weighted" => RelationUtils.weightedPartitioning(raw, bounds, parallelism, sampleSize)
+        case "rtree"    => RelationUtils.rtreePartitioning(raw, parallelism, sampleSize, threshold)
+        case s => throw new IllegalArgumentException(s"Invalid partitioning strategy: $s")
+      }
+
+      val rdd = RelationUtils.grid(raw, envelopes, parallelism)
+      rdd.persist(StorageLevel.MEMORY_ONLY)
+      Some(PartitionedRDD(rdd, raw, envelopes, partitions, get[Boolean]("cover", _.toBoolean, false)))
+    }
+
+    val cached = if (!get[Boolean]("cache", _.toBoolean, false)) { None } else {
+      val check = Collections.singletonMap[String, java.io.Serializable]("cqengine", "true")
+      if (!DataStoreFinder.getAvailableDataStores.asScala.exists(_.canProcess(check))) {
+        throw new IllegalArgumentException("Caching requires the GeoCQEngineDataStore to be available on the classpath")
+      }
+
+      // avoid closure on full sft
+      val typeName = sft.getTypeName
+      val encodedSft = SimpleFeatureTypes.encodeType(sft, includeUserData = true)
+
+      val indexGeom = get[Boolean]("indexGeom", _.toBoolean, false)
+
+      partitioned match {
+        case Some(p) =>
+          val rdd = p.rdd.mapValues { iter =>
+            val engine = new GeoCQEngineDataStore(indexGeom)
+            engine.createSchema(SimpleFeatureTypes.createType(typeName, encodedSft))
+            engine.namesToEngine.get(typeName).insert(iter)
+            engine
+          }
+          p.rdd.unpersist() // make this call blocking?
+          rdd.persist(StorageLevel.MEMORY_ONLY)
+          Some(PartitionedIndexedRDD(rdd, p.envelopes))
+
+        case None =>
+          val rdd = rawRDD.mapPartitions { iter =>
+            val engine = new GeoCQEngineDataStore(indexGeom)
+            engine.createSchema(SimpleFeatureTypes.createType(typeName, encodedSft))
+            engine.namesToEngine.get(typeName).insert(iter.toList)
+            Iterator.single(engine)
+          }
+          rdd.persist(StorageLevel.MEMORY_ONLY)
+          Some(IndexedRDD(rdd))
+      }
+    }
+
+    GeoMesaRelation(sqlContext, sft, schema, params, None, cached, partitioned)
+  }
+
+  /**
+    * Holder for a partitioning scheme
+    *
+    * @param rdd partitioned rdd
+    * @param raw underlying unpartitioned rdd
+    * @param envelopes envelopes used in partitioning
+    * @param partitions hint for number of partitions
+    * @param cover cover partitions or not when joining
+    */
+  case class PartitionedRDD(
+      rdd: RDD[(Int, Iterable[SimpleFeature])],
+      raw: SpatialRDD,
+      envelopes: List[Envelope],
+      partitions: Option[Int],
+      cover: Boolean
+    )
+
+  /**
+    * Trait for cached RDDs used to accelerate scans
+    */
+  sealed trait CachedRDD
+
+  /**
+    * An RDD where each element is a spatial index containing multiple features
+    *
+    * @param rdd indexed features
+    */
+  case class IndexedRDD(rdd: RDD[GeoCQEngineDataStore]) extends CachedRDD
+
+  /**
+    * An RDD where each element is a spatial index containing multiple features, partitioned by
+    * a spatial grid
+    *
+    * @param rdd grid cell -> indexed features
+    * @param envelopes envelopes corresponding the each grid cell
+    */
+  case class PartitionedIndexedRDD(rdd: RDD[(Int, GeoCQEngineDataStore)], envelopes: List[Envelope])
+      extends CachedRDD
 }


### PR DESCRIPTION
* Clean up signature of canProcess methods
* Clean up GeoMesaRelation
  * Replace nullable fields with Options
  * Consolidate caching/partitioning logic to avoid mutually exclusive fields,
    and statements like: `if (rel.spatiallyPartition) assert(rel.partitionedRDD != null)`
  * Move initialization logic into companion object
  * Move scan/join logic out of RelationUtils
* Separate out classes from GeoMesaSpark file

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>