### PR TITLE
GEOMESA-2709 Update Cassandra Quickstart Tutorials

### DIFF
--- a/docs/tutorials/geomesa-quickstart-cassandra.rst
+++ b/docs/tutorials/geomesa-quickstart-cassandra.rst
@@ -229,6 +229,8 @@ run the following command from the GeoMesa Cassandra tools distribution director
         --contact-point <host:port> \
         --key-space <keyspace>      \
         --catalog <table>           \
+        -f gdelt-quickstart         \
+        -o <filename>.html          \
         --user <user>               \
         --password <password>
 


### PR DESCRIPTION
* Updates the instructions for running bin/geomesa-cassandra export
  to be aligned with the 2.11-2.4.0-SNAPSHOT version.

Signed-off-by: Ray Zeng <zeng.j.ray@gmail.com>