### PR TITLE
GEOMESA-2707 Converters - check for nulls in date parsing methods

### DIFF
--- a/docs/user/convert/function_overview.rst
+++ b/docs/user/convert/function_overview.rst
@@ -104,6 +104,7 @@ Control Functions
 
 -  ``try``
 -  ``withDefault``
+-  ``require``
 
 State Functions
 ~~~~~~~~~~~~~~~

--- a/docs/user/convert/function_usage.rst
+++ b/docs/user/convert/function_usage.rst
@@ -27,6 +27,17 @@ Example: ``withDefault('foo', 'bar') = foo``
 
 Example: ``withDefault(null, 'bar') = bar``
 
+require
+^^^^^^^
+
+Description: Throw an exception if the value is null, otherwise return the value
+
+Usage: ``require($1)``
+
+Example: ``require('foo') = foo``
+
+Example: ``require(null) // throws an error``
+
 String Functions
 ~~~~~~~~~~~~~~~~
 

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/transforms/DateFunctionFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/transforms/DateFunctionFactory.scala
@@ -32,11 +32,21 @@ class DateFunctionFactory extends TransformerFunctionFactory {
   }
 
   private val millisToDate = TransformerFunction.pure("millisToDate") { args =>
-    new Date(args(0).asInstanceOf[Long])
+    args(0) match {
+      case null => null
+      case d: Long => new Date(d)
+      case d: Int  => new Date(d)
+      case d => throw new IllegalArgumentException(s"Invalid millisecond: $d")
+    }
   }
 
   private val secsToDate = TransformerFunction.pure("secsToDate") { args =>
-    new Date(args(0).asInstanceOf[Long] * 1000L)
+    args(0) match {
+      case null => null
+      case d: Long => new Date(d * 1000L)
+      case d: Int  => new Date(d * 1000L)
+      case d => throw new IllegalArgumentException(s"Invalid second: $d")
+    }
   }
 
   // yyyy-MM-dd'T'HH:mm:ss.SSSZZ (ZZ is time zone with colon)
@@ -151,8 +161,13 @@ object DateFunctionFactory {
 
   abstract class StandardDateParser(names: Seq[String]) extends NamedTransformerFunction(names, pure = true) {
     val format: DateTimeFormatter
-    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any =
-      DateParsing.parseDate(args(0).toString, format)
+    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = {
+      args(0) match {
+        case null => null
+        case d: String => DateParsing.parseDate(d, format)
+        case d => DateParsing.parseDate(d.toString, format)
+      }
+    }
   }
 
   class CustomFormatDateParser extends NamedTransformerFunction(Seq("date"), pure = true) {
@@ -165,7 +180,11 @@ object DateFunctionFactory {
       if (format == null) {
         format = DateTimeFormatter.ofPattern(args(0).asInstanceOf[String]).withZone(ZoneOffset.UTC)
       }
-      DateParsing.parseDate(args(1).toString, format)
+      args(1) match {
+        case null => null
+        case d: String => DateParsing.parseDate(d, format)
+        case d => DateParsing.parseDate(d.toString, format)
+      }
     }
   }
 

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/transforms/MiscFunctionFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/transforms/MiscFunctionFactory.scala
@@ -13,13 +13,20 @@ import org.locationtech.geomesa.convert2.transforms.TransformerFunction.NamedTra
 
 class MiscFunctionFactory extends TransformerFunctionFactory {
 
-  override def functions: Seq[TransformerFunction] = Seq(lineNumber, withDefault)
+  override def functions: Seq[TransformerFunction] = Seq(lineNumber, withDefault, require)
 
   private val withDefault = TransformerFunction.pure("withDefault") { args =>
     if (args(0) == null) { args(1) } else { args(0) }
   }
 
+  private val require = TransformerFunction.pure("require") { args =>
+    if (args(0) == null) {
+      throw new IllegalArgumentException("Required field is null")
+    }
+    args(0)
+  }
+
   private val lineNumber = new NamedTransformerFunction(Seq("lineNo", "lineNumber")) {
-    def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = ctx.line
+    override def eval(args: Array[Any])(implicit ctx: EvaluationContext): Any = ctx.line
   }
 }

--- a/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert2/transforms/ExpressionTest.scala
+++ b/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert2/transforms/ExpressionTest.scala
@@ -258,6 +258,25 @@ class ExpressionTest extends Specification {
       val exp = Expression("secsToDate($1)")
       exp.eval(Array("", secs)).asInstanceOf[Date] must be equalTo testDate
     }
+    "parse null dates" >> {
+      val input = Array[Any]("", null)
+      val expressions = Seq(
+        "date('yyyy-MM-dd\\'T\\'HH:mm:ss.SSSSSS', $1)",
+        "isodate($1)",
+        "basicDate($1)",
+        "isodatetime($1)",
+        "basicDateTime($1)",
+        "dateTime($1)",
+        "basicDateTimeNoMillis($1)",
+        "dateHourMinuteSecondMillis($1)",
+        "millisToDate($1)",
+        "secsToDate($1)"
+      )
+      foreach(expressions) { expression =>
+        Expression(expression).eval(input) must beNull
+        Expression(s"require($expression)").eval(input) must throwAn[IllegalArgumentException]
+      }
+    }
     "transform a date to a string" >> {
       val d = LocalDateTime.now()
       val fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS")


### PR DESCRIPTION
* Date parsing methods pass through nulls instead of throwing exceptions
  * Fix the anti-pattern of `try(date($0), null)`, which is expensive
* `require` function added to preserve old behavior if desired

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>