### PR TITLE
add the application of Google S2 algorithm in point data

### DIFF
--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -87,6 +87,7 @@ io.github.azagniotov:dropwizard-metrics-cloudwatch	1.0.13	compile
 io.netty:netty-all	4.1.17.Final	compile
 io.netty:netty-buffer	4.1.17.Final	compile
 io.netty:netty-common	4.1.17.Final	compile
+io.sgr:s2-geometry-library-java	1.0.1	compile
 it.geosolutions.jaiext.affine:jt-affine	1.1.9	compile
 it.geosolutions.jaiext.algebra:jt-algebra	1.1.9	compile
 it.geosolutions.jaiext.bandcombine:jt-bandcombine	1.1.9	compile

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
@@ -32,14 +32,16 @@ import org.locationtech.geomesa.hbase.coprocessor.aggregators.HBaseDensityAggreg
 import org.locationtech.geomesa.hbase.coprocessor.aggregators.HBaseStatsAggregator.HBaseStatsResultsToFeatures
 import org.locationtech.geomesa.hbase.coprocessor.aggregators.{HBaseArrowAggregator, HBaseBinAggregator, HBaseDensityAggregator, HBaseStatsAggregator}
 import org.locationtech.geomesa.hbase.data.HBaseQueryPlan.{CoprocessorPlan, EmptyPlan, ScanPlan}
-import org.locationtech.geomesa.hbase.filters.{CqlTransformFilter, Z2HBaseFilter, Z3HBaseFilter}
+import org.locationtech.geomesa.hbase.filters._
 import org.locationtech.geomesa.hbase.utils.HBaseVersions
-import org.locationtech.geomesa.index.api.IndexAdapter.{BaseIndexWriter, IndexWriter}
+import org.locationtech.geomesa.index.api.IndexAdapter.BaseIndexWriter
 import org.locationtech.geomesa.index.api.QueryPlan.IndexResultsToFeatures
 import org.locationtech.geomesa.index.api.WritableFeature.FeatureWrapper
 import org.locationtech.geomesa.index.api.{WritableFeature, _}
-import org.locationtech.geomesa.index.filters.{Z2Filter, Z3Filter}
+import org.locationtech.geomesa.index.filters.{S2Filter, S3Filter, Z2Filter, Z3Filter}
 import org.locationtech.geomesa.index.index.id.IdIndex
+import org.locationtech.geomesa.index.index.s2.{S2Index, S2IndexValues}
+import org.locationtech.geomesa.index.index.s3.{S3Index, S3IndexValues}
 import org.locationtech.geomesa.index.index.z2.{Z2Index, Z2IndexValues}
 import org.locationtech.geomesa.index.index.z3.{Z3Index, Z3IndexValues}
 import org.locationtech.geomesa.index.iterators.StatsScan
@@ -245,6 +247,15 @@ class HBaseIndexAdapter(ds: HBaseDataStore) extends IndexAdapter[HBaseDataStore]
               (Z2HBaseFilter.Priority, Z2HBaseFilter(Z2Filter(v), index.keySpace.sharding.length))
             }
 
+          case _: S2Index =>
+            strategy.values.map { case v: S2IndexValues =>
+              (S2HBaseFilter.Priority, S2HBaseFilter(S2Filter(v), index.keySpace.sharding.length))
+            }
+
+          case _: S3Index =>
+            strategy.values.map { case v: S3IndexValues =>
+              (S3HBaseFilter.Priority, S3HBaseFilter(S3Filter(v), index.keySpace.sharding.length))
+            }
           // TODO GEOMESA-1807 deal with non-points in a pushdown XZ filter
 
           case _ => None

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/filters/S2HBaseFilter.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/filters/S2HBaseFilter.scala
@@ -1,0 +1,83 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.hbase.filters
+
+import com.github.benmanes.caffeine.cache.{CacheLoader, Caffeine}
+import com.typesafe.scalalogging.StrictLogging
+import org.apache.hadoop.hbase.Cell
+import org.apache.hadoop.hbase.exceptions.DeserializationException
+import org.apache.hadoop.hbase.filter.{Filter, FilterBase}
+import org.locationtech.geomesa.index.filters.S2Filter
+import org.locationtech.geomesa.utils.cache.ByteArrayCacheKey
+import org.locationtech.geomesa.utils.index.ByteArrays
+
+/**
+  * @author sunyabo 2019年07月31日 10:31
+  * @version V1.0
+  */
+class S2HBaseFilter(filter: S2Filter, offset: Int, bytes: Array[Byte]) extends FilterBase {
+  override def filterKeyValue(v: Cell): Filter.ReturnCode = {
+    if (filter.inBounds(v.getRowArray, v.getRowOffset + offset)) {
+      Filter.ReturnCode.INCLUDE
+    } else {
+      Filter.ReturnCode.SKIP
+    }
+  }
+
+  override def toByteArray: Array[Byte] = bytes
+
+  override def toString: String = s"S2HBaseFilter[$filter]"
+}
+
+object S2HBaseFilter extends StrictLogging {
+
+  import org.locationtech.geomesa.index.FilterCacheSize
+
+  val Priority = 20
+
+  private val cache = Caffeine.newBuilder().maximumSize(FilterCacheSize.toInt.get).build(
+    new CacheLoader[ByteArrayCacheKey, (S2Filter, Int)]() {
+      override def load(key: ByteArrayCacheKey): (S2Filter, Int) = {
+        val filter = S2Filter.deserializeFromBytes(key.bytes)
+        val offset = ByteArrays.readInt(key.bytes, key.bytes.length - 4)
+        logger.trace(s"Deserialized $offset:$filter")
+        (filter, offset)
+      }
+    }
+  )
+
+  /**
+    * Create a new filter. Typically, filters created by this method will just be serialized to bytes and sent
+    * as part of an HBase scan
+    *
+    * @param filter z2 filter
+    * @param offset row offset
+    * @return
+    */
+  def apply(filter: S2Filter, offset: Int): S2HBaseFilter = {
+    val filterBytes = S2Filter.serializeToBytes(filter)
+    val serialized = Array.ofDim[Byte](filterBytes.length + 4)
+    System.arraycopy(filterBytes, 0, serialized, 0, filterBytes.length)
+    ByteArrays.writeInt(offset, serialized, filterBytes.length)
+    new S2HBaseFilter(filter, offset, serialized)
+  }
+
+  /**
+    * Override of static method from org.apache.hadoop.hbase.filter.Filter
+    *
+    * @param pbBytes serialized bytes
+    * @throws org.apache.hadoop.hbase.exceptions.DeserializationException serialization exception
+    * @return
+    */
+  @throws[DeserializationException]
+  def parseFrom(pbBytes: Array[Byte]): Filter = {
+    val (filter, offset) = cache.get(new ByteArrayCacheKey(pbBytes))
+    new S2HBaseFilter(filter, offset, pbBytes)
+  }
+}

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/filters/S3HBaseFilter.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/filters/S3HBaseFilter.scala
@@ -1,0 +1,83 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.hbase.filters
+
+import com.github.benmanes.caffeine.cache.{CacheLoader, Caffeine}
+import com.typesafe.scalalogging.StrictLogging
+import org.apache.hadoop.hbase.Cell
+import org.apache.hadoop.hbase.exceptions.DeserializationException
+import org.apache.hadoop.hbase.filter.{Filter, FilterBase}
+import org.locationtech.geomesa.index.filters.S3Filter
+import org.locationtech.geomesa.utils.cache.ByteArrayCacheKey
+import org.locationtech.geomesa.utils.index.ByteArrays
+
+/**
+  * @author sunyabo 2019年08月01日 09:27
+  * @version V1.0
+  */
+class S3HBaseFilter (filter: S3Filter, offset: Int, bytes: Array[Byte]) extends FilterBase {
+
+  override def filterKeyValue(v: Cell): Filter.ReturnCode = {
+    if (filter.inBounds(v.getRowArray, v.getRowOffset + offset)) {
+      Filter.ReturnCode.INCLUDE
+    } else {
+      Filter.ReturnCode.SKIP
+    }
+  }
+
+  override def toByteArray: Array[Byte] = bytes
+
+  override def toString: String = s"S3HBaseFilter[$filter]"
+}
+
+object S3HBaseFilter extends StrictLogging {
+  import org.locationtech.geomesa.index.FilterCacheSize
+
+  val Priority = 20
+
+  private val cache = Caffeine.newBuilder().maximumSize(FilterCacheSize.toInt.get).build(
+    new CacheLoader[ByteArrayCacheKey, (S3Filter, Int)]() {
+      override def load(key: ByteArrayCacheKey): (S3Filter, Int) = {
+        val filter = S3Filter.deserializeFromBytes(key.bytes)
+        val offset = ByteArrays.readInt(key.bytes, key.bytes.length - 4)
+        logger.trace(s"Deserialized $offset:$filter")
+        (filter, offset)
+      }
+    }
+  )
+
+  /**
+    * Create a new filter. Typically, filters created by this method will just be serialized to bytes and sent
+    * as part of an HBase scan
+    *
+    * @param filter s3 filter
+    * @param offset row offset
+    * @return
+    */
+  def apply(filter: S3Filter, offset: Int): S3HBaseFilter = {
+    val filterBytes = S3Filter.serializeToBytes(filter)
+    val serialized = Array.ofDim[Byte](filterBytes.length + 4)
+    System.arraycopy(filterBytes, 0, serialized, 0, filterBytes.length)
+    ByteArrays.writeInt(offset, serialized, filterBytes.length)
+    new S3HBaseFilter(filter, offset, serialized)
+  }
+
+  /**
+    * Override of static method from org.apache.hadoop.hbase.filter.Filter
+    *
+    * @param pbBytes serialized bytes
+    * @throws org.apache.hadoop.hbase.exceptions.DeserializationException serialization exception
+    * @return
+    */
+  @throws[DeserializationException]
+  def parseFrom(pbBytes: Array[Byte]): Filter = {
+    val (filter, offset) = cache.get(new ByteArrayCacheKey(pbBytes))
+    new S3HBaseFilter(filter, offset, pbBytes)
+  }
+}

