### PR TITLE
2.3.x  How to set Shapefile Convert  file encoding?

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/docs/user/accumulo/install.rst
+++ b/docs/user/accumulo/install.rst
@@ -227,7 +227,7 @@ Installing GeoMesa Accumulo in GeoServer
 
 .. warning::
 
-    GeoMesa 2.2.0 and later require GeoServer 2.14.0 or later. GeoMesa 2.1.0 and earlier require GeoServer 2.12.5.
+    GeoMesa 2.2.x and 2.3.x require GeoServer 2.14.x. GeoMesa 2.1.x and earlier require GeoServer 2.12.x.
 
 As described in section :ref:`geomesa_and_geoserver`, GeoMesa implements a
 `GeoTools`_-compatible data store. This makes it possible

--- a/docs/user/bigtable/install.rst
+++ b/docs/user/bigtable/install.rst
@@ -34,7 +34,7 @@ Installing GeoMesa Bigtable in GeoServer
 
 .. warning::
 
-    GeoMesa 2.2.0 and later require GeoServer 2.14.0 or later. GeoMesa 2.1.0 and earlier require GeoServer 2.12.5.
+    GeoMesa 2.2.x and 2.3.x require GeoServer 2.14.x. GeoMesa 2.1.x and earlier require GeoServer 2.12.x.
 
 The HBase GeoServer plugin is bundled by default in a GeoMesa binary distribution. To install, extract
 ``dist/gs-plugins/target/geomesa-bigtable-gs-plugin_2.11-$VERSION-install.tar.gz``

--- a/docs/user/cassandra/install.rst
+++ b/docs/user/cassandra/install.rst
@@ -122,7 +122,7 @@ Installing GeoMesa Cassandra in GeoServer
 
 .. warning::
 
-    GeoMesa 2.2.0 and later require GeoServer 2.14.0 or later. GeoMesa 2.1.0 and earlier require GeoServer 2.12.5.
+    GeoMesa 2.2.x and 2.3.x require GeoServer 2.14.x. GeoMesa 2.1.x and earlier require GeoServer 2.12.x.
 
 The GeoMesa Cassandra distribution includes a GeoServer plugin for including
 Cassandra data stores in GeoServer. The plugin files are in the

--- a/docs/user/cli/ingest.rst
+++ b/docs/user/cli/ingest.rst
@@ -126,3 +126,6 @@ disabled in this case, and progress indicators may not be entirely accurate, as 
 For example::
 
     cat foo.csv | geomesa-accumulo ingest ...
+
+For local ingests, feature writers will be pooled and only flushed periodically. The frequency of flushes can be
+controlled via the system property ``geomesa.ingest.local.batch.size``, and defaults to every 20,000 features.

--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -124,6 +124,12 @@ While the following filters both specify a 358-degree globe-spanning polygon:
   // no processing
   "intersects(geom, 'POLYGON((-179 90, 179 90, 179 -90, -179 -90, -179 90))')"
 
+geomesa.ingest.local.batch.size
++++++++++++++++++++++++++++++++
+
+Controls the batch size for local ingests via the command-line tools. By default, feature writers will be
+flushed every 20,000 features.
+
 geomesa.metadata.expiry
 +++++++++++++++++++++++
 

--- a/docs/user/filesystem/install.rst
+++ b/docs/user/filesystem/install.rst
@@ -73,7 +73,7 @@ Installing GeoMesa FileSystem in GeoServer
 
 .. warning::
 
-    GeoMesa 2.2.0 and later require GeoServer 2.14.0 or later. GeoMesa 2.1.0 and earlier require GeoServer 2.12.5.
+    GeoMesa 2.2.x and 2.3.x require GeoServer 2.14.x. GeoMesa 2.1.x and earlier require GeoServer 2.12.x.
 
 The FileSystem GeoServer plugin is bundled by default in the GeoMesa FS binary distribution. To install, extract
 ``$GEOMESA_FS_HOME/dist/gs-plugins/geomesa-fs-gs-plugin_2.11-$VERSION-install.tar.gz`` into GeoServer's

--- a/docs/user/geoserver.rst
+++ b/docs/user/geoserver.rst
@@ -8,7 +8,7 @@ how to work with the GeoMesa GeoServer plugins.
 
 .. warning::
 
-    GeoMesa 2.2.0 and later require GeoServer 2.14.0 or later. GeoMesa 2.1.0 and earlier require GeoServer 2.12.5.
+    GeoMesa 2.2.x and 2.3.x require GeoServer 2.14.x. GeoMesa 2.1.x and earlier require GeoServer 2.12.x.
 
 Installation
 ------------

--- a/docs/user/hbase/install.rst
+++ b/docs/user/hbase/install.rst
@@ -281,7 +281,7 @@ Installing GeoMesa HBase in GeoServer
 
 .. warning::
 
-    GeoMesa 2.2.0 and later require GeoServer 2.14.0 or later. GeoMesa 2.1.0 and earlier require GeoServer 2.12.5.
+    GeoMesa 2.2.x and 2.3.x require GeoServer 2.14.x. GeoMesa 2.1.x and earlier require GeoServer 2.12.x.
 
 The HBase GeoServer plugin is bundled by default in a GeoMesa binary distribution. To install, extract
 ``$GEOMESA_HBASE_HOME/dist/gs-plugins/geomesa-hbase-gs-plugin_2.11-$VERSION-install.tar.gz`` into GeoServer's

--- a/docs/user/kafka/install.rst
+++ b/docs/user/kafka/install.rst
@@ -107,7 +107,7 @@ Installing GeoMesa Kafka in GeoServer
 
 .. warning::
 
-    GeoMesa 2.2.0 and later require GeoServer 2.14.0 or later. GeoMesa 2.1.0 and earlier require GeoServer 2.12.5.
+    GeoMesa 2.2.x and 2.3.x require GeoServer 2.14.x. GeoMesa 2.1.x and earlier require GeoServer 2.12.x.
 
 As described in section :ref:`geomesa_and_geoserver`, GeoMesa implements a
 `GeoTools`_-compatible data store. This makes it possible

--- a/docs/user/kudu/install.rst
+++ b/docs/user/kudu/install.rst
@@ -113,7 +113,7 @@ Installing GeoMesa Kudu in GeoServer
 
 .. warning::
 
-    GeoMesa 2.2.0 and later require GeoServer 2.14.0 or later. GeoMesa 2.1.0 and earlier require GeoServer 2.12.5.
+    GeoMesa 2.2.x and 2.3.x require GeoServer 2.14.x. GeoMesa 2.1.x and earlier require GeoServer 2.12.x.
 
 The Kudu GeoServer plugin is bundled by default in a GeoMesa binary distribution. To install, extract
 ``$GEOMESA_KUDU_HOME/dist/gs-plugins/geomesa-kudu-gs-plugin_2.11-$VERSION-install.tar.gz`` into GeoServer's

--- a/docs/user/lambda/install.rst
+++ b/docs/user/lambda/install.rst
@@ -110,7 +110,7 @@ Installing GeoMesa Lambda in GeoServer
 
 .. warning::
 
-    GeoMesa 2.2.0 and later require GeoServer 2.14.0 or later. GeoMesa 2.1.0 and earlier require GeoServer 2.12.5.
+    GeoMesa 2.2.x and 2.3.x require GeoServer 2.14.x. GeoMesa 2.1.x and earlier require GeoServer 2.12.x.
 
 As described in section :ref:`geomesa_and_geoserver`, GeoMesa implements a `GeoTools`_-compatible data store.
 This makes it possible to use GeoMesa as a data store in `GeoServer`_. GeoServer's web site includes

--- a/docs/user/redis/install.rst
+++ b/docs/user/redis/install.rst
@@ -87,7 +87,7 @@ Installing GeoMesa Redis in GeoServer
 
 .. warning::
 
-    GeoMesa 2.2.0 and later require GeoServer 2.14.0 or later. GeoMesa 2.1.0 and earlier require GeoServer 2.12.5.
+    GeoMesa 2.2.x and 2.3.x require GeoServer 2.14.x. GeoMesa 2.1.x and earlier require GeoServer 2.12.x.
 
 The Redis GeoServer plugin is bundled by default in a GeoMesa binary distribution. To install, extract
 ``$GEOMESA_REDIS_HOME/dist/gs-plugins/geomesa-redis-gs-plugin_2.11-$VERSION-install.tar.gz`` into GeoServer's

--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -144,7 +144,7 @@ GeoMesa will no longer work with older versions of GeoTools and GeoServer.
 
 .. warning::
 
-  GeoMesa 2.2.0 requires GeoTools 20.0 or later and GeoServer 2.14 or later.
+  GeoMesa 2.2.0 requires GeoTools 20.x and GeoServer 2.14.x.
 
 Accumulo DataStore GeoServer Installation
 -----------------------------------------

--- a/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-compute/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
 
     <artifactId>geomesa-accumulo-datastore_2.11</artifactId>

--- a/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>geomesa-accumulo-datastore_2.11</artifactId>

--- a/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>geomesa-accumulo-datastore_2.11</artifactId>

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreAlterSchemaTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreAlterSchemaTest.scala
@@ -20,6 +20,7 @@ import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.TestWithDataStore
 import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.opengis.filter.Filter
 import org.specs2.runner.JUnitRunner
