### PR TITLE
GEOMESA-2708 Strict index to table for adopt

### DIFF
--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/data/ManagePartitionsCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/data/ManagePartitionsCommand.scala
@@ -12,6 +12,7 @@ import java.time.{ZoneOffset, ZonedDateTime}
 
 import com.beust.jcommander.{JCommander, Parameter, ParameterException, Parameters}
 import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
 import org.locationtech.geomesa.index.conf.partition.{TablePartition, TimePartition}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.tools._
@@ -110,22 +111,25 @@ object ManagePartitionsCommand {
         val version = s"v${index.version}"
         (index, name, attributes, version)
       }
-      val indicesAndTables = tables.map { table =>
-        val matchedByName = indexNames.filter { case (_, n, _, v) => table.contains(n) && table.contains(v) }
-        if (matchedByName.lengthCompare(1) == 0) {
-          (matchedByName.head._1, table)
-        } else {
-          val matchedByAttributes = matchedByName.filter(m => table.contains(m._3))
-          if (matchedByAttributes.lengthCompare(1) == 0) {
-            (matchedByAttributes.head._1, table)
+      val tableToIndexName = indexNames
+        .toList
+        .sortWith(_._3.size > _._3.size) // Sorted so we get best match first
+        .foldLeft(Map[String,(GeoMesaFeatureIndex[_,_],String,String,String)]()){
+          (mappedTables,indexName) =>
+          val fullMatches = tables.filter(table =>
+            !mappedTables.contains(table) // Don't match again
+              && table.contains(indexName._2) // Correct type name as in z3, attr, id...
+              && table.contains(indexName._3) // Correct attributes
+              && table.contains(indexName._4) // Correct version
+          )
+          if (fullMatches.lengthCompare(1) >= 0) {
+            mappedTables + (fullMatches.head -> indexName)
           } else {
-            throw new IllegalArgumentException(s"Could not match an index to table '$table'")
+           throw new IllegalArgumentException(s"Could not match a table to an index of '${indexName._3}'")
           }
         }
-      }
-
-      indicesAndTables.foreach { case (index, table) =>
-        ds.metadata.insert(sft.getTypeName, index.tableNameKey(Some(params.partition)), table)
+      tableToIndexName.foreach { case (table, indexName) =>
+          ds.metadata.insert(sft.getTypeName, indexName._1.tableNameKey(Some(params.partition)), table)
       }
       time.register(params.partition, start, end)
 


### PR DESCRIPTION
Make the mapping of indexes to user provided tables strict by
  1. Reversing the direction of the match from table -> index to
     index -> table.
  2. Matching the index with the longest attribute string first.
  3. Match only if the table has not already been matched.
  4. Match only if all of the index name, version and attributes
     are included in the table name.

Signed-off-by: Kevin Hobbs <khobbs@ccri.com>