--- a/geomesa-index-api/pom.xml
+++ b/geomesa-index-api/pom.xml
@@ -13,6 +13,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.sgr</groupId>
+            <artifactId>s2-geometry-library-java</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
         </dependency>

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryProperties.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryProperties.scala
@@ -24,7 +24,16 @@ object QueryProperties {
   // decomposition is disabled by default
   val PolygonDecompMultiplier = SystemProperty("geomesa.query.decomposition.multiplier", "0")
   val PolygonDecompBits = SystemProperty("geomesa.query.decomposition.bits", "20")
-
+  
+  // S2 parameter configuration
+  val S2CoverConfig = SystemProperty("google.s2.coverer.config", "0,30,1,8")
+    .get.trim.split(",")
+    .map(item => item.toInt)
+  val S2MinLevel = S2CoverConfig(0)
+  val S2MaxLevel = S2CoverConfig(1)
+  val S2LevelMod = S2CoverConfig(2)
+  val S2MaxCells = S2CoverConfig(3)
+  
   // noinspection TypeAnnotation
   // allow for full table scans or preempt them due to size of data set
   val BlockFullTableScans = new SystemProperty("geomesa.scan.block-full-table", "false") {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/S2Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/S2Filter.scala
@@ -1,0 +1,83 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.filters
+
+import java.nio.ByteBuffer
+
+import com.google.common.geometry.S2CellId
+import org.locationtech.geomesa.index.index.s2.S2IndexValues
+import org.locationtech.geomesa.utils.index.ByteArrays
+
+/**
+  * @author sunyabo 2019年07月29日 08:29
+  * @version V1.0
+  */
+class S2Filter(val xy: Array[Array[Double]]) {
+  def inBounds(buf: Array[Byte], offset: Int): Boolean = {
+    val s2CellId = new S2CellId(ByteArrays.readLong(buf, offset))
+    val x = s2CellId.toLatLng.lngDegrees()
+    val y = s2CellId.toLatLng.latDegrees()
+    var i = 0
+    while (i < xy.length) {
+      val xyi = xy(i)
+      if (x >= xyi(0) && x <= xyi(2) && y >= xyi(1) && y <= xyi(3)) {
+        return true
+      }
+      i += 1
+    }
+    false
+  }
+}
+
+object S2Filter {
+
+  private val RangeSeparator = ":"
+  private val TermSeparator  = ";"
+
+  val XYKey     = "sxy"
+  val TKey      = "st"
+  val EpochKey  = "epoch"
+
+  def apply(values: S2IndexValues): S2Filter = {
+    val sfc = values.sfc
+    val xy: Array[Array[Double]] = values.bounds.map { case (xmin, ymin, xmax, ymax) =>
+      Array(xmin, ymin, xmax, ymax)
+    }.toArray
+
+    new S2Filter(xy)
+  }
+
+  def serializeToBytes(filter: S2Filter): Array[Byte] = {
+    // 4 bytes for length plus 16 bytes for each xy val (4 doubles)
+    val xyLength = 4 + filter.xy.length * 32
+    val buffer = ByteBuffer.allocate(xyLength)
+
+    buffer.putInt(filter.xy.length)
+
+    filter.xy.foreach(bounds => bounds.foreach(buffer.putDouble))
+
+    buffer.array()
+  }
+
+  def deserializeFromBytes(serialized: Array[Byte]): S2Filter = {
+    val buffer = ByteBuffer.wrap(serialized)
+    val xy = Array.fill(buffer.getInt())(Array.fill(4)(buffer.getDouble))
+    new S2Filter(xy)
+  }
+
+  def serializeToStrings(filter: S2Filter): Map[String, String] = {
+    val xy = filter.xy.map(bounds => bounds.mkString(RangeSeparator)).mkString(TermSeparator)
+    Map(XYKey -> xy)
+  }
+
+  def deserializeFromStrings(serialized: scala.collection.Map[String, String]): S2Filter = {
+    val xy = serialized(XYKey).split(TermSeparator).map(_.split(RangeSeparator).map(_.toDouble))
+    new S2Filter(xy)
+  }
+}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/S3Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/S3Filter.scala
@@ -1,0 +1,186 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.filters
+
+import java.nio.ByteBuffer
+
+import com.google.common.geometry.S2CellId
+import org.locationtech.geomesa.index.index.s3.S3IndexValues
+import org.locationtech.geomesa.utils.index.ByteArrays
+
+/**
+  * @author sunyabo 2019年08月01日 09:26
+  * @version V1.0
+  */
+class S3Filter(val xy: Array[Array[Double]], val t: Array[Array[Array[Int]]], val minEpoch: Short, val maxEpoch: Short) {
+
+  /**
+    * Determine if the point is inside the rectangle
+    * @param buf row
+    * @param offset offset
+    * @return
+    */
+  def inBounds(buf: Array[Byte], offset: Int): Boolean = {
+    // account for epoch - first 2 bytes
+    val keyS = ByteArrays.readLong(buf, offset + 2)
+    val timeOffset = ByteArrays.readInt(buf, offset + 10)
+    pointInBounds(keyS) && timeInBounds(ByteArrays.readShort(buf, offset), timeOffset)
+  }
+
+  private def pointInBounds(s3Values: Long): Boolean = {
+    val s2CellId = new S2CellId(s3Values)
+    val x = s2CellId.toLatLng.lngDegrees()
+    val y = s2CellId.toLatLng.latDegrees()
+    var i = 0
+    while (i < xy.length) {
+      val xyi = xy(i)
+      if (x >= xyi(0) && x <= xyi(2) && y >= xyi(1) && y <= xyi(3)) {
+        return true
+      }
+      i += 1
+    }
+    false
+  }
+
+  private def timeInBounds(epoch: Short, offset: Int): Boolean = {
+    // we know we're only going to scan appropriate epochs, so leave out whole epochs
+    if (epoch > maxEpoch || epoch < minEpoch) { false } else {
+      val tEpoch = t(epoch - minEpoch)
+      if (tEpoch == null) { true } else {
+        val time = offset
+        var i = 0
+        while (i < tEpoch.length) {
+          val ti = tEpoch(i)
+          if (time >= ti(0) && time <= ti(1)) {
+            return true
+          }
+          i += 1
+        }
+        false
+      }
+    }
+  }
+
+  override def toString: String = S3Filter.serializeToStrings(this).toSeq.sortBy(_._1).mkString(",")
+}
+
+object S3Filter {
+
+  private val RangeSeparator = ":"
+  private val TermSeparator  = ";"
+  private val EpochSeparator = ","
+
+  val XYKey     = "sxy"
+  val TKey      = "st"
+  val EpochKey  = "epoch"
+
+  def apply(values: S3IndexValues): S3Filter = {
+    val S3IndexValues(sfc, _, spatialBounds, _, temporalBounds, _) = values
+
+    val xy: Array[Array[Double]] = spatialBounds.map { case (xmin, ymin, xmax, ymax) =>
+      Array(xmin, ymin, xmax, ymax)
+    }.toArray
+
+    // we know we're only going to scan appropriate periods, so leave out whole ones
+    val wholePeriod = Seq((0L, sfc.time))
+    var minEpoch: Short = Short.MaxValue
+    var maxEpoch: Short = Short.MinValue
+    val epochsAndTimes = temporalBounds.toSeq.filter(_._2 != wholePeriod).sortBy(_._1).map { case (epoch, times) =>
+      // set min/max epochs - note: side effect in map
+      if (epoch < minEpoch) {
+        minEpoch = epoch
+      }
+      if (epoch > maxEpoch) {
+        maxEpoch = epoch
+      }
+      (epoch, times.map { case (t1, t2) => Array(t1, t2)}.toArray)
+    }
+
+    val t: Array[Array[Array[Int]]] =
+      if (minEpoch == Short.MaxValue && maxEpoch == Short.MinValue) {
+        Array.empty
+      } else {
+        Array.ofDim(maxEpoch - minEpoch + 1)
+      }
+
+    epochsAndTimes.foreach { case (w, times) => t(w - minEpoch) = times }
+
+    new S3Filter(xy, t, minEpoch, maxEpoch)
+  }
+
+  def serializeToBytes(filter: S3Filter): Array[Byte] = {
+    // 4 bytes for length plus 32 bytes for each xy val (4 doubles)
+    val xyLength = 4 + filter.xy.length * 32
+    // 4 bytes for length, then per-epoch 4 bytes for length plus 8 bytes for each t val (2 ints)
+    val tLength = 4 + filter.t.map(bounds => if (bounds == null) { 4 } else { 4 + bounds.length * 8 } ).sum
+    // additional 4 bytes for min/max epoch
+    val buffer = ByteBuffer.allocate(xyLength + tLength + 4)
+
+    buffer.putInt(filter.xy.length)
+    filter.xy.foreach(bounds => bounds.foreach(buffer.putDouble))
+    buffer.putInt(filter.t.length)
+    filter.t.foreach { bounds =>
+      if (bounds == null) {
+        buffer.putInt(-1)
+      } else {
+        buffer.putInt(bounds.length)
+        bounds.foreach(inner => inner.foreach(buffer.putInt))
+      }
+    }
+
+    buffer.putShort(filter.minEpoch)
+    buffer.putShort(filter.maxEpoch)
+
+    buffer.array()
+  }
+
+  def deserializeFromBytes(serialized: Array[Byte]): S3Filter = {
+    val buffer = ByteBuffer.wrap(serialized)
+
+    val xy = Array.fill(buffer.getInt())(Array.fill(4)(buffer.getDouble()))
+    val t = Array.fill(buffer.getInt) {
+      val length = buffer.getInt
+      if (length == -1) { null } else {
+        Array.fill(length)(Array.fill(2)(buffer.getInt()))
+      }
+    }
+    val minEpoch = buffer.getShort
+    val maxEpoch = buffer.getShort
+
+    new S3Filter(xy, t, minEpoch, maxEpoch)
+  }
+
+  def serializeToStrings(filter: S3Filter): Map[String, String] = {
+    val xy = filter.xy.map(bounds => bounds.mkString(RangeSeparator)).mkString(TermSeparator)
+    val t = filter.t.map { bounds =>
+      if (bounds == null) { "" } else {
+        bounds.map(_.mkString(RangeSeparator)).mkString(TermSeparator)
+      }
+    }.mkString(EpochSeparator)
+    val epoch = s"${filter.minEpoch}$RangeSeparator${filter.maxEpoch}"
+
+    Map(
+      XYKey    -> xy,
+      TKey     -> t,
+      EpochKey -> epoch
+    )
+  }
+
+  def deserializeFromStrings(serialized: scala.collection.Map[String, String]): S3Filter = {
+    val xy = serialized(XYKey).split(TermSeparator).map(_.split(RangeSeparator).map(_.toDouble))
+    val t = serialized(TKey).split(EpochSeparator).map { bounds =>
+      if (bounds.isEmpty) { null } else {
+        bounds.split(TermSeparator).map(_.split(RangeSeparator).map(_.toInt))
+      }
+    }
+    val Array(minEpoch, maxEpoch) = serialized(EpochKey).split(RangeSeparator).map(_.toShort)
+
+    new S3Filter(xy, t, minEpoch, maxEpoch)
+  }
+}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/DefaultFeatureIndexFactory.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/DefaultFeatureIndexFactory.scala
@@ -8,6 +8,8 @@
 
 package org.locationtech.geomesa.index.index
 
+import org.locationtech.geomesa.index.index.s2.S2Index
+import org.locationtech.geomesa.index.index.s3.S3Index
 import org.locationtech.geomesa.index.api.{GeoMesaFeatureIndex, GeoMesaFeatureIndexFactory}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.attribute.AttributeIndex
@@ -28,7 +30,7 @@ import scala.util.Try
   */
 object DefaultFeatureIndexFactory extends GeoMesaFeatureIndexFactory {
 
-  private val available = Seq(Z3Index, XZ3Index, Z2Index, XZ2Index, IdIndex, AttributeIndex)
+  private val available = Seq(Z3Index, XZ3Index, Z2Index, XZ2Index, S3Index, S2Index, IdIndex, AttributeIndex)
 
   override def indices(sft: SimpleFeatureType, hint: Option[String]): Seq[IndexId] = {
     hint match {
@@ -74,6 +76,9 @@ object DefaultFeatureIndexFactory extends GeoMesaFeatureIndexFactory {
 
       case (XZ2Index.name, 2) => Some(new XZ2Index(ds, sft, geom2, index.mode))
       case (XZ2Index.name, 1) => Some(new XZ2IndexV1(ds, sft, geom2, index.mode))
+
+      case (S2Index.name, 1)  => Some(new S2Index(ds, sft, geom2, index.mode))
+      case (S3Index.name, 1)  => Some(new S3Index(ds, sft, geom3, dtg, index.mode))
 
       case (AtIndex.name, 8)  => Some(new AttributeIndex(ds, sft, attribute, secondary, index.mode))
       case (AtIndex.name, 7)  => Some(new AttributeIndexV7(ds, sft, attribute, secondary, index.mode))

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/S2Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/S2Index.scala
@@ -1,0 +1,51 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.index.s2
+
+import org.locationtech.geomesa.index.api.{GeoMesaFeatureIndex, IndexKeySpace}
+import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
+import org.locationtech.geomesa.index.index.ConfiguredIndex
+import org.locationtech.geomesa.index.index.s2.S2IndexValues
+import org.locationtech.geomesa.index.strategies.SpatialFilterStrategy
+import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
+import org.opengis.feature.simple.SimpleFeatureType
+
+/**
+  * @author sunyabo 2019年07月29日 8:23
+  * @version V1.0
+  * @param ds data store
+  * @param sft simple feature type stored in this index
+  * @param version version of the index
+  * @param geom
+  * @param mode mode of the index (read/write/both)
+  */
+class S2Index protected (ds: GeoMesaDataStore[_], sft: SimpleFeatureType,
+                         version: Int, val geom: String, mode: IndexMode)
+  extends GeoMesaFeatureIndex[S2IndexValues, Long](ds, sft, S2Index.name, version, Seq(geom), mode)
+    with SpatialFilterStrategy[S2IndexValues, Long] {
+
+  def this(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, mode: IndexMode) =
+    this(ds, sft, S2Index.version, geom, mode)
+
+  override val keySpace: S2IndexKeySpace = new S2IndexKeySpace(sft, ZShardStrategy(sft), geom)
+
+  override val tieredKeySpace: Option[IndexKeySpace[_, _]] = None
+}
+
+object S2Index extends ConfiguredIndex {
+
+  override val name = "s2"
+  override val version = 1
+
+  override def supports(sft: SimpleFeatureType, attributes: Seq[String]): Boolean =
+    S2IndexKeySpace.supports(sft, attributes)
+
+  override def defaults(sft: SimpleFeatureType): Seq[Seq[String]] = Seq.empty
+}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/S2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/S2IndexKeySpace.scala
@@ -1,0 +1,221 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.index.s2
+
+import org.geotools.util.factory.Hints
+import org.locationtech.geomesa.curve.S2SFC
+import org.locationtech.geomesa.filter.{FilterHelper, FilterValues}
+import org.locationtech.geomesa.index.api
+import org.locationtech.geomesa.index.api.IndexKeySpace.IndexKeySpaceFactory
+import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, ZShardStrategy}
+import org.locationtech.geomesa.index.api._
+import org.locationtech.geomesa.index.conf.QueryHints.LOOSE_BBOX
+import org.locationtech.geomesa.index.conf.QueryProperties
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory
+import org.locationtech.geomesa.index.index.s2.S2IndexValues
+import org.locationtech.geomesa.index.utils.Explainer
+import org.locationtech.geomesa.utils.geotools.{GeometryUtils, WholeWorldPolygon}
+import org.locationtech.geomesa.utils.index.ByteArrays
+import org.locationtech.jts.geom.{Geometry, Point}
+import org.opengis.feature.simple.SimpleFeatureType
+import org.opengis.filter.Filter
+
+import scala.util.control.NonFatal
+
+/**
+  * @author sunyabo 2019年07月24日 14:42
+  * @version V1.0
+  */
+class S2IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, geomField: String)
+  extends IndexKeySpace[S2IndexValues, Long] {
+
+  require(classOf[Point].isAssignableFrom(sft.getDescriptor(geomField).getType.getBinding),
+    s"Expected field $geomField to have a point binding, but instead it has: " +
+      sft.getDescriptor(geomField).getType.getBinding.getSimpleName)
+
+  protected val sfc: S2SFC = new S2SFC(QueryProperties.S2MinLevel, QueryProperties.S2MaxLevel,
+    QueryProperties.S2LevelMod, QueryProperties.S2MaxCells)
+
+  protected val geomIndex: Int = sft.indexOf(geomField)
+
+  /**
+    * The attributes used to create the index keys
+    *
+    * @return
+    */
+  override val attributes: Seq[String] = Seq(geomField)
+
+  /**
+    * Length of an index key. If static (general case), will return a Right with the length. If dynamic,
+    * will return Left with a function to determine the length from a given (row, offset, length)
+    *
+    * @return
+    */
+  override val indexKeyByteLength: Right[(Array[Byte], Int, Int) => Int, Int] = Right(8 + sharding.length)
+
+  /**
+    * Table sharing
+    *
+    * @return
+    */
+  override val sharing: Array[Byte] = Array.empty
+
+  /**
+    * Index key from the attributes of a simple feature
+    *
+    * @param writable simple feature with cached values
+    * @param tier    tier bytes
+    * @param id      feature id bytes
+    * @param lenient if input values should be strictly checked, default false
+    * @return
+    */
+  override def toIndexKey(writable: WritableFeature,
+                          tier: Array[Byte],
+                          id: Array[Byte],
+                          lenient: Boolean): RowKeyValue[Long] = {
+    val geom = writable.getAttribute[Point](geomIndex)
+    if (geom == null) {
+      throw new IllegalArgumentException(s"Null geometry in feature ${writable.feature.getID}")
+    }
+    val s = try { sfc.index(geom.getX, geom.getY, lenient) } catch {
+      case NonFatal(e) => throw new IllegalArgumentException(s"Invalid s value from geometry: $geom", e)
+    }
+    val shard = sharding(writable)
+
+    // create the byte array - allocate a single array up front to contain everything
+    // ignore tier, not used here
+    val bytes = Array.ofDim[Byte](shard.length + 8 + id.length)
+
+    if (shard.isEmpty) {
+      ByteArrays.writeLong(s.id(), bytes, 0)
+      System.arraycopy(id, 0, bytes, 8, id.length)
+    } else {
+      bytes(0) = shard.head // shard is only a single byte
+      ByteArrays.writeLong(s.id(), bytes, 1)
+      System.arraycopy(id, 0, bytes, 9, id.length)
+    }
+
+    SingleRowKeyValue(bytes, sharing, shard, s.id(), tier, id, writable.values)
+  }
+
+  /**
+    * Extracts values out of the filter used for range and push-down predicate creation
+    *
+    * @param filter  query filter
+    * @param explain explainer
+    * @return
+    */
+  override def getIndexValues(filter: Filter, explain: Explainer): S2IndexValues = {
+
+    val geometries: FilterValues[Geometry] = {
+      val extracted = FilterHelper.extractGeometries(filter, geomField, intersect = true) // intersect since we have points
+      if (extracted.nonEmpty) { extracted } else { FilterValues(Seq(WholeWorldPolygon)) }
+    }
+
+    explain(s"Geometries: $geometries")
+
+    if (geometries.disjoint) {
+      explain("Non-intersecting geometries extracted, short-circuiting to empty query")
+      return S2IndexValues(sfc, geometries, Seq.empty)
+    }
+
+    // compute our ranges based on the coarse bounds for our query
+    val xy: Seq[(Double, Double, Double, Double)] = {
+      val multiplier = QueryProperties.PolygonDecompMultiplier.toInt.get
+      val bits = QueryProperties.PolygonDecompBits.toInt.get
+      geometries.values.flatMap(GeometryUtils.bounds(_, multiplier, bits))
+    }
+
+    S2IndexValues(sfc, geometries, xy)
+  }
+
+  /**
+    * Creates ranges over the index keys
+    *
+    * @param values     index values @see getIndexValues
+    * @param multiplier hint for how many times the ranges will be multiplied. can be used to
+    *                   inform the number of ranges generated
+    * @return
+    */
+  override def getRanges(values: S2IndexValues, multiplier: Int): Iterator[ScanRange[Long]] = {
+    val S2IndexValues(_, _, xy) = values
+    if (xy.isEmpty) {
+      Iterator.empty
+    } else {
+      // note: `target` will always be Some, as ScanRangesTarget has a default value
+      val target = QueryProperties.ScanRangesTarget.option.map(t => math.max(1, t.toInt / multiplier))
+      sfc.ranges(xy, target).iterator.map(r => BoundedRange(r.rangeMin().id(), r.rangeMax().id()))
+    }
+  }
+
+  /**
+    * Creates bytes from ranges
+    *
+    * @param ranges typed scan ranges. @see `getRanges`
+    * @param tier   will the ranges have tiered ranges appended, or not
+    * @return
+    */
+  override def getRangeBytes(ranges: Iterator[ScanRange[Long]], tier: Boolean): Iterator[api.ByteRange] = {
+    if (sharding.length == 0) {
+      ranges.map {
+        case BoundedRange(lo, hi) => BoundedByteRange(ByteArrays.toBytes(lo), ByteArrays.toBytes(hi))
+        case r => throw new IllegalArgumentException(s"Unexpected range type $r")
+      }
+    } else {
+      ranges.flatMap {
+        case BoundedRange(lo, hi) =>
+          val lower = ByteArrays.toBytes(lo)
+          val upper = ByteArrays.toBytes(hi)
+          sharding.shards.map(p => BoundedByteRange(ByteArrays.concat(p, lower), ByteArrays.concat(p, upper)))
+
+        case r => throw new IllegalArgumentException(s"Unexpected range type $r")
+      }
+    }
+  }
+
+  /**
+    * Determines if the ranges generated by `getRanges` are sufficient to fulfill the query,
+    * or if additional filtering needs to be done
+    *
+    * @param config data store config
+    * @param values index values @see getIndexValues
+    * @param hints  query hints
+    * @return
+    */
+  override def useFullFilter(values: Option[S2IndexValues],
+                             config: Option[GeoMesaDataStoreFactory.GeoMesaDataStoreConfig],
+                             hints: Hints): Boolean = {
+    // if the user has requested strict bounding boxes, we apply the full filter
+    // if the spatial predicate is rectangular (e.g. a bbox), the index is fine enough that we
+    // don't need to apply the filter on top of it. this may cause some minor errors at extremely
+    // fine resolutions, but the performance is worth it
+    // if we have a complicated geometry predicate, we need to pass it through to be evaluated
+    val looseBBox = Option(hints.get(LOOSE_BBOX)).map(Boolean.unbox).getOrElse(config.forall(_.looseBBox))
+    lazy val simpleGeoms = values.toSeq.flatMap(_.geometries.values).forall(GeometryUtils.isRectangular)
+
+    !looseBBox || !simpleGeoms
+  }
+
+}
+
+object S2IndexKeySpace extends IndexKeySpaceFactory[S2IndexValues, Long] {
+
+  override def supports(sft: SimpleFeatureType, attributes: Seq[String]): Boolean =
+    attributes.lengthCompare(1) == 0 && sft.indexOf(attributes.head) != -1 &&
+      classOf[Point].isAssignableFrom(sft.getDescriptor(attributes.head).getType.getBinding)
+
+  override def apply(sft: SimpleFeatureType, attributes: Seq[String], tier: Boolean): S2IndexKeySpace = {
+    val shards = if (tier) {
+      NoShardStrategy
+    } else {
+      ZShardStrategy(sft)
+    }
+    new S2IndexKeySpace(sft, shards, attributes.head)
+  }
+}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/package.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/package.scala
@@ -1,0 +1,26 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.index
+
+import org.locationtech.geomesa.curve.S2SFC
+import org.locationtech.geomesa.filter.FilterValues
+import org.locationtech.jts.geom.Geometry
+
+/**
+  * <p></p>
+  *
+  * @author sunyabo 2019年07月24日 14:26
+  * @version V1.0
+  */
+package object s2 {
+
+  case class S2IndexValues(sfc: S2SFC,
+                           geometries: FilterValues[Geometry],
+                           bounds: Seq[(Double, Double, Double, Double)])
+}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/S3Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/S3Index.scala
@@ -56,5 +56,4 @@ object S3Index extends ConfiguredIndex {
     S3IndexKeySpace.supports(sft, attributes)
 
   override def defaults(sft: SimpleFeatureType): Seq[Seq[String]] = Seq.empty
-  }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/S3Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/S3Index.scala
@@ -1,0 +1,60 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.index.s3
+
+import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.{GeoMesaFeatureIndex, IndexKeySpace}
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
+import org.locationtech.geomesa.index.index.ConfiguredIndex
+import org.locationtech.geomesa.index.strategies.SpatioTemporalFilterStrategy
+import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
+import org.opengis.feature.simple.SimpleFeatureType
+
+/**
+  * @author sunyabo 2019年08月01日 09:25
+  * @version V1.0
+  */
+class S3Index protected (ds: GeoMesaDataStore[_],
+                         sft: SimpleFeatureType,
+                         version: Int,
+                         val geom: String,
+                         val dtg: String,
+                         mode: IndexMode)
+  extends GeoMesaFeatureIndex[S3IndexValues, S3IndexKey](ds, sft, S3Index.name, version, Seq(geom, dtg), mode)
+    with SpatioTemporalFilterStrategy[S3IndexValues, S3IndexKey] {
+
+  def this(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geomField: String, dtgField: String, mode: IndexMode) =
+    this(ds, sft, S3Index.version, geomField, dtgField, mode)
+
+  /**
+    * Primary key space used by this index
+    *
+    * @return
+    */
+  override def keySpace: IndexKeySpace[S3IndexValues, S3IndexKey] = new S3IndexKeySpace(sft, ZShardStrategy(sft), geom, dtg)
+
+  /**
+    * Tiered key space beyond the primary one, if any
+    *
+    * @return
+    */
+  override def tieredKeySpace: Option[IndexKeySpace[_, _]] = None
+}
+
+object S3Index extends ConfiguredIndex {
+
+  override val name = "s3"
+  override val version = 1
+
+  override def supports(sft: SimpleFeatureType, attributes: Seq[String]): Boolean =
+    S3IndexKeySpace.supports(sft, attributes)
+
+  override def defaults(sft: SimpleFeatureType): Seq[Seq[String]] = Seq.empty
+  }
+}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/S3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/S3IndexKeySpace.scala
@@ -1,0 +1,333 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.index.s3
+
+import java.util.Date
+
+import com.typesafe.scalalogging.LazyLogging
+import org.geotools.util.factory.Hints
+import org.locationtech.geomesa.curve.BinnedTime.TimeToBinnedTime
+import org.locationtech.geomesa.curve.{BinnedTime, S3SFC}
+import org.locationtech.geomesa.filter.FilterValues
+import org.locationtech.geomesa.index.api
+import org.locationtech.geomesa.index.api.IndexKeySpace.IndexKeySpaceFactory
+import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, ZShardStrategy}
+import org.locationtech.geomesa.index.api._
+import org.locationtech.geomesa.index.conf.QueryHints.LOOSE_BBOX
+import org.locationtech.geomesa.index.conf.QueryProperties
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory
+import org.locationtech.geomesa.index.utils.Explainer
+import org.locationtech.geomesa.utils.geotools.{GeometryUtils, WholeWorldPolygon}
+import org.locationtech.geomesa.utils.index.ByteArrays
+import org.locationtech.jts.geom.{Geometry, Point}
+import org.opengis.feature.simple.SimpleFeatureType
+import org.opengis.filter.Filter
+
+import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
+
+/**
+  * @author sunyabo 2019年08月01日 09:26
+  * @version V1.0
+  */
+class S3IndexKeySpace(val sft: SimpleFeatureType,
+                      val sharding: ShardStrategy,
+                      geomField: String,
+                      dtgField: String) extends IndexKeySpace[S3IndexValues, S3IndexKey] with LazyLogging {
+
+  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
+  require(classOf[Point].isAssignableFrom(sft.getDescriptor(geomField).getType.getBinding),
+    s"Expected field $geomField to have a point binding, but instead it has: " +
+      sft.getDescriptor(geomField).getType.getBinding.getSimpleName)
+  require(classOf[Date].isAssignableFrom(sft.getDescriptor(dtgField).getType.getBinding),
+    s"Expected field $dtgField to have a date binding, but instead it has: " +
+      sft.getDescriptor(dtgField).getType.getBinding.getSimpleName)
+
+  protected val sfc = S3SFC(QueryProperties.S2MinLevel, QueryProperties.S2MaxLevel,
+    QueryProperties.S2LevelMod, QueryProperties.S2MaxCells, sft.getS3Interval)
+
+  protected val geomIndex: Int = sft.indexOf(geomField)
+  protected val dtgIndex: Int = sft.indexOf(dtgField)
+
+  protected val timeToIndex: TimeToBinnedTime = BinnedTime.timeToBinnedTime(sft.getS3Interval)
+
+  private val dateToIndex = BinnedTime.dateToBinnedTime(sft.getS3Interval)
+  private val boundsToDates = BinnedTime.boundsToIndexableDates(sft.getS3Interval)
+
+  /**
+    * The attributes used to create the index keys
+    *
+    * @return
+    */
+  override def attributes: Seq[String] = Seq(geomField, dtgField)
+
+  /**
+    * Length of an index key. If static (general case), will return a Right with the length. If dynamic,
+    * will return Left with a function to determine the length from a given (row, offset, length)
+    *
+    * @return
+    */
+  override def indexKeyByteLength: Right[(Array[Byte], Int, Int) => Int, Int] = Right(10 + sharding.length)
+
+  /**
+    * Table sharing
+    *
+    * @return
+    */
+  override def sharing: Array[Byte] = Array.empty
+
+  /**
+    * Index key from the attributes of a simple feature
+    *
+    * @param writable simple feature with cached values
+    * @param tier    tier bytes
+    * @param id      feature id bytes
+    * @param lenient if input values should be strictly checked, or normalized instead
+    * @return
+    */
+  override def toIndexKey(writable: WritableFeature, tier: Array[Byte],
+                          id: Array[Byte], lenient: Boolean): api.RowKeyValue[S3IndexKey] = {
+    val geom = writable.getAttribute[Point](geomIndex)
+    if (geom == null) {
+      throw new IllegalArgumentException(s"Null geometry in feature ${writable.feature.getID}")
+    }
+    val dtg = writable.getAttribute[Date](dtgIndex)
+    val time = if (dtg == null) { 0 } else { dtg.getTime }
+    val BinnedTime(b, t) = timeToIndex(time)
+    val s = try { sfc.index(geom.getX, geom.getY, lenient) } catch {
+      case NonFatal(e) => throw new IllegalArgumentException(s"Invalid s value from geometry/time: $geom,$dtg", e)
+    }
+    val shard = sharding(writable)
+
+    // create the byte array - allocate a single array up front to contain everything
+    // ignore tier, not used here
+    val bytes = Array.ofDim[Byte](shard.length + 14 + id.length)
+
+    if (shard.isEmpty) {
+      ByteArrays.writeShort(b, bytes, 0)
+      ByteArrays.writeLong(s.id(), bytes, 2)
+      ByteArrays.writeInt(t.toInt, bytes, 10)
+      System.arraycopy(id, 0, bytes, 14, id.length)
+    } else {
+      bytes(0) = shard.head // shard is only a single byte
+      ByteArrays.writeShort(b, bytes, 1)
+      ByteArrays.writeLong(s.id(), bytes, 3)
+      ByteArrays.writeInt(t.toInt, bytes, 11)
+      System.arraycopy(id, 0, bytes, 15, id.length)
+    }
+
+    SingleRowKeyValue(bytes, sharing, shard, S3IndexKey(b, s.id(), t.toInt), tier, id, writable.values)
+  }
+
+  /**
+    * Extracts values out of the filter used for range and push-down predicate creation
+    *
+    * @param filter  query filter
+    * @param explain explainer
+    * @return
+    */
+  override def getIndexValues(filter: Filter, explain: Explainer): S3IndexValues = {
+
+    import org.locationtech.geomesa.filter.FilterHelper._
+
+    // standardize the two key query arguments:  polygon and date-range
+
+    val geometries: FilterValues[Geometry] = {
+      val extracted = extractGeometries(filter, geomField, intersect = true) // intersect since we have points
+      if (extracted.nonEmpty) { extracted } else { FilterValues(Seq(WholeWorldPolygon)) }
+    }
+
+    // since we don't apply a temporal filter, we pass handleExclusiveBounds to
+    // make sure we exclude the non-inclusive endpoints of a during filter.
+    // note that this isn't completely accurate, as we only index down to the second
+    val intervals = extractIntervals(filter, dtgField, handleExclusiveBounds = true)
+
+    explain(s"Geometries: $geometries")
+    explain(s"Intervals: $intervals")
+
+    if (geometries.disjoint || intervals.disjoint) {
+      explain("Disjoint geometries or dates extracted, short-circuiting to empty query")
+      return S3IndexValues(sfc, geometries, Seq.empty, intervals, Map.empty, Seq.empty)
+    }
+
+    // compute our ranges based on the coarse bounds for our query
+    val xy: Seq[(Double, Double, Double, Double)] = {
+      val multiplier = QueryProperties.PolygonDecompMultiplier.toInt.get
+      val bits = QueryProperties.PolygonDecompBits.toInt.get
+      geometries.values.flatMap(GeometryUtils.bounds(_, multiplier, bits))
+    }
+
+    val minTime = 0
+    val maxTime = sfc.time.toInt
+
+    // calculate map of weeks to time intervals in that week
+    val timesByBin = scala.collection.mutable.Map.empty[Short, Seq[(Int, Int)]].withDefaultValue(Seq.empty)
+    val unboundedBins = Seq.newBuilder[(Short, Short)]
+
+    // note: intervals shouldn't have any overlaps
+    intervals.foreach { interval =>
+      val (lower, upper) = boundsToDates(interval.bounds)
+      val BinnedTime(lb, lt) = dateToIndex(lower)
+      val BinnedTime(ub, ut) = dateToIndex(upper)
+
+      if (interval.isBoundedBothSides) {
+        if (lb == ub) {
+          timesByBin(lb) ++= Seq((lt.toInt, ut.toInt))
+        } else {
+          timesByBin(lb) ++= Seq((lt.toInt, maxTime))
+          timesByBin(ub) ++= Seq((minTime, ut.toInt))
+          Range.inclusive(lb + 1, ub - 1).foreach(b => timesByBin(b.toShort) = sfc.wholePeriod)
+        }
+      } else if (interval.lower.value.isDefined) {
+        timesByBin(lb) ++= Seq((lt.toInt, maxTime))
+        unboundedBins += (((lb + 1).toShort, Short.MaxValue))
+      } else if (interval.upper.value.isDefined) {
+        timesByBin(ub) ++= Seq((minTime, ut.toInt))
+        unboundedBins += ((0, (ub - 1).toShort))
+      }
+    }
+
+    S3IndexValues(sfc, geometries, xy, intervals, timesByBin.toMap, unboundedBins.result())
+  }
+
+  /**
+    * Creates ranges over the index keys
+    *
+    * @param values     index values @see getIndexValues
+    * @param multiplier hint for how many times the ranges will be multiplied. can be used to
+    *                   inform the number of ranges generated
+    * @return
+    */
+  override def getRanges(values: S3IndexValues, multiplier: Int): Iterator[ScanRange[S3IndexKey]] = {
+
+    val S3IndexValues(s3, _, xy, _, timesByBin, unboundedBins) = values
+
+    // note: `target` will always be Some, as ScanRangesTarget has a default value
+    val target = QueryProperties.ScanRangesTarget.option.map { t =>
+      math.max(1, if (timesByBin.isEmpty) { t.toInt } else { t.toInt / timesByBin.size } / multiplier)
+    }
+
+    /*lazy val wholePeriodRanges = s3.wholePeriod*/
+
+    val s2CellId = s3.ranges(xy, target)
+    import scala.collection.JavaConversions._
+    val bounded = timesByBin.iterator.flatMap { case (bin, times) => {
+      val s3ScanRanges = ListBuffer.empty[ScanRange[S3IndexKey]]
+      times.foreach(time => s2CellId.foreach(item=> s3ScanRanges
+        .add(BoundedRange(S3IndexKey(bin, item.rangeMin().id(), time._1),
+        S3IndexKey(bin, item.rangeMax().id(), time._2)))))
+      s3ScanRanges
+      }
+    }
+
+    val unbounded = unboundedBins.iterator.map {
+      case (0, Short.MaxValue)     => UnboundedRange(S3IndexKey(0, 0L, 0))
+      case (lower, Short.MaxValue) => LowerBoundedRange(S3IndexKey(lower, 0L, 0))
+      case (0, upper)              => UpperBoundedRange(S3IndexKey(upper, 0L, Int.MaxValue))
+      case (lower, upper) =>
+        logger.error(s"Unexpected unbounded bin endpoints: $lower:$upper")
+        UnboundedRange(S3IndexKey(0, 0L, 0))
+    }
+
+    bounded ++ unbounded
+  }
+
+  /**
+    * Creates bytes from ranges
+    *
+    * @param ranges typed scan ranges. @see `getRanges`
+    * @param tier   will the ranges have tiered ranges appended, or not
+    * @return
+    */
+  override def getRangeBytes(ranges: Iterator[api.ScanRange[S3IndexKey]], tier: Boolean): Iterator[api.ByteRange] = {
+
+    if (sharding.length == 0) {
+      ranges.map {
+        case BoundedRange(lo, hi) =>
+          BoundedByteRange(ByteArrays.toS3Bytes(lo.bin, lo.s, lo.offset),
+            ByteArrays.toS3Bytes(hi.bin, hi.s, hi.offset))
+
+        case LowerBoundedRange(lo) =>
+          BoundedByteRange(ByteArrays.toS3Bytes(lo.bin, lo.s, lo.offset), ByteRange.UnboundedUpperRange)
+
+        case UpperBoundedRange(hi) =>
+          BoundedByteRange(ByteRange.UnboundedLowerRange, ByteArrays.toS3Bytes(hi.bin, hi.s, hi.offset))
+
+        case UnboundedRange(_) =>
+          BoundedByteRange(ByteRange.UnboundedLowerRange, ByteRange.UnboundedUpperRange)
+
+        case r =>
+          throw new IllegalArgumentException(s"Unexpected range type $r")
+      }
+    } else {
+      ranges.flatMap {
+        case BoundedRange(lo, hi) =>
+          val lower = ByteArrays.toS3Bytes(lo.bin, lo.s, lo.offset)
+          val upper = ByteArrays.toS3Bytes(hi.bin, hi.s, hi.offset)
+          sharding.shards.map(p => BoundedByteRange(ByteArrays.concat(p, lower), ByteArrays.concat(p, upper)))
+
+        case LowerBoundedRange(lo) =>
+          val lower = ByteArrays.toS3Bytes(lo.bin, lo.s, lo.offset)
+          val upper = ByteRange.UnboundedUpperRange
+          sharding.shards.map(p => BoundedByteRange(ByteArrays.concat(p, lower), ByteArrays.concat(p, upper)))
+
+        case UpperBoundedRange(hi) =>
+          val lower = ByteRange.UnboundedLowerRange
+          val upper = ByteArrays.toS3Bytes(hi.bin, hi.s, hi.offset)
+          sharding.shards.map(p => BoundedByteRange(ByteArrays.concat(p, lower), ByteArrays.concat(p, upper)))
+
+        case UnboundedRange(_) =>
+          Seq(BoundedByteRange(ByteRange.UnboundedLowerRange, ByteRange.UnboundedUpperRange))
+
+        case r =>
+          throw new IllegalArgumentException(s"Unexpected range type $r")
+      }
+    }
+  }
+
+  /**
+    * Determines if the ranges generated by `getRanges` are sufficient to fulfill the query,
+    * or if additional filtering needs to be done
+    *
+    * @param config data store config
+    * @param values index values @see getIndexValues
+    * @param hints  query hints
+    * @return
+    */
+  override def useFullFilter(values: Option[S3IndexValues],
+                             config: Option[GeoMesaDataStoreFactory.GeoMesaDataStoreConfig],
+                             hints: Hints): Boolean = {
+
+    // if the user has requested strict bounding boxes, we apply the full filter
+    // if we have a complicated geometry predicate, we need to pass it through to be evaluated
+    // if we have unbounded dates, we need to pass them through as we don't have z-values for all periods
+
+    // if the spatial predicate is rectangular (e.g. a bbox), the index is fine enough that we
+    // don't need to apply the filter on top of it. this may cause some minor errors at extremely
+    // fine resolutions, but the performance is worth it
+    val looseBBox = Option(hints.get(LOOSE_BBOX)).map(Boolean.unbox).getOrElse(config.forall(_.looseBBox))
+    def unboundedDates: Boolean = values.exists(_.temporalUnbounded.nonEmpty)
+    def complexGeoms: Boolean = values.exists(_.geometries.values.exists(g => !GeometryUtils.isRectangular(g)))
+    !looseBBox || unboundedDates || complexGeoms
+  }
+}
+
+object S3IndexKeySpace extends IndexKeySpaceFactory[S3IndexValues, S3IndexKey]{
+
+  override def supports(sft: SimpleFeatureType, attributes: Seq[String]): Boolean =
+    attributes.lengthCompare(2) == 0 && attributes.forall(sft.indexOf(_) != -1) &&
+      classOf[Point].isAssignableFrom(sft.getDescriptor(attributes.head).getType.getBinding) &&
+      classOf[Date].isAssignableFrom(sft.getDescriptor(attributes.last).getType.getBinding)
+
+  override def apply(sft: SimpleFeatureType, attributes: Seq[String], tier: Boolean): S3IndexKeySpace = {
+    val shards = if (tier) { NoShardStrategy } else { ZShardStrategy(sft) }
+    new S3IndexKeySpace(sft, shards, attributes.head, attributes.last)
+  }
+}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/package.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/package.scala
@@ -1,0 +1,38 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.index
+
+import java.time.ZonedDateTime
+
+import org.locationtech.geomesa.curve.S3SFC
+import org.locationtech.geomesa.filter.{Bounds, FilterValues}
+import org.locationtech.jts.geom.Geometry
+
+/**
+  * @author sunyabo 2019年08月01日 09:25
+  * @version V1.0
+  */
+package object s3 {
+
+  case class S3IndexKey(bin: Short, s: Long, offset: Int) extends Ordered[S3IndexKey] {
+    override def compare(that: S3IndexKey): Int = {
+      val b = Ordering.Short.compare(bin, that.bin)
+      if (b != 0) { b } else {
+        Ordering.Long.compare(s, that.s)
+      }
+    }
+  }
+
+  case class S3IndexValues(sfc: S3SFC,
+                           geometries: FilterValues[Geometry],
+                           spatialBounds: Seq[(Double, Double, Double, Double)],
+                           intervals: FilterValues[Bounds[ZonedDateTime]],
+                           temporalBounds: Map[Short, Seq[(Int, Int)]],
+                           temporalUnbounded: Seq[(Short, Short)])
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -259,6 +259,12 @@ object RichSimpleFeatureType {
     }
     def setZ3Interval(i: TimePeriod): Unit = sft.getUserData.put(IndexZ3Interval, i.toString)
 
+    def getS3Interval: TimePeriod = userData[String](S3_INTERVAL_KEY) match {
+      case None    => TimePeriod.Week
+      case Some(i) => TimePeriod.withName(i.toLowerCase)
+    }
+    def setS3Interval(i: TimePeriod): Unit = sft.getUserData.put(S3_INTERVAL_KEY, i.toString)
+
     def getXZPrecision: Short = userData[String](IndexXzPrecision).map(_.toShort).getOrElse(XZSFC.DefaultPrecision)
     def setXZPrecision(p: Short): Unit = sft.getUserData.put(IndexXzPrecision, p.toString)
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
@@ -44,6 +44,7 @@ object SimpleFeatureTypes {
     val IndexVisibilityLevel  = "geomesa.visibility.level"
     val IndexXzPrecision      = "geomesa.xz.precision"
     val IndexZ3Interval       = "geomesa.z3.interval"
+    val S3_INTERVAL_KEY       = "geomesa.s3.interval"
     val IndexZShards          = "geomesa.z.splits"
     val Keywords              = "geomesa.keywords"
     val MixedGeometries       = "geomesa.mixed.geometries"

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/ByteArrays.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/ByteArrays.scala
@@ -257,6 +257,19 @@ object ByteArrays {
   }
 
   /**
+    * @author sunyabo 2019年8月2日 10:15
+    * @version V1.0
+    * Creates a byte array with a short and a long
+    */
+  def toS3Bytes(bin: Short, cellId: Long, offset: Long): Array[Byte] = {
+    val result = Array.ofDim[Byte](18)
+    writeShort(bin, result, 0)
+    writeLong(cellId, result, 2)
+    writeLong(offset, result, 10)
+    result
+  }
+
+  /**
     * Creates a byte array with a short and a long, preserving the sort order of the short for negative values
     *
     * @param bin time bin

--- a/geomesa-z3/pom.xml
+++ b/geomesa-z3/pom.xml
@@ -13,6 +13,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.sgr</groupId>
+            <artifactId>s2-geometry-library-java</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.locationtech.sfcurve</groupId>
             <artifactId>sfcurve-zorder_${scala.binary.version}</artifactId>
             <version>0.2.0</version>

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/S2SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/S2SFC.scala
@@ -1,0 +1,70 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.curve
+
+import com.google.common.geometry._
+
+import scala.collection.JavaConversions._
+
+/**
+  * s2 space-filling curve
+  *
+  * @author sunyabo 2019年07月26日 09:11
+  * @version V1.0
+  */
+class S2SFC(minLevel: Int, maxLevel: Int, levelMod: Int, maxCells: Int) extends S2SpaceFillingCurve[S2CellId] {
+
+  private val lonMin: Double = -180d
+  private val latMin: Double = -90d
+  private val lonMax: Double = 180d
+  private val latMax: Double = 90d
+
+  override def index(x: Double, y: Double, lenient: Boolean): S2CellId = {
+    try {
+      require(x >= lonMin && x <= lonMax && y >= latMin && y <= latMax,
+        s"Value(s) out of bounds ([$lonMin,$lonMax], [$latMin,$latMax]): $x, $y")
+      S2CellId.fromLatLng(S2LatLng.fromDegrees(y, x))
+    } catch {
+      case _: IllegalArgumentException if lenient => lenientIndex(x, y)
+    }
+  }
+
+  protected def lenientIndex(x: Double, y: Double): S2CellId = {
+    val bx = if (x < lonMin) { lonMin } else if (x > lonMax) { lonMax } else { x }
+    val by = if (y < latMin) { latMin } else if (y > latMax) { latMax } else { y }
+    S2CellId.fromLatLng(S2LatLng.fromDegrees(by, bx))
+  }
+
+  /**
+    * get s2 cell union as ranges
+    * @return
+    */
+  override def ranges(xy: Seq [(Double, Double, Double, Double)],
+                      maxRanges: Option[Int]): Seq[S2CellId] = {
+
+    val rect = new S2LatLngRect(S2LatLng.fromDegrees(xy.head._2, xy.head._1),
+      S2LatLng.fromDegrees(xy.head._4, xy.head._3))
+
+    val cover: S2RegionCoverer = new S2RegionCoverer
+    cover.setMinLevel(minLevel)
+    cover.setMaxLevel(maxLevel)
+    cover.setLevelMod(levelMod)
+    cover.setMaxCells(maxCells)
+
+    val s2CellUnion = cover.getCovering(rect)
+
+    s2CellUnion.cellIds().toSeq
+  }
+}
+
+object S2SFC {
+  def apply(minLevel: Int, maxLevel: Int, levelMod: Int, maxCells: Int): S2SFC =
+    new S2SFC(minLevel, maxLevel, levelMod, maxCells)
+}
+

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/S3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/S3SFC.scala
@@ -1,0 +1,80 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.curve
+
+import com.google.common.geometry._
+import org.locationtech.geomesa.curve.TimePeriod.TimePeriod
+
+import scala.collection.JavaConversions._
+
+/**
+  * @author sunyabo 2019年08月01日 10:21
+  * @version V1.0
+  */
+class S3SFC(minLevel: Int, maxLevel: Int, levelMod: Int, maxCells: Int, period: TimePeriod) extends S3SpaceFillingCurve[S2CellId] {
+
+  protected val lonMin: Double = -180d
+  protected val latMin: Double = -90d
+  protected val lonMax: Double = 180d
+  protected val latMax: Double = 90d
+
+  override def time: Int = BinnedTime.maxOffset(period).toInt
+
+  val wholePeriod = Seq((0, time))
+
+  override def index(x: Double, y: Double, lenient: Boolean): S2CellId = {
+    try {
+      require(x >= lonMin && x <= lonMax && y >= latMin && y <= latMax,
+        s"Value(s) out of bounds ([$lonMin,$lonMax], [$latMin,$latMax]): $x, $y")
+      S2CellId.fromLatLng(S2LatLng.fromDegrees(y, x))
+    } catch {
+      case _: IllegalArgumentException if lenient => lenientIndex(y, x)
+    }
+  }
+
+  protected def lenientIndex(x: Double, y: Double): S2CellId = {
+    val bx = if (x < lonMin) { lonMin } else if (x > lonMax) { lonMax } else { x }
+    val by = if (y < latMin) { latMin } else if (y > latMax) { latMax } else { y }
+
+    S2CellId.fromLatLng(S2LatLng.fromDegrees(by, bx))
+  }
+
+  /**
+    * Gets google-s2 cell ids as ranges
+    *
+    * @return
+    */
+  override def ranges(xy: Seq[(Double, Double, Double, Double)],
+                      maxRanges: Option[Int]): Seq[S2CellId] = {
+    val startS2 = S2LatLng.fromDegrees(xy.head._2, xy.head._1)
+    val endS2 = S2LatLng.fromDegrees(xy.head._4, xy.head._3)
+    val rect = new S2LatLngRect(startS2, endS2)
+
+    val cover = new S2RegionCoverer
+    cover.setMinLevel(minLevel)
+    cover.setMaxLevel(maxLevel)
+    cover.setLevelMod(levelMod)
+    cover.setMaxCells(maxCells)
+
+    val cellUnion = cover.getCovering(rect)
+
+    cellUnion.cellIds().toSeq
+  }
+}
+
+object S3SFC {
+
+  def apply(minLevel: Int, maxLevel: Int, levelMod: Int, maxCells: Int, period: TimePeriod): S3SFC = period match {
+    case TimePeriod.Day   => new S3SFC(minLevel, maxLevel, levelMod, maxCells, TimePeriod.Day)
+    case TimePeriod.Week  => new S3SFC(minLevel, maxLevel, levelMod, maxCells, TimePeriod.Week)
+    case TimePeriod.Month => new S3SFC(minLevel, maxLevel, levelMod, maxCells, TimePeriod.Month)
+    case TimePeriod.Year  => new S3SFC(minLevel, maxLevel, levelMod, maxCells, TimePeriod.Year)
+  }
+}
+

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/SpaceFillingCurve.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/SpaceFillingCurve.scala
@@ -8,6 +8,7 @@
 
 package org.locationtech.geomesa.curve
 
+import com.google.common.geometry.S2CellId
 import org.locationtech.sfcurve.IndexRange
 
 trait SpaceFillingCurve[T] {
@@ -77,6 +78,41 @@ trait SpaceTimeFillingCurve[T] {
              t: Seq[(Long, Long)],
              precision: Int = FullPrecision,
              maxRanges: Option[Int] = None): Seq[IndexRange]
+}
+
+/**
+  * @author sunyabo 2019/7/29 11:17
+  * @version V1.0
+  */
+trait S2SpaceFillingCurve[T] {
+
+  def index(x: Double, y: Double, lenient: Boolean = false): S2CellId
+
+  /**
+    * Gets google-s2 cellunion as ranges
+    * @return
+    */
+  def ranges(xy: Seq [(Double, Double, Double, Double)],
+             maxRanges: Option[Int]): Seq[S2CellId]
+}
+
+/**
+  * @author sunyabo 2019年8月1日 15:35
+  * @version V1.0
+  */
+trait S3SpaceFillingCurve[T] {
+
+  def time: Int
+
+  def index(x: Double, y: Double, lenient: Boolean = false): S2CellId
+
+  /**
+    * Gets google-s2 cellunion as ranges
+    * @return
+    */
+  def ranges(xy: Seq [(Double, Double, Double, Double)],
+             maxRanges: Option[Int]): Seq[S2CellId]
+
 }
 
 object SpaceFillingCurve {


### PR DESCRIPTION
The implementation of S2 is completely implemented by Google's algorithm; s3 I use epoch+S2+Time to encode, so although the 3D is not uniformly coded, the performance of the actual test is very good. We also analyzed the reasons, mainly in the 64-bit encoding. If the accuracy of each dimension is 3, the accuracy of each dimension will be 21, and the number of results of the scan will be more. More than the final result, through the above S3 encoding, we have tested this scan+mutiRowFilter to extract data from HBase with a higher accuracy than Z3, of course not absolute, most of the scenarios we tested.
In addition, very excited, this is the first time I submitted a PR to the open source community. If there is something wrong, please correct me.