### PR TITLE
GEOMESA-2731 geomesa-jupyter-leaflet assumes availability of Leaflet etc

### DIFF
--- a/geomesa-jupyter/geomesa-jupyter-leaflet/src/test/scala/org/locationtech/geomesa/jupyter/LeafletTest.scala
+++ b/geomesa-jupyter/geomesa-jupyter-leaflet/src/test/scala/org/locationtech/geomesa/jupyter/LeafletTest.scala
@@ -36,6 +36,7 @@ class LeafletTest extends Specification {
           |     format: 'image/png',
           |     version: '1.1.1'
           |  }).getLayer('foo').addTo(map);
+          |
         """.stripMargin) must be equalTo rendered
     }
 
@@ -46,6 +47,17 @@ class LeafletTest extends Specification {
       println(rendered)
       s"L.polygon([[10.0,10.0],[11.0,10.0],[11.0,11.0],[10.0,11.0],[10.0,10.0]],${clean(StyleOptions().render)}).addTo(map);" must be equalTo rendered
     }
+
+  }
+
+  "L without path should include CDN links" >> {
+    val html = L.buildMap(Seq(), (0,0), 8, None)
+    html must contain(L.leafletCssCdn) and contain (L.leafletJsCdn) and contain (L.leafletWmsJsCdn)
+  }
+
+  "L with path should not include CDN links" >> {
+    val html = L.buildMap(Seq(), (0,0), 8, Some("js"))
+    html must not contain(L.leafletCssCdn) and not contain (L.leafletJsCdn) and not contain (L.leafletWmsJsCdn)
   }
 
 


### PR DESCRIPTION
API change so that path is a Scala Option
If specified, uses that path
If not specified, uses CDN links so works out of the box

Renamed countries.geo.json
to
countries.geo.js
to match MIME type of actual content

Safe handling of absence of countries.geo.js(on)

Basic unit tests for CDN

Tested in Jupyter 5.7.8 w Toree 0.3.0

Signed-off-by: James Srinivasan <james.srinivasan@gmail.com>