@@ -88,21 +89,21 @@ class AccumuloDataStoreAlterSchemaTest extends TestWithDataStore {
         features.map(_.getID) must containTheSameElementsAs(Seq("f1", "f2"))
         features.sortBy(_.getID).map(_.getAttribute("geom").toString) mustEqual Seq("POINT (51 50)", "POINT (52 50)")
         features.sortBy(_.getID).map(_.getAttribute("dtg"))
-            .map(d => ZonedDateTime.ofInstant(d.asInstanceOf[Date].toInstant, ZoneOffset.UTC).getHour) mustEqual Seq(1, 2)
+            .map(d => ZonedDateTime.ofInstant(toInstant(d.asInstanceOf[Date]), ZoneOffset.UTC).getHour) mustEqual Seq(1, 2)
       }
       "for old attributes with new features" >> {
         val query = new Query(sftName, ECQL.toFilter("IN ('f1')"), Array("geom", "dtg"))
         val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toList
         features.map(_.getID) must containTheSameElementsAs(Seq("f1"))
         features.head.getAttribute("geom").toString mustEqual "POINT (51 50)"
-        ZonedDateTime.ofInstant(features.head.getAttribute("dtg").asInstanceOf[Date].toInstant, ZoneOffset.UTC).getHour mustEqual 1
+        ZonedDateTime.ofInstant(toInstant(features.head.getAttribute("dtg").asInstanceOf[Date]), ZoneOffset.UTC).getHour mustEqual 1
       }
       "for old attributes with old features" >> {
         val query = new Query(sftName, ECQL.toFilter("IN ('f2')"), Array("geom", "dtg"))
         val features = SelfClosingIterator(ds.getFeatureSource(sftName).getFeatures(query).features).toList
         features.map(_.getID) must containTheSameElementsAs(Seq("f2"))
         features.head.getAttribute("geom").toString mustEqual "POINT (52 50)"
-        ZonedDateTime.ofInstant(features.head.getAttribute("dtg").asInstanceOf[Date].toInstant, ZoneOffset.UTC).getHour mustEqual 2
+        ZonedDateTime.ofInstant(toInstant(features.head.getAttribute("dtg").asInstanceOf[Date]), ZoneOffset.UTC).getHour mustEqual 2
       }
       "for new attributes with new and old features" >> {
         val query = new Query(sftName, ECQL.toFilter("IN ('f1', 'f2')"), Array("geom", "attr1"))

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloFeatureWriterTest.scala
@@ -7,460 +7,423 @@
  ***********************************************************************/
 
 package org.locationtech.geomesa.accumulo.data
-
-import java.text.SimpleDateFormat
-import java.util.TimeZone
+import java.util.Collections
 
 import org.apache.accumulo.core.client.BatchWriterConfig
-import org.apache.accumulo.core.data.{Range => aRange}
 import org.apache.accumulo.core.security.Authorizations
 import org.geotools.data._
 import org.geotools.factory.Hints
 import org.geotools.feature.DefaultFeatureCollection
-import org.geotools.filter.text.cql2.CQL
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.accumulo.TestWithDataStore
-import org.locationtech.geomesa.accumulo.index.JoinIndex
+import org.locationtech.geomesa.accumulo.TestWithMultipleSfts
 import org.locationtech.geomesa.features.ScalaSimpleFeature
-import org.locationtech.geomesa.features.avro.AvroSimpleFeatureFactory
-import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
-import org.locationtech.geomesa.index.index.id.IdIndex
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
+import org.locationtech.geomesa.utils.geotools.FeatureUtils
 import org.locationtech.geomesa.utils.io.WithClose
-import org.locationtech.geomesa.utils.text.WKTUtils
+import org.opengis.feature.simple.SimpleFeature
 import org.opengis.filter.Filter
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.BeforeEach
 
-import scala.collection.JavaConversions._
 
 @RunWith(classOf[JUnitRunner])
-class AccumuloFeatureWriterTest extends Specification with TestWithDataStore with BeforeEach {
-
-  override def before: Any = clearTablesHard()
+class AccumuloFeatureWriterTest extends Specification with TestWithMultipleSfts with BeforeEach {
 
   sequential
 
   val spec = "name:String:index=join,age:Integer,dtg:Date,geom:Point:srid=4326"
 
-  val sdf = new SimpleDateFormat("yyyyMMdd")
-  sdf.setTimeZone(TimeZone.getTimeZone("Zulu"))
-  val dateToIndex = sdf.parse("20140102")
-  val geomToIndex = WKTUtils.read("POINT(45.0 49.0)")
+  lazy val logical = createNewSchema(s"$spec;geomesa.logical.time=true")
+  lazy val millis = createNewSchema(s"$spec;geomesa.logical.time=false")
+
+  lazy val sfts = Seq(logical, millis)
+
+  override def before: Any = {
+    sfts.foreach{ sft =>
+      ds.manager.indices(sft).flatMap(_.getTableNames()).foreach { name =>
+        val deleter = connector.createBatchDeleter(name, new Authorizations(), 5, new BatchWriterConfig())
+        deleter.setRanges(Collections.singletonList(new org.apache.accumulo.core.data.Range()))
+        deleter.delete()
+        deleter.close()
+      }
+    }
+  }
 
   "AccumuloFeatureWriter" should {
     "provide ability to update a single feature that it wrote and preserve feature IDs" in {
-      /* create a feature */
-      val originalFeature1 = AvroSimpleFeatureFactory.buildAvroFeature(sft, List(), "id1")
-      originalFeature1.setDefaultGeometry(geomToIndex)
-      originalFeature1.setAttribute("name", "fred")
-      originalFeature1.setAttribute("age", 50.asInstanceOf[Any])
+      foreach(sfts) { sft =>
+        val features = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "fred", 50, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid2", "tom", 60, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid3", "kyle", 2, "2014-01-02", "POINT(45.0 49.0)")
+        )
 
-      /* create a second feature */
-      val originalFeature2 = AvroSimpleFeatureFactory.buildAvroFeature(sft, List(), "id2")
-      originalFeature2.setDefaultGeometry(geomToIndex)
-      originalFeature2.setAttribute("name", "tom")
-      originalFeature2.setAttribute("age", 60.asInstanceOf[Any])
+        addFeatures(sft, features)
 
-      /* create a third feature */
-      val originalFeature3 = AvroSimpleFeatureFactory.buildAvroFeature(sft, List(), "id3")
-      originalFeature3.setDefaultGeometry(geomToIndex)
-      originalFeature3.setAttribute("name", "kyle")
-      originalFeature3.setAttribute("age", 2.asInstanceOf[Any])
+        val fs = ds.getFeatureSource(sft.getTypeName)
+        // turn fred into billy
+        fs.modifyFeatures(Array("name", "age"), Array[AnyRef]("billy", Int.box(25)), ECQL.toFilter("name = 'fred'"))
 
-      addFeatures(Seq(originalFeature1, originalFeature2, originalFeature3))
+        // delete kyle
+        fs.removeFeatures(ECQL.toFilter("name = 'kyle'"))
 
-      /* turn fred into billy */
-      val filter = CQL.toFilter("name = 'fred'")
-      fs.modifyFeatures(Array("name", "age"), Array("billy", 25.asInstanceOf[AnyRef]), filter)
+        val expected = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "billy", 25, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid2", "tom", 60, "2014-01-02", "POINT(45.0 49.0)")
+        )
 
-      /* delete kyle */
-      val deleteFilter = CQL.toFilter("name = 'kyle'")
-      fs.removeFeatures(deleteFilter)
+        // read out what we wrote...we should only get tom and billy back out
+        val filters = Seq(
+          "IN ('fid1', 'fid2', 'fid3')",
+          "name IN ('billy', 'tom')",
+          "bbox(geom,44,48,46,50)",
+          "bbox(geom,44,48,46,50) and dtg during 2014-01-01T23:00:00.000Z/2014-01-02T01:00:00.000Z",
+          "dtg during 2014-01-01T23:00:00.000Z/2014-01-02T01:00:00.000Z",
+          "age IN (25, 60)"
+        )
 
-      /* query everything */
-      val cqlFilter = Filter.INCLUDE
+        foreach(filters) { filter =>
+          val query = new Query(sft.getTypeName, ECQL.toFilter(filter))
+          val result = SelfClosingIterator(fs.getFeatures(query).features).toList.sortBy(_.getID)
+          result mustEqual expected
+        }
 
-      /* Let's read out what we wrote...we should only get tom and billy back out */
-      val features = SelfClosingIterator(fs.getFeatures(new Query(sftName, Filter.INCLUDE)).features).toSeq
+        val excludes = Seq(
+          "IN ('id3')",
+          "name IN ('kyle', 'fred')",
+          "age IN (50, 2)"
+        )
 
-      features must haveSize(2)
-      features.map(f => (f.getAttribute("name"), f.getAttribute("age"))) must
-          containTheSameElementsAs(Seq(("tom", Int.box(60)), ("billy", Int.box(25))))
-      features.map(f => (f.getAttribute("name"), f.getID)) must
-          containTheSameElementsAs(Seq(("tom", "id2"), ("billy", "id1")))
+        foreach(excludes) { filter =>
+          val query = new Query(sft.getTypeName, ECQL.toFilter(filter))
+          val result = SelfClosingIterator(fs.getFeatures(query).features).toList.sortBy(_.getID)
+          result must beEmpty
+        }
+      }
     }
 
-    "be able to replace all features in a store using a general purpose FeatureWriter" in {
-      /* repopulate it */
-      val c = new DefaultFeatureCollection
-      c.add(AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("will", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid1"))
-      c.add(AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("george", 33.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid2"))
-      c.add(AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("sue", 99.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid3"))
-      c.add(AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("karen", 50.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid4"))
-      c.add(AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("bob", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid5"))
+    "be able to write features to a store using a general purpose FeatureWriter" in {
+      foreach(sfts) { sft =>
+        val writer = ds.getFeatureWriterAppend(sft.getTypeName, Transaction.AUTO_COMMIT)
+        val features = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "will", 56, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid2", "george", 33, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid3", "sue", 99, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid4", "karen", 50, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid5", "bob", 56, "2014-01-02", "POINT(45.0 49.0)")
+        )
+        features.foreach { f =>
+          val writerCreatedFeature = writer.next()
+          writerCreatedFeature.setAttributes(f.getAttributes)
+          writerCreatedFeature.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+          writerCreatedFeature.getUserData.put(Hints.PROVIDED_FID, f.getID)
+          writer.write()
+        }
+        writer.close()
 
-      val writer = ds.getFeatureWriterAppend(sftName, Transaction.AUTO_COMMIT)
-
-      c.foreach {f =>
-        val writerCreatedFeature = writer.next()
-        writerCreatedFeature.setAttributes(f.getAttributes)
-        writerCreatedFeature.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
-        writerCreatedFeature.getUserData.put(Hints.PROVIDED_FID, f.getID)
-        writer.write()
+        val query = new Query(sft.getTypeName)
+        val result = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList.sortBy(_.getID)
+        result mustEqual features
       }
-      writer.close()
-
-      val features = SelfClosingIterator(fs.getFeatures(Filter.INCLUDE).features).toSeq
-
-      features must haveSize(5)
-
-      features.map(f => (f.getAttribute("name"), f.getID)) must
-          containTheSameElementsAs(Seq(("will", "fid1"), ("george", "fid2"), ("sue", "fid3"), ("karen", "fid4"), ("bob", "fid5")))
     }
 
     "be able to update all features based on some ecql" in {
-      val toAdd = Seq(
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("will", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid1"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("george", 33.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid2"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("sue", 99.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid3"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("karen", 50.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid4"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("bob", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid5")
-      )
-      addFeatures(toAdd)
+      foreach(sfts) { sft =>
+        val features = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "will", 56, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid2", "george", 33, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid3", "sue", 99, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid4", "karen", 50, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid5", "bob", 56, "2014-01-02", "POINT(45.0 49.0)")
+        )
+        addFeatures(sft, features)
 
-      val filter = CQL.toFilter("(age > 50 AND age < 99) or (name = 'karen')")
-      fs.modifyFeatures(Array("age"), Array(60.asInstanceOf[AnyRef]), filter)
+        val fs = ds.getFeatureSource(sft.getTypeName)
+        fs.modifyFeatures("age", Int.box(60), ECQL.toFilter("(age > 50 AND age < 99) OR (name = 'karen')"))
 
-      val updated = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("age = 60")).features).toSeq
+        val expected = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "will", 60, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid4", "karen", 60, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid5", "bob", 60, "2014-01-02", "POINT(45.0 49.0)")
+        )
 
-      updated.map(f => (f.getAttribute("name"), f.getAttribute("age"))) must
-          containTheSameElementsAs(Seq(("will", Int.box(60)), ("karen", Int.box(60)), ("bob", Int.box(60))))
-      updated.map(f => (f.getAttribute("name"), f.getID)) must
-          containTheSameElementsAs(Seq(("will", "fid1"), ("karen", "fid4"), ("bob", "fid5")))
+        val result = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("age = 60")).features).toList.sortBy(_.getID)
+        result mustEqual expected
+      }
     }
 
     "provide ability to remove features" in {
-      val toAdd = Seq(
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("will", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid1"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("george", 33.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid2"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("sue", 99.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid3"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("karen", 50.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid4"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("bob", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid5")
-      )
-      addFeatures(toAdd)
+      foreach(sfts) { sft =>
+        val features = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "will", 56, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid2", "george", 33, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid3", "sue", 99, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid4", "karen", 50, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid5", "bob", 56, "2014-01-02", "POINT(45.0 49.0)")
+        )
+        addFeatures(sft, features)
 
-      val writer = ds.getFeatureWriter(sftName, Filter.INCLUDE, Transaction.AUTO_COMMIT)
-      while (writer.hasNext) {
-        writer.next()
-        writer.remove()
-      }
-      writer.close()
+        WithClose(ds.getFeatureWriter(sft.getTypeName, Filter.INCLUDE, Transaction.AUTO_COMMIT)) { writer =>
+          while (writer.hasNext) {
+            writer.next()
+            writer.remove()
+          }
+        }
 
-      val features = SelfClosingIterator(fs.getFeatures(Filter.INCLUDE).features).toSeq
-      features must beEmpty
+        // ensure that features are deleted
+        val filters = Seq(
+          "IN ('fid1', 'fid2', 'fid3', 'fid4', 'fid5')",
+          "name IN ('will', 'george', 'sue', 'karen', 'bob')",
+          "bbox(geom,44,48,46,50)",
+          "bbox(geom,44,48,46,50) and dtg during 2014-01-01T23:00:00.000Z/2014-01-02T01:00:00.000Z",
+          "dtg during 2014-01-01T23:00:00.000Z/2014-01-02T01:00:00.000Z",
+          "age > 30 AND age < 100"
+        )
 
-      forall(ds.manager.indices(sft).flatMap(_.getTableNames())) { name =>
-        WithClose(connector.createScanner(name, new Authorizations()))(_.iterator.hasNext must beFalse)
-      }
-    }
+        foreach(filters) { filter =>
+          val query = new Query(sft.getTypeName, ECQL.toFilter(filter))
+          val result = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList.sortBy(_.getID)
+          result must beEmpty
+        }
 
-    "provide ability to add data inside transactions" in {
-      val c = new DefaultFeatureCollection
-      c.add(AvroSimpleFeatureFactory.buildAvroFeature(sft, Array("dude1", 15.asInstanceOf[AnyRef], null, geomToIndex), "fid10"))
-      c.add(AvroSimpleFeatureFactory.buildAvroFeature(sft, Array("dude2", 16.asInstanceOf[AnyRef], null, geomToIndex), "fid11"))
-      c.add(AvroSimpleFeatureFactory.buildAvroFeature(sft, Array("dude3", 17.asInstanceOf[AnyRef], null, geomToIndex), "fid12"))
-
-      val trans = new DefaultTransaction("trans1")
-      fs.setTransaction(trans)
-      try {
-        fs.addFeatures(c)
-        trans.commit()
-
-        val features = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("(age = 15) or (age = 16) or (age = 17)")).features).toSeq
-        features.map(f => (f.getAttribute("name"), f.getAttribute("age"))) must
-            containTheSameElementsAs(Seq(("dude1", Int.box(15)), ("dude2", Int.box(16)), ("dude3", Int.box(17))))
-      } catch {
-        case e: Exception =>
-          trans.rollback()
-          throw e
-      } finally {
-        trans.close()
-        fs.setTransaction(Transaction.AUTO_COMMIT)
+        forall(ds.manager.indices(sft).flatMap(_.getTableNames())) { name =>
+          WithClose(connector.createScanner(name, new Authorizations()))(_.iterator.hasNext must beFalse)
+        }
       }
     }
 
-    "provide ability to remove inside transactions" in {
-      val toAdd = Seq(
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("will", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid1"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("george", 33.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid2"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("sue", 99.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid3"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("dude1", 15.asInstanceOf[AnyRef], null, geomToIndex), "fid10"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("dude2", 16.asInstanceOf[AnyRef], null, geomToIndex), "fid11"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("dude3", 17.asInstanceOf[AnyRef], null, geomToIndex), "fid12")
-      )
-      addFeatures(toAdd)
+    "work with transactions (while ignoring them)" in {
+      foreach(sfts) { sft =>
+        val features = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "will", 56, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid2", "george", 33, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid3", "sue", 99, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid4", "karen", 50, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid5", "bob", 56, "2014-01-02", "POINT(45.0 49.0)")
+        )
 
-      val trans = new DefaultTransaction("trans1")
-      fs.setTransaction(trans)
-      try {
-        fs.removeFeatures(CQL.toFilter("name = 'dude1' or name='dude2' or name='dude3'"))
-        trans.commit()
+        val c = new DefaultFeatureCollection("0", sft)
+        features.foreach { f =>
+          f.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+          c.add(f)
+        }
 
-        val features = SelfClosingIterator(fs.getFeatures(Filter.INCLUDE).features).toSeq
+        val fs = ds.getFeatureSource(sft.getTypeName)
 
-        features must haveSize(3)
-        features.map(f => f.getAttribute("name")) must containTheSameElementsAs(Seq("will", "george", "sue"))
-      } catch {
-        case e: Exception =>
-          trans.rollback()
-          throw e
-      } finally {
-        trans.close()
-        fs.setTransaction(Transaction.AUTO_COMMIT)
+        fs.setTransaction(new DefaultTransaction("t1"))
+        try {
+          fs.addFeatures(c)
+          fs.getTransaction.commit()
+        } catch {
+          case e: Exception =>
+            fs.getTransaction.rollback()
+            throw e
+        } finally {
+          fs.getTransaction.close()
+          fs.setTransaction(Transaction.AUTO_COMMIT)
+        }
+
+        val filters = Seq(
+          "IN ('fid1', 'fid2', 'fid3', 'fid4', 'fid5')",
+          "name IN ('will', 'george', 'sue', 'karen', 'bob')",
+          "bbox(geom,44,48,46,50)",
+          "bbox(geom,44,48,46,50) and dtg during 2014-01-01T23:00:00.000Z/2014-01-02T01:00:00.000Z",
+          "dtg during 2014-01-01T23:00:00.000Z/2014-01-02T01:00:00.000Z",
+          "age > 30 AND age < 100"
+        )
+
+        foreach(filters) { filter =>
+          val query = new Query(sft.getTypeName, ECQL.toFilter(filter))
+          val result = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList.sortBy(_.getID)
+          result mustEqual features
+        }
       }
     }
 
-    "issue delete keys when geometry changes" in {
-      val toAdd = Seq(
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("will", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid1"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("george", 33.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid2"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("sue", 99.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid3"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("karen", 50.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid4"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("bob", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid5")
-      )
-      addFeatures(toAdd)
+    "correctly update keys when indexed values change" in {
+      foreach(sfts) { sft =>
+        val features = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "will", 56, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid2", "george", 33, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid3", "sue", 99, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid4", "karen", 50, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid5", "bob", 56, "2014-01-02", "POINT(45.0 49.0)")
+        )
+        addFeatures(sft, features)
 
-      val filter = CQL.toFilter("name = 'bob' or name = 'karen'")
-      val writer = ds.getFeatureWriter(sftName, filter, Transaction.AUTO_COMMIT)
+        val update = ECQL.toFilter("name = 'bob' or name = 'karen'")
+        WithClose(ds.getFeatureWriter(sft.getTypeName, update, Transaction.AUTO_COMMIT)) { writer =>
+          while (writer.hasNext) {
+            val feature = writer.next()
+            feature.setAttribute("geom", "POINT(50.0 50.0)")
+            feature.setAttribute("dtg", "2014-02-02")
+            writer.write()
+          }
+        }
 
-      while (writer.hasNext) {
-        val sf = writer.next
-        sf.setDefaultGeometry(WKTUtils.read("POINT(50.0 50)"))
-        writer.write()
-      }
-      writer.close()
+        val expected = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "will", 56, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid2", "george", 33, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid3", "sue", 99, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid4", "karen", 50, "2014-02-02", "POINT(50.0 50.0)"),
+          ScalaSimpleFeature.create(sft, "fid5", "bob", 56, "2014-02-02", "POINT(50.0 50.0)")
+        )
 
-      // Verify old geo bbox doesn't return them
-      val features45 = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("BBOX(geom, 44.9,48.9,45.1,49.1)")).features).toSeq
-      features45.map(_.getAttribute("name")) must containTheSameElementsAs(Seq("will", "george", "sue"))
+        def query(filter: String): Seq[SimpleFeature] = {
+          val query = new Query(sft.getTypeName, ECQL.toFilter(filter))
+          SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList.sortBy(_.getID)
+        }
 
-      // Verify that new geometries are written with a bbox query that uses the index
-      val features50 = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("BBOX(geom, 49.9,49.9,50.1,50.1)")).features).toSeq
-      features50.map(_.getAttribute("name")) must containTheSameElementsAs(Seq("bob", "karen"))
+        // verify old bbox/dtg doesn't return them
+        val old = Seq(
+          "BBOX(geom,44.9,48.9,45.1,49.1)",
+          "dtg DURING 2014-01-01T23:00:00Z/2014-01-02T01:00:00Z",
+          "BBOX(geom,44.9,48.9,45.1,49.1) AND dtg DURING 2014-01-01T23:00:00Z/2014-01-02T01:00:00Z"
+        )
+        foreach(old) { filter =>
+          query(filter) mustEqual expected.filter(f => Seq("will", "george", "sue").contains(f.getAttribute("name")))
+        }
 
-      // get them all
-      val all = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("BBOX(geom, 44.0,44.0,51.0,51.0)")).features).toSeq
-      all.map(_.getAttribute("name")) must containTheSameElementsAs(Seq("will", "george", "sue", "bob", "karen"))
+        // verify new bbox/dtg works
+        val updated = Seq(
+          "BBOX(geom,49.9,49.9,50.1,50.1)",
+          "dtg DURING 2014-02-01T23:00:00Z/2014-02-02T01:00:00Z",
+          "BBOX(geom,49.9,49.9,50.1,50.1) AND dtg DURING 2014-02-01T23:00:00Z/2014-02-02T01:00:00Z"
+        )
+        foreach(updated) { filter =>
+          query(filter) mustEqual expected.filter(f => Seq("bob", "karen").contains(f.getAttribute("name")))
+        }
 
-      // get none
-      val none = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("BBOX(geom, 30.0,30.0,31.0,31.0)")).features).toSeq
-      none must beEmpty
-    }
+        // get them all
+        val all = Seq(
+          "BBOX(geom,44.0,44.0,51.0,51.0)",
+          "dtg DURING 2014-01-01T00:00:00Z/2014-02-03T00:00:00Z",
+          "BBOX(geom,44.0,44.0,51.0,51.0) AND dtg DURING 2014-01-01T00:00:00Z/2014-02-03T00:00:00Z"
+        )
+        foreach(all) { filter =>
+          query(filter) mustEqual expected
+        }
 
-    "issue delete keys when datetime changes" in {
-      val toAdd = Seq(
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("will", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid1"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("george", 33.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid2"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("sue", 99.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid3"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("karen", 50.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid4"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("bob", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid5")
-      )
-      addFeatures(toAdd)
-
-      val filter = CQL.toFilter("name = 'will' or name='george'")
-      val writer = ds.getFeatureWriter(sftName, filter, Transaction.AUTO_COMMIT)
-
-      val newDate = sdf.parse("20140202")
-      while (writer.hasNext) {
-        val sf = writer.next
-        sf.setAttribute("dtg", newDate)
-        writer.write()
-      }
-      writer.close()
-
-      // Verify old daterange doesn't return them
-      val jan = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("dtg DURING 2013-12-29T00:00:00Z/2014-01-04T00:00:00Z")).features).toSeq
-      jan.map(_.getAttribute("name")) must containTheSameElementsAs(Seq("sue", "bob", "karen"))
-
-      // Verify new date range returns things
-      val feb = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("dtg DURING 2014-02-01T00:00:00Z/2014-02-03T00:00:00Z")).features).toSeq
-      feb.map(_.getAttribute("name")) must containTheSameElementsAs(Seq("will","george"))
-
-      // Verify large date range returns everything
-      val all = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("dtg DURING 2014-01-01T00:00:00Z/2014-02-03T00:00:00Z")).features).toSeq
-      all.map(_.getAttribute("name")) must containTheSameElementsAs(Seq("will", "george", "sue", "bob", "karen"))
-
-      // Verify other date range returns nothing
-      val none = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("dtg DURING 2013-12-01T00:00:00Z/2013-12-31T00:00:00Z")).features).toSeq
-      none must beEmpty
-    }
-
-    "verify that start end times are excluded in filter" in { // TODO this should be moved somewhere else...
-      val toAdd = Seq(
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("will", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid1"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("george", 33.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid2"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("sue", 99.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid3"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("karen", 50.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid4"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("bob", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid5")
-      )
-      addFeatures(toAdd)
-
-      val afterFilter = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("dtg AFTER 2014-02-02T00:00:00Z")).features).toSeq
-      afterFilter must beEmpty
-
-      val beforeFilter = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("dtg BEFORE 2014-01-02T00:00:00Z")).features).toSeq
-      beforeFilter must beEmpty
-    }
-
-    "ensure that feature IDs are not changed when spatiotemporal indexes change" in {
-      val toAdd = Seq(
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("will", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid1"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("george", 33.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid2"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("sue", 99.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid3"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("karen", 50.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid4"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("bob", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid5")
-      )
-      addFeatures(toAdd)
-
-      val writer = ds.getFeatureWriter(sftName, Filter.INCLUDE, Transaction.AUTO_COMMIT)
-      val newDate = sdf.parse("20120102")
-      while (writer.hasNext) {
-        val sf = writer.next
-        sf.setAttribute("dtg", newDate)
-        sf.setDefaultGeometry(WKTUtils.read("POINT(10.0 10.0)"))
-        writer.write()
-      }
-      writer.close()
-
-      val features = SelfClosingIterator(fs.getFeatures(Filter.INCLUDE).features).toSeq
-
-      features.size mustEqual toAdd.size
-
-      val compare = features.sortBy(_.getID).zip(toAdd.sortBy(_.getID))
-      forall(compare) { case (updated, original) =>
-        updated.getID mustEqual original.getID
-        updated.getDefaultGeometry must not be equalTo(original.getDefaultGeometry)
-        updated.getAttribute("dtg") must not be equalTo(original.getAttribute("dtg"))
+        // get none
+        val none = Seq(
+          "BBOX(geom, 30.0,30.0,31.0,31.0)",
+          "dtg DURING 2013-12-01T00:00:00Z/2013-12-31T00:00:00Z",
+          "BBOX(geom, 30.0,30.0,31.0,31.0) AND dtg DURING 2013-12-01T00:00:00Z/2013-12-31T00:00:00Z"
+        )
+        foreach(none) { filter =>
+          query(filter) must beEmpty
+        }
       }
     }
 
-    "verify delete and add same key works" in {
-      val toAdd = Seq(
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("will", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid1"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("george", 33.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid2"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("sue", 99.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid3"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("karen", 50.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid4"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("bob", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid5")
-      )
-      addFeatures(toAdd)
+    "delete and re-add the same feature" in {
+      foreach(sfts) { sft =>
+        val features = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "will", 56, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid2", "george", 33, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid3", "sue", 99, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid4", "karen", 50, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid5", "bob", 56, "2014-01-02", "POINT(45.0 49.0)")
+        )
+        addFeatures(sft, features)
 
-      val filter = CQL.toFilter("name = 'will'")
+        // ensure that features are added
+        val filters = Seq(
+          "IN ('fid1', 'fid2', 'fid3', 'fid4', 'fid5')",
+          "name IN ('will', 'george', 'sue', 'karen', 'bob')",
+          "bbox(geom,44,48,46,50)",
+          "bbox(geom,44,48,46,50) and dtg during 2014-01-01T23:00:00.000Z/2014-01-02T01:00:00.000Z",
+          "dtg during 2014-01-01T23:00:00.000Z/2014-01-02T01:00:00.000Z",
+          "age > 30 AND age < 100"
+        )
 
-      ds.getQueryPlan(new Query(sft.getTypeName, filter)).head.filter.index.name mustEqual JoinIndex.name
+        foreach(filters) { filter =>
+          val query = new Query(sft.getTypeName, ECQL.toFilter(filter))
+          val result = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList.sortBy(_.getID)
+          result mustEqual features
+        }
 
-      // Retrieve Will's ID before deletion.
-      val featuresBeforeDelete = SelfClosingIterator(fs.getFeatures(filter).features).toSeq
+        val delete = ECQL.toFilter("name = 'will'")
+        WithClose(ds.getFeatureWriter(sft.getTypeName, delete, Transaction.AUTO_COMMIT)) { writer =>
+          while (writer.hasNext) {
+            writer.next()
+            writer.remove()
+          }
+        }
 
-      featuresBeforeDelete must haveSize(1)
-      val willId = featuresBeforeDelete.head.getID
+        // ensure that will was deleted
+        foreach(filters) { filter =>
+          val query = new Query(sft.getTypeName, ECQL.toFilter(filter))
+          val result = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList.sortBy(_.getID)
+          result mustEqual features.drop(1)
+        }
 
-      fs.removeFeatures(filter)
+        // re-add will
+        WithClose(ds.getFeatureWriterAppend(sft.getTypeName, Transaction.AUTO_COMMIT)) { writer =>
+          val feature = writer.next()
+          feature.setAttributes(features.head.getAttributes)
+          feature.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+          feature.getUserData.put(Hints.PROVIDED_FID, features.head.getID)
+          writer.write()
+        }
 
-      // NB: We really need a test which reads from the attribute table directly since missing records entries
-      //  will result in attribute queries
-      // This verifies that 'will' has been deleted from the attribute table.
-      val attributeTableFeatures = SelfClosingIterator(fs.getFeatures(filter).features).toSeq
-      attributeTableFeatures must beEmpty
-
-      // This verifies that 'will' has been deleted from the record table.
-      val recordTableFeatures = SelfClosingIterator(fs.getFeatures(ECQL.toFilter(s"IN('$willId')")).features).toSeq
-      recordTableFeatures must beEmpty
-
-      // This verifies that 'will' has been deleted from the ST idx table.
-      val stTableFeatures = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("BBOX(geom, 44.0,44.0,51.0,51.0)")).features).toSeq
-      stTableFeatures.count(_.getID == willId) mustEqual 0
-
-      val featureCollection = new DefaultFeatureCollection(sftName, sft)
-      val geom = WKTUtils.read("POINT(10.0 10.0)")
-      val date = sdf.parse("20120102")
-      /* create a feature */
-      featureCollection.add(AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("will", 56.asInstanceOf[AnyRef], date, geom), "fid1"))
-      fs.addFeatures(featureCollection)
-
-      val features = SelfClosingIterator(fs.getFeatures(filter).features).toSeq
-      features must haveSize(1)
+        foreach(filters) { filter =>
+          val query = new Query(sft.getTypeName, ECQL.toFilter(filter))
+          val result = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList.sortBy(_.getID)
+          result mustEqual features
+        }
+      }
     }
 
     "not write partial features" in {
-      val invalid = Seq(
-        ScalaSimpleFeature.create(sft, "no-geom",  "name", 56, "2016-01-01T00:00:00.000Z", null),
-        ScalaSimpleFeature.create(sft, "bad-geom", "name", 56, "2016-01-01T00:00:00.000Z", "POINT(181 0)"),
-        ScalaSimpleFeature.create(sft, "bad-date", "name", 56, "2599-01-01T00:00:00.000Z", "POINT(10 10)")
-      )
-      forall(invalid) { feature =>
-        addFeatures(Seq(feature)) must throwAn[IllegalArgumentException]
-        forall(ds.manager.indices(sft).flatMap(_.getTableNames())) { table =>
-          WithClose(connector.createScanner(table, new Authorizations()))(_.iterator.hasNext must beFalse)
+      foreach(sfts) { sft =>
+        val invalid = Seq(
+          ScalaSimpleFeature.create(sft, "no-geom",  "name", 56, "2016-01-01T00:00:00.000Z", null),
+          ScalaSimpleFeature.create(sft, "bad-geom", "name", 56, "2016-01-01T00:00:00.000Z", "POINT(181 0)"),
+          ScalaSimpleFeature.create(sft, "bad-date", "name", 56, "2599-01-01T00:00:00.000Z", "POINT(10 10)")
+        )
+        forall(invalid) { feature =>
+          addFeatures(sft, Seq(feature)) must throwAn[IllegalArgumentException]
+          forall(ds.manager.indices(sft).flatMap(_.getTableNames())) { table =>
+            WithClose(connector.createScanner(table, new Authorizations()))(_.iterator.hasNext must beFalse)
+          }
         }
       }
     }
 
     "create z3 based uuids" in {
-      val toAdd = Seq(
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("will", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid1"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("george", 33.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid2"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("sue", 99.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid3"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("karen", 50.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid4"),
-        AvroSimpleFeatureFactory.buildAvroFeature(sft, Seq("bob", 56.asInstanceOf[AnyRef], dateToIndex, geomToIndex), "fid5")
-      )
-      // space out the adding slightly so we ensure they sort how we want - resolution is to the ms
-      // also ensure we don't set use_provided_fid
-      toAdd.foreach { f =>
-        val featureCollection = new DefaultFeatureCollection(sftName, sft)
-        f.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.FALSE)
-        f.getUserData.remove(Hints.PROVIDED_FID)
-        featureCollection.add(f)
-        // write the feature to the store
-        fs.addFeatures(featureCollection)
-        Thread.sleep(2)
+      foreach(sfts) { sft =>
+        val features = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "will", 56, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid2", "george", 33, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid3", "sue", 99, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid4", "karen", 50, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid5", "bob", 56, "2014-01-02", "POINT(45.0 49.0)")
+        )
+
+        // space out the adding slightly so we ensure they sort how we want - resolution is to the ms
+        // also ensure we don't set use_provided_fid
+        WithClose(ds.getFeatureWriterAppend(sft.getTypeName, Transaction.AUTO_COMMIT)) { writer =>
+          features.foreach { f =>
+            FeatureUtils.copyToWriter(writer, f, useProvidedFid = false)
+            writer.write()
+            writer.flush()
+            Thread.sleep(2)
+          }
+        }
+
+        val query = new Query(sft.getTypeName)
+        val ids = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList.map(_.getID).sorted
+        ids must haveLength(5)
+        forall(ids)(_ must not(beMatching("fid\\d")))
+
+        // ensure that the z3 range is the same
+        ids.map(_.substring(0, 18)).distinct must haveLength(1)
+        // ensure that the second part of the UUID is random
+        ids.map(_.substring(19)).distinct must haveLength(5)
       }
-
-      val idIndex = ds.manager.indices(sft).find(_.name == IdIndex.name).orNull
-      idIndex must not(beNull)
-
-      val serializer = KryoFeatureSerializer(sft)
-      val rows = idIndex.getTableNames().flatMap { table =>
-        WithClose(ds.connector.createScanner(table, new Authorizations))(_.toList)
-      }
-
-      // trim off table prefix to get the UUIDs
-      val rowKeys = rows.map(_.getKey.getRow.toString).map(r => r.substring(r.length - 36))
-      rowKeys must haveLength(5)
-
-      // ensure that the z3 range is the same
-      rowKeys.map(_.substring(0, 18)).toSet must haveLength(1)
-      // ensure that the second part of the UUID is random
-      rowKeys.map(_.substring(19)).toSet must haveLength(5)
-
-      val ids = rows.map(e => idIndex.getIdFromRow(e.getKey.getRow.getBytes, 0, e.getKey.getRow.getLength, null))
-      ids must haveLength(5)
-      forall(ids)(_ must not(beMatching("fid\\d")))
-      // ensure they share a common prefix, since they have the same dtg/geom
-      ids.map(_.substring(0, 18)).toSet must haveLength(1)
-      // ensure that the second part of the UUID is random
-      ids.map(_.substring(19)).toSet must haveLength(5)
-    }
-  }
-
-  def clearTablesHard(): Unit = {
-    ds.manager.indices(sft).flatMap(_.getTableNames()).foreach { name =>
-      val deleter = connector.createBatchDeleter(name, new Authorizations(), 5, new BatchWriterConfig())
-      deleter.setRanges(Seq(new aRange()))
-      deleter.delete()
-      deleter.close()
     }
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-dist/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-accumulo/geomesa-accumulo-dist/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-accumulo/geomesa-accumulo-dist/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>geomesa-accumulo-distributed-runtime_2.11</artifactId>

--- a/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>geomesa-accumulo-distributed-runtime_2.11</artifactId>

--- a/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-distributed-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
 
     <artifactId>geomesa-accumulo-distributed-runtime_2.11</artifactId>

--- a/geomesa-accumulo/geomesa-accumulo-gs-plugin/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-accumulo/geomesa-accumulo-gs-plugin/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-accumulo/geomesa-accumulo-gs-plugin/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-accumulo/geomesa-accumulo-jobs/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-jobs/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-jobs/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-native-api/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-native-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-native-api/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-native-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-native-api/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-native-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-raster-distributed-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-raster-distributed-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
 
     <artifactId>geomesa-accumulo-raster-distributed-runtime_2.11</artifactId>

--- a/geomesa-accumulo/geomesa-accumulo-raster-distributed-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-raster-distributed-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>geomesa-accumulo-raster-distributed-runtime_2.11</artifactId>

--- a/geomesa-accumulo/geomesa-accumulo-raster-distributed-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-raster-distributed-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>geomesa-accumulo-raster-distributed-runtime_2.11</artifactId>

--- a/geomesa-accumulo/geomesa-accumulo-raster/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-raster/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-raster/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-raster/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-raster/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-raster/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-raster/src/main/scala/org/locationtech/geomesa/raster/index/RasterEntry.scala
+++ b/geomesa-accumulo/geomesa-accumulo-raster/src/main/scala/org/locationtech/geomesa/raster/index/RasterEntry.scala
@@ -21,6 +21,7 @@ import org.locationtech.geomesa.features.{ScalaSimpleFeatureFactory, SimpleFeatu
 import org.locationtech.geomesa.raster._
 import org.locationtech.geomesa.raster.data.Raster
 import org.locationtech.geomesa.raster.index.RasterEntryDecoder.DecodedIndexValue
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.opengis.feature.simple.SimpleFeature
 
 object RasterEntry {
@@ -78,7 +79,7 @@ object RasterEntryEncoder extends LazyLogging {
   private def getCF(raster: Raster): Text = new Text("")
 
   private def getCQ(raster: Raster): Text = {
-    new Text(RasterEntry.encodeIndexCQMetadata(raster.id, raster.metadata.geom, Option(Date.from(raster.time.toInstant))))
+    new Text(RasterEntry.encodeIndexCQMetadata(raster.id, raster.metadata.geom, Option(Date.from(toInstant(raster.time)))))
   }
 
   private def encodeValue(raster: Raster): Value = new Value(raster.serializedChunk)

--- a/geomesa-accumulo/geomesa-accumulo-security/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-security/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-security/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-spark-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-spark-runtime/pom.xml
@@ -118,7 +118,6 @@
                                     <exclude>com.esotericsoftware.kryo:*</exclude>
                                     <exclude>org.ow2.asm:*</exclude>
                                     <exclude>org.scala-lang:*</exclude>
-                                    <exclude>org.json4s:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <filters>
@@ -150,6 +149,11 @@
                                 <relocation>
                                     <pattern>shapeless</pattern>
                                     <shadedPattern>org.locationtech.geomesa.accumulo.shaded.shapeless</shadedPattern>
+                                </relocation>
+                                <!-- spark needs json4s to use the jsonpath function -->
+                                <relocation>
+                                    <pattern>org.json4s</pattern>
+                                    <shadedPattern>org.locationtech.geomesa.accumulo.shaded.org.json4s</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>

--- a/geomesa-accumulo/geomesa-accumulo-spark-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-spark-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-spark-runtime/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-spark/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-spark/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-spark/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-accumulo_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-stats-gs-plugin/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-stats-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-accumulo/geomesa-accumulo-stats-gs-plugin/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-stats-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-accumulo/geomesa-accumulo-stats-gs-plugin/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-stats-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-accumulo/geomesa-accumulo-tools/bin/geomesa-accumulo
+++ b/geomesa-accumulo/geomesa-accumulo-tools/bin/geomesa-accumulo
@@ -120,6 +120,6 @@ else
       GEOMESA_OPTS="$GEOMESA_OPTS $GEOMESA_DEBUG_OPTS"
       shift 1
     fi
-    java ${CUSTOM_JAVA_OPTS} ${GEOMESA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.accumulo.tools.AccumuloRunner "$@"
+    java ${GEOMESA_OPTS} ${CUSTOM_JAVA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.accumulo.tools.AccumuloRunner "$@"
   fi
 fi

--- a/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-accumulo_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/accumulo/tools/ingest/AccumuloIngestCommand.scala
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/main/scala/org/locationtech/geomesa/accumulo/tools/ingest/AccumuloIngestCommand.scala
@@ -10,10 +10,12 @@ package org.locationtech.geomesa.accumulo.tools.ingest
 
 import java.io.File
 
-import com.beust.jcommander.Parameters
+import com.beust.jcommander.{Parameter, Parameters}
 import org.apache.accumulo.core.client.Connector
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
+import org.locationtech.geomesa.accumulo.tools.ingest.AccumuloIngestCommand.AccumuloIngestParams
 import org.locationtech.geomesa.accumulo.tools.{AccumuloDataStoreCommand, AccumuloDataStoreParams}
+import org.locationtech.geomesa.tools.Command
 import org.locationtech.geomesa.tools.ingest.IngestCommand
 import org.locationtech.geomesa.tools.ingest.IngestCommand.IngestParams
 import org.locationtech.geomesa.utils.classpath.ClassPathUtils
@@ -31,7 +33,27 @@ class AccumuloIngestCommand extends IngestCommand[AccumuloDataStore] with Accumu
     () => ClassPathUtils.getJarsFromClasspath(classOf[AccumuloDataStore]),
     () => ClassPathUtils.getJarsFromClasspath(classOf[Connector])
   )
+
+  override def execute(): Unit = {
+    super.execute()
+    if (params.compact) {
+      withDataStore { ds =>
+        if (ds.config.generateStats) {
+          Command.user.info("Triggering stat table compaction")
+          ds.stats.compact(wait = false)
+        }
+      }
+    }
+  }
 }
 
-@Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")
-class AccumuloIngestParams extends IngestParams with AccumuloDataStoreParams
+object AccumuloIngestCommand {
+  @Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")
+  class AccumuloIngestParams extends IngestParams with AccumuloDataStoreParams {
+    @Parameter(
+      names = Array("--compact-stats"),
+      description = "Compact stats table after ingest, for improved performance",
+      arity = 1)
+    var compact: Boolean = true
+  }
+}

--- a/geomesa-accumulo/pom.xml
+++ b/geomesa-accumulo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/pom.xml
+++ b/geomesa-accumulo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-accumulo/pom.xml
+++ b/geomesa-accumulo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml
+++ b/geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-archetypes_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml
+++ b/geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-archetypes_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml
+++ b/geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-archetypes_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-archetypes/pom.xml
+++ b/geomesa-archetypes/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>geomesa-archetypes_2.11</artifactId>

--- a/geomesa-archetypes/pom.xml
+++ b/geomesa-archetypes/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
 
     <artifactId>geomesa-archetypes_2.11</artifactId>

--- a/geomesa-archetypes/pom.xml
+++ b/geomesa-archetypes/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>geomesa-archetypes_2.11</artifactId>

--- a/geomesa-arrow/geomesa-arrow-datastore/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-arrow_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/geomesa-arrow-datastore/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-arrow_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/geomesa-arrow-datastore/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-arrow_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/geomesa-arrow-dist/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-arrow_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-arrow/geomesa-arrow-dist/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-arrow_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-arrow/geomesa-arrow-dist/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-arrow_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-arrow/geomesa-arrow-gs-plugin/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-arrow/geomesa-arrow-gs-plugin/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-arrow/geomesa-arrow-gs-plugin/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-arrow/geomesa-arrow-gt/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-gt/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-arrow_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/geomesa-arrow-gt/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-gt/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-arrow_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/geomesa-arrow-gt/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-gt/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-arrow_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/geomesa-arrow-jts/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-jts/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-arrow_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/geomesa-arrow-jts/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-jts/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-arrow_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/geomesa-arrow-jts/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-jts/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-arrow_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/geomesa-arrow-tools/bin/geomesa-arrow
+++ b/geomesa-arrow/geomesa-arrow-tools/bin/geomesa-arrow
@@ -47,6 +47,6 @@ else
       GEOMESA_OPTS="$GEOMESA_OPTS $GEOMESA_DEBUG_OPTS"
       shift 1
     fi
-    java ${CUSTOM_JAVA_OPTS} ${GEOMESA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.arrow.tools.ArrowRunner "$@"
+    java ${GEOMESA_OPTS} ${CUSTOM_JAVA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.arrow.tools.ArrowRunner "$@"
   fi
 fi

--- a/geomesa-arrow/geomesa-arrow-tools/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-arrow_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/geomesa-arrow-tools/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-arrow_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/geomesa-arrow-tools/pom.xml
+++ b/geomesa-arrow/geomesa-arrow-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-arrow_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/pom.xml
+++ b/geomesa-arrow/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/pom.xml
+++ b/geomesa-arrow/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-arrow/pom.xml
+++ b/geomesa-arrow/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/geomesa-bigtable-datastore/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-bigtable_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/geomesa-bigtable-datastore/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-bigtable_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/geomesa-bigtable-datastore/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-bigtable_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/geomesa-bigtable-datastore/src/main/scala/org/locationtech/geomesa/bigtable/data/BigtableDataStore.scala
+++ b/geomesa-bigtable/geomesa-bigtable-datastore/src/main/scala/org/locationtech/geomesa/bigtable/data/BigtableDataStore.scala
@@ -8,67 +8,12 @@
 
 package org.locationtech.geomesa.bigtable.data
 
-import java.io.Serializable
-
-import org.apache.hadoop.hbase.HBaseConfiguration
 import org.apache.hadoop.hbase.client._
-import org.geotools.data.DataAccessFactory.Param
 import org.locationtech.geomesa.hbase.data.HBaseDataStoreFactory.HBaseDataStoreConfig
-import org.locationtech.geomesa.hbase.data.HBaseDataStoreParams._
 import org.locationtech.geomesa.hbase.data._
-import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDataStoreInfo
-import org.locationtech.geomesa.utils.geotools.GeoMesaParam
 
 class BigtableDataStore(connection: Connection, config: HBaseDataStoreConfig)
     extends HBaseDataStore(connection, config) {
   override val adapter: BigtableIndexAdapter = new BigtableIndexAdapter(this)
   override protected def loadIteratorVersions: Set[String] = Set.empty
-}
-
-class BigtableDataStoreFactory extends HBaseDataStoreFactory {
-
-  import BigtableDataStoreFactory.BigtableCatalogParam
-
-  override def getDisplayName: String = BigtableDataStoreFactory.DisplayName
-  override def getDescription: String = BigtableDataStoreFactory.Description
-
-  override protected def getCatalog(params: java.util.Map[String, Serializable]): String =
-    BigtableCatalogParam.lookup(params)
-
-  override protected def buildDataStore(connection: Connection, config: HBaseDataStoreConfig): BigtableDataStore = {
-    // note: bigtable never has push-down predicates
-    new BigtableDataStore(connection, config.copy(remoteFilter = false))
-  }
-
-  override protected def validateConnection: Boolean = false
-
-  override def canProcess(params: java.util.Map[java.lang.String,java.io.Serializable]): Boolean =
-    BigtableDataStoreFactory.canProcess(params)
-
-  override def getParametersInfo: Array[Param] = BigtableDataStoreFactory.ParameterInfo :+ NamespaceParam
-}
-
-object BigtableDataStoreFactory extends GeoMesaDataStoreInfo {
-
-  val BigtableCatalogParam = new GeoMesaParam[String]("bigtable.catalog", "Catalog table name", optional = false, deprecatedKeys = Seq("bigtable.table.name"))
-
-  override val DisplayName = "Google Bigtable (GeoMesa)"
-  override val Description = "Google Bigtable\u2122 distributed key/value store"
-
-  override val ParameterInfo: Array[GeoMesaParam[_]] =
-    Array(
-      BigtableCatalogParam,
-      QueryThreadsParam,
-      QueryTimeoutParam,
-      GenerateStatsParam,
-      AuditQueriesParam,
-      LooseBBoxParam,
-      CachingParam
-    )
-
-  // verify that the hbase-site.xml exists and contains the appropriate bigtable keys
-  override def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean = {
-    BigtableCatalogParam.exists(params) &&
-      Option(HBaseConfiguration.create().get(HBaseDataStoreFactory.BigTableParamCheck)).exists(_.trim.nonEmpty)
-  }
 }

--- a/geomesa-bigtable/geomesa-bigtable-datastore/src/main/scala/org/locationtech/geomesa/bigtable/data/BigtableDataStoreFactory.scala
+++ b/geomesa-bigtable/geomesa-bigtable-datastore/src/main/scala/org/locationtech/geomesa/bigtable/data/BigtableDataStoreFactory.scala
@@ -1,0 +1,69 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.bigtable.data
+
+import java.io.Serializable
+
+import org.apache.hadoop.hbase.HBaseConfiguration
+import org.apache.hadoop.hbase.client.Connection
+import org.geotools.data.DataAccessFactory.Param
+import org.locationtech.geomesa.hbase.data.HBaseDataStoreFactory
+import org.locationtech.geomesa.hbase.data.HBaseDataStoreFactory.HBaseDataStoreConfig
+import org.locationtech.geomesa.hbase.data.HBaseDataStoreParams._
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.{GeoMesaDataStoreInfo, NamespaceParams}
+import org.locationtech.geomesa.utils.geotools.GeoMesaParam
+
+class BigtableDataStoreFactory extends HBaseDataStoreFactory {
+
+  import BigtableDataStoreFactory.BigtableCatalogParam
+
+  override def getDisplayName: String = BigtableDataStoreFactory.DisplayName
+  override def getDescription: String = BigtableDataStoreFactory.Description
+
+  override protected def getCatalog(params: java.util.Map[String, Serializable]): String =
+    BigtableCatalogParam.lookup(params)
+
+  override protected def buildDataStore(connection: Connection, config: HBaseDataStoreConfig): BigtableDataStore = {
+    // note: bigtable never has push-down predicates
+    new BigtableDataStore(connection, config.copy(remoteFilter = false))
+  }
+
+  override protected def validateConnection: Boolean = false
+
+  override def canProcess(params: java.util.Map[java.lang.String,java.io.Serializable]): Boolean =
+    BigtableDataStoreFactory.canProcess(params)
+
+  override def getParametersInfo: Array[Param] =
+    BigtableDataStoreFactory.ParameterInfo :+ BigtableDataStoreFactory.NamespaceParam
+}
+
+object BigtableDataStoreFactory extends GeoMesaDataStoreInfo with NamespaceParams {
+
+  val BigtableCatalogParam = new GeoMesaParam[String]("bigtable.catalog", "Catalog table name", optional = false, deprecatedKeys = Seq("bigtable.table.name"))
+
+  override val DisplayName = "Google Bigtable (GeoMesa)"
+  override val Description = "Google Bigtable\u2122 distributed key/value store"
+
+  override val ParameterInfo: Array[GeoMesaParam[_]] =
+    Array(
+      BigtableCatalogParam,
+      QueryThreadsParam,
+      QueryTimeoutParam,
+      GenerateStatsParam,
+      AuditQueriesParam,
+      LooseBBoxParam,
+      CachingParam
+    )
+
+  // verify that the hbase-site.xml exists and contains the appropriate bigtable keys
+  override def canProcess(params: java.util.Map[String, java.io.Serializable]): Boolean = {
+    BigtableCatalogParam.exists(params) &&
+        Option(HBaseConfiguration.create().get(HBaseDataStoreFactory.BigTableParamCheck)).exists(_.trim.nonEmpty)
+  }
+}

--- a/geomesa-bigtable/geomesa-bigtable-datastore/src/main/scala/org/locationtech/geomesa/bigtable/data/BigtableIndexAdapter.scala
+++ b/geomesa-bigtable/geomesa-bigtable-datastore/src/main/scala/org/locationtech/geomesa/bigtable/data/BigtableIndexAdapter.scala
@@ -8,20 +8,29 @@
 
 package org.locationtech.geomesa.bigtable.data
 
+import java.util.UUID
+
 import com.google.cloud.bigtable.hbase.BigtableExtendedScan
 import com.google.common.collect.Lists
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.hbase.client.Scan
 import org.apache.hadoop.hbase.filter.{Filter => HFilter}
 import org.locationtech.geomesa.hbase.data.HBaseIndexAdapter
+import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
+import org.locationtech.geomesa.utils.text.StringSerialization
 
 class BigtableIndexAdapter(ds: BigtableDataStore) extends HBaseIndexAdapter(ds) {
 
   import scala.collection.JavaConverters._
 
-  override protected def configureScans(originalRanges: Seq[Scan],
-                                        colFamily: Array[Byte],
-                                        filters: Seq[HFilter],
-                                        coprocessor: Boolean): Seq[Scan] = {
+  // https://cloud.google.com/bigtable/quotas#limits-table-id
+  override val tableNameLimit: Option[Int] = Some(50)
+
+  override protected def configureScans(
+      originalRanges: Seq[Scan],
+      colFamily: Array[Byte],
+      filters: Seq[HFilter],
+      coprocessor: Boolean): Seq[Scan] = {
     if (filters.nonEmpty) {
       // bigtable does support some filters, but currently we only use custom filters that aren't supported
       throw new IllegalArgumentException(s"Bigtable doesn't support filters: ${filters.mkString(", ")}")

--- a/geomesa-bigtable/geomesa-bigtable-dist/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-bigtable_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-bigtable/geomesa-bigtable-dist/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-bigtable_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-bigtable/geomesa-bigtable-dist/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-bigtable_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-bigtable/geomesa-bigtable-gs-plugin/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-bigtable/geomesa-bigtable-gs-plugin/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-bigtable/geomesa-bigtable-gs-plugin/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-bigtable/geomesa-bigtable-spark-runtime/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-spark-runtime/pom.xml
@@ -129,7 +129,6 @@
                                     <exclude>com.esotericsoftware.kryo:*</exclude>
                                     <exclude>org.ow2.asm:*</exclude>
                                     <exclude>org.scala-lang:*</exclude>
-                                    <exclude>org.json4s:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <filters>
@@ -156,7 +155,12 @@
                                 <!-- spark also includes shapeless, relocate to avoid version conflicts -->
                                 <relocation>
                                     <pattern>shapeless</pattern>
-                                    <shadedPattern>org.locationtech.geomesa.accumulo.shaded.shapeless</shadedPattern>
+                                    <shadedPattern>org.locationtech.geomesa.bigtable.shaded.shapeless</shadedPattern>
+                                </relocation>
+                                <!-- spark needs json4s to use the jsonpath function -->
+                                <relocation>
+                                    <pattern>org.json4s</pattern>
+                                    <shadedPattern>org.locationtech.geomesa.bigtable.shaded.org.json4s</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>

--- a/geomesa-bigtable/geomesa-bigtable-spark-runtime/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-bigtable_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/geomesa-bigtable-spark-runtime/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-bigtable_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/geomesa-bigtable-spark-runtime/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-bigtable_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/geomesa-bigtable-spark/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-bigtable_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/geomesa-bigtable-spark/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-bigtable_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/geomesa-bigtable-spark/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-bigtable_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/geomesa-bigtable-tools/bin/geomesa-bigtable
+++ b/geomesa-bigtable/geomesa-bigtable-tools/bin/geomesa-bigtable
@@ -105,6 +105,6 @@ else
     fi
     # we have to include java.util.logging override file, slf4j can't handle it automatically
     LOGGING_OPT="-Djava.util.logging.config.file=${%%gmtools.dist.name%%_HOME}/conf/java-logging.properties"
-    java ${CUSTOM_JAVA_OPTS} ${GEOMESA_OPTS} ${LOGGING_OPT} -cp ${CLASSPATH} org.locationtech.geomesa.bigtable.tools.BigtableRunner "$@"
+    java ${LOGGING_OPT} ${GEOMESA_OPTS} ${CUSTOM_JAVA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.bigtable.tools.BigtableRunner "$@"
   fi
 fi

--- a/geomesa-bigtable/geomesa-bigtable-tools/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-bigtable_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/geomesa-bigtable-tools/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-bigtable_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/geomesa-bigtable-tools/pom.xml
+++ b/geomesa-bigtable/geomesa-bigtable-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-bigtable_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/pom.xml
+++ b/geomesa-bigtable/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/pom.xml
+++ b/geomesa-bigtable/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-bigtable/pom.xml
+++ b/geomesa-bigtable/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-accumulo/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-accumulo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-accumulo/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-accumulo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-accumulo/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-accumulo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-api/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-api/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-api/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-gs-plugin/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-blobstore/geomesa-blobstore-gs-plugin/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-blobstore/geomesa-blobstore-gs-plugin/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-exif-handler/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-exif-handler/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore-handlers_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-exif-handler/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-exif-handler/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore-handlers_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-exif-handler/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-exif-handler/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore-handlers_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-gdal-handler/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-gdal-handler/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore-handlers_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-gdal-handler/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-gdal-handler/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore-handlers_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-gdal-handler/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/geomesa-blobstore-gdal-handler/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore-handlers_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-handlers/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-handlers/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-handlers/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-handlers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-web/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-web/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/geomesa-blobstore-web/pom.xml
+++ b/geomesa-blobstore/geomesa-blobstore-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-blobstore_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/pom.xml
+++ b/geomesa-blobstore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/pom.xml
+++ b/geomesa-blobstore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-blobstore/pom.xml
+++ b/geomesa-blobstore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-cassandra_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-cassandra_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-cassandra_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraBackedMetadata.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraBackedMetadata.scala
@@ -13,7 +13,6 @@ import java.nio.charset.StandardCharsets
 
 import com.datastax.driver.core.Session
 import com.datastax.driver.core.querybuilder.QueryBuilder
-import org.locationtech.geomesa.index.metadata.CachedLazyMetadata.ScanQuery
 import org.locationtech.geomesa.index.metadata._
 import org.locationtech.geomesa.utils.collection.CloseableIterator
 
@@ -54,16 +53,22 @@ class CassandraBackedMetadata[T](val session: Session, val catalog: String, val 
     }
   }
 
-  override protected def scanValues(query: Option[ScanQuery]): CloseableIterator[(String, String, Array[Byte])] = {
-    val select = QueryBuilder.select("sft", "key", "value").from(catalog)
-    query.foreach(q => select.where(QueryBuilder.eq("sft", q.typeName)))
-    val values = session.execute(select).all().iterator.map { row =>
-      (row.getString("sft"), row.getString("key"), row.getString("value").getBytes(StandardCharsets.UTF_8))
+  override protected def scanValues(typeName: String, prefix: String): CloseableIterator[(String, Array[Byte])] = {
+    val select = QueryBuilder.select("key", "value").from(catalog).where(QueryBuilder.eq("sft", typeName))
+    val iter = session.execute(select).all().iterator.map { row =>
+      (row.getString("key"), row.getString("value").getBytes(StandardCharsets.UTF_8))
     }
-    query.flatMap(_.prefix) match {
-      case None => CloseableIterator(values)
-      case Some(prefix) => CloseableIterator(values.filter(_._2.startsWith(prefix)))
+    if (prefix == null || prefix.isEmpty) {
+      CloseableIterator(iter)
+    } else {
+      CloseableIterator(iter.filter { case (k, _) => k.startsWith(prefix) })
     }
+  }
+
+  override protected def scanKeys(): CloseableIterator[(String, String)] = {
+    val select = QueryBuilder.select("sft", "key").from(catalog)
+    val values = session.execute(select).all().iterator.map(row => (row.getString("sft"), row.getString("key")))
+    CloseableIterator(values)
   }
 
   override def close(): Unit = {} // session gets closed by datastore dispose

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraIndexAdapter.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraIndexAdapter.scala
@@ -198,7 +198,7 @@ object CassandraIndexAdapter {
 
     private var i = 0
 
-    override protected def write(feature: WritableFeature, values: Array[RowKeyValue[_]]): Unit = {
+    override protected def write(feature: WritableFeature, values: Array[RowKeyValue[_]], update: Boolean): Unit = {
       i = 0
       while (i < values.length) {
         val (mapper, statement, _) = mappers(i)

--- a/geomesa-cassandra/geomesa-cassandra-dist/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-cassandra_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-cassandra/geomesa-cassandra-dist/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-cassandra_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-cassandra/geomesa-cassandra-dist/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-cassandra_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-cassandra/geomesa-cassandra-gs-plugin/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-cassandra/geomesa-cassandra-gs-plugin/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-cassandra/geomesa-cassandra-gs-plugin/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-cassandra/geomesa-cassandra-tools/bin/geomesa-cassandra
+++ b/geomesa-cassandra/geomesa-cassandra-tools/bin/geomesa-cassandra
@@ -49,6 +49,6 @@ else
       GEOMESA_OPTS="$GEOMESA_OPTS $GEOMESA_DEBUG_OPTS"
       shift 1
     fi
-    java ${CUSTOM_JAVA_OPTS} ${GEOMESA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.cassandra.tools.CassandraRunner "$@"
+    java ${GEOMESA_OPTS} ${CUSTOM_JAVA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.cassandra.tools.CassandraRunner "$@"
   fi
 fi

--- a/geomesa-cassandra/geomesa-cassandra-tools/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-cassandra_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-cassandra/geomesa-cassandra-tools/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-cassandra_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-cassandra/geomesa-cassandra-tools/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-cassandra_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-cassandra/pom.xml
+++ b/geomesa-cassandra/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-cassandra/pom.xml
+++ b/geomesa-cassandra/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-cassandra/pom.xml
+++ b/geomesa-cassandra/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-all/pom.xml
+++ b/geomesa-convert/geomesa-convert-all/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-all/pom.xml
+++ b/geomesa-convert/geomesa-convert-all/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-all/pom.xml
+++ b/geomesa-convert/geomesa-convert-all/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/pom.xml
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/pom.xml
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/pom.xml
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-avro/pom.xml
+++ b/geomesa-convert/geomesa-convert-avro/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-avro/pom.xml
+++ b/geomesa-convert/geomesa-convert-avro/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-avro/pom.xml
+++ b/geomesa-convert/geomesa-convert-avro/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-common/pom.xml
+++ b/geomesa-convert/geomesa-convert-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-common/pom.xml
+++ b/geomesa-convert/geomesa-convert-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-common/pom.xml
+++ b/geomesa-convert/geomesa-convert-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/AbstractConverter.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/AbstractConverter.scala
@@ -53,6 +53,10 @@ abstract class AbstractConverter[T, C <: ConverterConfig, F <: Field, O <: Conve
 
   private val configCaches = config.caches.map { case (k, v) => (k, EnrichmentCache(v)) }
 
+  private val idFieldConfig = config.idField.orNull
+
+  private val userDataConfig = config.userData.toArray
+
   override def targetSft: SimpleFeatureType = sft
 
   override def createEvaluationContext(globalParams: Map[String, Any],
@@ -151,17 +155,20 @@ abstract class AbstractConverter[T, C <: ConverterConfig, F <: Field, O <: Conve
     }
 
     // if no id builder, empty feature id will be replaced with an auto-gen one
-    config.idField.foreach { expr =>
-      try { sf.setId(expr.eval(rawValues)(ec).asInstanceOf[String]) } catch {
+    if (idFieldConfig != null) {
+      try { sf.setId(idFieldConfig.eval(rawValues)(ec).asInstanceOf[String]) } catch {
         case NonFatal(e) => return failure("feature id", e)
       }
       sf.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
     }
 
-    config.userData.foreach { case (k, v) =>
+    i = 0
+    while (i < userDataConfig.length) {
+      val (k, v) = userDataConfig(i)
       try { sf.getUserData.put(k, v.eval(rawValues)(ec).asInstanceOf[AnyRef]) } catch {
         case NonFatal(e) => return failure(s"user-data:$k", e)
       }
+      i += 1
     }
 
     val error = options.validators.validate(sf)

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/TypeInference.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/TypeInference.scala
@@ -391,7 +391,7 @@ object TypeInference {
 
   object InferredType {
 
-    private val dateParsers = TransformerFunction.functions.values.collect { case f: StandardDateParser => f }.toSeq
+    private val dateParsers = TransformerFunction.functions.values.collect { case f: StandardDateParser => f }.toArray
 
     /**
       * Infer a type from a value. Returned type will have an empty name
@@ -445,10 +445,13 @@ object TypeInference {
     }
 
     private def tryDateParsing(s: String): Option[InferredType] = {
-      dateParsers.foreach { p =>
+      var i = 0
+      while (i < dateParsers.length) {
+        val p = dateParsers(i)
         if (Try(DateParsing.parseDate(s, p.format)).isSuccess) {
           return Some(InferredType("", DATE, FunctionTransform(s"${p.names.head}(", ")")))
         }
+        i += 1
       }
       None
     }

--- a/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
+++ b/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
+++ b/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
+++ b/geomesa-convert/geomesa-convert-fixedwidth/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-jdbc/pom.xml
+++ b/geomesa-convert/geomesa-convert-jdbc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-jdbc/pom.xml
+++ b/geomesa-convert/geomesa-convert-jdbc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-jdbc/pom.xml
+++ b/geomesa-convert/geomesa-convert-jdbc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-json/pom.xml
+++ b/geomesa-convert/geomesa-convert-json/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-json/pom.xml
+++ b/geomesa-convert/geomesa-convert-json/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-json/pom.xml
+++ b/geomesa-convert/geomesa-convert-json/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-osm/pom.xml
+++ b/geomesa-convert/geomesa-convert-osm/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-convert_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-osm/pom.xml
+++ b/geomesa-convert/geomesa-convert-osm/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-convert_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-osm/pom.xml
+++ b/geomesa-convert/geomesa-convert-osm/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-convert_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-redis-cache/pom.xml
+++ b/geomesa-convert/geomesa-convert-redis-cache/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-redis-cache/pom.xml
+++ b/geomesa-convert/geomesa-convert-redis-cache/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-redis-cache/pom.xml
+++ b/geomesa-convert/geomesa-convert-redis-cache/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-scripting/pom.xml
+++ b/geomesa-convert/geomesa-convert-scripting/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-scripting/pom.xml
+++ b/geomesa-convert/geomesa-convert-scripting/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-scripting/pom.xml
+++ b/geomesa-convert/geomesa-convert-scripting/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-shp/pom.xml
+++ b/geomesa-convert/geomesa-convert-shp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-shp/pom.xml
+++ b/geomesa-convert/geomesa-convert-shp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-shp/pom.xml
+++ b/geomesa-convert/geomesa-convert-shp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-simplefeature/pom.xml
+++ b/geomesa-convert/geomesa-convert-simplefeature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-simplefeature/pom.xml
+++ b/geomesa-convert/geomesa-convert-simplefeature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-simplefeature/pom.xml
+++ b/geomesa-convert/geomesa-convert-simplefeature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-text/pom.xml
+++ b/geomesa-convert/geomesa-convert-text/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-text/pom.xml
+++ b/geomesa-convert/geomesa-convert-text/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-text/pom.xml
+++ b/geomesa-convert/geomesa-convert-text/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
+++ b/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverter.scala
@@ -202,7 +202,7 @@ object DelimitedTextConverter {
   )
 
   // check quoted before default - if values are quoted, we don't want the quotes to be captured as part of the value
-  private [text] val inferences = Seq(Formats.Tabs, Formats.Quoted, Formats.Default)
+  private [text] val inferences = Stream(Formats.Tabs, Formats.Quoted, Formats.Default)
 
   case class DelimitedTextConfig(
       `type`: String,

--- a/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterTest.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.convert.text
 
 import java.io.{ByteArrayInputStream, InputStreamReader}
 import java.nio.charset.StandardCharsets
-import java.util.Collections
+import java.util.{Collections, Date}
 
 import com.google.common.hash.Hashing
 import com.google.common.io.Resources
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.convert.{DefaultCounter, SimpleFeatureConverters}
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.converters.FastConverter
 import org.locationtech.geomesa.utils.io.WithClose
 import org.locationtech.geomesa.utils.text.WKTUtils
 import org.specs2.mutable.Specification
@@ -858,6 +859,41 @@ class DelimitedTextConverterTest extends Specification {
         features(i).getAttribute(1) mustEqual i
         features(i).getAttribute(2) mustEqual WKTUtils.read(s"POINT(4$i 5$i)")
       }
+    }
+
+    "type infer and ingest magic files" >> {
+      import scala.collection.JavaConverters._
+
+      val data =
+        """id,fid:Integer,name:String,age:Integer,lastseen:Date,friends:List[String],"talents:Map[String,Integer]",*geom:Point:srid=4326
+          |23623,23623,Harry,20,2015-05-06T00:00:00.000Z,"Will,Mark,Suzan","patronus->10,expelliarmus->9",POINT (-100.2365 23)
+          |26236,26236,Hermione,25,2015-06-07T00:00:00.000Z,"Edward,Bill,Harry",accio->10,POINT (40.232 -53.2356)
+          |3233,3233,Severus,30,2015-10-23T00:00:00.000Z,"Tom,Riddle,Voldemort",potions->10,POINT (3 -62.23)
+          |""".stripMargin
+
+      val factory = new DelimitedTextConverterFactory()
+      val inferred = factory.infer(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)))
+      inferred must beSome
+
+      val (sft, config) = inferred.get
+
+      SimpleFeatureTypes.encodeType(sft) mustEqual
+          "fid:Integer,name:String,age:Integer,lastseen:Date,friends:List[String],talents:Map[String,Integer],*geom:Point:srid=4326"
+
+      val converter = factory.apply(sft, config)
+      converter must beSome
+
+      val features = converter.get.process(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))).toList
+      converter.get.close()
+
+      features must haveLength(3)
+      features.map(_.getID) mustEqual Seq("23623", "26236", "3233")
+
+      features.map(_.getAttributes.asScala) mustEqual Seq(
+        Seq(23623, "Harry", 20, FastConverter.convert("2015-05-06T00:00:00.000Z", classOf[Date]), Seq("Will", "Mark", "Suzan").asJava, Map("patronus" -> 10, "expelliarmus" -> 9).asJava, WKTUtils.read("POINT (-100.2365 23)")),
+        Seq(26236, "Hermione", 25, FastConverter.convert("2015-06-07T00:00:00.000Z", classOf[Date]), Seq("Edward", "Bill", "Harry").asJava, Map("accio" -> 10).asJava, WKTUtils.read("POINT (40.232 -53.2356)")),
+        Seq(3233, "Severus", 30, FastConverter.convert("2015-10-23T00:00:00.000Z", classOf[Date]), Seq("Tom", "Riddle", "Voldemort").asJava, Map("potions" -> 10).asJava, WKTUtils.read("POINT (3 -62.23)"))
+      )
     }
   }
 }

--- a/geomesa-convert/geomesa-convert-xml/pom.xml
+++ b/geomesa-convert/geomesa-convert-xml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-xml/pom.xml
+++ b/geomesa-convert/geomesa-convert-xml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/geomesa-convert-xml/pom.xml
+++ b/geomesa-convert/geomesa-convert-xml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-convert_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/pom.xml
+++ b/geomesa-convert/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/pom.xml
+++ b/geomesa-convert/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-convert/pom.xml
+++ b/geomesa-convert/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-all/pom.xml
+++ b/geomesa-features/geomesa-feature-all/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-all/pom.xml
+++ b/geomesa-features/geomesa-feature-all/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-all/pom.xml
+++ b/geomesa-features/geomesa-feature-all/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-avro/pom.xml
+++ b/geomesa-features/geomesa-feature-avro/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-avro/pom.xml
+++ b/geomesa-features/geomesa-feature-avro/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-avro/pom.xml
+++ b/geomesa-features/geomesa-feature-avro/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-common/pom.xml
+++ b/geomesa-features/geomesa-feature-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-common/pom.xml
+++ b/geomesa-features/geomesa-feature-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-common/pom.xml
+++ b/geomesa-features/geomesa-feature-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-kryo/pom.xml
+++ b/geomesa-features/geomesa-feature-kryo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-kryo/pom.xml
+++ b/geomesa-features/geomesa-feature-kryo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-kryo/pom.xml
+++ b/geomesa-features/geomesa-feature-kryo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-nio/pom.xml
+++ b/geomesa-features/geomesa-feature-nio/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-nio/pom.xml
+++ b/geomesa-features/geomesa-feature-nio/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/geomesa-feature-nio/pom.xml
+++ b/geomesa-features/geomesa-feature-nio/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-features_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/pom.xml
+++ b/geomesa-features/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/pom.xml
+++ b/geomesa-features/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-features/pom.xml
+++ b/geomesa-features/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-filter/pom.xml
+++ b/geomesa-filter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-filter/pom.xml
+++ b/geomesa-filter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-filter/pom.xml
+++ b/geomesa-filter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterHelper.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterHelper.scala
@@ -17,6 +17,7 @@ import org.locationtech.geomesa.filter.Bounds.Bound
 import org.locationtech.geomesa.filter.expression.AttributeExpression.{FunctionLiteral, PropertyLiteral}
 import org.locationtech.geomesa.filter.visitor.IdDetectingFilterVisitor
 import org.locationtech.geomesa.utils.geotools.GeometryUtils
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.locationtech.jts.geom._
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter._
@@ -173,7 +174,7 @@ object FilterHelper {
                              round: ZonedDateTime => ZonedDateTime,
                              roundExclusive: Boolean): Bound[ZonedDateTime] = {
     if (bound.value.isEmpty) { Bound.unbounded } else {
-      val dt = bound.value.map(d => ZonedDateTime.ofInstant(d.toInstant, ZoneOffset.UTC))
+      val dt = bound.value.map(d => ZonedDateTime.ofInstant(toInstant(d), ZoneOffset.UTC))
       if (roundExclusive && !bound.inclusive) {
         Bound(dt.map(round), inclusive = true)
       } else {

--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterHelperTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterHelperTest.scala
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.filter.Bounds.Bound
 import org.locationtech.geomesa.filter.visitor.QueryPlanFilterVisitor
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.opengis.filter._
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -32,8 +33,8 @@ class FilterHelperTest extends Specification {
   def updateFilter(filter: Filter): Filter = QueryPlanFilterVisitor.apply(sft, filter)
 
   def toInterval(dt1: String, dt2: String, inclusive: Boolean = true): Bounds[ZonedDateTime] = {
-    val s = Option(Converters.convert(dt1, classOf[Date])).map(d => ZonedDateTime.ofInstant(d.toInstant, ZoneOffset.UTC))
-    val e = Option(Converters.convert(dt2, classOf[Date])).map(d => ZonedDateTime.ofInstant(d.toInstant, ZoneOffset.UTC))
+    val s = Option(Converters.convert(dt1, classOf[Date])).map(d => ZonedDateTime.ofInstant(toInstant(d), ZoneOffset.UTC))
+    val e = Option(Converters.convert(dt2, classOf[Date])).map(d => ZonedDateTime.ofInstant(toInstant(d), ZoneOffset.UTC))
     Bounds(Bound(s, if (s.isDefined) inclusive else false), Bound(e, if (e.isDefined) inclusive else false))
   }
 

--- a/geomesa-fs/geomesa-fs-datastore/pom.xml
+++ b/geomesa-fs/geomesa-fs-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-datastore/pom.xml
+++ b/geomesa-fs/geomesa-fs-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-datastore/pom.xml
+++ b/geomesa-fs/geomesa-fs-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-dist/pom.xml
+++ b/geomesa-fs/geomesa-fs-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-fs_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-fs/geomesa-fs-dist/pom.xml
+++ b/geomesa-fs/geomesa-fs-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-fs_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-fs/geomesa-fs-dist/pom.xml
+++ b/geomesa-fs/geomesa-fs-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-fs_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-fs/geomesa-fs-gs-plugin/pom.xml
+++ b/geomesa-fs/geomesa-fs-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-fs/geomesa-fs-gs-plugin/pom.xml
+++ b/geomesa-fs/geomesa-fs-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-fs/geomesa-fs-gs-plugin/pom.xml
+++ b/geomesa-fs/geomesa-fs-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
@@ -112,7 +112,6 @@
                                     <exclude>com.esotericsoftware.kryo:*</exclude>
                                     <exclude>org.ow2.asm:*</exclude>
                                     <exclude>org.scala-lang:*</exclude>
-                                    <exclude>org.json4s:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <filters>
@@ -155,6 +154,11 @@
                                 <relocation>
                                     <pattern>com.esotericsoftware.kryo</pattern>
                                     <shadedPattern>org.locationtech.geomesa.fs.shaded.com.esotericsoftware.kryo</shadedPattern>
+                                </relocation>
+                                <!-- spark needs json4s to use the jsonpath function -->
+                                <relocation>
+                                    <pattern>org.json4s</pattern>
+                                    <shadedPattern>org.locationtech.geomesa.fs.shaded.org.json4s</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>

--- a/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-spark/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-spark/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-spark/pom.xml
+++ b/geomesa-fs/geomesa-fs-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/partitions/DateTimeScheme.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/partitions/DateTimeScheme.scala
@@ -16,6 +16,7 @@ import java.util.Date
 import org.locationtech.geomesa.filter.FilterHelper
 import org.locationtech.geomesa.fs.storage.api.PartitionScheme.SimplifiedFilter
 import org.locationtech.geomesa.fs.storage.api.{NamedOptions, PartitionScheme, PartitionSchemeFactory}
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 
@@ -51,7 +52,7 @@ case class DateTimeScheme(format: String, stepUnit: ChronoUnit, step: Int, dtg: 
   override val depth: Int = format.count(_ == '/')
 
   override def getPartitionName(feature: SimpleFeature): String =
-    fmt.format(feature.getAttribute(dtgIndex).asInstanceOf[Date].toInstant.atZone(ZoneOffset.UTC))
+    fmt.format(toInstant(feature.getAttribute(dtgIndex).asInstanceOf[Date]).atZone(ZoneOffset.UTC))
 
   override def getSimplifiedFilters(filter: Filter, partition: Option[String]): Option[Seq[SimplifiedFilter]] = {
     val bounds = FilterHelper.extractIntervals(filter, dtg, handleExclusiveBounds = false)

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs-storage_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-storage/pom.xml
+++ b/geomesa-fs/geomesa-fs-storage/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-tools/bin/geomesa-fs
+++ b/geomesa-fs/geomesa-fs-tools/bin/geomesa-fs
@@ -102,6 +102,6 @@ else
       GEOMESA_OPTS="$GEOMESA_OPTS $GEOMESA_DEBUG_OPTS"
       shift 1
     fi
-    java ${CUSTOM_JAVA_OPTS} ${GEOMESA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.fs.tools.FsRunner "$@"
+    java ${GEOMESA_OPTS} ${CUSTOM_JAVA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.fs.tools.FsRunner "$@"
   fi
 fi

--- a/geomesa-fs/geomesa-fs-tools/pom.xml
+++ b/geomesa-fs/geomesa-fs-tools/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-tools/pom.xml
+++ b/geomesa-fs/geomesa-fs-tools/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/geomesa-fs-tools/pom.xml
+++ b/geomesa-fs/geomesa-fs-tools/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-fs_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/pom.xml
+++ b/geomesa-fs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/pom.xml
+++ b/geomesa-fs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-fs/pom.xml
+++ b/geomesa-fs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-geojson/geomesa-geojson-api/pom.xml
+++ b/geomesa-geojson/geomesa-geojson-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-geojson_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-geojson/geomesa-geojson-api/pom.xml
+++ b/geomesa-geojson/geomesa-geojson-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-geojson_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-geojson/geomesa-geojson-api/pom.xml
+++ b/geomesa-geojson/geomesa-geojson-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-geojson_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-geojson/geomesa-geojson-gs-plugin/pom.xml
+++ b/geomesa-geojson/geomesa-geojson-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-geojson/geomesa-geojson-gs-plugin/pom.xml
+++ b/geomesa-geojson/geomesa-geojson-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-geojson/geomesa-geojson-gs-plugin/pom.xml
+++ b/geomesa-geojson/geomesa-geojson-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-geojson/geomesa-geojson-rest/pom.xml
+++ b/geomesa-geojson/geomesa-geojson-rest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-geojson_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-geojson/geomesa-geojson-rest/pom.xml
+++ b/geomesa-geojson/geomesa-geojson-rest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-geojson_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-geojson/geomesa-geojson-rest/pom.xml
+++ b/geomesa-geojson/geomesa-geojson-rest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-geojson_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-geojson/pom.xml
+++ b/geomesa-geojson/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-geojson/pom.xml
+++ b/geomesa-geojson/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-geojson/pom.xml
+++ b/geomesa-geojson/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-datastore/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-datastore/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-datastore/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
@@ -60,7 +60,7 @@ class HBaseIndexAdapter(ds: HBaseDataStore) extends IndexAdapter[HBaseDataStore]
       index: GeoMesaFeatureIndex[_, _],
       partition: Option[String],
       splits: => Seq[Array[Byte]]): Unit = {
-    val table = index.configureTableName(partition) // writes table name to metadata
+    val table = index.configureTableName(partition, tableNameLimit) // write table name to metadata
     val name = TableName.valueOf(table)
 
     WithClose(ds.connection.getAdmin) { admin =>
@@ -274,7 +274,6 @@ class HBaseIndexAdapter(ds: HBaseDataStore) extends IndexAdapter[HBaseDataStore]
                             indices: Seq[GeoMesaFeatureIndex[_, _]],
                             partition: Option[String]): HBaseIndexWriter =
     new HBaseIndexWriter(ds, indices, WritableFeature.wrapper(sft, groups), partition)
-
 
   /**
     * Configure the hbase scan

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
@@ -477,7 +477,12 @@ object HBaseIndexAdapter extends LazyLogging {
 
     private var i = 0
 
-    override protected def write(feature: WritableFeature, values: Array[RowKeyValue[_]]): Unit = {
+    override protected def write(feature: WritableFeature, values: Array[RowKeyValue[_]], update: Boolean): Unit = {
+      if (update) {
+        // for updates, ensure that our timestamps don't clobber each other
+        flush()
+        Thread.sleep(1)
+      }
       i = 0
       while (i < values.length) {
         val mutator = mutators(i)

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreTest.scala
@@ -29,7 +29,8 @@ import org.locationtech.geomesa.process.query.ProximitySearchProcess
 import org.locationtech.geomesa.process.tube.TubeSelectProcess
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.conf.{GeoMesaProperties, SemanticVersion}
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.{FeatureUtils, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.io.WithClose
 import org.opengis.feature.simple.SimpleFeature
 import org.opengis.filter.{Filter, Id}
 import org.specs2.matcher.MatchResult
@@ -234,6 +235,51 @@ class HBaseDataStoreTest extends HBaseTest with LazyLogging {
             testQuery(ds, typeName, "name = 'name5'", transforms, Seq(toAdd(5)))
           }
         }
+      } finally {
+        ds.dispose()
+      }
+    }
+
+    "support updates" in {
+      val typeName = "test-updates"
+
+      val params = Map(ConnectionParam.getName -> connection, HBaseCatalogParam.getName -> catalogTableName)
+      val ds = DataStoreFinder.getDataStore(params).asInstanceOf[HBaseDataStore]
+      ds must not(beNull)
+
+      try {
+        ds.getSchema(typeName) must beNull
+
+        val spec = "name:String:index=true,age:Integer,dtg:Date,geom:Point:srid=4326"
+        ds.createSchema(SimpleFeatureTypes.createType(typeName, spec))
+        val sft = ds.getSchema(typeName)
+
+        val features = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "will", 56, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid2", "george", 33, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid3", "sue", 99, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid4", "karen", 50, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid5", "bob", 56, "2014-01-02", "POINT(45.0 49.0)")
+        )
+
+        WithClose(ds.getFeatureWriterAppend(typeName, Transaction.AUTO_COMMIT)) { writer =>
+          features.foreach { f =>
+            FeatureUtils.copyToWriter(writer, f, useProvidedFid = true)
+            writer.write()
+          }
+        }
+
+        val fs = ds.getFeatureSource(sft.getTypeName)
+        fs.modifyFeatures("age", Int.box(60), ECQL.toFilter("(age > 50 AND age < 99) OR (name = 'karen')"))
+
+        val expected = Seq(
+          ScalaSimpleFeature.create(sft, "fid1", "will", 60, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid4", "karen", 60, "2014-01-02", "POINT(45.0 49.0)"),
+          ScalaSimpleFeature.create(sft, "fid5", "bob", 60, "2014-01-02", "POINT(45.0 49.0)")
+        )
+
+        val result = SelfClosingIterator(fs.getFeatures(ECQL.toFilter("age = 60")).features).toList.sortBy(_.getID)
+        result mustEqual expected
       } finally {
         ds.dispose()
       }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBasePartitioningTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBasePartitioningTest.scala
@@ -30,6 +30,7 @@ import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.Configs
 import org.locationtech.geomesa.utils.geotools.{FeatureUtils, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.io.WithClose
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.opengis.feature.simple.SimpleFeature
 import org.specs2.matcher.MatchResult
 
@@ -98,7 +99,7 @@ class HBasePartitioningTest extends HBaseTest with LazyLogging {
           ds.metadata.insert(sft.getTypeName, index.tableNameKey(Some("foo")), table)
         }
         def zonedDateTime(sf: SimpleFeature) =
-          ZonedDateTime.ofInstant(sf.getAttribute("dtg").asInstanceOf[Date].toInstant, ZoneOffset.UTC)
+          ZonedDateTime.ofInstant(toInstant(sf.getAttribute("dtg").asInstanceOf[Date]), ZoneOffset.UTC)
         TablePartition(ds, sft).get.asInstanceOf[TimePartition].register("foo", zonedDateTime(toAdd(8)), zonedDateTime(toAdd(9)))
 
         // verify the table was adopted

--- a/geomesa-hbase/geomesa-hbase-dist/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-dist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-hbase_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-hbase/geomesa-hbase-dist/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-dist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-hbase_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-hbase/geomesa-hbase-dist/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-dist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-hbase_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-hbase/geomesa-hbase-distributed-runtime/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-distributed-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-hbase_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>geomesa-hbase-distributed-runtime_2.11</artifactId>

--- a/geomesa-hbase/geomesa-hbase-distributed-runtime/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-distributed-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-hbase_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
 
     <artifactId>geomesa-hbase-distributed-runtime_2.11</artifactId>

--- a/geomesa-hbase/geomesa-hbase-distributed-runtime/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-distributed-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-hbase_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>geomesa-hbase-distributed-runtime_2.11</artifactId>

--- a/geomesa-hbase/geomesa-hbase-gs-plugin/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-hbase/geomesa-hbase-gs-plugin/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-hbase/geomesa-hbase-gs-plugin/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-hbase/geomesa-hbase-jobs/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-jobs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-hbase_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-jobs/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-jobs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-hbase_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-jobs/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-jobs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-hbase_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-native-api/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-native-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-native-api/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-native-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-native-api/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-native-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
@@ -166,7 +166,6 @@
                                     <exclude>org.ow2.asm:*</exclude>
                                     <exclude>org.scala-lang:*</exclude>
                                     <exclude>io.netty:*</exclude>
-                                    <exclude>org.json4s:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <filters>
@@ -193,13 +192,18 @@
                                 <!-- spark also includes shapeless, relocate to avoid version conflicts -->
                                 <relocation>
                                     <pattern>shapeless</pattern>
-                                    <shadedPattern>org.locationtech.geomesa.accumulo.shaded.shapeless</shadedPattern>
+                                    <shadedPattern>org.locationtech.geomesa.hbase.shaded.shapeless</shadedPattern>
                                 </relocation>
                                 <!-- Databricks uses an old version of scalalogging, include it to allow us to run on databricks clusters -->
                                 <relocation>
                                     <pattern>com.typesafe.scalalogging</pattern>
                                     <shadedPattern>org.locationtech.geomesa.hbase.shaded.com.typesafe.scalalogging
                                     </shadedPattern>
+                                </relocation>
+                                <!-- spark needs json4s to use the jsonpath function -->
+                                <relocation>
+                                    <pattern>org.json4s</pattern>
+                                    <shadedPattern>org.locationtech.geomesa.hbase.shaded.org.json4s</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>

--- a/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-spark/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-spark/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-spark/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-hbase_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-tools/bin/geomesa-hbase
+++ b/geomesa-hbase/geomesa-hbase-tools/bin/geomesa-hbase
@@ -84,5 +84,5 @@ else
     GEOMESA_OPTS="$GEOMESA_OPTS $GEOMESA_DEBUG_OPTS"
     shift 1
   fi
-  java ${CUSTOM_JAVA_OPTS} ${GEOMESA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.hbase.tools.HBaseRunner "$@"
+  java ${GEOMESA_OPTS} ${CUSTOM_JAVA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.hbase.tools.HBaseRunner "$@"
 fi

--- a/geomesa-hbase/geomesa-hbase-tools/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-hbase_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-tools/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-hbase_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/geomesa-hbase-tools/pom.xml
+++ b/geomesa-hbase/geomesa-hbase-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-hbase_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/pom.xml
+++ b/geomesa-hbase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/pom.xml
+++ b/geomesa-hbase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-hbase/pom.xml
+++ b/geomesa-hbase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-index-api/pom.xml
+++ b/geomesa-index-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-index-api/pom.xml
+++ b/geomesa-index-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-index-api/pom.xml
+++ b/geomesa-index-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
@@ -172,12 +172,10 @@ abstract class GeoMesaFeatureIndex[T, U](val ds: GeoMesaDataStore[_],
     * @return
     */
   def getTablesForQuery(filter: Option[Filter]): Seq[String] = {
-    val partitions = filter.toSeq.flatMap(f => TablePartition(ds, sft).toSeq.flatMap(_.partitions(f)))
-    if (partitions.isEmpty) {
-      getTableNames(None)
-    } else {
+    val partitioned = for { f <- filter; tp <- TablePartition(ds, sft); partitions <- tp.partitions(f) } yield {
       partitions.flatMap(p => getTableNames(Some(p)))
     }
+    partitioned.getOrElse(getTableNames(None))
   }
 
   /**

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
@@ -116,8 +116,11 @@ abstract class GeoMesaFeatureIndex[T, U](val ds: GeoMesaDataStore[_],
   def deleteTableNames(partition: Option[String] = None): Seq[String] = {
     val tables = getTableNames(partition)
     partition match {
-      case None => ds.metadata.scan(sft.getTypeName, tableNameKey).foreach(k => ds.metadata.remove(sft.getTypeName, k._1))
       case Some(p) => ds.metadata.remove(sft.getTypeName, s"$tableNameKey.$p")
+      case None =>
+        ds.metadata.scan(sft.getTypeName, tableNameKey, cache = false).foreach { case (k, _) =>
+          ds.metadata.remove(sft.getTypeName, k)
+        }
     }
     tables
   }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
@@ -99,10 +99,10 @@ abstract class GeoMesaFeatureIndex[T, U](val ds: GeoMesaDataStore[_],
     * @param partition partition
     * @return table name
     */
-  def configureTableName(partition: Option[String] = None): String = {
+  def configureTableName(partition: Option[String] = None, limit: Option[Int] = None): String = {
     val key = tableNameKey(partition)
     ds.metadata.read(sft.getTypeName, key).getOrElse {
-      val name = generateTableName(partition)
+      val name = generateTableName(partition, limit)
       ds.metadata.insert(sft.getTypeName, key, name)
       name
     }
@@ -342,16 +342,30 @@ abstract class GeoMesaFeatureIndex[T, U](val ds: GeoMesaDataStore[_],
     * Creates a valid, unique string for the underlying table
     *
     * @param partition partition
+    * @param limit limit on the length of a table name in the underlying database
     * @return
     */
-  protected def generateTableName(partition: Option[String] = None): String = {
-    val builder = Seq.newBuilder[String]
-    builder += ds.config.catalog
-    builder ++= Seq(sft.getTypeName, name).map(StringSerialization.alphaNumericSafeString)
-    builder ++= attributes.map(StringSerialization.alphaNumericSafeString)
-    builder += s"v$version"
-    val base = builder.result.mkString("_")
-    partition.map(p => s"${base}_$p").getOrElse(base)
+  protected def generateTableName(partition: Option[String] = None, limit: Option[Int] = None): String = {
+    import StringSerialization.alphaNumericSafeString
+
+    val prefix = (ds.config.catalog +: Seq(sft.getTypeName, name).map(alphaNumericSafeString)).mkString("_")
+    val suffix = s"_v$version${partition.map(p => s"_$p").getOrElse("")}"
+
+    def build(attrs: Seq[String]): String = (prefix +: attrs :+ suffix).mkString("_")
+
+    val full = build(attributes.map(alphaNumericSafeString))
+
+    limit match {
+      case Some(lim) if full.lengthCompare(lim) > 0 =>
+        // try using the attribute numbers instead
+        val nums = build(attributes.map(a => s"${sft.indexOf(a)}"))
+        if (nums.lengthCompare(lim) <= 0) { nums } else {
+          logger.warn(s"Table name length exceeds configured limit ($lim), falling back to UUID: $full")
+          IndexAdapter.truncateTableName(full, lim)
+        }
+
+      case _ => full
+    }
   }
 
   override def toString: String = s"${getClass.getSimpleName}${attributes.mkString("(", ",", ")")}"

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
@@ -349,7 +349,7 @@ abstract class GeoMesaFeatureIndex[T, U](val ds: GeoMesaDataStore[_],
     import StringSerialization.alphaNumericSafeString
 
     val prefix = (ds.config.catalog +: Seq(sft.getTypeName, name).map(alphaNumericSafeString)).mkString("_")
-    val suffix = s"_v$version${partition.map(p => s"_$p").getOrElse("")}"
+    val suffix = s"v$version${partition.map(p => s"_$p").getOrElse("")}"
 
     def build(attrs: Seq[String]): String = (prefix +: attrs :+ suffix).mkString("_")
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/IndexAdapter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/IndexAdapter.scala
@@ -91,8 +91,9 @@ object IndexAdapter {
       * validating that all of the indices can index it successfully
       *
       * @param feature feature
+      * @param update true if this is an update to an existing feature
       */
-    def write(feature: SimpleFeature): Unit = {
+    def write(feature: SimpleFeature, update: Boolean): Unit = {
       val writable = wrapper.wrap(feature)
 
       i = 0
@@ -102,7 +103,7 @@ object IndexAdapter {
         i +=1
       }
 
-      write(writable, values)
+      write(writable, values, update)
     }
 
     /**
@@ -128,8 +129,9 @@ object IndexAdapter {
       *
       * @param feature feature being written
       * @param values derived values, one per index
+      * @param update true if this is an update to an existing feature
       */
-    protected def write(feature: WritableFeature, values: Array[RowKeyValue[_]]): Unit
+    protected def write(feature: WritableFeature, values: Array[RowKeyValue[_]], update: Boolean): Unit
 
     /**
       * Delete values derived from the feature

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/IndexAdapter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/IndexAdapter.scala
@@ -86,13 +86,11 @@ object IndexAdapter {
     */
   @throws[IllegalArgumentException]("Limit does not fit a UUID (34 chars)")
   def truncateTableName(name: String, limit: Int): String = {
-    if (name.lengthCompare(limit) <= 0) { name } else {
-      val offset = limit - 33
-      if (offset <= 0) {
-        throw new IllegalArgumentException(s"Limit is too small to fit a UUID, must be at least 34 chars: $limit")
-      }
-      s"${name.substring(0, offset)}_${UUID.randomUUID().toString.replaceAllLiterally("-", "")}"
+    val offset = limit - 33
+    if (offset <= 0) {
+      throw new IllegalArgumentException(s"Limit is too small to fit a UUID, must be at least 34 chars: $limit")
     }
+    s"${name.substring(0, offset)}_${UUID.randomUUID().toString.replaceAllLiterally("-", "")}"
   }
 
   /**

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/partition/TablePartition.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/partition/TablePartition.scala
@@ -31,12 +31,12 @@ trait TablePartition {
 
   /**
     * Gets the partitions that intersect a given filter. If partitions can't be determined, (e.g. if the filter
-    * doesn't have a predicate on the partition), then an empty seq is returned
+    * doesn't have a predicate on the partition), then an empty option is returned
     *
     * @param filter filter
-    * @return partitions, or an empty seq representing all partitions
+    * @return partitions, or an empty option representing all partitions
     */
-  def partitions(filter: Filter): Seq[String]
+  def partitions(filter: Filter): Option[Seq[String]]
 
   /**
     * Convert from a partition back to a partition-able value

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/partition/TimePartition.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/partition/TimePartition.scala
@@ -18,6 +18,7 @@ import org.locationtech.geomesa.filter.{Bounds, FilterHelper, FilterValues}
 import org.locationtech.geomesa.index.conf.partition.TimePartition.CustomPartitionCache
 import org.locationtech.geomesa.index.metadata.{CachedLazyMetadata, GeoMesaMetadata, HasGeoMesaMetadata}
 import org.locationtech.geomesa.utils.text.DateParsing
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 
@@ -56,7 +57,7 @@ class TimePartition(metadata: GeoMesaMetadata[String], typeName: String, dtg: St
 
   override def partition(feature: SimpleFeature): String = {
     val date = feature.getAttribute(dtgIndex).asInstanceOf[Date]
-    f"${toBin(ZonedDateTime.ofInstant(date.toInstant, ZoneOffset.UTC))}%05d" // a short should fit into 5 digits
+    f"${toBin(ZonedDateTime.ofInstant(toInstant(date), ZoneOffset.UTC))}%05d" // a short should fit into 5 digits
   }
 
   override def partitions(filter: Filter): Seq[String] = {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureCollection.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureCollection.scala
@@ -11,34 +11,57 @@ package org.locationtech.geomesa.index.geotools
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 
 import com.typesafe.scalalogging.LazyLogging
+import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
 import org.geotools.data.store.DataFeatureCollection
 import org.geotools.data.{FeatureReader, Query, Transaction}
+import org.geotools.factory.Hints
+import org.geotools.feature.FeatureCollection
+import org.geotools.feature.collection.{DecoratingFeatureCollection, DecoratingSimpleFeatureCollection}
 import org.geotools.feature.visitor.{BoundsVisitor, MaxVisitor, MinVisitor}
 import org.geotools.geometry.jts.ReferencedEnvelope
+import org.geotools.util.NullProgressListener
+import org.locationtech.geomesa.filter.FilterHelper
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection.GeoMesaFeatureVisitingCollection
 import org.locationtech.geomesa.index.process.GeoMesaProcessVisitor
+import org.locationtech.geomesa.index.stats.GeoMesaStats
+import org.locationtech.geomesa.utils.collection.CloseableIterator
+import org.locationtech.geomesa.utils.io.WithClose
 import org.opengis.feature.FeatureVisitor
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import org.opengis.filter.Filter
 import org.opengis.filter.expression.PropertyName
+import org.opengis.filter.sort.SortBy
 import org.opengis.util.ProgressListener
+
+import scala.annotation.tailrec
 
 /**
   * Feature collection implementation
   */
-class GeoMesaFeatureCollection(private [geotools] val source: GeoMesaFeatureSource,
-                               private [geotools] val query: Query)
-    extends DataFeatureCollection(GeoMesaFeatureCollection.nextId) with LazyLogging {
+class GeoMesaFeatureCollection(source: GeoMesaFeatureSource, original: Query)
+    extends GeoMesaFeatureVisitingCollection(source, source.ds.stats, original) {
+
+  import org.locationtech.geomesa.index.conf.QueryHints.RichHints
 
   private val open = new AtomicBoolean(false)
 
-  override def getSchema: SimpleFeatureType = {
-    import org.locationtech.geomesa.index.conf.QueryHints.RichHints
-    if (!open.get) {
-      // once opened the query will already be configured by the query planner,
-      // otherwise we have to compute it here
-      source.runner.configureQuery(source.getSchema, query)
-    }
-    query.getHints.getReturnSft
+  // copy of the original query, so that we don't modify hints/sorts/etc
+  private val query = {
+    val copy = new Query(original)
+    copy.setHints(new Hints(original.getHints))
+    copy
   }
+
+  // configured version of the query, with hints set
+  // once opened the query will already be configured by the query planner
+  private lazy val configured = {
+    if (!open.get) {
+      source.runner.configureQuery(source.sft, query)
+    }
+    query
+  }
+
+  override def getSchema: SimpleFeatureType = configured.getHints.getReturnSft
 
   override protected def openIterator(): java.util.Iterator[SimpleFeature] = {
     val iter = super.openIterator()
@@ -46,47 +69,31 @@ class GeoMesaFeatureCollection(private [geotools] val source: GeoMesaFeatureSour
     iter
   }
 
-  override def accepts(visitor: FeatureVisitor, progress: ProgressListener): Unit =
-    visitor match {
-      case v: BoundsVisitor => v.reset(source.ds.stats.getBounds(source.getSchema, query.getFilter))
-
-      case v: MinVisitor if v.getExpression.isInstanceOf[PropertyName] =>
-        val attribute = v.getExpression.asInstanceOf[PropertyName].getPropertyName
-        minMax(attribute, exact = false).orElse(minMax(attribute, exact = true)) match {
-          case Some((min, _)) => v.setValue(min)
-          case None           => super.accepts(visitor, progress)
-        }
-
-      case v: MaxVisitor if v.getExpression.isInstanceOf[PropertyName] =>
-        val attribute = v.getExpression.asInstanceOf[PropertyName].getPropertyName
-        minMax(attribute, exact = false).orElse(minMax(attribute, exact = true)) match {
-          case Some((_, max)) => v.setValue(max)
-          case None           => super.accepts(visitor, progress)
-        }
-
-      case v: GeoMesaProcessVisitor => v.execute(source, query)
-
-      case v =>
-        logger.debug(s"Using unoptimized method for visiting '${v.getClass.getName}'")
-        super.accepts(visitor, progress)
-    }
-
-  private def minMax(attribute: String, exact: Boolean): Option[(Any, Any)] =
-    source.ds.stats.getAttributeBounds[Any](source.getSchema, attribute, query.getFilter, exact).map(_.bounds)
-
   override def reader(): FeatureReader[SimpleFeatureType, SimpleFeature] =
     source.ds.getFeatureReader(query, Transaction.AUTO_COMMIT)
 
+  override def subCollection(filter: Filter): SimpleFeatureCollection = {
+    val merged = new Query(original)
+    merged.setHints(new Hints(original.getHints))
+    val filters = Seq(merged.getFilter, filter).filter(_ != Filter.INCLUDE)
+    FilterHelper.filterListAsAnd(filters).foreach(merged.setFilter)
+    new GeoMesaFeatureCollection(source, merged)
+  }
+
+  override def sort(order: SortBy): SimpleFeatureCollection = {
+    val merged = new Query(original)
+    merged.setHints(new Hints(original.getHints))
+    if (merged.getSortBy == null) {
+      merged.setSortBy(Array(order))
+    } else {
+      merged.setSortBy(merged.getSortBy :+ order)
+    }
+    new GeoMesaFeatureCollection(source, merged)
+  }
+
   override def getBounds: ReferencedEnvelope = source.getBounds(query)
 
-  override def getCount: Int = {
-    if (!open.get) {
-      // once opened the query will already be configured by the query planner,
-      // otherwise do it here
-      source.runner.configureQuery(source.getSchema, query)
-    }
-    source.getCount(query)
-  }
+  override def getCount: Int = source.getCount(configured)
 
   // note: this shouldn't return -1 (as opposed to FeatureSource.getCount), but we still don't return a valid
   // size unless exact counts are enabled
@@ -94,9 +101,154 @@ class GeoMesaFeatureCollection(private [geotools] val source: GeoMesaFeatureSour
     val count = getCount
     if (count < 0) { 0 } else { count }
   }
+
+  override def contains(o: Any): Boolean = {
+    o match {
+      case f: SimpleFeature =>
+        val sub = subCollection(org.locationtech.geomesa.filter.ff.id(f.getIdentifier))
+        WithClose(CloseableIterator(sub.features()))(_.nonEmpty)
+
+      case _ => false
+    }
+  }
+
+  override def containsAll(collection: java.util.Collection[_]): Boolean = {
+    val size = collection.size()
+    if (size == 0) { true } else {
+      val filters = Seq.newBuilder[Filter]
+      filters.sizeHint(size)
+
+      val features = collection.iterator()
+      while (features.hasNext) {
+        features.next match {
+          case f: SimpleFeature => filters += org.locationtech.geomesa.filter.ff.id(f.getIdentifier)
+          case _ => return false
+        }
+      }
+
+      val sub = subCollection(org.locationtech.geomesa.filter.orFilters(filters.result))
+      WithClose(CloseableIterator(sub.features()))(_.length) == size
+    }
+  }
 }
 
-object GeoMesaFeatureCollection {
+object GeoMesaFeatureCollection extends LazyLogging {
+
   private val oneUp = new AtomicLong(0)
+
   def nextId: String = s"GeoMesaFeatureCollection-${oneUp.getAndIncrement()}"
+
+  /**
+    * Attempts to visit the feature collection in an optimized manner. This will unwrap any decorating
+    * feature collections that may interfere with the `accepts` method.
+    *
+    * Note that generally this may not be a good idea - collections are presumably wrapped for a reason.
+    * However, our visitation functionality keeps being broken by changes in GeoServer, so we're being
+    * defensive here.
+    *
+    * @param collection feature collection
+    * @param visitor visitor
+    * @param progress progress monitor
+    */
+  def visit(
+      collection: FeatureCollection[SimpleFeatureType, SimpleFeature],
+      visitor: FeatureVisitor,
+      progress: ProgressListener = new NullProgressListener): Unit = {
+    val unwrapped = if (collection.isInstanceOf[GeoMesaFeatureVisitingCollection]) { collection } else {
+      try { unwrap(collection) } catch {
+        case e: Throwable => logger.debug("Error trying to unwrap feature collection:", e); collection
+      }
+    }
+    unwrapped.accepts(visitor, progress)
+  }
+
+  /**
+    * Attempts to remove any decorating feature collections
+    *
+    * @param collection collection
+    * @param level level of collections that have been removed, used to detect potentially infinite looping
+    * @return
+    */
+  @tailrec
+  private def unwrap(
+      collection: FeatureCollection[SimpleFeatureType, SimpleFeature],
+      level: Int = 1): FeatureCollection[SimpleFeatureType, SimpleFeature] = {
+
+    // noinspection TypeCheckCanBeMatch
+    val unwrapped = if (collection.isInstanceOf[DecoratingSimpleFeatureCollection]) {
+      getDelegate(collection, classOf[DecoratingSimpleFeatureCollection])
+    } else if (collection.isInstanceOf[DecoratingFeatureCollection[SimpleFeatureType, SimpleFeature]]) {
+      getDelegate(collection, classOf[DecoratingFeatureCollection[SimpleFeatureType, SimpleFeature]])
+    } else {
+      logger.debug(s"Unable to unwrap feature collection $collection of class ${collection.getClass.getName}")
+      return collection
+    }
+
+    logger.debug(s"Unwrapped feature collection $collection of class ${collection.getClass.getName} to " +
+        s"$unwrapped of class ${unwrapped.getClass.getName}")
+
+    if (unwrapped.isInstanceOf[GeoMesaFeatureVisitingCollection]) {
+      unwrapped
+    } else if (level > 9) {
+      logger.debug("Aborting feature collection unwrapping after 10 iterations")
+      unwrapped
+    } else {
+      unwrap(unwrapped, level + 1)
+    }
+  }
+
+  /**
+    * Uses reflection to access the protected field 'delegate' in decorating feature collection classes
+    *
+    * @param collection decorating feature collection
+    * @param clas decorating feature base class
+    * @return
+    */
+  private def getDelegate(
+      collection: FeatureCollection[SimpleFeatureType, SimpleFeature],
+      clas: Class[_]): FeatureCollection[SimpleFeatureType, SimpleFeature] = {
+    val m = clas.getDeclaredField("delegate")
+    m.setAccessible(true)
+    m.get(collection).asInstanceOf[FeatureCollection[SimpleFeatureType, SimpleFeature]]
+  }
+
+  /**
+    * Base class for handling feature visitors
+    *
+    * @param source feature source
+    * @param stats geomesa stat hook
+    * @param query query
+    */
+  abstract class GeoMesaFeatureVisitingCollection(source: SimpleFeatureSource, stats: GeoMesaStats, query: Query)
+      extends DataFeatureCollection(nextId) with LazyLogging {
+
+    override def accepts(visitor: FeatureVisitor, progress: ProgressListener): Unit = {
+      visitor match {
+        case v: BoundsVisitor => v.reset(stats.getBounds(source.getSchema, query.getFilter))
+
+        case v: MinVisitor if v.getExpression.isInstanceOf[PropertyName] =>
+          val attribute = v.getExpression.asInstanceOf[PropertyName].getPropertyName
+          minMax(attribute, exact = false).orElse(minMax(attribute, exact = true)) match {
+            case Some((min, _)) => v.setValue(min)
+            case None           => super.accepts(visitor, progress)
+          }
+
+        case v: MaxVisitor if v.getExpression.isInstanceOf[PropertyName] =>
+          val attribute = v.getExpression.asInstanceOf[PropertyName].getPropertyName
+          minMax(attribute, exact = false).orElse(minMax(attribute, exact = true)) match {
+            case Some((_, max)) => v.setValue(max)
+            case None           => super.accepts(visitor, progress)
+          }
+
+        case v: GeoMesaProcessVisitor => v.execute(source, query)
+
+        case v =>
+          logger.warn(s"Using unoptimized method for visiting '${v.getClass.getName}'")
+          super.accepts(visitor, progress)
+      }
+    }
+
+    private def minMax(attribute: String, exact: Boolean): Option[(Any, Any)] =
+      stats.getAttributeBounds[Any](source.getSchema, attribute, query.getFilter, exact).map(_.bounds)
+  }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureWriter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureWriter.scala
@@ -45,11 +45,11 @@ trait GeoMesaFeatureWriter[DS <: GeoMesaDataStore[DS]] extends SimpleFeatureWrit
 
   protected def getWriter(feature: SimpleFeature): IndexWriter
 
-  protected def writeFeature(feature: SimpleFeature): Unit = {
+  protected def writeFeature(feature: SimpleFeature, update: Boolean = false): Unit = {
     // see if there's a suggested ID to use for this feature, else create one based on the feature
     val writable = GeoMesaFeatureWriter.featureWithFid(sft, feature)
     // `write` will calculate all mutations up front in case the feature is not valid, so we don't write partial entries
-    try { getWriter(writable).write(writable) } catch {
+    try { getWriter(writable).write(writable, update) } catch {
       case NonFatal(e) =>
         val attributes = s"${writable.getID}:${writable.getAttributes.asScala.mkString("|")}"
         throw new IllegalArgumentException(s"Error indexing feature '$attributes'", e)
@@ -266,7 +266,7 @@ object GeoMesaFeatureWriter extends LazyLogging {
       // comparison of feature ID and attributes - doesn't consider concrete class used
       if (!ScalaSimpleFeature.equalIdAndAttributes(live, original)) {
         removeFeature(original)
-        writeFeature(live)
+        writeFeature(live, update = true)
       }
       original = null
       live = null

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/package.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/package.scala
@@ -58,7 +58,9 @@ package object index {
     abstract override def deleteTableNames(partition: Option[String]): Seq[String] = {
       val deleted = super.deleteTableNames(partition)
       if (partition.isEmpty) {
-        ds.metadata.scan(sft.getTypeName, fallbackTableNameKey).foreach(k => ds.metadata.remove(sft.getTypeName, k._1))
+        ds.metadata.scan(sft.getTypeName, fallbackTableNameKey, cache = false).foreach { case (k, _) =>
+          ds.metadata.remove(sft.getTypeName, k)
+        }
       }
       deleted
     }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/CachedLazyBinaryMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/CachedLazyBinaryMetadata.scala
@@ -11,7 +11,6 @@ package org.locationtech.geomesa.index.metadata
 import java.nio.charset.StandardCharsets
 
 import org.locationtech.geomesa.index.metadata.CachedLazyBinaryMetadata.decodeRow
-import org.locationtech.geomesa.index.metadata.CachedLazyMetadata.ScanQuery
 import org.locationtech.geomesa.utils.collection.CloseableIterator
 
 import scala.util.control.NonFatal
@@ -39,16 +38,28 @@ trait CachedLazyBinaryMetadata[T] extends CachedLazyMetadata[T] {
   override protected def scanValue(typeName: String, key: String): Option[Array[Byte]] =
     scanValue(encodeRow(typeName, key))
 
-  override protected def scanValues(query: Option[ScanQuery]): CloseableIterator[(String, String, Array[Byte])] = {
-    val prefix = query.map(q => encodeRow(q.typeName, q.prefix.getOrElse("")))
-    scanRows(prefix).flatMap { case (row, value) =>
+  override protected def scanValues(typeName: String, prefix: String): CloseableIterator[(String, Array[Byte])] = {
+    scanRows(Some(encodeRow(typeName, prefix))).flatMap { case (row, value) =>
       try {
-        val (typeName, key) = decodeRow(row, typeNameSeparator)
-        Iterator.single((typeName, key, value))
+        val key = decodeRow(row, typeNameSeparator)._2
+        CloseableIterator.single((key, value))
       } catch {
         case NonFatal(_) =>
           logger.warn(s"Ignoring unexpected row in catalog table: ${new String(row, StandardCharsets.UTF_8)}")
-          Iterator.empty
+          CloseableIterator.empty
+      }
+    }
+  }
+
+  override protected def scanKeys(): CloseableIterator[(String, String)] = {
+    scanRows(None).flatMap { case (row, _) =>
+      try {
+        val key = decodeRow(row, typeNameSeparator)
+        CloseableIterator.single(key)
+      } catch {
+        case NonFatal(_) =>
+          logger.warn(s"Ignoring unexpected row in catalog table: ${new String(row, StandardCharsets.UTF_8)}")
+          CloseableIterator.empty
       }
     }
   }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/CachedLazyMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/CachedLazyMetadata.scala
@@ -156,14 +156,16 @@ trait CachedLazyMetadata[T] extends GeoMesaMetadata[T] with LazyLogging {
     invalidate(metaDataScanCache, typeName)
   }
 
-  override def remove(typeName: String, key: String): Unit = {
+  override def remove(typeName: String, key: String): Unit = remove(typeName, Seq(key))
+
+  override def remove(typeName: String, keys: Seq[String]): Unit = {
     if (tableExists.get) {
-      delete(typeName, Seq(key))
+      delete(typeName, keys)
       // also remove from the cache
-      metaDataCache.invalidate((typeName, key))
+      keys.foreach(k => metaDataCache.invalidate((typeName, k)))
       invalidate(metaDataScanCache, typeName)
     } else {
-      logger.debug(s"Trying to delete '$typeName:$key' but table does not exist")
+      logger.debug(s"Trying to delete '$typeName: ${keys.mkString(", ")}' but table does not exist")
     }
   }
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/GeoMesaMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/GeoMesaMetadata.scala
@@ -49,6 +49,14 @@ trait GeoMesaMetadata[T] extends Closeable {
   def remove(typeName: String, key: String): Unit
 
   /**
+    * Delete multiple keys at once - may be more efficient than single deletes
+    *
+    * @param typeName simple feature type name
+    * @param keys keys
+    */
+  def remove(typeName: String, keys: Seq[String]): Unit
+
+  /**
    * Reads a value
    *
    * @param typeName simple feature type name

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/NoOpMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/NoOpMetadata.scala
@@ -18,6 +18,8 @@ class NoOpMetadata[T] extends GeoMesaMetadata[T] {
 
   override def remove(typeName: String, key: String): Unit = {}
 
+  override def remove(typeName: String, keys: Seq[String]): Unit = {}
+
   override def read(typeName: String, key: String, cache: Boolean): Option[T] = None
 
   override def scan(typeName: String, prefix: String, cache: Boolean): Seq[(String, T)] = Seq.empty

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/FilterSplitter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/FilterSplitter.scala
@@ -225,7 +225,13 @@ class FilterSplitter(sft: SimpleFeatureType, indices: Seq[GeoMesaFeatureIndex[_,
   private def fullTableScanOption(filter: Filter, transform: Option[SimpleFeatureType]): FilterStrategy = {
     val secondary = if (filter == Filter.INCLUDE) { None } else { Some(filter) }
     // note: early return after we find a matching strategy
-    indices.foreach(_.getFilterStrategy(Filter.INCLUDE, transform, stats).foreach(i => return i.copy(secondary)))
+    val iter = indices.iterator
+    while (iter.hasNext) {
+      iter.next().getFilterStrategy(Filter.INCLUDE, transform, stats) match {
+        case None => // no-op
+        case Some(i) => return i.copy(secondary)
+      }
+    }
     throw new UnsupportedOperationException(s"Configured indices do not support the query ${filterToString(filter)}")
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/LocalQueryRunner.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/LocalQueryRunner.scala
@@ -332,13 +332,13 @@ object LocalQueryRunner {
                              transform: Option[(String, SimpleFeatureType)],
                              query: String,
                              encode: Boolean): CloseableIterator[SimpleFeature] = {
-    val stat = Stat(sft, query)
-    val toObserve = transform match {
-      case None                => features
-      case Some((tdefs, tsft)) => projectionTransform(features, sft, tsft, tdefs, None)
+    val (statSft, toObserve) = transform match {
+      case None                => (sft, features)
+      case Some((tdefs, tsft)) => (tsft, projectionTransform(features, sft, tsft, tdefs, None))
     }
+    val stat = Stat(statSft, query)
     try { toObserve.foreach(stat.observe) } finally { toObserve.close() }
-    val encoded = if (encode) { StatsScan.encodeStat(sft)(stat) } else { stat.toJson }
+    val encoded = if (encode) { StatsScan.encodeStat(statSft)(stat) } else { stat.toJson }
     CloseableIterator(Iterator(new ScalaSimpleFeature(StatsScan.StatsSft, "stat", Array(encoded, GeometryUtils.zeroPoint))))
   }
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/stats/MetadataBackedStats.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/stats/MetadataBackedStats.scala
@@ -127,7 +127,7 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
     import org.locationtech.geomesa.utils.geotools.GeoToolsDateFormat
 
     // calculate the stats we'll be gathering based on the simple feature type attributes
-    val statString = buildStatsFor(sft)
+    val statString = buildStatsFor(sft, bounds(sft))
 
     logger.debug(s"Calculating stats for ${sft.getTypeName}: $statString")
 
@@ -174,7 +174,7 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
   }
 
   override def statUpdater(sft: SimpleFeatureType): StatUpdater =
-    if (update) new MetadataStatUpdater(this, sft, Stat(sft, buildStatsFor(sft))) else NoopStatUpdater
+    if (update) { new MetadataStatUpdater(sft) } else { NoopStatUpdater }
 
   override def clearStats(sft: SimpleFeatureType): Unit = metadata.delete(sft.getTypeName)
 
@@ -252,9 +252,10 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
     * For any flagged attributes, we collect min/max and top-k
     *
     * @param sft simple feature type
+    * @param bounds lookup function for histogram bounds
     * @return stat string
     */
-  protected def buildStatsFor(sft: SimpleFeatureType): String = {
+  protected def buildStatsFor(sft: SimpleFeatureType, bounds: String => Option[MinMax[Any]]): String = {
     import GeoMesaStats._
     import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 
@@ -306,13 +307,7 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
       // calculate the endpoints for the histogram
       // the histogram will expand as needed, but this is a starting point
       val (lower, upper, cardinality) = {
-        val mm = try {
-          readStat[MinMax[Any]](sft, minMaxKey(attribute))
-        } catch {
-          case NonFatal(e) =>
-            logger.error("Error reading existing stats - possibly the distributed runtime jar is not available", e)
-            None
-        }
+        val mm = bounds(attribute)
         val (min, max) = mm match {
           case None => defaultBounds(binding)
           // max has to be greater than min for the histogram bounds
@@ -336,6 +331,65 @@ abstract class MetadataBackedStats(ds: DataStore, metadata: GeoMesaMetadata[Stat
     }
 
     Stat.SeqStat(Seq(count) ++ minMax ++ topK ++ histograms ++ frequencies ++ z3Histogram)
+  }
+
+  /**
+    * Default lookup function for histogram bounds
+    *
+    * @param sft simple feature type
+    * @param attribute attribute
+    * @return
+    */
+  private def bounds(sft: SimpleFeatureType)(attribute: String): Option[MinMax[Any]] = {
+    try {
+      readStat[MinMax[Any]](sft, minMaxKey(attribute))
+    } catch {
+      case NonFatal(e) =>
+        logger.error("Error reading existing stats - possibly the distributed runtime jar is not available", e)
+        None
+    }
+  }
+
+  /**
+    * Stores stats as metadata entries
+    *
+    * @param sft simple feature type
+    */
+  class MetadataStatUpdater(sft: SimpleFeatureType) extends StatUpdater with LazyLogging {
+
+    private var stat: Stat = Stat(sft, buildStatsFor(sft, bounds(sft)))
+
+    override def add(sf: SimpleFeature): Unit = stat.observe(sf)
+
+    override def remove(sf: SimpleFeature): Unit = stat.unobserve(sf)
+
+    override def close(): Unit = {
+      if (!stat.isEmpty) {
+        writeStat(stat, sft, merge = true)
+      }
+    }
+
+    override def flush(): Unit = {
+      if (!stat.isEmpty) {
+        writeStat(stat, sft, merge = true)
+      }
+      // reload the tracker - for long-held updaters, this will refresh the histogram ranges
+      stat = Stat(sft, buildStatsFor(sft, localBounds))
+    }
+
+    /**
+      * Get the bounds we've seen so far in this updater, but don't re-load from Accumulo as that
+      * can be slow
+      *
+      * @param attribute attribute
+      * @return
+      */
+    private def localBounds(attribute: String): Option[MinMax[Any]] = {
+      stat match {
+        case s: SeqStat => s.stats.collectFirst { case m: MinMax[Any] if m.property == attribute => m }
+        case _ => logger.error(s"Expected to have a SeqStat but got: $stat"); None
+      }
+    }
   }
 }
 
@@ -430,37 +484,5 @@ object MetadataBackedStats {
 
     override def deserialize(typeName: String, value: Array[Byte]): Stat =
       serializer(typeName).deserialize(value, immutable = true)
-  }
-
-  /**
-    * Stores stats as metadata entries
-    *
-    * @param stats persistence
-    * @param sft simple feature type
-    * @param statFunction creates stats for tracking new features - this will be re-created on flush,
-    *                     so that our bounds are more accurate
-    */
-  class MetadataStatUpdater(stats: MetadataBackedStats, sft: SimpleFeatureType, statFunction: => Stat)
-      extends StatUpdater with LazyLogging {
-
-    private var stat: Stat = statFunction
-
-    override def add(sf: SimpleFeature): Unit = stat.observe(sf)
-
-    override def remove(sf: SimpleFeature): Unit = stat.unobserve(sf)
-
-    override def close(): Unit = {
-      if (!stat.isEmpty) {
-        stats.writeStat(stat, sft, merge = true)
-      }
-    }
-
-    override def flush(): Unit = {
-      if (!stat.isEmpty) {
-        stats.writeStat(stat, sft, merge = true)
-      }
-      // reload the tracker - for long-held updaters, this will refresh the histogram ranges
-      stat = statFunction
-    }
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/MergedFeatureSourceView.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/MergedFeatureSourceView.scala
@@ -15,22 +15,16 @@ import java.util.concurrent.atomic.AtomicBoolean
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.data._
 import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
-import org.geotools.data.store.DataFeatureCollection
-import org.geotools.factory.Hints
-import org.geotools.feature.visitor.{BoundsVisitor, MaxVisitor, MinVisitor}
 import org.geotools.geometry.jts.ReferencedEnvelope
-import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
+import org.geotools.factory.Hints
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection.GeoMesaFeatureVisitingCollection
 import org.locationtech.geomesa.index.geotools.GeoMesaFeatureSource.DelegatingResourceInfo
 import org.locationtech.geomesa.index.planning.QueryPlanner
-import org.locationtech.geomesa.index.process.GeoMesaProcessVisitor
 import org.locationtech.geomesa.index.view.MergedFeatureSourceView.MergedQueryCapabilities
-import org.opengis.feature.FeatureVisitor
 import org.opengis.feature.`type`.Name
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
-import org.opengis.filter.expression.PropertyName
 import org.opengis.filter.sort.SortBy
-import org.opengis.util.ProgressListener
 
 /**
   * Feature source for merged data store view
@@ -94,7 +88,8 @@ class MergedFeatureSourceView(
     *
     * @param query query
     */
-  class MergedFeatureCollection(query: Query) extends DataFeatureCollection(GeoMesaFeatureCollection.nextId) {
+  class MergedFeatureCollection(query: Query)
+      extends GeoMesaFeatureVisitingCollection(MergedFeatureSourceView.this, ds.stats, query) {
 
     private val open = new AtomicBoolean(false)
 
@@ -116,35 +111,6 @@ class MergedFeatureSourceView(
       open.set(true)
       iter
     }
-
-    override def accepts(visitor: FeatureVisitor, progress: ProgressListener): Unit =
-      visitor match {
-        case v: BoundsVisitor =>
-          v.reset(ds.stats.getBounds(sft, query.getFilter))
-
-        case v: MinVisitor if v.getExpression.isInstanceOf[PropertyName] =>
-          val attribute = v.getExpression.asInstanceOf[PropertyName].getPropertyName
-          minMax(attribute, exact = false).orElse(minMax(attribute, exact = true)) match {
-            case Some((min, _)) => v.setValue(min)
-            case None           => super.accepts(visitor, progress)
-          }
-
-        case v: MaxVisitor if v.getExpression.isInstanceOf[PropertyName] =>
-          val attribute = v.getExpression.asInstanceOf[PropertyName].getPropertyName
-          minMax(attribute, exact = false).orElse(minMax(attribute, exact = true)) match {
-            case Some((_, max)) => v.setValue(max)
-            case None           => super.accepts(visitor, progress)
-          }
-
-        case v: GeoMesaProcessVisitor =>
-          v.execute(MergedFeatureSourceView.this, query)
-
-        case _ =>
-          super.accepts(visitor, progress)
-      }
-
-    private def minMax(attribute: String, exact: Boolean): Option[(Any, Any)] =
-      ds.stats.getAttributeBounds[Any](sft, attribute, query.getFilter, exact).map(_.bounds)
 
     override def reader(): FeatureReader[SimpleFeatureType, SimpleFeature] =
       ds.getFeatureReader(query, Transaction.AUTO_COMMIT)

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/InMemoryMetadata.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/InMemoryMetadata.scala
@@ -31,6 +31,8 @@ class InMemoryMetadata[T] extends GeoMesaMetadata[T] {
     schemas.get(typeName).foreach(_.remove(key))
   }
 
+  override def remove(typeName: String, keys: Seq[String]): Unit = keys.foreach(remove(typeName, _))
+
   override def read(typeName: String, key: String, cache: Boolean): Option[T] = synchronized {
     schemas.get(typeName).flatMap(_.get(key))
   }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/TestGeoMesaDataStore.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/TestGeoMesaDataStore.scala
@@ -156,7 +156,7 @@ object TestGeoMesaDataStore {
 
     private var i = 0
 
-    override protected def write(feature: WritableFeature, values: Array[RowKeyValue[_]]): Unit = {
+    override protected def write(feature: WritableFeature, values: Array[RowKeyValue[_]], update: Boolean): Unit = {
       i = 0
       values.foreach {
         case kv: SingleRowKeyValue[_] => tables(i).add(kv); i += 1

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/conf/partition/TablePartitionTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/conf/partition/TablePartitionTest.scala
@@ -68,7 +68,28 @@ class TablePartitionTest extends Specification {
       val partitionOption = TablePartition(ds, sft)
       partitionOption must beSome
       val partition = partitionOption.get
-      partition.partitions(filter).map(_.toShort) must containTheSameElementsAs(Seq.range(min, max + 1).map(_.toShort))
+      val partitionsOption = partition.partitions(filter)
+      partitionsOption must beSome
+      partitionsOption.get.map(_.toShort) must containTheSameElementsAs(Seq.range(min, max + 1).map(_.toShort))
+    }
+
+    "extract partitions from disjoint filters" in {
+      val filter = ECQL.toFilter("dtg < '2018-01-01T00:00:00.000Z' AND dtg > '2018-02-01T00:00:00.000Z'")
+      val partitionOption = TablePartition(ds, sft)
+      partitionOption must beSome
+      val partition = partitionOption.get
+      val partitionsOption = partition.partitions(filter)
+      partitionsOption must beSome
+      partitionsOption.get must beEmpty
+    }
+
+    "extract nothing from non-selective filters" in {
+      val filter = ECQL.toFilter("bbox(geom,-10,-10,10,10)")
+      val partitionOption = TablePartition(ds, sft)
+      partitionOption must beSome
+      val partition = partitionOption.get
+      val partitionsOption = partition.partitions(filter)
+      partitionsOption must beNone
     }
   }
 }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreTest.scala
@@ -9,19 +9,25 @@
 package org.locationtech.geomesa.index.geotools
 
 import org.geotools.data.collection.ListFeatureCollection
+import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
+import org.geotools.data.store.{ReTypingFeatureCollection, ReprojectingFeatureCollection}
 import org.geotools.data.{DataStore, Query, Transaction}
 import org.geotools.factory.Hints
+import org.geotools.feature.collection.{DecoratingFeatureCollection, DecoratingSimpleFeatureCollection}
+import org.geotools.feature.visitor.CalcResult
 import org.geotools.filter.text.ecql.ECQL
 import org.geotools.geometry.jts.JTS
 import org.geotools.referencing.CRS
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.index.TestGeoMesaDataStore
-import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreTest.TestQueryInterceptor
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreTest.{TestFeatureCollection, TestQueryInterceptor, TestSimpleFeatureCollection, TestVisitor}
 import org.locationtech.geomesa.index.planning.QueryInterceptor
+import org.locationtech.geomesa.index.process.GeoMesaProcessVisitor
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.jts.geom.{Geometry, Point}
+import org.opengis.feature.Feature
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 import org.specs2.mutable.Specification
@@ -89,14 +95,46 @@ class GeoMesaDataStoreTest extends Specification {
       results = SelfClosingIterator(ds.getFeatureReader(new Query(sft.getTypeName, ECQL.toFilter("bbox(geom,39,54,51,56)")), Transaction.AUTO_COMMIT)).toSeq
       results must haveLength(10)
     }
+    "unwrap decorating feature collections" in {
+      val fc = ds.getFeatureSource(sft.getTypeName).getFeatures()
+      val collections = Seq(
+        new ReTypingFeatureCollection(fc, SimpleFeatureTypes.renameSft(sft, "foo")),
+        new ReprojectingFeatureCollection(fc, epsg3857),
+        new TestFeatureCollection(fc),
+        new TestSimpleFeatureCollection(fc)
+      )
+      foreach(collections) { collection =>
+        val visitor = new TestVisitor()
+        GeoMesaFeatureCollection.visit(collection, visitor)
+        visitor.visited must beFalse
+        visitor.executed must beTrue
+      }
+    }
   }
 }
 
 object GeoMesaDataStoreTest {
+
   class TestQueryInterceptor extends QueryInterceptor {
     override def init(ds: DataStore, sft: SimpleFeatureType): Unit = {}
     override def rewrite(query: Query): Unit =
       if (query.getFilter == Filter.INCLUDE) { query.setFilter(Filter.EXCLUDE) }
     override def close(): Unit = {}
   }
+
+  class TestVisitor extends GeoMesaProcessVisitor {
+    var executed = false
+    var visited = false
+    override def execute(source: SimpleFeatureSource, query: Query): Unit = executed = true
+    override def visit(feature: Feature): Unit = visited = true
+    override def getResult: CalcResult = null
+  }
+
+  // example class extending DecoratingFeatureCollection
+  class TestFeatureCollection(delegate: SimpleFeatureCollection)
+      extends DecoratingFeatureCollection[SimpleFeatureType, SimpleFeature](delegate)
+
+  // example class extending DecoratingSimpleFeatureCollection
+  class TestSimpleFeatureCollection(delegate: SimpleFeatureCollection)
+      extends DecoratingSimpleFeatureCollection(delegate)
 }

--- a/geomesa-jobs/pom.xml
+++ b/geomesa-jobs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-jobs/pom.xml
+++ b/geomesa-jobs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-jobs/pom.xml
+++ b/geomesa-jobs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-jupyter/geomesa-jupyter-leaflet/pom.xml
+++ b/geomesa-jupyter/geomesa-jupyter-leaflet/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-jupyter_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-jupyter/geomesa-jupyter-leaflet/pom.xml
+++ b/geomesa-jupyter/geomesa-jupyter-leaflet/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-jupyter_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-jupyter/geomesa-jupyter-leaflet/pom.xml
+++ b/geomesa-jupyter/geomesa-jupyter-leaflet/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-jupyter_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-jupyter/geomesa-jupyter-leaflet/src/main/scala/org/locationtech/geomesa/jupyter/Leaflet.scala
+++ b/geomesa-jupyter/geomesa-jupyter-leaflet/src/main/scala/org/locationtech/geomesa/jupyter/Leaflet.scala
@@ -9,13 +9,12 @@
 package org.locationtech.geomesa.jupyter
 
 object L {
-  import org.locationtech.jts.geom._
   import org.apache.commons.text.CharacterPredicates.ASCII_ALPHA_NUMERALS
   import org.apache.commons.text.{RandomStringGenerator, StringEscapeUtils}
   import org.apache.spark.sql._
-  import org.geotools.feature.simple.SimpleFeatureBuilder
   import org.geotools.geojson.geom.GeometryJSON
   import org.locationtech.geomesa.spark.{GeoMesaDataSource, SparkUtils}
+  import org.locationtech.jts.geom._
   import org.opengis.feature.`type`.AttributeDescriptor
   import org.opengis.feature.simple.SimpleFeature
 
@@ -145,10 +144,9 @@ object L {
     extends GeoRenderable with DataFrameLayer {
     private val dfc = df.collect() // expensive operation
     private val sft = new GeoMesaDataSource().structType2SFT(df.schema, "sft")
-    private val builder = new SimpleFeatureBuilder(sft)
     // expensive map operation
-    private val nameMappings = SparkUtils.getSftRowNameMappings(sft, df.schema)
-    private val sftSeq = dfc.map(r => SparkUtils.row2Sf(nameMappings, r, builder, r.getAs[String](idField))).toSeq
+    private val mappings = SparkUtils.sftToRowMappings(sft, df.schema)
+    private val sftSeq = dfc.map(r => SparkUtils.row2Sf(sft, mappings, r, r.getAs[String](idField))).toSeq
     private val sftLayer = SimpleFeatureLayerNonPoint(sftSeq, style)
     override def render: String = sftLayer.render
   }
@@ -157,10 +155,9 @@ object L {
     extends GeoRenderable with DataFrameLayer {
     private val dfc = df.collect() // expensive operation
     private val sft = new GeoMesaDataSource().structType2SFT(df.schema, "sft")
-    private val builder = new SimpleFeatureBuilder(sft)
     // expensive map operation
-    private val nameMappings = SparkUtils.getSftRowNameMappings(sft, df.schema)
-    private val sftSeq = dfc.map(r => SparkUtils.row2Sf(nameMappings, r, builder, r.getAs[String](idField))).toSeq
+    private val mappings = SparkUtils.sftToRowMappings(sft, df.schema)
+    private val sftSeq = dfc.map(r => SparkUtils.row2Sf(sft, mappings, r, r.getAs[String](idField))).toSeq
     private val sftLayer = SimpleFeatureLayerPoint(sftSeq, style, radius)
     override def render: String = sftLayer.render
   }

--- a/geomesa-jupyter/geomesa-jupyter-vegas/pom.xml
+++ b/geomesa-jupyter/geomesa-jupyter-vegas/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-jupyter_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-jupyter/pom.xml
+++ b/geomesa-jupyter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-jupyter/pom.xml
+++ b/geomesa-jupyter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-jupyter/pom.xml
+++ b/geomesa-jupyter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kafka/geomesa-kafka-confluent/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-confluent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/geomesa-kafka/geomesa-kafka-confluent/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-confluent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/geomesa-kafka/geomesa-kafka-confluent/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-confluent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/geomesa-kafka/geomesa-kafka-confluent/src/main/scala/org/locationtech/geomesa/kafka/confluent/ConfluentMetadata.scala
+++ b/geomesa-kafka/geomesa-kafka-confluent/src/main/scala/org/locationtech/geomesa/kafka/confluent/ConfluentMetadata.scala
@@ -81,6 +81,7 @@ class ConfluentMetadata(val schemaRegistry: SchemaRegistryClient) extends GeoMes
   override def insert(typeName: String, key: String, value: String): Unit = {}
   override def insert(typeName: String, kvPairs: Map[String, String]): Unit = {}
   override def remove(typeName: String, key: String): Unit = {}
+  override def remove(typeName: String, keys: Seq[String]): Unit = {}
   override def delete(typeName: String): Unit = {}
 }
 

--- a/geomesa-kafka/geomesa-kafka-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/geomesa-kafka/geomesa-kafka-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/geomesa-kafka/geomesa-kafka-datastore/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/geomesa-kafka/geomesa-kafka-dist/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-kafka/geomesa-kafka-dist/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-kafka/geomesa-kafka-dist/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-dist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-kafka/geomesa-kafka-gs-plugin/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-kafka/geomesa-kafka-gs-plugin/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-kafka/geomesa-kafka-gs-plugin/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-kafka/geomesa-kafka-tools/bin/geomesa-kafka
+++ b/geomesa-kafka/geomesa-kafka-tools/bin/geomesa-kafka
@@ -58,6 +58,6 @@ else
       GEOMESA_OPTS="$GEOMESA_OPTS $GEOMESA_DEBUG_OPTS"
       shift 1
     fi
-    java ${CUSTOM_JAVA_OPTS} ${GEOMESA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.kafka.tools.KafkaRunner "$@"
+    java ${GEOMESA_OPTS} ${CUSTOM_JAVA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.kafka.tools.KafkaRunner "$@"
   fi
 fi

--- a/geomesa-kafka/geomesa-kafka-tools/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kafka/geomesa-kafka-tools/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kafka/geomesa-kafka-tools/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kafka/geomesa-kafka-utils/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-utils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kafka/geomesa-kafka-utils/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-utils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kafka/geomesa-kafka-utils/pom.xml
+++ b/geomesa-kafka/geomesa-kafka-utils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kafka_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kafka/pom.xml
+++ b/geomesa-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kafka/pom.xml
+++ b/geomesa-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kafka/pom.xml
+++ b/geomesa-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/geomesa-kudu-datastore/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-kudu_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/geomesa-kudu-datastore/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-kudu_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/geomesa-kudu-datastore/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-kudu_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/data/KuduBackedMetadata.scala
+++ b/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/data/KuduBackedMetadata.scala
@@ -14,7 +14,6 @@ import org.apache.kudu.ColumnSchema.Encoding
 import org.apache.kudu.client.KuduPredicate.ComparisonOp
 import org.apache.kudu.client.{CreateTableOptions, KuduClient, KuduPredicate}
 import org.apache.kudu.{ColumnSchema, Schema, Type}
-import org.locationtech.geomesa.index.metadata.CachedLazyMetadata.ScanQuery
 import org.locationtech.geomesa.index.metadata._
 import org.locationtech.geomesa.kudu.utils.ColumnConfiguration
 import org.locationtech.geomesa.utils.collection.CloseableIterator
@@ -23,13 +22,15 @@ import org.locationtech.geomesa.utils.io.WithClose
 class KuduBackedMetadata[T](val client: KuduClient, val catalog: String, val serializer: MetadataSerializer[T])
     extends CachedLazyMetadata[T] {
 
+  import org.locationtech.geomesa.kudu.utils.RichKuduClient.RichScanner
+
+  import scala.collection.JavaConverters._
+
   lazy private val table = client.openTable(catalog)
 
   override protected def checkIfTableExists: Boolean = client.tableExists(catalog)
 
   override protected def createTable(): Unit = {
-    import scala.collection.JavaConverters._
-
     val sftCol = new ColumnSchema.ColumnSchemaBuilder("type", Type.STRING)
         .encoding(Encoding.PREFIX_ENCODING)
         .compressionAlgorithm(ColumnConfiguration.compression())
@@ -92,7 +93,6 @@ class KuduBackedMetadata[T](val client: KuduClient, val catalog: String, val ser
 
   override protected def scanValue(typeName: String, key: String): Option[Array[Byte]] = {
     import KuduPredicate.newComparisonPredicate
-    import org.locationtech.geomesa.kudu.utils.RichKuduClient.RichScanner
     import org.locationtech.geomesa.utils.conversions.ScalaImplicits.RichIterator
 
     val scanner = client.newScannerBuilder(table)
@@ -103,23 +103,21 @@ class KuduBackedMetadata[T](val client: KuduClient, val catalog: String, val ser
     WithClose(scanner.iterator)(_.headOption.map(_.getBinaryCopy(0)))
   }
 
-  override protected def scanValues(query: Option[ScanQuery]): CloseableIterator[(String, String, Array[Byte])] = {
+  override protected def scanValues(typeName: String, prefix: String): CloseableIterator[(String, Array[Byte])] = {
     import KuduPredicate.newComparisonPredicate
-    import org.locationtech.geomesa.kudu.utils.RichKuduClient.RichScanner
-
-    import scala.collection.JavaConverters._
 
     val builder = client.newScannerBuilder(table).setProjectedColumnIndexes(Seq[Integer](0, 1, 2).asJava)
-    query.foreach { q =>
-      builder.addPredicate(newComparisonPredicate(table.getSchema.getColumnByIndex(0), ComparisonOp.EQUAL, q.typeName))
-    }
+    builder.addPredicate(newComparisonPredicate(table.getSchema.getColumnByIndex(0), ComparisonOp.EQUAL, typeName))
 
-    val iter = builder.build().iterator.map(r => (r.getString(0), r.getString(1), r.getBinaryCopy(2)))
-
-    query.flatMap(_.prefix) match {
-      case None => iter
-      case Some(p) => iter.filter(_._2.startsWith(p))
+    val iter = builder.build().iterator.map(r => (r.getString(1), r.getBinaryCopy(2)))
+    if (prefix == null || prefix.isEmpty) { iter } else {
+      iter.filter(_._2.startsWith(prefix))
     }
+  }
+
+  override protected def scanKeys(): CloseableIterator[(String, String)] = {
+    val builder = client.newScannerBuilder(table).setProjectedColumnIndexes(Seq[Integer](0, 1).asJava)
+    builder.build().iterator.map(r => (r.getString(0), r.getString(1)))
   }
 
   override def close(): Unit = {} // client gets closed by datastore dispose

--- a/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/data/KuduBackedMetadata.scala
+++ b/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/data/KuduBackedMetadata.scala
@@ -111,7 +111,7 @@ class KuduBackedMetadata[T](val client: KuduClient, val catalog: String, val ser
 
     val iter = builder.build().iterator.map(r => (r.getString(1), r.getBinaryCopy(2)))
     if (prefix == null || prefix.isEmpty) { iter } else {
-      iter.filter(_._2.startsWith(prefix))
+      iter.filter { case (k, _) => k.startsWith(prefix) }
     }
   }
 

--- a/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/data/KuduIndexAdapter.scala
+++ b/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/data/KuduIndexAdapter.scala
@@ -145,7 +145,7 @@ object KuduIndexAdapter {
 
     private var i = 0
 
-    override protected def write(feature: WritableFeature, values: Array[RowKeyValue[_]]): Unit = {
+    override protected def write(feature: WritableFeature, values: Array[RowKeyValue[_]], update: Boolean): Unit = {
       val kf = feature.asInstanceOf[KuduWritableFeature]
 
       i = 0

--- a/geomesa-kudu/geomesa-kudu-dist/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kudu_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-kudu/geomesa-kudu-dist/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kudu_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-kudu/geomesa-kudu-dist/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kudu_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-kudu/geomesa-kudu-gs-plugin/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-gs-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-kudu/geomesa-kudu-gs-plugin/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-gs-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-kudu/geomesa-kudu-gs-plugin/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-gs-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-kudu/geomesa-kudu-spark-runtime/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-spark-runtime/pom.xml
@@ -92,7 +92,6 @@
                                     <exclude>org.ow2.asm:*</exclude>
                                     <exclude>org.scala-lang:*</exclude>
                                     <exclude>io.netty:*</exclude>
-                                    <exclude>org.json4s:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <filters>
@@ -109,12 +108,17 @@
                             <relocations>
                                 <relocation>
                                     <pattern>com.google.common</pattern>
-                                    <shadedPattern>org.locationtech.geomesa.hbase.shaded.com.google.common</shadedPattern>
+                                    <shadedPattern>org.locationtech.geomesa.kudu.shaded.com.google.common</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.commons.codec</pattern>
-                                    <shadedPattern>org.locationtech.geomesa.hbase.shaded.org.apache.commons.codec
+                                    <shadedPattern>org.locationtech.geomesa.kudu.shaded.org.apache.commons.codec
                                     </shadedPattern>
+                                </relocation>
+                                <!-- spark needs json4s to use the jsonpath function -->
+                                <relocation>
+                                    <pattern>org.json4s</pattern>
+                                    <shadedPattern>org.locationtech.geomesa.kudu.shaded.org.json4s</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>

--- a/geomesa-kudu/geomesa-kudu-spark-runtime/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-kudu_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/geomesa-kudu-spark-runtime/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-kudu_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/geomesa-kudu-spark-runtime/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-spark-runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-kudu_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/geomesa-kudu-spark/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-kudu_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/geomesa-kudu-spark/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-kudu_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/geomesa-kudu-spark/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-kudu_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/geomesa-kudu-tools/bin/geomesa-kudu
+++ b/geomesa-kudu/geomesa-kudu-tools/bin/geomesa-kudu
@@ -54,5 +54,5 @@ else
     GEOMESA_OPTS="$GEOMESA_OPTS $GEOMESA_DEBUG_OPTS"
     shift 1
   fi
-  java ${CUSTOM_JAVA_OPTS} ${GEOMESA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.kudu.tools.KuduRunner "$@"
+  java ${GEOMESA_OPTS} ${CUSTOM_JAVA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.kudu.tools.KuduRunner "$@"
 fi

--- a/geomesa-kudu/geomesa-kudu-tools/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kudu_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/geomesa-kudu-tools/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kudu_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/geomesa-kudu-tools/pom.xml
+++ b/geomesa-kudu/geomesa-kudu-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-kudu_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/pom.xml
+++ b/geomesa-kudu/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/pom.xml
+++ b/geomesa-kudu/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-kudu/pom.xml
+++ b/geomesa-kudu/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-lambda/geomesa-lambda-datastore/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-lambda_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>geomesa-lambda-datastore_2.11</artifactId>

--- a/geomesa-lambda/geomesa-lambda-datastore/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-lambda_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>geomesa-lambda-datastore_2.11</artifactId>

--- a/geomesa-lambda/geomesa-lambda-datastore/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-lambda_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
 
     <artifactId>geomesa-lambda-datastore_2.11</artifactId>

--- a/geomesa-lambda/geomesa-lambda-dist/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-lambda_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-lambda/geomesa-lambda-dist/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-lambda_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-lambda/geomesa-lambda-dist/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-lambda_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-lambda/geomesa-lambda-gs-plugin/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-lambda/geomesa-lambda-gs-plugin/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-lambda/geomesa-lambda-gs-plugin/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-gs-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
 

--- a/geomesa-lambda/geomesa-lambda-tools/bin/geomesa-lambda
+++ b/geomesa-lambda/geomesa-lambda-tools/bin/geomesa-lambda
@@ -127,6 +127,6 @@ else
       GEOMESA_OPTS="$GEOMESA_OPTS $GEOMESA_DEBUG_OPTS"
       shift 1
     fi
-    java ${CUSTOM_JAVA_OPTS} ${GEOMESA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.lambda.tools.LambdaRunner "$@"
+    java ${GEOMESA_OPTS} ${CUSTOM_JAVA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.lambda.tools.LambdaRunner "$@"
   fi
 fi

--- a/geomesa-lambda/geomesa-lambda-tools/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-lambda_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-lambda/geomesa-lambda-tools/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-lambda_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-lambda/geomesa-lambda-tools/pom.xml
+++ b/geomesa-lambda/geomesa-lambda-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-lambda_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-lambda/pom.xml
+++ b/geomesa-lambda/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-lambda/pom.xml
+++ b/geomesa-lambda/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-lambda/pom.xml
+++ b/geomesa-lambda/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-memory/geomesa-cqengine-datastore/pom.xml
+++ b/geomesa-memory/geomesa-cqengine-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-memory_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-memory/geomesa-cqengine-datastore/pom.xml
+++ b/geomesa-memory/geomesa-cqengine-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-memory_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-memory/geomesa-cqengine-datastore/pom.xml
+++ b/geomesa-memory/geomesa-cqengine-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-memory_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-memory/geomesa-cqengine/pom.xml
+++ b/geomesa-memory/geomesa-cqengine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-memory_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-memory/geomesa-cqengine/pom.xml
+++ b/geomesa-memory/geomesa-cqengine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-memory_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-memory/geomesa-cqengine/pom.xml
+++ b/geomesa-memory/geomesa-cqengine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa-memory_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/utils/SFTAttributes.scala
+++ b/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/utils/SFTAttributes.scala
@@ -8,55 +8,24 @@
 
 package org.locationtech.geomesa.memory.cqengine.utils
 
-import java.util.UUID
-
 import com.googlecode.cqengine.attribute.Attribute
-import org.locationtech.jts.geom.Geometry
-import org.locationtech.geomesa.memory.cqengine.attribute.{SimpleFeatureFidAttribute, SimpleFeatureAttribute}
+import org.locationtech.geomesa.memory.cqengine.attribute.{SimpleFeatureAttribute, SimpleFeatureFidAttribute}
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
-import scala.collection.JavaConversions._
-
 case class SFTAttributes(sft: SimpleFeatureType) {
-  private val attributes = sft.getAttributeDescriptors
 
-  private val lookupMap: Map[String, Attribute[SimpleFeature, _]] = attributes.map { attr =>
-    val name = attr.getLocalName
-    name -> buildSimpleFeatureAttribute(attr.getType.getBinding, name)
-  }.toMap
+  import scala.collection.JavaConverters._
+
+  private val lookupMap: Map[String, Attribute[SimpleFeature, _]] =
+    sft.getAttributeDescriptors.asScala.map(buildSimpleFeatureAttribute).map(a => a.getAttributeName -> a).toMap
 
   // TODO: this is really, really bad :)
-  def lookup[T](attributeName: String): Attribute[SimpleFeature, T] = {
+  def lookup[T](attributeName: String): Attribute[SimpleFeature, T] =
     lookupMap(attributeName).asInstanceOf[Attribute[SimpleFeature, T]]
-  }
 
-  def buildSimpleFeatureAttribute(ad: AttributeDescriptor): Attribute[SimpleFeature, _] = {
-    buildSimpleFeatureAttribute(ad.getType.getBinding, ad.getLocalName)
-  }
-
-  def buildSimpleFeatureAttribute[A](binding: Class[_], name: String): Attribute[SimpleFeature, _] = {
-    binding match {
-      case c if classOf[java.lang.String].isAssignableFrom(c)
-        => new SimpleFeatureAttribute(classOf[String], sft, name)
-      case c if classOf[java.lang.Integer].isAssignableFrom(c)
-        => new SimpleFeatureAttribute(classOf[Integer], sft, name)
-      case c if classOf[java.lang.Long].isAssignableFrom(c)
-        => new SimpleFeatureAttribute(classOf[java.lang.Long], sft, name)
-      case c if classOf[java.lang.Float].isAssignableFrom(c)
-        => new SimpleFeatureAttribute(classOf[java.lang.Float], sft, name)
-      case c if classOf[java.lang.Double].isAssignableFrom(c)
-        => new SimpleFeatureAttribute(classOf[java.lang.Double], sft, name)
-      case c if classOf[java.lang.Boolean].isAssignableFrom(c)
-        => new SimpleFeatureAttribute(classOf[java.lang.Boolean], sft, name)
-      case c if classOf[java.util.Date].isAssignableFrom(c)
-       => new SimpleFeatureAttribute(classOf[java.util.Date], sft, name)
-      case c if classOf[UUID].isAssignableFrom(c)
-        => new SimpleFeatureAttribute(classOf[UUID], sft, name)
-      case c if classOf[Geometry].isAssignableFrom(c)
-        => new SimpleFeatureAttribute(classOf[Geometry], sft, name)
-    }
-  }
+  def buildSimpleFeatureAttribute(ad: AttributeDescriptor): Attribute[SimpleFeature, _] =
+    new SimpleFeatureAttribute(ad.getType.getBinding, sft, ad.getLocalName)
 }
 
 object SFTAttributes {

--- a/geomesa-memory/pom.xml
+++ b/geomesa-memory/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-memory/pom.xml
+++ b/geomesa-memory/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-memory/pom.xml
+++ b/geomesa-memory/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-metrics/pom.xml
+++ b/geomesa-metrics/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-metrics/pom.xml
+++ b/geomesa-metrics/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-metrics/pom.xml
+++ b/geomesa-metrics/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-native-api/pom.xml
+++ b/geomesa-native-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-native-api/pom.xml
+++ b/geomesa-native-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-native-api/pom.xml
+++ b/geomesa-native-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-process/geomesa-process-vector/pom.xml
+++ b/geomesa-process/geomesa-process-vector/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-process_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-process/geomesa-process-vector/pom.xml
+++ b/geomesa-process/geomesa-process-vector/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-process_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-process/geomesa-process-vector/pom.xml
+++ b/geomesa-process/geomesa-process-vector/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-process_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/analytic/MinMaxProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/analytic/MinMaxProcess.scala
@@ -13,8 +13,8 @@ import org.geotools.data.Query
 import org.geotools.data.collection.ListFeatureCollection
 import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
 import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
-import org.geotools.util.NullProgressListener
 import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
 import org.locationtech.geomesa.index.iterators.StatsScan
 import org.locationtech.geomesa.index.stats.HasGeoMesaStats
 import org.locationtech.geomesa.process.analytic.MinMaxProcess.MinMaxVisitor
@@ -56,7 +56,7 @@ class MinMaxProcess extends GeoMesaProcess with LazyLogging {
     logger.debug(s"Attempting min/max process on type ${features.getClass.getName}")
 
     val visitor = new MinMaxVisitor(features, attribute, Option(cached).forall(_.booleanValue()))
-    features.accepts(visitor, new NullProgressListener)
+    GeoMesaFeatureCollection.visit(features, visitor)
     visitor.getResult.results
   }
 }

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/analytic/Point2PointProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/analytic/Point2PointProcess.scala
@@ -20,6 +20,7 @@ import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.locationtech.geomesa.process.GeoMesaProcess
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.geotools.SchemaBuilder
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.opengis.feature.simple.SimpleFeature
 
 @DescribeProcess(title = "Point2PointProcess", description = "Aggregates a collection of points into a collection of line segments")
@@ -112,5 +113,5 @@ class Point2PointProcess extends GeoMesaProcess {
   }
 
   def getDayOfYear(sortFieldIndex: Int, f: SimpleFeature): Int =
-    ZonedDateTime.ofInstant(f.getAttribute(sortFieldIndex).asInstanceOf[Date].toInstant, ZoneOffset.UTC).getDayOfYear
+    ZonedDateTime.ofInstant(toInstant(f.getAttribute(sortFieldIndex).asInstanceOf[Date]), ZoneOffset.UTC).getDayOfYear
 }

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/analytic/SamplingProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/analytic/SamplingProcess.scala
@@ -15,6 +15,7 @@ import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
 import org.geotools.process.ProcessException
 import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
 import org.locationtech.geomesa.index.conf.QueryHints
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
 import org.locationtech.geomesa.index.utils.FeatureSampler
 import org.locationtech.geomesa.process.{FeatureResult, GeoMesaProcess, GeoMesaProcessVisitor}
 import org.opengis.feature.Feature
@@ -53,7 +54,7 @@ class SamplingProcess extends GeoMesaProcess with LazyLogging {
     logger.trace(s"Attempting sampling on ${data.getClass.getName}")
 
     val visitor = new SamplingVisitor(data, samplePercent, Option(threadBy))
-    data.accepts(visitor, monitor)
+    GeoMesaFeatureCollection.visit(data, visitor, monitor)
     visitor.getResult.results
   }
 }

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/analytic/StatsProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/analytic/StatsProcess.scala
@@ -13,9 +13,9 @@ import org.geotools.data.Query
 import org.geotools.data.collection.ListFeatureCollection
 import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
 import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
-import org.geotools.util.NullProgressListener
 import org.locationtech.geomesa.features.{ScalaSimpleFeature, TransformSimpleFeature}
 import org.locationtech.geomesa.index.conf.QueryHints
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
 import org.locationtech.geomesa.index.iterators.StatsScan
 import org.locationtech.geomesa.index.planning.QueryPlanner
 import org.locationtech.geomesa.process.{FeatureResult, GeoMesaProcess, GeoMesaProcessVisitor}
@@ -63,8 +63,7 @@ class StatsProcess extends GeoMesaProcess with LazyLogging {
     val propsArray = Option(properties).map(_.toArray(Array.empty[String])).filter(_.length > 0).orNull
 
     val visitor = new StatsVisitor(features, statString, Option(encode).exists(_.booleanValue()), propsArray)
-
-    features.accepts(visitor, new NullProgressListener)
+    GeoMesaFeatureCollection.visit(features, visitor)
     visitor.getResult.results
   }
 }

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/analytic/UniqueProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/analytic/UniqueProcess.scala
@@ -17,6 +17,7 @@ import org.geotools.feature.visitor.{AbstractCalcResult, CalcResult}
 import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
 import org.locationtech.geomesa.filter.factory.FastFilterFactory
 import org.locationtech.geomesa.index.conf.QueryHints
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
 import org.locationtech.geomesa.index.index.attribute.AttributeIndex
 import org.locationtech.geomesa.index.iterators.StatsScan
 import org.locationtech.geomesa.process.{GeoMesaProcess, GeoMesaProcessVisitor}
@@ -64,7 +65,7 @@ class UniqueProcess extends GeoMesaProcess with LazyLogging {
     val sortBy = Option(sortByCount).exists(_.booleanValue)
 
     val visitor = new AttributeVisitor(features, attributeDescriptor, Option(filter).filter(_ != Filter.INCLUDE), hist)
-    features.accepts(visitor, progressListener)
+    GeoMesaFeatureCollection.visit(features, visitor, progressListener)
     val uniqueValues = visitor.getResult.attributes
 
     val binding = attributeDescriptor.getType.getBinding

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/knn/KNearestNeighborSearchProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/knn/KNearestNeighborSearchProcess.scala
@@ -9,15 +9,15 @@
 package org.locationtech.geomesa.process.knn
 
 import com.typesafe.scalalogging.LazyLogging
-import org.locationtech.jts.geom.Point
 import org.geotools.data.Query
 import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
 import org.geotools.feature.DefaultFeatureCollection
 import org.geotools.feature.visitor.{AbstractCalcResult, CalcResult}
 import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
-import org.geotools.util.NullProgressListener
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
 import org.locationtech.geomesa.process.{GeoMesaProcess, GeoMesaProcessVisitor}
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
+import org.locationtech.jts.geom.Point
 import org.opengis.feature.Feature
 
 import scala.collection.JavaConverters._
@@ -60,7 +60,7 @@ class KNearestNeighborSearchProcess extends GeoMesaProcess with LazyLogging {
     logger.debug("Attempting Geomesa K-Nearest Neighbor Search on collection type " + dataFeatures.getClass.getName)
 
     val visitor = new KNNVisitor(inputFeatures, dataFeatures, numDesired, estimatedDistance, maxSearchDistance)
-    dataFeatures.accepts(visitor, new NullProgressListener)
+    GeoMesaFeatureCollection.visit(dataFeatures, visitor)
     visitor.getResult.asInstanceOf[KNNResult].results
   }
 }

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/query/JoinProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/query/JoinProcess.scala
@@ -16,8 +16,8 @@ import org.geotools.feature.collection.DecoratingSimpleFeatureCollection
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.geotools.process.ProcessException
 import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
-import org.geotools.util.NullProgressListener
 import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
 import org.locationtech.geomesa.process.GeoMesaProcess
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -102,7 +102,7 @@ class JoinProcess extends GeoMesaProcess with LazyLogging {
       val or = ff.or(joinFilters.toList)
       val filter = if (joinFilter != null && joinFilter != Filter.INCLUDE) { ff.and(or, joinFilter) } else { or }
       val visitor = new QueryVisitor(secondary, filter, null)
-      secondary.accepts(visitor, new NullProgressListener)
+      GeoMesaFeatureCollection.visit(secondary, visitor)
       val results = visitor.getResult.results
 
       // mappings from the secondary feature result to the return schema

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/query/ProximitySearchProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/query/ProximitySearchProcess.scala
@@ -13,8 +13,8 @@ import org.geotools.data.Query
 import org.geotools.data.collection.ListFeatureCollection
 import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
 import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
-import org.geotools.util.NullProgressListener
 import org.locationtech.geomesa.filter.factory.FastFilterFactory
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
 import org.locationtech.geomesa.process.{FeatureResult, GeoMesaProcess, GeoMesaProcessVisitor}
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.geotools.Conversions._
@@ -49,7 +49,7 @@ class ProximitySearchProcess extends GeoMesaProcess with LazyLogging {
     logger.debug(s"Attempting Geomesa Proximity Search on collection type ${dataFeatures.getClass.getName}")
 
     val visitor = new ProximityVisitor(inputFeatures, dataFeatures, bufferDistance.doubleValue())
-    dataFeatures.accepts(visitor, new NullProgressListener)
+    GeoMesaFeatureCollection.visit(dataFeatures, visitor)
     visitor.getResult.results
   }
 }

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/query/QueryProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/query/QueryProcess.scala
@@ -13,9 +13,9 @@ import org.geotools.data.Query
 import org.geotools.data.collection.ListFeatureCollection
 import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
 import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
-import org.geotools.util.NullProgressListener
 import org.locationtech.geomesa.features.{ScalaSimpleFeature, TransformSimpleFeature}
 import org.locationtech.geomesa.filter.factory.FastFilterFactory
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
 import org.locationtech.geomesa.index.planning.QueryPlanner
 import org.locationtech.geomesa.process.{FeatureResult, GeoMesaProcess, GeoMesaProcessVisitor}
 import org.opengis.feature.Feature
@@ -56,7 +56,7 @@ class QueryProcess extends GeoMesaProcess with LazyLogging {
     val propsArray = Option(properties).map(_.toArray(Array.empty[String])).filter(_.length > 0).orNull
 
     val visitor = new QueryVisitor(features, Option(filter).getOrElse(Filter.INCLUDE), propsArray)
-    features.accepts(visitor, new NullProgressListener)
+    GeoMesaFeatureCollection.visit(features, visitor)
     visitor.getResult.results
   }
 }

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/query/RouteSearchProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/query/RouteSearchProcess.scala
@@ -11,21 +11,21 @@ package org.locationtech.geomesa.process.query
 import java.util.concurrent.ConcurrentHashMap
 
 import com.typesafe.scalalogging.LazyLogging
-import org.locationtech.jts.geom._
-import org.locationtech.jts.operation.distance.DistanceOp
 import org.geotools.data.Query
 import org.geotools.data.collection.ListFeatureCollection
 import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureIterator, SimpleFeatureSource}
 import org.geotools.feature.collection.DecoratingSimpleFeatureCollection
 import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
 import org.geotools.referencing.GeodeticCalculator
-import org.geotools.util.NullProgressListener
 import org.locationtech.geomesa.filter.factory.FastFilterFactory
 import org.locationtech.geomesa.filter.{ff, orFilters}
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
 import org.locationtech.geomesa.process.{FeatureResult, GeoMesaProcess, GeoMesaProcessVisitor}
 import org.locationtech.geomesa.utils.collection.{CloseableIterator, SelfClosingIterator}
 import org.locationtech.geomesa.utils.geotools.converters.FastConverter
 import org.locationtech.geomesa.utils.text.WKTUtils
+import org.locationtech.jts.geom._
+import org.locationtech.jts.operation.distance.DistanceOp
 import org.opengis.feature.Feature
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
@@ -115,7 +115,7 @@ class RouteSearchProcess extends GeoMesaProcess with LazyLogging {
 
     val visitor = new RouteVisitor(sft, routeGeoms, bufferSize, headingThreshold, bi,
       geomAttribute, isPoints, Option(headingField))
-    features.accepts(visitor, new NullProgressListener)
+    GeoMesaFeatureCollection.visit(features, visitor)
     visitor.getResult.results
   }
 }

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/transform/ArrowConversionProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/transform/ArrowConversionProcess.scala
@@ -22,6 +22,7 @@ import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEn
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding.Encoding
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.index.conf.QueryHints
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
 import org.locationtech.geomesa.process.transform.ArrowConversionProcess.ArrowVisitor
 import org.locationtech.geomesa.process.{GeoMesaProcess, GeoMesaProcessVisitor}
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
@@ -89,7 +90,7 @@ class ArrowConversionProcess extends GeoMesaProcess with LazyLogging {
 
     val visitor =
       new ArrowVisitor(sft, encoding, toEncode, cacheDictionaries, Option(sortField), reverse, false, batch, double)
-    features.accepts(visitor, null)
+    GeoMesaFeatureCollection.visit(features, visitor)
     visitor.getResult.results
   }
 }

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/transform/BinConversionProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/transform/BinConversionProcess.scala
@@ -16,6 +16,7 @@ import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
 import org.geotools.feature.visitor._
 import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
 import org.locationtech.geomesa.index.conf.QueryHints
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
 import org.locationtech.geomesa.process.{GeoMesaProcess, GeoMesaProcessVisitor}
 import org.locationtech.geomesa.utils.bin.BinaryOutputEncoder.{BIN_ATTRIBUTE_INDEX, EncodingOptions}
 import org.locationtech.geomesa.utils.bin.{AxisOrder, BinaryOutputEncoder}
@@ -87,7 +88,7 @@ class BinConversionProcess extends GeoMesaProcess with LazyLogging {
     }
 
     val visitor = new BinVisitor(sft, EncodingOptions(geomField, dtgField, trackField, labelField, axis))
-    features.accepts(visitor, null)
+    GeoMesaFeatureCollection.visit(features, visitor)
     visitor.getResult.results
   }
 }

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/transform/DateOffsetProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/transform/DateOffsetProcess.scala
@@ -18,6 +18,7 @@ import org.geotools.process.ProcessException
 import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
 import org.locationtech.geomesa.process.GeoMesaProcess
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 
 import scala.collection.JavaConversions._
 
@@ -44,7 +45,7 @@ class DateOffsetProcess extends GeoMesaProcess {
 
     val iter = SelfClosingIterator(obsFeatures.features()).map { sf =>
       val dtg = sf.getAttribute(dateField).asInstanceOf[Date]
-      val offset = ZonedDateTime.ofInstant(dtg.toInstant, ZoneOffset.UTC).plus(period)
+      val offset = ZonedDateTime.ofInstant(toInstant(dtg), ZoneOffset.UTC).plus(period)
       val newDtg = Date.from(offset.toInstant)
       sf.setAttribute(dtgIndex, newDtg)
       sf

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeBuilder.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeBuilder.scala
@@ -23,6 +23,7 @@ import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType._
 import org.locationtech.geomesa.utils.geotools.{GeometryUtils, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.geotools.converters.FastConverter
 import org.locationtech.geomesa.utils.text.WKTUtils
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.immutable.NumericRange
@@ -240,10 +241,10 @@ class InterpolatedGapFill(tubeFeatures: SimpleFeatureCollection,
         //If the distance between points is greater than the buffer distance, segment the line
         //So that no segment is larger than the buffer. This ensures that each segment has an
         //times and distance. Also ensure that features do not share a time value.
-        val timeDiffMillis = t2.toInstant.toEpochMilli - t1.toInstant.toEpochMilli
+        val timeDiffMillis = toInstant(t2).toEpochMilli - toInstant(t1).toEpochMilli
         val segCount = (dist / bufferDistance).toInt
         val segDuration = timeDiffMillis / segCount
-        val timeSteps = NumericRange.inclusive(t1.toInstant.toEpochMilli, t2.toInstant.toEpochMilli, segDuration)
+        val timeSteps = NumericRange.inclusive(toInstant(t1).toEpochMilli, toInstant(t2).toEpochMilli, segDuration)
         if (dist > bufferDistance && timeSteps.lengthCompare(1) > 0) {
           val heading = calc.getAzimuth
           var segStep = new Coordinate(p1.getX, p1.getY, 0)

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeSelectProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/tube/TubeSelectProcess.scala
@@ -11,19 +11,19 @@ package org.locationtech.geomesa.process.tube
 import java.util.Date
 
 import com.typesafe.scalalogging.LazyLogging
-import org.locationtech.jts.geom._
 import org.geotools.data.Query
 import org.geotools.data.collection.ListFeatureCollection
 import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
 import org.geotools.data.store.EmptyFeatureCollection
 import org.geotools.feature.visitor._
 import org.geotools.process.factory.{DescribeParameter, DescribeProcess, DescribeResult}
-import org.geotools.util.NullProgressListener
+import org.locationtech.geomesa.index.geotools.GeoMesaFeatureCollection
 import org.locationtech.geomesa.process.{GeoMesaProcess, GeoMesaProcessVisitor}
 import org.locationtech.geomesa.utils.collection.{CloseableIterator, SelfClosingIterator}
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.io.WithClose
 import org.locationtech.geomesa.utils.iterators.DeduplicatingSimpleFeatureIterator
+import org.locationtech.jts.geom._
 import org.opengis.feature.Feature
 import org.opengis.filter.Filter
 
@@ -98,7 +98,8 @@ class TubeSelectProcess extends GeoMesaProcess with LazyLogging {
                                       Option(maxBins).getOrElse(0).asInstanceOf[Int],
                                       Option(gapFill).map(GapFill.withName).getOrElse(GapFill.NOFILL))
 
-    featureCollection.accepts(tubeVisitor, new NullProgressListener)
+    GeoMesaFeatureCollection.visit(featureCollection, tubeVisitor)
+
     tubeVisitor.getResult.asInstanceOf[TubeResult].results
   }
 }

--- a/geomesa-process/geomesa-process-wps/pom.xml
+++ b/geomesa-process/geomesa-process-wps/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-process_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-process/geomesa-process-wps/pom.xml
+++ b/geomesa-process/geomesa-process-wps/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-process_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-process/geomesa-process-wps/pom.xml
+++ b/geomesa-process/geomesa-process-wps/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-process_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-process/pom.xml
+++ b/geomesa-process/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-process/pom.xml
+++ b/geomesa-process/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-process/pom.xml
+++ b/geomesa-process/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-redis/geomesa-redis-datastore/pom.xml
+++ b/geomesa-redis/geomesa-redis-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-redis_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/geomesa-redis/geomesa-redis-datastore/pom.xml
+++ b/geomesa-redis/geomesa-redis-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-redis_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/geomesa-redis/geomesa-redis-datastore/pom.xml
+++ b/geomesa-redis/geomesa-redis-datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-redis_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/index/RedisIndexAdapter.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/index/RedisIndexAdapter.scala
@@ -221,7 +221,7 @@ object RedisIndexAdapter extends LazyLogging {
 
     private val errors = ArrayBuffer.empty[Throwable]
 
-    override protected def write(feature: WritableFeature, values: Array[RowKeyValue[_]]): Unit = {
+    override protected def write(feature: WritableFeature, values: Array[RowKeyValue[_]], update: Boolean): Unit = {
       i = 0
       while (i < values.length) {
         val insert = inserts(i)

--- a/geomesa-redis/geomesa-redis-dist/pom.xml
+++ b/geomesa-redis/geomesa-redis-dist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-redis_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-redis/geomesa-redis-dist/pom.xml
+++ b/geomesa-redis/geomesa-redis-dist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-redis_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-redis/geomesa-redis-dist/pom.xml
+++ b/geomesa-redis/geomesa-redis-dist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-redis_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/geomesa-redis/geomesa-redis-gs-plugin/pom.xml
+++ b/geomesa-redis/geomesa-redis-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-redis/geomesa-redis-gs-plugin/pom.xml
+++ b/geomesa-redis/geomesa-redis-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-redis/geomesa-redis-gs-plugin/pom.xml
+++ b/geomesa-redis/geomesa-redis-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-redis/geomesa-redis-tools/bin/geomesa-redis
+++ b/geomesa-redis/geomesa-redis-tools/bin/geomesa-redis
@@ -47,6 +47,6 @@ else
       GEOMESA_OPTS="$GEOMESA_OPTS $GEOMESA_DEBUG_OPTS"
       shift 1
     fi
-    java ${CUSTOM_JAVA_OPTS} ${GEOMESA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.redis.tools.RedisRunner "$@"
+    java ${GEOMESA_OPTS} ${CUSTOM_JAVA_OPTS} -cp ${CLASSPATH} org.locationtech.geomesa.redis.tools.RedisRunner "$@"
   fi
 fi

--- a/geomesa-redis/geomesa-redis-tools/pom.xml
+++ b/geomesa-redis/geomesa-redis-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-redis_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-redis/geomesa-redis-tools/pom.xml
+++ b/geomesa-redis/geomesa-redis-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-redis_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-redis/geomesa-redis-tools/pom.xml
+++ b/geomesa-redis/geomesa-redis-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-redis_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-redis/pom.xml
+++ b/geomesa-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-redis/pom.xml
+++ b/geomesa-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-redis/pom.xml
+++ b/geomesa-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-security/pom.xml
+++ b/geomesa-security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-security/pom.xml
+++ b/geomesa-security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-security/pom.xml
+++ b/geomesa-security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-converter/pom.xml
+++ b/geomesa-spark/geomesa-spark-converter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-converter/pom.xml
+++ b/geomesa-spark/geomesa-spark-converter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-converter/pom.xml
+++ b/geomesa-spark/geomesa-spark-converter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-core/pom.xml
+++ b/geomesa-spark/geomesa-spark-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-core/pom.xml
+++ b/geomesa-spark/geomesa-spark-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-core/pom.xml
+++ b/geomesa-spark/geomesa-spark-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-geotools/pom.xml
+++ b/geomesa-spark/geomesa-spark-geotools/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-geotools/pom.xml
+++ b/geomesa-spark/geomesa-spark-geotools/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-geotools/pom.xml
+++ b/geomesa-spark/geomesa-spark-geotools/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-jts/pom.xml
+++ b/geomesa-spark/geomesa-spark-jts/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-jts/pom.xml
+++ b/geomesa-spark/geomesa-spark-jts/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-jts/pom.xml
+++ b/geomesa-spark/geomesa-spark-jts/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-sql/pom.xml
+++ b/geomesa-spark/geomesa-spark-sql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-sql/pom.xml
+++ b/geomesa-spark/geomesa-spark-sql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-sql/pom.xml
+++ b/geomesa-spark/geomesa-spark-sql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/apache/spark/sql/SQLRules.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/apache/spark/sql/SQLRules.scala
@@ -23,6 +23,7 @@ import org.geotools.factory.CommonFactoryFinder
 import org.locationtech.geomesa.spark.jts.rules.GeometryLiteral
 import org.locationtech.geomesa.spark.jts.udf.SpatialRelationFunctions._
 import org.locationtech.geomesa.spark.{GeoMesaJoinRelation, GeoMesaRelation, RelationUtils, SparkVersions}
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.opengis.filter.expression.{Expression => GTExpression, Literal => GTLiteral}
 import org.opengis.filter.{FilterFactory2, Filter => GTFilter}
 
@@ -117,7 +118,7 @@ object SQLRules extends LazyLogging {
       lazy val zone = c.timeZoneId.map(ZoneId.of).orNull
       sparkExprToGTExpr(c.child).map {
         case lit: GTLiteral if lit.getValue.isInstanceOf[Date] && zone != null =>
-          val date = LocalDateTime.ofInstant(lit.getValue.asInstanceOf[Date].toInstant, zone)
+          val date = LocalDateTime.ofInstant(toInstant(lit.getValue.asInstanceOf[Date]), zone)
           ff.literal(new Date(date.atZone(ZoneOffset.UTC).toInstant.toEpochMilli))
         case e => e
       }

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/GeoMesaSparkSQL.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/GeoMesaSparkSQL.scala
@@ -9,13 +9,9 @@
 package org.locationtech.geomesa.spark
 
 import java.sql.Timestamp
-import java.time.Instant
-import java.util.{Date, UUID}
+import java.util.Date
 
 import com.typesafe.scalalogging.LazyLogging
-import org.locationtech.jts.geom._
-import org.locationtech.jts.index.strtree.{AbstractNode, Boundable, STRtree}
-import org.locationtech.jts.index.sweepline.{SweepLineIndex, SweepLineInterval, SweepLineOverlapAction}
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
@@ -25,16 +21,20 @@ import org.apache.spark.sql.jts.JTSTypes
 import org.apache.spark.sql.sources.{Filter, _}
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType, TimestampType}
 import org.apache.spark.storage.StorageLevel
-import org.geotools.data.DataUtilities.compare
-import org.geotools.data.{DataStoreFinder, Query, Transaction}
+import org.geotools.data._
 import org.geotools.factory.{CommonFactoryFinder, Hints}
-import org.geotools.feature.simple.{SimpleFeatureBuilder, SimpleFeatureTypeBuilder}
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.geotools.filter.text.ecql.ECQL
+import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.memory.cqengine.datastore.GeoCQEngineDataStore
 import org.locationtech.geomesa.spark.jts.util.WKTUtils
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.geotools.{SftArgResolver, SftArgs, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.uuid.TimeSortedUuidGenerator
+import org.locationtech.jts.geom._
+import org.locationtech.jts.index.strtree.{AbstractNode, Boundable, STRtree}
+import org.locationtech.jts.index.sweepline.{SweepLineIndex, SweepLineInterval, SweepLineOverlapAction}
 import org.opengis.feature.`type`._
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
@@ -65,7 +65,10 @@ import org.locationtech.geomesa.spark.GeoMesaSparkSQL._
 class GeoMesaDataSource extends DataSourceRegister
   with RelationProvider with SchemaRelationProvider with CreatableRelationProvider
   with LazyLogging {
+
   import CaseInsensitiveMapFix._
+
+  import scala.collection.JavaConverters._
 
   override def shortName(): String = "geomesa"
 
@@ -77,7 +80,9 @@ class GeoMesaDataSource extends DataSourceRegister
     //  Below the details of the Converter RDD Provider and Providers which are backed by GT DSes are leaking through
     val ds = DataStoreFinder.getDataStore(parameters)
     val sft = if (ds != null) {
-      ds.getSchema(parameters(GEOMESA_SQL_FEATURE))
+      try { ds.getSchema(parameters(GEOMESA_SQL_FEATURE)) } finally {
+        ds.dispose()
+      }
     } else {
       if (parameters.contains(GEOMESA_SQL_FEATURE) && parameters.contains("geomesa.sft")) {
         SimpleFeatureTypes.createType(parameters(GEOMESA_SQL_FEATURE), parameters("geomesa.sft"))
@@ -86,7 +91,6 @@ class GeoMesaDataSource extends DataSourceRegister
           case Right(s) => s
           case Left(e) => throw new IllegalArgumentException("Could not resolve simple feature type", e)
         }
-
       }
     }
     logger.trace(s"Creating GeoMesa Relation with sft : $sft")
@@ -98,7 +102,11 @@ class GeoMesaDataSource extends DataSourceRegister
   // JNH: Q: Why doesn't this method have the call to SQLTypes.init(sqlContext)?
   override def createRelation(sqlContext: SQLContext, parameters: Map[String, String], schema: StructType): BaseRelation = {
     val ds = DataStoreFinder.getDataStore(parameters)
-    val sft = ds.getSchema(parameters(GEOMESA_SQL_FEATURE))
+    val sft = try { ds.getSchema(parameters(GEOMESA_SQL_FEATURE)) } finally {
+      if (ds != null) {
+        ds.dispose()
+      }
+    }
     GeoMesaRelation(sqlContext, sft, schema, parameters)
   }
 
@@ -170,45 +178,52 @@ class GeoMesaDataSource extends DataSourceRegister
 
     // reuse the __fid__ if available for joins,
     // otherwise use a random id prefixed with the current time
-    val fidIndex = data.schema.fields.indexWhere(_.name == "__fid__")
-    val fidFn: Row => String =
-      if(fidIndex > -1) (row: Row) => row.getString(fidIndex)
-      else _ => "%d%s".format(Instant.now().getEpochSecond, UUID.randomUUID().toString)
-
+    val fidFn: Row => String = data.schema.fields.indexWhere(_.name == "__fid__") match {
+      case -1 => _ => TimeSortedUuidGenerator.createUuid().toString
+      case i  => r => r.getString(i)
+    }
 
     val ds = DataStoreFinder.getDataStore(parameters)
-    val schemaInDs = ds.getTypeNames.contains(newFeatureName)
-
-    if (schemaInDs) {
-      if (compare(ds.getSchema(newFeatureName),sft) != 0) {
-        throw new IllegalStateException(s"The schema of the RDD conflicts with schema:$newFeatureName in the data store")
+    try {
+      if (ds.getTypeNames.contains(newFeatureName)) {
+        val existing = ds.getSchema(newFeatureName)
+          if (!compatible(existing, sft)) {
+          throw new IllegalStateException("The dataframe is not compatible with the existing schema in the datastore:" +
+                  s"\n  Dataframe schema: ${SimpleFeatureTypes.encodeType(sft)}" +
+                  s"\n  Datastore schema: ${SimpleFeatureTypes.encodeType(existing)}")
+        }
+      } else {
+        sft.getUserData.put("override.reserved.words", java.lang.Boolean.TRUE)
+        ds.createSchema(sft)
       }
-    } else {
-      sft.getUserData.put("override.reserved.words", java.lang.Boolean.TRUE)
-      ds.createSchema(sft)
+    } finally {
+      if (ds != null) {
+        ds.dispose()
+      }
     }
 
-
-    val structType = if (data.queryExecution == null) {
-      sft2StructType(sft)
-    } else {
-      data.schema
-    }
+    val structType = if (data.queryExecution == null) { sft2StructType(sft) } else { data.schema }
 
     val rddToSave: RDD[SimpleFeature] = data.rdd.mapPartitions( iterRow => {
       val innerDS = DataStoreFinder.getDataStore(parameters)
-      val sft = innerDS.getSchema(newFeatureName)
-      val builder = new SimpleFeatureBuilder(sft)
-
-      val nameMappings: List[(String, Int)] = SparkUtils.getSftRowNameMappings(sft, structType)
-      iterRow.map { r =>
-        SparkUtils.row2Sf(nameMappings, r, builder, fidFn(r))
+      val sft = try { innerDS.getSchema(newFeatureName) } finally {
+        innerDS.dispose()
       }
+      val mappings = SparkUtils.sftToRowMappings(sft, structType)
+      iterRow.map(r => SparkUtils.row2Sf(sft, mappings, r, fidFn(r)))
     })
 
     GeoMesaSpark(parameters).save(rddToSave, parameters, newFeatureName)
 
     GeoMesaRelation(sqlContext, sft, data.schema, parameters)
+  }
+
+  // are schemas compatible? we're flexible with order, but require the same number, names and types
+  private def compatible(sft: SimpleFeatureType, dataframe: SimpleFeatureType): Boolean = {
+    sft.getAttributeCount == dataframe.getAttributeCount && sft.getAttributeDescriptors.asScala.forall { ad =>
+      val df = dataframe.getDescriptor(ad.getLocalName)
+      df != null && ad.getType.getBinding.isAssignableFrom(df.getType.getBinding)
+    }
   }
 }
 
@@ -761,21 +776,24 @@ object SparkUtils {
   }
 
   // Since each attribute's corresponding index in the Row is fixed. Compute the mapping once
-  def getSftRowNameMappings(sft: SimpleFeatureType, schema: StructType): List[(String, Int)] = {
-    sft.getAttributeDescriptors.map{ ad =>
-      val name = ad.getLocalName
-      (name, schema.fieldIndex(ad.getLocalName))
-    }.toList
-  }
+  def sftToRowMappings(sft: SimpleFeatureType, schema: StructType): Seq[(Int, Int)] =
+    Seq.tabulate(sft.getAttributeCount)(i => i -> schema.fieldIndex(sft.getDescriptor(i).getLocalName))
 
-  def row2Sf(nameMappings: List[(String, Int)], row: Row, builder: SimpleFeatureBuilder, id: String): SimpleFeature = {
-    builder.reset()
-    nameMappings.foreach{ case (name, index) =>
-      builder.set(name, row.getAs[Object](index))
-    }
-
-    builder.userData(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
-    builder.buildFeature(id)
+  /**
+    * Convert a dataframe row to a simple feature
+    *
+    * @param sft simple feature type
+    * @param mappings sft attribute -> row index
+    * @param row row
+    * @param id feature id
+    * @return
+    */
+  def row2Sf(sft: SimpleFeatureType, mappings: Seq[(Int, Int)], row: Row, id: String): SimpleFeature = {
+    val userData = new java.util.HashMap[AnyRef, AnyRef](1)
+    userData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+    val feature = new ScalaSimpleFeature(sft, id, null, userData)
+    mappings.foreach { case (to, from) => feature.setAttributeNoConvert(to, row.getAs[Object](from)) }
+    feature
   }
 }
 

--- a/geomesa-spark/geomesa-spark-sql/src/test/scala/org/locationtech/geomesa/spark/SparkSQLColumnsTest.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/test/scala/org/locationtech/geomesa/spark/SparkSQLColumnsTest.scala
@@ -1,0 +1,161 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.spark
+
+import java.util.{Collections, UUID}
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.spark.sql.jts.JTSTypes
+import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.{SQLContext, SQLTypes, SparkSession}
+import org.geotools.data.{DataStore, DataStoreFinder, Transaction}
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.utils.geotools.{FeatureUtils, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.io.WithClose
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class SparkSQLColumnsTest extends Specification with LazyLogging {
+
+  import scala.collection.JavaConverters._
+
+  sequential
+
+  var ds: DataStore = _
+  var spark: SparkSession = _
+  var sc: SQLContext = _
+
+  val spec =
+    """int:Integer,
+      |long:Long,
+      |float:Float,
+      |double:Double,
+      |uuid:UUID,
+      |string:String,
+      |boolean:Boolean,
+      |dtg:Date,
+      |time:Timestamp,
+      |bytes:Bytes,
+      |list:List[String],
+      |map:Map[String,Integer],
+      |line:LineString:srid=4326,
+      |poly:Polygon:srid=4326,
+      |points:MultiPoint:srid=4326,
+      |lines:MultiLineString:srid=4326,
+      |polys:MultiPolygon:srid=4326,
+      |geoms:GeometryCollection:srid=4326,
+      |*point:Point:srid=4326
+    """.stripMargin
+
+  lazy val sft = SimpleFeatureTypes.createType("complex", spec)
+  lazy val sf = {
+    val sf = new ScalaSimpleFeature(sft, "0")
+    sf.setAttribute("int", "1")
+    sf.setAttribute("long", "-100")
+    sf.setAttribute("float", "1.0")
+    sf.setAttribute("double", "5.37")
+    sf.setAttribute("uuid", UUID.randomUUID())
+    sf.setAttribute("string", "mystring")
+    sf.setAttribute("boolean", "false")
+    sf.setAttribute("dtg", "2013-01-02T00:00:00.000Z")
+    sf.setAttribute("time", "2013-01-02T00:00:00.000Z")
+    sf.setAttribute("bytes", Array[Byte](0, 1))
+    sf.setAttribute("list", Collections.singletonList("mylist"))
+    sf.setAttribute("map", Collections.singletonMap("mykey", 1))
+    sf.setAttribute("line", "LINESTRING(0 2, 2 0, 8 6)")
+    sf.setAttribute("poly", "POLYGON((20 10, 30 0, 40 10, 30 20, 20 10))")
+    sf.setAttribute("points", "MULTIPOINT(0 0, 2 2)")
+    sf.setAttribute("lines", "MULTILINESTRING((0 2, 2 0, 8 6),(0 2, 2 0, 8 6))")
+    sf.setAttribute("polys", "MULTIPOLYGON(((-1 0, 0 1, 1 0, 0 -1, -1 0)), ((-2 6, 1 6, 1 3, -2 3, -2 6)), ((-1 5, 2 5, 2 2, -1 2, -1 5)))")
+    sf.setAttribute("geoms", "GEOMETRYCOLLECTION(POINT(45.0 49.0),POINT(45.1 49.1))")
+    sf.setAttribute("point", "POINT(45.0 49.0)")
+    sf
+  }
+
+  // we turn off the geo-index on the CQEngine DataStore because
+  // BucketIndex doesn't do polygon <-> polygon comparisons properly;
+  // acceptable performance-wise because the test data set is small
+  val dsParams = Map(
+    "geotools" -> "true",
+    "cqengine" -> "true",
+    "useGeoIndex" -> "false"
+  )
+
+  // before
+  step {
+    ds = DataStoreFinder.getDataStore(dsParams.asJava)
+    spark = SparkSQLTestUtils.createSparkSession()
+    sc = spark.sqlContext
+    SQLTypes.init(sc)
+
+    ds.createSchema(sft)
+
+    WithClose(ds.getFeatureWriterAppend(sft.getTypeName, Transaction.AUTO_COMMIT)) { writer =>
+      FeatureUtils.copyToWriter(writer, sf, useProvidedFid = true)
+      writer.write()
+    }
+
+    val df = spark.read
+        .format("geomesa")
+        .options(dsParams)
+        .option("geomesa.feature", sft.getTypeName)
+        .load()
+
+    logger.debug(df.schema.treeString)
+    df.createOrReplaceTempView(sft.getTypeName)
+  }
+
+  "GeoMesaSparkSQL" should {
+
+    "map appropriate column types" in {
+      val df = sc.sql(s"select * from ${sft.getTypeName}")
+
+      val expected = Seq(
+        "__fid__" -> DataTypes.StringType,
+        "int"     -> DataTypes.IntegerType,
+        "long"    -> DataTypes.LongType,
+        "float"   -> DataTypes.FloatType,
+        "double"  -> DataTypes.DoubleType,
+        "string"  -> DataTypes.StringType,
+        "boolean" -> DataTypes.BooleanType,
+        "dtg"     -> DataTypes.TimestampType,
+        "time"    -> DataTypes.TimestampType,
+        "line"    -> JTSTypes.LineStringTypeInstance,
+        "poly"    -> JTSTypes.PolygonTypeInstance,
+        "points"  -> JTSTypes.MultiPointTypeInstance,
+        "lines"   -> JTSTypes.MultiLineStringTypeInstance,
+        "polys"   -> JTSTypes.MultipolygonTypeInstance,
+        "geoms"   -> JTSTypes.GeometryTypeInstance,
+        "point"   -> JTSTypes.PointTypeInstance
+      )
+
+      val schema = df.schema
+      schema must haveLength(16) // note: bytes, list, map not supported
+      schema.map(_.name) mustEqual expected.map(_._1)
+      schema.map(_.dataType) mustEqual expected.map(_._2)
+
+      val result = df.collect()
+      result must haveLength(1)
+
+      val row = result.head
+
+      // note: have to compare backwards so that java.util.Date == java.sql.Timestamp
+      Seq(sf.getID) ++ expected.drop(1).map { case (n, _) => sf.getAttribute(n) } mustEqual
+          Seq.tabulate(16)(i => row.get(i))
+    }
+  }
+
+  // after
+  step {
+    ds.dispose()
+    spark.stop()
+  }
+}

--- a/geomesa-spark/geomesa_pyspark/pom.xml
+++ b/geomesa-spark/geomesa_pyspark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa_pyspark/pom.xml
+++ b/geomesa-spark/geomesa_pyspark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/geomesa_pyspark/pom.xml
+++ b/geomesa-spark/geomesa_pyspark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-spark_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/pom.xml
+++ b/geomesa-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/pom.xml
+++ b/geomesa-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-spark/pom.xml
+++ b/geomesa-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-stream/geomesa-stream-api/pom.xml
+++ b/geomesa-stream/geomesa-stream-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-stream_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-stream/geomesa-stream-api/pom.xml
+++ b/geomesa-stream/geomesa-stream-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-stream_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-stream/geomesa-stream-api/pom.xml
+++ b/geomesa-stream/geomesa-stream-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-stream_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-stream/geomesa-stream-datastore/pom.xml
+++ b/geomesa-stream/geomesa-stream-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-stream_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-stream/geomesa-stream-datastore/pom.xml
+++ b/geomesa-stream/geomesa-stream-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-stream_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-stream/geomesa-stream-datastore/pom.xml
+++ b/geomesa-stream/geomesa-stream-datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-stream_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-stream/geomesa-stream-generic/pom.xml
+++ b/geomesa-stream/geomesa-stream-generic/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-stream_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-stream/geomesa-stream-generic/pom.xml
+++ b/geomesa-stream/geomesa-stream-generic/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-stream_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-stream/geomesa-stream-generic/pom.xml
+++ b/geomesa-stream/geomesa-stream-generic/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-stream_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-stream/geomesa-stream-gs-plugin/pom.xml
+++ b/geomesa-stream/geomesa-stream-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-stream/geomesa-stream-gs-plugin/pom.xml
+++ b/geomesa-stream/geomesa-stream-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-stream/geomesa-stream-gs-plugin/pom.xml
+++ b/geomesa-stream/geomesa-stream-gs-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa-archetypes-gs-plugin_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../geomesa-archetypes/geomesa-archetypes-gs-plugin/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-stream/pom.xml
+++ b/geomesa-stream/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-stream/pom.xml
+++ b/geomesa-stream/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-stream/pom.xml
+++ b/geomesa-stream/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-tools/pom.xml
+++ b/geomesa-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-tools/pom.xml
+++ b/geomesa-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-tools/pom.xml
+++ b/geomesa-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/data/ManagePartitionsCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/data/ManagePartitionsCommand.scala
@@ -20,6 +20,7 @@ import org.locationtech.geomesa.tools.utils.ParameterConverters.IntervalConverte
 import org.locationtech.geomesa.tools.utils.Prompt
 import org.locationtech.geomesa.utils.index.IndexMode
 import org.locationtech.geomesa.utils.text.StringSerialization
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.opengis.feature.simple.SimpleFeatureType
 
 /**
@@ -92,7 +93,7 @@ object ManagePartitionsCommand {
       }
       val (start, end) = {
         val (s, e) = new IntervalConverter("value").convert(params.value)
-        (ZonedDateTime.ofInstant(s.toInstant, ZoneOffset.UTC), ZonedDateTime.ofInstant(e.toInstant, ZoneOffset.UTC))
+        (ZonedDateTime.ofInstant(toInstant(s), ZoneOffset.UTC), ZonedDateTime.ofInstant(toInstant(e), ZoneOffset.UTC))
       }
       val tables = params.tables.asScala
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/data/ManagePartitionsCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/data/ManagePartitionsCommand.scala
@@ -12,6 +12,7 @@ import java.time.{ZoneOffset, ZonedDateTime}
 
 import com.beust.jcommander.{JCommander, Parameter, ParameterException, Parameters}
 import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
 import org.locationtech.geomesa.index.conf.partition.{TablePartition, TimePartition}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.tools._
@@ -110,22 +111,25 @@ object ManagePartitionsCommand {
         val version = s"v${index.version}"
         (index, name, attributes, version)
       }
-      val indicesAndTables = tables.map { table =>
-        val matchedByName = indexNames.filter { case (_, n, _, v) => table.contains(n) && table.contains(v) }
-        if (matchedByName.lengthCompare(1) == 0) {
-          (matchedByName.head._1, table)
-        } else {
-          val matchedByAttributes = matchedByName.filter(m => table.contains(m._3))
-          if (matchedByAttributes.lengthCompare(1) == 0) {
-            (matchedByAttributes.head._1, table)
+      val tableToIndexName = indexNames
+        .toList
+        .sortWith(_._3.size > _._3.size) // Sorted so we get best match first
+        .foldLeft(Map[String,(GeoMesaFeatureIndex[_,_],String,String,String)]()){
+          (mappedTables,indexName) =>
+          val fullMatches = tables.filter(table =>
+            !mappedTables.contains(table) // Don't match again
+              && table.contains(indexName._2) // Correct type name as in z3, attr, id...
+              && table.contains(indexName._3) // Correct attributes
+              && table.contains(indexName._4) // Correct version
+          )
+          if (fullMatches.lengthCompare(1) >= 0) {
+            mappedTables + (fullMatches.head -> indexName)
           } else {
-            throw new IllegalArgumentException(s"Could not match an index to table '$table'")
+           throw new IllegalArgumentException(s"Could not match a table to an index of '${indexName._3}'")
           }
         }
-      }
-
-      indicesAndTables.foreach { case (index, table) =>
-        ds.metadata.insert(sft.getTypeName, index.tableNameKey(Some(params.partition)), table)
+      tableToIndexName.foreach { case (table, indexName) =>
+          ds.metadata.insert(sft.getTypeName, indexName._1.tableNameKey(Some(params.partition)), table)
       }
       time.register(params.partition, start, end)
 

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/IngestCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/IngestCommand.scala
@@ -27,6 +27,7 @@ import org.locationtech.geomesa.tools._
 import org.locationtech.geomesa.tools.ingest.IngestCommand.IngestParams
 import org.locationtech.geomesa.tools.utils.{CLArgResolver, Prompt}
 import org.locationtech.geomesa.utils.collection.CloseableIterator
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
 import org.locationtech.geomesa.utils.geotools.{ConfigSftParsing, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.io.fs.LocalDelegate.StdInHandle
 import org.locationtech.geomesa.utils.io.{CloseWithLogging, PathUtils, WithClose}
@@ -128,6 +129,8 @@ trait IngestCommand[DS <: DataStore] extends DataStoreCommand[DS] with Interacti
 }
 
 object IngestCommand extends LazyLogging {
+
+  val LocalBatchSize = SystemProperty("geomesa.ingest.local.batch.size", "20000")
 
   // @Parameters(commandDescription = "Ingest/convert various file formats into GeoMesa")
   trait IngestParams extends OptionalTypeNameParam with OptionalFeatureSpecParam with OptionalForceParam

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/LocalConverterIngest.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/LocalConverterIngest.scala
@@ -8,13 +8,12 @@
 
 package org.locationtech.geomesa.tools.ingest
 
-import java.util.concurrent.Executors
+import java.io.Flushable
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+import java.util.concurrent.{ConcurrentHashMap, Executors}
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.commons.pool2.impl.{DefaultPooledObject, GenericObjectPool}
-import org.apache.commons.pool2.{BasePooledObjectFactory, PooledObject}
 import org.geotools.data.{DataStore, DataUtilities, FeatureWriter, Transaction}
 import org.locationtech.geomesa.convert.{DefaultCounter, EvaluationContext}
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
@@ -25,7 +24,7 @@ import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.locationtech.geomesa.utils.geotools.FeatureUtils
 import org.locationtech.geomesa.utils.io.fs.FileSystemDelegate.FileHandle
 import org.locationtech.geomesa.utils.io.fs.LocalDelegate.StdInHandle
-import org.locationtech.geomesa.utils.io.{CloseWithLogging, PathUtils, WithClose}
+import org.locationtech.geomesa.utils.io.{CloseWithLogging, CloseablePool, PathUtils, WithClose}
 import org.locationtech.geomesa.utils.text.TextTools
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
@@ -59,13 +58,22 @@ class LocalConverterIngest(
   override protected def runIngest(ds: DataStore, sft: SimpleFeatureType, callback: StatusCallback): Unit = {
     Command.user.info("Running ingestion in local mode")
 
-    val converters = new GenericObjectPool[SimpleFeatureConverter](
-      new BasePooledObjectFactory[SimpleFeatureConverter] {
-        override def wrap(obj: SimpleFeatureConverter) = new DefaultPooledObject[SimpleFeatureConverter](obj)
-        override def create(): SimpleFeatureConverter = SimpleFeatureConverter(sft, converterConfig)
-        override def destroyObject(p: PooledObject[SimpleFeatureConverter]): Unit = p.getObject.close()
-      }
-    )
+    val start = System.currentTimeMillis()
+
+    // if inputs is empty, we've already validated that stdin has data to read
+    val stdin = inputs.isEmpty
+    val files = if (stdin) { StdInHandle.available().toSeq } else { inputs.flatMap(PathUtils.interpretPath) }
+
+    val threads = if (numThreads <= files.length) { numThreads } else {
+      Command.user.warn("Can't use more threads than there are input files - reducing thread count")
+      files.length
+    }
+
+    val batch = IngestCommand.LocalBatchSize.toInt.getOrElse {
+      throw new IllegalArgumentException(
+        s"Invalid batch size for property ${IngestCommand.LocalBatchSize.property}: " +
+            IngestCommand.LocalBatchSize.get)
+    }
 
     // global counts shared among threads
     val written = new AtomicLong(0)
@@ -74,100 +82,103 @@ class LocalConverterIngest(
 
     val bytesRead = new AtomicLong(0L)
 
-    class LocalIngestWorker(file: FileHandle) extends Runnable {
-      override def run(): Unit = {
-        try {
-          val converter = converters.borrowObject()
-          val counter = new LocalIngestCounter(failed)
-          val ec = converter.createEvaluationContext(EvaluationContext.inputFileParam(file.path), counter = counter)
+    val converters = CloseablePool(SimpleFeatureConverter(sft, converterConfig), threads)
+    val writers = CloseablePool(ds.getFeatureWriterAppend(sft.getTypeName, Transaction.AUTO_COMMIT), threads)
+    val batches = new ConcurrentHashMap[FeatureWriter[SimpleFeatureType, SimpleFeature], AtomicInteger](threads)
 
-          var fw: FeatureWriter[SimpleFeatureType, SimpleFeature] = null
-
+    try {
+      class LocalIngestWorker(file: FileHandle) extends Runnable {
+        override def run(): Unit = {
           try {
-            WithClose(file.open) { streams =>
-              streams.foreach { case (name, is) =>
-                ec.setInputFilePath(name.getOrElse(file.path))
-                val features = LocalConverterIngest.this.features(converter.process(is, ec))
-                if (fw == null && features.hasNext) {
-                  fw = ds.getFeatureWriterAppend(sft.getTypeName, Transaction.AUTO_COMMIT)
-                }
-                features.foreach { sf =>
-                  FeatureUtils.copyToWriter(fw, sf, useProvidedFid = true)
-                  try {
-                    fw.write()
-                    written.incrementAndGet()
-                  } catch {
-                    case NonFatal(e) =>
-                      logger.error(s"Failed to write '${DataUtilities.encodeFeature(sf)}'", e)
-                      failed.incrementAndGet()
+            converters.borrow { converter =>
+              val counter = new LocalIngestCounter(failed)
+              val ec = converter.createEvaluationContext(EvaluationContext.inputFileParam(file.path), counter = counter)
+              WithClose(file.open) { streams =>
+                streams.foreach { case (name, is) =>
+                  ec.setInputFilePath(name.getOrElse(file.path))
+                  val features = LocalConverterIngest.this.features(converter.process(is, ec))
+                  writers.borrow { writer =>
+                    var count = batches.get(writer)
+                    if (count == null) {
+                      count = new AtomicInteger(0)
+                      batches.put(writer, count)
+                    }
+                    features.foreach { sf =>
+                      FeatureUtils.copyToWriter(writer, sf, useProvidedFid = true)
+                      try {
+                        writer.write()
+                        written.incrementAndGet()
+                        count.incrementAndGet()
+                      } catch {
+                        case NonFatal(e) =>
+                          logger.error(s"Failed to write '${DataUtilities.encodeFeature(sf)}'", e)
+                          failed.incrementAndGet()
+                      }
+                      if (count.get % batch == 0) {
+                        count.set(0)
+                        writer match {
+                          case f: Flushable => f.flush()
+                          case _ => // no-op
+                        }
+                      }
+                    }
                   }
                 }
               }
             }
-          } finally {
-            converters.returnObject(converter)
-            bytesRead.addAndGet(file.length)
-            if (fw != null) {
-              fw.close() // allow exception to propagate
-            }
-          }
-        } catch {
-          case e @ (_: ClassNotFoundException | _: NoClassDefFoundError) =>
-            // Rethrow exception so it can be caught by getting the future of this runnable in the main thread
-            // which will in turn cause the exception to be handled by org.locationtech.geomesa.tools.Runner
-            // Likely all threads will fail if a dependency is missing so it will terminate quickly
-            throw e
+          } catch {
+            case e @ (_: ClassNotFoundException | _: NoClassDefFoundError) =>
+              // Rethrow exception so it can be caught by getting the future of this runnable in the main thread
+              // which will in turn cause the exception to be handled by org.locationtech.geomesa.tools.Runner
+              // Likely all threads will fail if a dependency is missing so it will terminate quickly
+              throw e
 
-          case NonFatal(e) =>
-            // Don't kill the entire program b/c this thread was bad! use outer try/catch
-            val msg = s"Fatal error running local ingest worker on ${file.path}"
-            Command.user.error(msg)
-            logger.error(msg, e)
-            errors.incrementAndGet()
+            case NonFatal(e) =>
+              // Don't kill the entire program b/c this thread was bad! use outer try/catch
+              val msg = s"Fatal error running local ingest worker on ${file.path}"
+              Command.user.error(msg)
+              logger.error(msg, e)
+              errors.incrementAndGet()
+          } finally {
+            bytesRead.addAndGet(file.length)
+          }
         }
       }
+
+      Command.user.info(s"Ingesting ${if (stdin) { "from stdin" } else { TextTools.getPlural(files.length, "file") }} " +
+          s"with ${TextTools.getPlural(threads, "thread")}")
+
+      val totalLength: () => Float = if (stdin) {
+        () => (bytesRead.get + files.map(_.length).sum).toFloat // re-evaluate each time as bytes are read from stdin
+      } else {
+        val length = files.map(_.length).sum.toFloat // only evaluate once
+        () => length
+      }
+
+      def progress(): Float = bytesRead.get() / totalLength()
+
+      val start = System.currentTimeMillis()
+      val es = Executors.newFixedThreadPool(threads)
+      val futures = files.map(f => es.submit(new LocalIngestWorker(f))).toList
+      es.shutdown()
+
+      def counters = Seq(("ingested", written.get()), ("failed", failed.get()))
+
+      while (!es.isTerminated) {
+        Thread.sleep(500)
+        callback("", progress(), counters, done = false)
+      }
+      callback("", progress(), counters, done = true)
+
+      CloseWithLogging(converters)
+
+      // Get all futures so that we can propagate the logging up to the top level for handling
+      // in org.locationtech.geomesa.tools.Runner to catch missing dependencies
+      futures.foreach(_.get)
+    } finally {
+      CloseWithLogging(converters)
+      CloseWithLogging(writers).foreach(_ => errors.incrementAndGet())
     }
-
-    // if inputs is empty, we've already validated that stdin has data to read
-    val stdin = inputs.isEmpty
-
-    val files = if (stdin) { StdInHandle.available().toSeq } else { inputs.flatMap(PathUtils.interpretPath) }
-
-    val threads = if (numThreads <= files.length) { numThreads } else {
-      Command.user.warn("Can't use more threads than there are input files - reducing thread count")
-      files.length
-    }
-
-    Command.user.info(s"Ingesting ${if (stdin) { "from stdin" } else { TextTools.getPlural(files.length, "file") }} " +
-        s"with ${TextTools.getPlural(threads, "thread")}")
-
-    val totalLength: () => Float = if (stdin) {
-      () => (bytesRead.get + files.map(_.length).sum).toFloat // re-evaluate each time as bytes are read from stdin
-    } else {
-      val length = files.map(_.length).sum.toFloat // only evaluate once
-      () => length
-    }
-
-    def progress(): Float = bytesRead.get() / totalLength()
-
-    val start = System.currentTimeMillis()
-    val es = Executors.newFixedThreadPool(threads)
-    val futures = files.map(f => es.submit(new LocalIngestWorker(f))).toList
-    es.shutdown()
-
-    def counters = Seq(("ingested", written.get()), ("failed", failed.get()))
-
-    while (!es.isTerminated) {
-      Thread.sleep(500)
-      callback("", progress(), counters, done = false)
-    }
-    callback("", progress(), counters, done = true)
-
-    CloseWithLogging(converters)
-
-    // Get all futures so that we can propagate the logging up to the top level for handling
-    // in org.locationtech.geomesa.tools.Runner to catch missing dependencies
-    futures.foreach(_.get)
 
     Command.user.info(s"Local ingestion complete in ${TextTools.getTime(start)}")
     if (files.lengthCompare(1) == 0) {

--- a/geomesa-utils/pom.xml
+++ b/geomesa-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-utils/pom.xml
+++ b/geomesa-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-utils/pom.xml
+++ b/geomesa-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/date/DateUtils.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/date/DateUtils.scala
@@ -1,0 +1,28 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.date
+
+import java.time.Instant
+import java.util.Date
+
+/**
+  * Date utilities
+  */
+object DateUtils {
+
+  /**
+    * Converts this {@code Date} object to an {@code Instant}.
+    *
+    * Note: we can't use Date.toInstant, as java.sql.Date does not implement that method
+    *
+    * @param date
+    * @return
+    */
+  def toInstant(date: Date): Instant = Instant.ofEpochMilli(date.getTime)
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geohash/GeohashUtils.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geohash/GeohashUtils.scala
@@ -364,14 +364,18 @@ object GeohashUtils
     val height = ur.getY - ll.getY
     require(width >= 0 && height >= 0, s"Wrong width $width and height $height of input bounding box, cannot process")
 
-    (60 to 0 by -5).foreach(prec => {
+    var prec = 60
+    while (prec >= 0) {
       val lonDelta = GeoHash.longitudeDeltaForPrecision(prec)
       val latDelta = GeoHash.latitudeDeltaForPrecision(prec)
       if (lonDelta >= width && latDelta >= height) {
         val geo = GeoHash(ll.getX, ll.getY, prec)
-        if (geo.bbox.covers(ur)) return Some(geo)
+        if (geo.bbox.covers(ur)) {
+          return Some(geo)
+        }
       }
-    })
+      prec -= 5
+    }
     None
   }
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/converters/FastConverter.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/converters/FastConverter.scala
@@ -56,17 +56,19 @@ object FastConverter extends StrictLogging {
       cache.put((clas, binding), converters)
     }
 
-    converters.foreach { converter =>
+    var i = 0
+    while (i < converters.length) {
       try {
-        val result = converter.convert(value, binding)
+        val result = converters(i).convert(value, binding)
         if (result != null) {
           return result
         }
       } catch {
         case NonFatal(e) =>
           logger.trace(s"Error converting $value (of type ${value.getClass.getName}) " +
-            s"to ${binding.getName} using converter ${converter.getClass.getName}:", e)
+              s"to ${binding.getName} using converter ${converters(i).getClass.getName}:", e)
       }
+      i += 1
     }
 
     logger.warn(s"Could not convert '$value' (of type ${value.getClass.getName}) to ${binding.getName}")

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/CloseablePool.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/CloseablePool.scala
@@ -1,0 +1,75 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.io
+
+import java.io.Closeable
+
+import org.apache.commons.pool2.impl.{DefaultPooledObject, GenericObjectPool, GenericObjectPoolConfig}
+import org.apache.commons.pool2.{BasePooledObjectFactory, PooledObject}
+
+/**
+  * Pool for sharing a finite set of closeable resources
+  *
+  * @tparam T object type
+  */
+trait CloseablePool[T <: Closeable] extends Closeable {
+
+  /**
+    * Borrow an item from the pool. The item will be returned to the pool after execution.
+    *
+    * @param fn function to execute on the borrowed item
+    * @tparam U return type
+    * @return
+    */
+  def borrow[U](fn: T => U): U
+}
+
+object CloseablePool {
+
+  /**
+    * Create a pool
+    *
+    * @param factory method for instantiating pool objects
+    * @param size max size of the pool
+    * @tparam T object type
+    * @return
+    */
+  def apply[T <: Closeable](factory: => T, size: Int = 8): CloseablePool[T] = {
+    val config = new GenericObjectPoolConfig[T]()
+    config.setMaxTotal(size)
+    new CommonsPoolPool(factory, config)
+  }
+
+  /**
+    * Apache commons-pool-backed pool
+    *
+    * @param create factory method for creating new pool objects
+    * @param config pool configuration options
+    * @tparam T object type
+    */
+  class CommonsPoolPool[T <: Closeable](create: => T, config: GenericObjectPoolConfig[T]) extends CloseablePool[T] {
+
+    private val factory: BasePooledObjectFactory[T] = new BasePooledObjectFactory[T] {
+      override def wrap(obj: T) = new DefaultPooledObject[T](obj)
+      override def create(): T = CommonsPoolPool.this.create
+      override def destroyObject(p: PooledObject[T]): Unit = p.getObject.close()
+    }
+
+    private val pool = new GenericObjectPool[T](factory, config)
+
+    override def borrow[U](fn: T => U): U = {
+      val t = pool.borrowObject()
+      try { fn(t) } finally {
+        pool.returnObject(t)
+      }
+    }
+
+    override def close(): Unit = pool.close()
+  }
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/DescriptiveStats.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/DescriptiveStats.scala
@@ -23,7 +23,7 @@ class DescriptiveStats private [stats] (val sft: SimpleFeatureType,
   @deprecated("properties")
   lazy val attributes: Seq[Int] = properties.map(sft.indexOf)
 
-  private val indices = properties.map(sft.indexOf)
+  private val indices = properties.map(sft.indexOf).toArray
 
   private val size = properties.size
   private val size_squared = size * size
@@ -123,20 +123,27 @@ class DescriptiveStats private [stats] (val sft: SimpleFeatureType,
     if (_count < count) Array.fill(length)(Double.NaN) else op.getMatrix.data.clone()
 
   override def observe(sf: SimpleFeature): Unit = {
-    val values = indices.map(sf.getAttribute).map {
-      case n: Number =>
-        val double = n.doubleValue()
-        if (double != double) {
-          return // NaN, short-circuit evaluation
-        }
-        double
+    val values = Array.newBuilder[Double]
+    values.sizeHint(indices.length)
 
-      case null => return // short-circuit evaluation
+    var i = 0
+    while (i < indices.length) {
+      sf.getAttribute(indices(i)) match {
+        case n: Number =>
+          val double = n.doubleValue()
+          if (double != double) {
+            return // NaN, short-circuit evaluation
+          }
+          values += double
 
-      case n => throw new IllegalArgumentException(s"Not a number: $n")
+        case null => return // short-circuit evaluation
+
+        case n => throw new IllegalArgumentException(s"Not a number: $n")
+      }
+      i += 1
     }
 
-    val values_v = new SimpleMatrix(size, 1, true, values: _*)
+    val values_v = new SimpleMatrix(size, 1, true, values.result(): _*)
 
     if (_count < 1) {
       _count = 1

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/Stat.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/stats/Stat.scala
@@ -17,7 +17,9 @@ import org.locationtech.jts.geom.Geometry
 import org.apache.commons.text.StringEscapeUtils
 import org.locationtech.geomesa.curve.TimePeriod.TimePeriod
 import org.locationtech.geomesa.utils.geotools._
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.locationtech.geomesa.utils.text.WKTUtils
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import scala.collection.JavaConverters._
@@ -150,7 +152,7 @@ object Stat {
   }
   private val DateSerializer = new JsonSerializer[Date] {
     def serialize(d: Date, t: Type, jsc: JsonSerializationContext): JsonElement =
-      new JsonPrimitive(GeoToolsDateFormat.format(d.toInstant))
+      new JsonPrimitive(GeoToolsDateFormat.format(toInstant(d)))
   }
   private val DoubleSerializer = new JsonSerializer[jDouble]() {
     def serialize(double: jDouble, t: Type, jsc: JsonSerializationContext): JsonElement = double match {
@@ -342,7 +344,7 @@ object Stat {
     val toString: (Any) => String = if (classOf[Geometry].isAssignableFrom(clas)) {
       (v) => WKTUtils.write(v.asInstanceOf[Geometry])
     } else if (clas == classOf[Date]) {
-      (v) => GeoToolsDateFormat.format(v.asInstanceOf[Date].toInstant)
+      (v) => GeoToolsDateFormat.format(toInstant(v.asInstanceOf[Date]))
     } else {
       (v) => v.toString
     }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/text/DateParsing.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/text/DateParsing.scala
@@ -8,6 +8,8 @@
 
 package org.locationtech.geomesa.utils.text
 
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
+
 import java.time._
 import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
 import java.time.temporal.{ChronoField, TemporalAccessor, TemporalQuery}
@@ -119,7 +121,7 @@ object DateParsing {
   def format(value: ZonedDateTime, format: DateTimeFormatter = format): String = value.format(format)
 
   def formatDate(value: Date, format: DateTimeFormatter = format): String =
-    ZonedDateTime.ofInstant(value.toInstant, ZoneOffset.UTC).format(format)
+    ZonedDateTime.ofInstant(toInstant(value), ZoneOffset.UTC).format(format)
 
   def formatInstant(value: Instant, format: DateTimeFormatter = format): String =
     ZonedDateTime.ofInstant(value, ZoneOffset.UTC).format(format)

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/text/StringSerialization.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/text/StringSerialization.scala
@@ -19,6 +19,8 @@ import org.apache.commons.codec.binary.Hex
 import org.apache.commons.csv.{CSVFormat, CSVParser, CSVPrinter}
 import org.opengis.feature.simple.SimpleFeatureType
 
+import org.locationtech.geomesa.utils.date.DateUtils.toInstant
+
 object StringSerialization extends LazyLogging {
 
   private val dateFormat: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneOffset.UTC)
@@ -37,7 +39,7 @@ object StringSerialization extends LazyLogging {
     val printer = new CSVPrinter(sb, CSVFormat.DEFAULT)
     map.foreach { case (k, v) =>
       val strings = v.headOption match {
-        case Some(_: Date) => v.map(d => ZonedDateTime.ofInstant(d.asInstanceOf[Date].toInstant, ZoneOffset.UTC).format(dateFormat))
+        case Some(_: Date) => v.map(d => ZonedDateTime.ofInstant(toInstant(d.asInstanceOf[Date]), ZoneOffset.UTC).format(dateFormat))
         case _ => v
       }
       printer.print(k)

--- a/geomesa-web/geomesa-web-core/pom.xml
+++ b/geomesa-web/geomesa-web-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-web/geomesa-web-core/pom.xml
+++ b/geomesa-web/geomesa-web-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-web/geomesa-web-core/pom.xml
+++ b/geomesa-web/geomesa-web-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-web/geomesa-web-data/pom.xml
+++ b/geomesa-web/geomesa-web-data/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-web/geomesa-web-data/pom.xml
+++ b/geomesa-web/geomesa-web-data/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-web/geomesa-web-data/pom.xml
+++ b/geomesa-web/geomesa-web-data/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-web/geomesa-web-stats/pom.xml
+++ b/geomesa-web/geomesa-web-stats/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-web/geomesa-web-stats/pom.xml
+++ b/geomesa-web/geomesa-web-stats/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-web/geomesa-web-stats/pom.xml
+++ b/geomesa-web/geomesa-web-stats/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>geomesa-web_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-web/pom.xml
+++ b/geomesa-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-web/pom.xml
+++ b/geomesa-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-web/pom.xml
+++ b/geomesa-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/geomesa-z3/pom.xml
+++ b/geomesa-z3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-z3/pom.xml
+++ b/geomesa-z3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-z3/pom.xml
+++ b/geomesa-z3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>geomesa_2.11</artifactId>
         <groupId>org.locationtech.geomesa</groupId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-zk-utils/pom.xml
+++ b/geomesa-zk-utils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-zk-utils/pom.xml
+++ b/geomesa-zk-utils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/geomesa-zk-utils/pom.xml
+++ b/geomesa-zk-utils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.locationtech.geomesa</groupId>
         <artifactId>geomesa_2.11</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.locationtech.geomesa</groupId>
     <artifactId>geomesa_2.11</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.0</version>
+    <version>2.3.1-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.locationtech.geomesa</groupId>
     <artifactId>geomesa_2.11</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.1</version>
 
     <licenses>
         <license>
@@ -2813,7 +2813,7 @@
         <connection>scm:git:git@github.com:locationtech/geomesa.git</connection>
         <developerConnection>scm:git:git@github.com:locationtech/geomesa.git</developerConnection>
         <url>https://github.com/locationtech/geomesa</url>
-        <tag>geomesa_2.11-2.3.0</tag>
+        <tag>geomesa_2.11-2.3.1</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.locationtech.geomesa</groupId>
     <artifactId>geomesa_2.11</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.1</version>
+    <version>2.3.2-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -2813,7 +2813,7 @@
         <connection>scm:git:git@github.com:locationtech/geomesa.git</connection>
         <developerConnection>scm:git:git@github.com:locationtech/geomesa.git</developerConnection>
         <url>https://github.com/locationtech/geomesa</url>
-        <tag>geomesa_2.11-2.3.1</tag>
+        <tag>geomesa_2.11-2.3.0</tag>
     </scm>
 
     <developers>


### PR DESCRIPTION
when I use
geomesa-hbase ingest -c catlog-f test -C convert.conf map.shp
In the Chinese environment, Attribute will appear garbled.
how to set file endofing.

In my code, I can
DataStoreFinder.getDataStore(params).asInstanceOf[ShapefileDataStore].setCharset(Charset.forName("UTF-8")) 
to read shpefile,That is ok,
but i can't set encoding in geomesa commmand-line tools.