### PR TITLE
GEOMESA-2737 GeoCQEngine STRtree and Quadtree indexes support

### DIFF
--- a/docs/user/appendix/memory.rst
+++ b/docs/user/appendix/memory.rst
@@ -61,3 +61,11 @@ Sample usage
 
     // clear the cache
     cq.clear()
+
+You can also choose the geometry index type. By default a Bucket index is used that provides better performance in case of frequent inserts or updates. In the case of you need to search inside a immutable (or with few variation) collection of data you can use the QuadTree or the SRTtree index.
+To do that you must create the GeoCqEngine as in the following:
+
+.. code-block:: scala
+
+   val cq1 = new GeoCQEngine(featureType, Seq(("Who", CQIndexType.DEFAULT), ("Where", CQIndexType.GEOMETRY)),geoIndexType = GeoIndexType.STRtree,geoIndexParam = Option.apply(new STRtreeIndexParam(/*nodeCapacity*/10)))
+   val cq2 = new GeoCQEngine(featureType, Seq(("Who", CQIndexType.DEFAULT), ("Where", CQIndexType.GEOMETRY)),geoIndexType = GeoIndexType.QuadTree)

--- a/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/AbstractGeoIndex.java
+++ b/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/AbstractGeoIndex.java
@@ -1,0 +1,195 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.memory.cqengine.index;
+
+import com.googlecode.cqengine.attribute.Attribute;
+import com.googlecode.cqengine.index.Index;
+import com.googlecode.cqengine.index.support.AbstractAttributeIndex;
+import com.googlecode.cqengine.index.support.indextype.OnHeapTypeIndex;
+import com.googlecode.cqengine.persistence.support.ObjectSet;
+import com.googlecode.cqengine.persistence.support.ObjectStore;
+import com.googlecode.cqengine.query.Query;
+import com.googlecode.cqengine.query.option.QueryOptions;
+import com.googlecode.cqengine.resultset.ResultSet;
+import org.locationtech.geomesa.memory.cqengine.GeoCQEngine;
+import org.locationtech.geomesa.memory.cqengine.query.Intersects;
+import org.locationtech.geomesa.utils.index.SpatialIndex;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Function1;
+import scala.collection.JavaConversions;
+import scala.runtime.AbstractFunction1;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+public abstract class AbstractGeoIndex<A extends Geometry, O extends SimpleFeature> extends AbstractAttributeIndex<A, O> implements OnHeapTypeIndex {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractGeoIndex.class);
+
+    private static final int INDEX_RETRIEVAL_COST = 40;
+
+    protected SpatialIndex<O> index;
+    protected int geomAttributeIndex;
+
+    static Set<Class<? extends Query>> supportedQueries = new HashSet<Class<? extends Query>>() {{
+        add(Intersects.class);
+    }};
+
+    AbstractGeoIndex(SimpleFeatureType sft, Attribute<O, A> attribute) {
+        super(attribute, supportedQueries);
+    }
+
+
+    @Override
+    public void init(ObjectStore<O> objectStore, QueryOptions queryOptions) {
+        addAll(ObjectSet.fromObjectStore(objectStore, queryOptions), queryOptions);
+    }
+
+    @Override
+    public boolean addAll(ObjectSet<O> objectSet, QueryOptions queryOptions) {
+        try {
+            boolean modified = false;
+
+            for (O object : objectSet) {
+                Envelope env = ((Geometry) object.getDefaultGeometry()).getEnvelopeInternal();
+                index.insert(env, object.getID(), object);
+                modified = true;
+            }
+
+            return modified;
+        } finally {
+            objectSet.close();
+        }
+    }
+
+    @Override
+    public boolean removeAll(ObjectSet<O> objectSet, QueryOptions queryOptions) {
+        try {
+            boolean modified = false;
+
+            for (O object : objectSet) {
+                Envelope env = ((Geometry) object.getDefaultGeometry()).getEnvelopeInternal();
+                index.remove(env, object.getID());
+                modified = true;
+            }
+
+            return modified;
+        } finally {
+            objectSet.close();
+        }
+    }
+
+    @Override
+    public void clear(QueryOptions queryOptions) {
+        this.index.clear();
+    }
+
+
+    private void traceIndexForDebug() {
+        if (GeoCQEngine.isDebugEnabled()) {
+            GeoCQEngine.setLastIndexUsed(index);
+        }
+    }
+
+    @Override
+    public ResultSet<O> retrieve(final Query<O> query, final QueryOptions queryOptions) {
+        traceIndexForDebug();
+        return new ResultSet<O>() {
+            @Override
+            public Iterator<O> iterator() {
+                scala.collection.Iterator<O> iter =
+                        getSimpleFeatureIteratorInternal((Intersects) query, queryOptions);
+                return (Iterator<O>) JavaConversions.asJavaIterator(iter);
+            }
+
+            @Override
+            public boolean contains(O object) {
+                final Intersects intersects = (Intersects) query;
+                Geometry geom = (Geometry) object.getAttribute(geomAttributeIndex);
+                return intersects.matchesValue(geom, queryOptions);
+            }
+
+            @Override
+            public boolean matches(O object) {
+                return query.matches(object, queryOptions);
+            }
+
+            @Override
+            public Query<O> getQuery() {
+                return query;
+            }
+
+            @Override
+            public QueryOptions getQueryOptions() {
+                return queryOptions;
+            }
+
+            @Override
+            public int getRetrievalCost() {
+                return INDEX_RETRIEVAL_COST;
+            }
+
+            // Returning the size here as the MergeCost.
+            // The geoindex size isn't optimal, so there might be a better
+            // measure of this.
+            @Override
+            public int getMergeCost() {
+                return size();
+            }
+
+            @Override
+            public int size() {
+                return getSimpleFeatureIteratorInternal((Intersects) query, queryOptions).size();
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+    }
+
+    private scala.collection.Iterator<O> getSimpleFeatureIteratorInternal(Intersects query,
+                                                                          final QueryOptions queryOptions) {
+        final Intersects intersects = query;
+        Envelope queryEnvelope = intersects.getEnvelope();
+        return index.query(queryEnvelope).filter((Function1<O, Object>) new AbstractFunction1<SimpleFeature, Object>() {
+            @Override
+            public Object apply(SimpleFeature feature) {
+                try {
+                    Geometry geom = (Geometry) feature.getAttribute(geomAttributeIndex);
+                    return intersects.matchesValue(geom, queryOptions);
+                } catch (Exception e) {
+                    LOGGER.warn("Caught exception while trying to look up geometry", e);
+                    return false;
+                }
+            }
+        });
+    }
+
+
+    @Override
+    public boolean isMutable() {
+        return true;
+    }
+
+    @Override
+    public boolean isQuantized() {
+        return false;
+    }
+
+    @Override
+    public Index<O> getEffectiveIndex() {
+        return this;
+    }
+}

--- a/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/AbstractGeoIndex.java
+++ b/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/AbstractGeoIndex.java
@@ -40,7 +40,7 @@ public abstract class AbstractGeoIndex<A extends Geometry, O extends SimpleFeatu
     private static final int INDEX_RETRIEVAL_COST = 40;
 
     protected SpatialIndex<O> index;
-    protected int geomAttributeIndex;
+    protected final int geomAttributeIndex;
 
     static Set<Class<? extends Query>> supportedQueries = new HashSet<Class<? extends Query>>() {{
         add(Intersects.class);
@@ -48,6 +48,7 @@ public abstract class AbstractGeoIndex<A extends Geometry, O extends SimpleFeatu
 
     AbstractGeoIndex(SimpleFeatureType sft, Attribute<O, A> attribute) {
         super(attribute, supportedQueries);
+        geomAttributeIndex = sft.indexOf(attribute.getAttributeName());
     }
 
 

--- a/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/BucketGeoIndex.java
+++ b/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/BucketGeoIndex.java
@@ -31,7 +31,6 @@ public class BucketGeoIndex<A extends Geometry, O extends SimpleFeature> extends
 
     public BucketGeoIndex(SimpleFeatureType sft, Attribute<O, A> attribute, Optional<BucketIndexParam> geoIndexParams) {
         super(sft, attribute);
-        geomAttributeIndex = sft.indexOf(attribute.getAttributeName());
         AttributeDescriptor attributeDescriptor = sft.getDescriptor(geomAttributeIndex);
 
         BucketIndexParam params = geoIndexParams.orElse(new BucketIndexParam());

--- a/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/GeoIndex.java
+++ b/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/GeoIndex.java
@@ -28,9 +28,8 @@ public class GeoIndex<A extends Geometry, O extends SimpleFeature> extends Abstr
     @Deprecated
     public GeoIndex(SimpleFeatureType sft, Attribute<O, A> attribute, int xBuckets, int yBuckets) {
         super(sft, attribute);
-        geomAttributeIndex = sft.indexOf(attribute.getAttributeName());
-        AttributeDescriptor attributeDescriptor = sft.getDescriptor(geomAttributeIndex);
-        if (attributeDescriptor.getType().getBinding() == Point.class) {
+        AttributeDescriptor geomAttributeDescriptor = sft.getDescriptor(geomAttributeIndex);
+        if (geomAttributeDescriptor.getType().getBinding() == Point.class) {
             index = new BucketIndex<>(xBuckets, yBuckets, new Envelope(-180.0, 180.0, -90.0, 90.0));
         } else {
             index = new SizeSeparatedBucketIndex<>(SizeSeparatedBucketIndex$.MODULE$.DefaultTiers(),

--- a/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/GeoIndexType.java
+++ b/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/GeoIndexType.java
@@ -1,0 +1,13 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.memory.cqengine.index;
+
+public enum GeoIndexType {
+    Bucket, STRtree, QuadTree;
+}

--- a/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/QuadTreeGeoIndex.java
+++ b/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/QuadTreeGeoIndex.java
@@ -1,0 +1,23 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.memory.cqengine.index;
+
+import com.googlecode.cqengine.attribute.Attribute;
+import org.locationtech.geomesa.utils.index.WrappedQuadtree;
+import org.locationtech.jts.geom.Geometry;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+public class QuadTreeGeoIndex<A extends Geometry, O extends SimpleFeature> extends AbstractGeoIndex<A, O> {
+    public QuadTreeGeoIndex(SimpleFeatureType sft, Attribute<O, A> attribute) {
+        super(sft, attribute);
+        geomAttributeIndex = sft.indexOf(attribute.getAttributeName());
+        index = new WrappedQuadtree<O>();
+    }
+}

--- a/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/QuadTreeGeoIndex.java
+++ b/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/QuadTreeGeoIndex.java
@@ -17,7 +17,6 @@ import org.opengis.feature.simple.SimpleFeatureType;
 public class QuadTreeGeoIndex<A extends Geometry, O extends SimpleFeature> extends AbstractGeoIndex<A, O> {
     public QuadTreeGeoIndex(SimpleFeatureType sft, Attribute<O, A> attribute) {
         super(sft, attribute);
-        geomAttributeIndex = sft.indexOf(attribute.getAttributeName());
         index = new WrappedQuadtree<O>();
     }
 }

--- a/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/STRtreeGeoIndex.java
+++ b/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/STRtreeGeoIndex.java
@@ -1,0 +1,40 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.memory.cqengine.index;
+
+import com.googlecode.cqengine.attribute.Attribute;
+import org.locationtech.geomesa.memory.cqengine.index.param.STRtreeIndexParam;
+import org.locationtech.geomesa.utils.index.WrappedSTRtree;
+import org.locationtech.jts.geom.Geometry;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.MessageFormat;
+import java.util.Optional;
+
+public class STRtreeGeoIndex<A extends Geometry, O extends SimpleFeature> extends AbstractGeoIndex<A, O> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(STRtreeGeoIndex.class);
+
+    public STRtreeGeoIndex(SimpleFeatureType sft, Attribute<O, A> attribute, Optional<STRtreeIndexParam> geoIndexParams) {
+        super(sft, attribute);
+
+        geomAttributeIndex = sft.indexOf(attribute.getAttributeName());
+        AttributeDescriptor attributeDescriptor = sft.getDescriptor(geomAttributeIndex);
+
+        STRtreeIndexParam stRtreeIndexParam = geoIndexParams.orElse(new STRtreeIndexParam());
+        int nodeCapacity = stRtreeIndexParam.getNodeCapacity();
+        LOGGER.debug(MessageFormat.format("STR Tree Index in use :nodeCapacity = {0}", nodeCapacity));
+
+        index = new WrappedSTRtree<>(nodeCapacity);
+    }
+}

--- a/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/STRtreeGeoIndex.java
+++ b/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/STRtreeGeoIndex.java
@@ -14,7 +14,6 @@ import org.locationtech.geomesa.utils.index.WrappedSTRtree;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
-import org.opengis.feature.type.AttributeDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,14 +26,9 @@ public class STRtreeGeoIndex<A extends Geometry, O extends SimpleFeature> extend
 
     public STRtreeGeoIndex(SimpleFeatureType sft, Attribute<O, A> attribute, Optional<STRtreeIndexParam> geoIndexParams) {
         super(sft, attribute);
-
-        geomAttributeIndex = sft.indexOf(attribute.getAttributeName());
-        AttributeDescriptor attributeDescriptor = sft.getDescriptor(geomAttributeIndex);
-
         STRtreeIndexParam stRtreeIndexParam = geoIndexParams.orElse(new STRtreeIndexParam());
         int nodeCapacity = stRtreeIndexParam.getNodeCapacity();
         LOGGER.debug(MessageFormat.format("STR Tree Index in use :nodeCapacity = {0}", nodeCapacity));
-
         index = new WrappedSTRtree<>(nodeCapacity);
     }
 }

--- a/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/param/BucketIndexParam.java
+++ b/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/param/BucketIndexParam.java
@@ -1,0 +1,38 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.memory.cqengine.index.param;
+
+import org.locationtech.geomesa.memory.cqengine.index.GeoIndexType;
+
+public class BucketIndexParam implements GeoIndexParams {
+    private int xBuckets = 360;
+    private int yBuckets = 180;
+
+
+    public BucketIndexParam() {
+    }
+
+    public BucketIndexParam(int xBuckets, int yBuckets) {
+        this.xBuckets = xBuckets;
+        this.yBuckets = yBuckets;
+    }
+
+    public int getxBuckets() {
+        return xBuckets;
+    }
+
+    public int getyBuckets() {
+        return yBuckets;
+    }
+
+    @Override
+    public GeoIndexType getGeoIndexType() {
+        return GeoIndexType.Bucket;
+    }
+}

--- a/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/param/GeoIndexParams.java
+++ b/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/param/GeoIndexParams.java
@@ -1,0 +1,16 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.memory.cqengine.index.param;
+
+import org.locationtech.geomesa.memory.cqengine.index.GeoIndexType;
+
+public interface GeoIndexParams {
+
+    public GeoIndexType getGeoIndexType();
+}

--- a/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/param/STRtreeIndexParam.java
+++ b/geomesa-memory/geomesa-cqengine/src/main/java/org/locationtech/geomesa/memory/cqengine/index/param/STRtreeIndexParam.java
@@ -1,0 +1,32 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.memory.cqengine.index.param;
+
+import org.locationtech.geomesa.memory.cqengine.index.GeoIndexType;
+
+public class STRtreeIndexParam implements GeoIndexParams {
+
+    int nodeCapacity = 10;
+
+    public STRtreeIndexParam() {
+    }
+
+    public STRtreeIndexParam(int nodeCapacity) {
+        this.nodeCapacity = nodeCapacity;
+    }
+
+    public int getNodeCapacity() {
+        return nodeCapacity;
+    }
+
+    @Override
+    public GeoIndexType getGeoIndexType() {
+        return GeoIndexType.STRtree;
+    }
+}

--- a/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/GeoCQEngine.scala
+++ b/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/GeoCQEngine.scala
@@ -162,27 +162,24 @@ class GeoCQEngine(val sft: SimpleFeatureType,
 
 object GeoCQEngine {
 
-  private var lastIndexUsed: ThreadLocal[SpatialIndex[_ <: SimpleFeature]] = null
+  private val lastIndexUsed : Option[ThreadLocal[SpatialIndex[_ <: SimpleFeature]]] =
+    sys.props.get("GeoCQEngineDebugEnabled").collect {
+      case e if e.toBoolean => new ThreadLocal[SpatialIndex[_ <: SimpleFeature]]
+    }
 
-  var isDebugEnabled = false
-
-  if ("true".equals(System.getProperty("GeoCQEngineDebugEnabled"))) {
-    lastIndexUsed = new ThreadLocal[SpatialIndex[_ <: SimpleFeature]]
-    isDebugEnabled = true
-  }
+  def isDebugEnabled(): Boolean = lastIndexUsed.nonEmpty
 
   def setLastIndexUsed(spatialIndex: SpatialIndex[_ <: SimpleFeature]) = {
-    if (!isDebugEnabled) {
+    if (lastIndexUsed.isEmpty) {
       throw new UnsupportedOperationException("GeoCQEngineDebugEnabled = false, debug mode disabled")
     }
-    lastIndexUsed.set(spatialIndex)
-
+    lastIndexUsed.foreach(_.set(spatialIndex))
   }
 
-  def getLastIndexUsed(): SpatialIndex[_ <: SimpleFeature] = {
-    if (!isDebugEnabled) {
+  def getLastIndexUsed(): Option[SpatialIndex[_ <: SimpleFeature]] = {
+    if (lastIndexUsed.isEmpty) {
       throw new UnsupportedOperationException("GeoCQEngineDebugEnabled = false, debug mode disabled")
     }
-    return lastIndexUsed.get()
+    return lastIndexUsed.map(_.get())
   }
 }

--- a/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/GeoCQEngine.scala
+++ b/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/GeoCQEngine.scala
@@ -21,12 +21,13 @@ import com.googlecode.cqengine.query.simple.{All, Equal}
 import com.googlecode.cqengine.query.{Query, QueryFactory}
 import com.googlecode.cqengine.{ConcurrentIndexedCollection, IndexedCollection}
 import com.typesafe.scalalogging.LazyLogging
-import org.locationtech.jts.geom.Geometry
 import org.locationtech.geomesa.memory.cqengine.attribute.SimpleFeatureAttribute
-import org.locationtech.geomesa.memory.cqengine.index.GeoIndex
+import org.locationtech.geomesa.memory.cqengine.index.GeoIndexType
+import org.locationtech.geomesa.memory.cqengine.index.param.{BucketIndexParam, GeoIndexParams}
 import org.locationtech.geomesa.memory.cqengine.utils.CQIndexType.CQIndexType
 import org.locationtech.geomesa.memory.cqengine.utils._
-import org.locationtech.geomesa.utils.index.SimpleFeatureIndex
+import org.locationtech.geomesa.utils.index.{SimpleFeatureIndex, SpatialIndex}
+import org.locationtech.jts.geom.Geometry
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter._
 
@@ -35,10 +36,27 @@ import scala.collection.JavaConversions._
 class GeoCQEngine(val sft: SimpleFeatureType,
                   attributes: Seq[(String, CQIndexType)],
                   enableFidIndex: Boolean = false,
-                  geomResolution: (Int, Int) = (360, 180),
+                  geoIndexType: GeoIndexType = GeoIndexType.Bucket,
+                  geoIndexParam: Option[_ <: GeoIndexParams] = Option.empty,
                   dedupe: Boolean = true) extends SimpleFeatureIndex with LazyLogging {
 
   protected val cqcache: IndexedCollection[SimpleFeature] = new ConcurrentIndexedCollection[SimpleFeature]()
+
+  def this(sft: SimpleFeatureType,
+           attributes: Seq[(String, CQIndexType)],
+           enableFidIndex: Boolean,
+           geomResolution: (Int, Int),
+           dedupe: Boolean) = {
+    this(sft, attributes, enableFidIndex, GeoIndexType.Bucket, Option.apply(new BucketIndexParam(geomResolution._1, geomResolution._2).asInstanceOf[GeoIndexParams]), dedupe)
+  }
+
+
+  def this(sft: SimpleFeatureType,
+           attributes: Seq[(String, CQIndexType)],
+           enableFidIndex: Boolean,
+           geomResolution: (Int, Int)) = {
+    this(sft, attributes, enableFidIndex, geomResolution, true)
+  }
 
   addIndices()
 
@@ -116,7 +134,7 @@ class GeoCQEngine(val sft: SimpleFeatureType,
 
           case GEOMETRY | DEFAULT if classOf[Geometry].isAssignableFrom(binding) =>
               val attribute = new SimpleFeatureAttribute(binding.asInstanceOf[Class[Geometry]], sft, name)
-              GeoIndex.onAttribute(sft, attribute, geomResolution._1, geomResolution._2)
+              GeoIndexFactory.onAttribute(sft, attribute, geoIndexType, geoIndexParam);
 
           case DEFAULT if classOf[UUID].isAssignableFrom(binding) =>
               UniqueIndex.onAttribute(new SimpleFeatureAttribute(classOf[UUID], sft, name))
@@ -139,5 +157,32 @@ class GeoCQEngine(val sft: SimpleFeatureType,
         cqcache.addIndex(index)
       }
     }
+  }
+}
+
+object GeoCQEngine {
+
+  private var lastIndexUsed: ThreadLocal[SpatialIndex[_ <: SimpleFeature]] = null
+
+  var isDebugEnabled = false
+
+  if ("true".equals(System.getProperty("GeoCQEngineDebugEnabled"))) {
+    lastIndexUsed = new ThreadLocal[SpatialIndex[_ <: SimpleFeature]]
+    isDebugEnabled = true
+  }
+
+  def setLastIndexUsed(spatialIndex: SpatialIndex[_ <: SimpleFeature]) = {
+    if (!isDebugEnabled) {
+      throw new UnsupportedOperationException("GeoCQEngineDebugEnabled = false, debug mode disabled")
+    }
+    lastIndexUsed.set(spatialIndex)
+
+  }
+
+  def getLastIndexUsed(): SpatialIndex[_ <: SimpleFeature] = {
+    if (!isDebugEnabled) {
+      throw new UnsupportedOperationException("GeoCQEngineDebugEnabled = false, debug mode disabled")
+    }
+    return lastIndexUsed.get()
   }
 }

--- a/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/GeoIndexFactory.scala
+++ b/geomesa-memory/geomesa-cqengine/src/main/scala/org/locationtech/geomesa/memory/cqengine/GeoIndexFactory.scala
@@ -1,0 +1,42 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.memory.cqengine
+
+import com.googlecode.cqengine.attribute.Attribute
+import org.locationtech.geomesa.memory.cqengine.index.param.{BucketIndexParam, GeoIndexParams, STRtreeIndexParam}
+import org.locationtech.geomesa.memory.cqengine.index.{AbstractGeoIndex, BucketGeoIndex, GeoIndexType, QuadTreeGeoIndex, STRtreeGeoIndex}
+import org.opengis.feature.simple.SimpleFeatureType
+import org.locationtech.jts.geom.Geometry
+import org.opengis.feature.simple.SimpleFeature
+
+
+object GeoIndexFactory{
+
+
+  import org.locationtech.geomesa.utils.conversions.JavaConverters._
+  def onAttribute[A <: Geometry, O <: SimpleFeature](sft: SimpleFeatureType, attribute: Attribute[O, A], geoIndexType: GeoIndexType, geoIndexParams: Option[GeoIndexParams]): AbstractGeoIndex[A, O] = {
+    val geomAttributeIndex = sft.indexOf(attribute.getAttributeName)
+    val attributeDescriptor = sft.getDescriptor(geomAttributeIndex)
+    checkParams(geoIndexType, geoIndexParams)
+    geoIndexType match {
+      case GeoIndexType.Bucket =>
+        return new BucketGeoIndex[A, O](sft, attribute, geoIndexParams.map(p => p.asInstanceOf[BucketIndexParam]).asJava)
+      case GeoIndexType.STRtree =>
+        return new STRtreeGeoIndex[A, O](sft, attribute, geoIndexParams.map(p => p.asInstanceOf[STRtreeIndexParam]).asJava)
+      case GeoIndexType.QuadTree =>
+        return new QuadTreeGeoIndex[A, O](sft, attribute)
+    }
+    throw new IllegalArgumentException("UNKNOWN GEO INDEX TYPE")
+  }
+
+  private def checkParams(geoIndexType: GeoIndexType, geoIndexParams: Option[_ <: GeoIndexParams]): Unit = {
+    if (geoIndexParams != null && geoIndexParams.isDefined && geoIndexParams.get.getGeoIndexType != geoIndexType)
+      throw new IllegalArgumentException("Index type and parameters does not match")
+  }
+}

--- a/geomesa-memory/geomesa-cqengine/src/test/scala/org/locationtech/geomesa/memory/cqengine/utils/CQIndexingOptionsTest.scala
+++ b/geomesa-memory/geomesa-cqengine/src/test/scala/org/locationtech/geomesa/memory/cqengine/utils/CQIndexingOptionsTest.scala
@@ -18,7 +18,7 @@ import com.googlecode.cqengine.index.unique.UniqueIndex
 import org.locationtech.jts.geom.Geometry
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.memory.cqengine.GeoCQEngine
-import org.locationtech.geomesa.memory.cqengine.index.GeoIndex
+import org.locationtech.geomesa.memory.cqengine.index.AbstractGeoIndex
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.SimpleFeature
 import org.specs2.mutable.Specification
@@ -71,7 +71,7 @@ class CQIndexingOptionsTest extends Specification {
         }
       }
 
-      nameToIndex.get("Where") must beSome[AttributeIndex[_, SimpleFeature]](beAnInstanceOf[GeoIndex[Geometry, SimpleFeature]])
+      nameToIndex.get("Where") must beSome[AttributeIndex[_, SimpleFeature]](beAnInstanceOf[AbstractGeoIndex[Geometry, SimpleFeature]])
 
       // Who is a string field and the 'default' hint is used.  This should be a Radix index
       nameToIndex.get("Who")  must beSome[AttributeIndex[_, SimpleFeature]](beAnInstanceOf[RadixTreeIndex[String, SimpleFeature]])

--- a/geomesa-memory/geomesa-cqengine/src/test/scala/org/locationtech/geomesa/memory/cqengine/utils/GeoCQEngineIndexChoiseTest.scala
+++ b/geomesa-memory/geomesa-cqengine/src/test/scala/org/locationtech/geomesa/memory/cqengine/utils/GeoCQEngineIndexChoiseTest.scala
@@ -72,8 +72,8 @@ class GeoCQEngineIndexChoiseTest extends Specification with LazyLogging {
     val lastIndexUsed = GeoCQEngine.getLastIndexUsed()
     if (spatialIndex.isDefined) {
       val expected = spatialIndex.get
-      lastIndexUsed must not(beNull)
-      lastIndexUsed.getClass must equalTo(expected)
+      lastIndexUsed.nonEmpty must beTrue
+      lastIndexUsed.get.getClass must equalTo(expected)
     }
 
     // since GT count is (presumably) correct

--- a/geomesa-memory/geomesa-cqengine/src/test/scala/org/locationtech/geomesa/memory/cqengine/utils/SampleFeatures.scala
+++ b/geomesa-memory/geomesa-cqengine/src/test/scala/org/locationtech/geomesa/memory/cqengine/utils/SampleFeatures.scala
@@ -228,6 +228,11 @@ object SampleFilters {
     s"BBOX(Where, -180, 0, 0, 90)"
   )
 
+  val spatialIndexesForIndexChoise: Seq[Filter] = Seq(
+    s"INTERSECTS(Where, $bbox2)",
+    s"BBOX(Where, -180, 0, 0, 90)"
+  )
+
   val andedSpatialPredicates: Seq[Filter] = Seq(
     s"INTERSECTS(Where, $bbox1) AND OVERLAPS(Where, $bbox2)",
     s"INTERSECTS(Where, $bbox1) AND WITHIN(Where, $bbox2)",

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/WrappedSTRtree.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/WrappedSTRtree.scala
@@ -10,14 +10,9 @@ package org.locationtech.geomesa.utils.index
 
 import org.locationtech.jts.index.strtree.STRtree
 
-class WrappedSTRtree[T](nodeCapacity:Int) extends WrapperIndex[T,STRtree](
+class WrappedSTRtree[T](nodeCapacity:Int = 10) extends WrapperIndex[T,STRtree](
   indexBuider = () => new STRtree(nodeCapacity)
 ) with Serializable {
-
-  def this()
-  {
-    this(10)
-  }
 
   override def size(): Int = index.size()
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/WrappedSTRtree.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/WrappedSTRtree.scala
@@ -8,20 +8,16 @@
 
 package org.locationtech.geomesa.utils.index
 
-import org.locationtech.jts.index.quadtree.Quadtree
+import org.locationtech.jts.index.strtree.STRtree
 
-import scala.collection.JavaConverters._
-
-/**
- * Spatial index wrapper for un-synchronized quad tree
- */
-class WrappedQuadtree[T] extends WrapperIndex[T,Quadtree](
-  indexBuider = () => new Quadtree()
-
+class WrappedSTRtree[T](nodeCapacity:Int) extends WrapperIndex[T,STRtree](
+  indexBuider = () => new STRtree(nodeCapacity)
 ) with Serializable {
 
-  override def query(): Iterator[T] =
-    index.queryAll().iterator.asScala.asInstanceOf[Iterator[(String, T)]].map(_._2)
+  def this()
+  {
+    this(10)
+  }
 
   override def size(): Int = index.size()
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/WrapperIndex.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/WrapperIndex.scala
@@ -1,0 +1,47 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.index
+
+import org.locationtech.jts.geom.{Envelope, Geometry}
+import org.locationtech.jts.index.{SpatialIndex => JSTSpatialIndex}
+
+import scala.collection.JavaConverters._
+
+class WrapperIndex[T, Index <: JSTSpatialIndex](val indexBuider : () => Index) extends SpatialIndex[T] with Serializable {
+
+  var index = indexBuider()
+
+  override def insert(geom: Geometry, key: String, value: T): Unit = index.insert(geom.getEnvelopeInternal, (key, value))
+
+  override def remove(geom: Geometry, key: String): T = {
+    val envelope = geom.getEnvelopeInternal
+    index.query(envelope).asScala.asInstanceOf[Seq[(String, T)]].find(_._1 == key) match {
+      case None => null.asInstanceOf[T]
+      case Some(kv) => index.remove(envelope, kv); kv._2
+    }
+  }
+
+  override def get(geom: Geometry, key: String): T = {
+    val intersect = index.query(geom.getEnvelopeInternal).asScala.asInstanceOf[Seq[(String, T)]]
+    intersect.find(_._1 == key).map(_._2).getOrElse(null.asInstanceOf[T])
+  }
+
+  override def query(xmin: Double, ymin: Double, xmax: Double, ymax: Double): Iterator[T] =
+    index.query(new Envelope(xmin, xmax, ymin, ymax)).iterator.asScala.asInstanceOf[Iterator[(String, T)]].map(_._2)
+
+  override def query(): Iterator[T] = {
+    query(-180,-90,180,90)
+  }
+
+  override def size(): Int = query().size
+
+  override def clear(): Unit = index = indexBuider()
+}
+
+

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/WrapperIndex.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/WrapperIndex.scala
@@ -15,7 +15,7 @@ import scala.collection.JavaConverters._
 
 class WrapperIndex[T, Index <: JSTSpatialIndex](val indexBuider : () => Index) extends SpatialIndex[T] with Serializable {
 
-  var index = indexBuider()
+  protected var index = indexBuider()
 
   override def insert(geom: Geometry, key: String, value: T): Unit = index.insert(geom.getEnvelopeInternal, (key, value))
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <attach.installers>true</attach.installers> <!-- whether install artifacts are published to maven or not -->
 
         <!-- testing properties -->
-        <maven.test.jvmargs>-Duser.timezone=UTC -Xms1g -Xmx8g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dgeomesa.scan.ranges.target=500</maven.test.jvmargs>
+        <maven.test.jvmargs>-Duser.timezone=UTC -Xms1g -Xmx8g -XX:-UseGCOverheadLimit -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Dgeomesa.scan.ranges.target=500 -Duser.language=en -Duser.region=US</maven.test.jvmargs>
         <test.fork.count>1</test.fork.count>
         <test.fork.reuse>true</test.fork.reuse>
 


### PR DESCRIPTION
I provided the new features just via API, is not possible to configure them in the sft schema. This  avoids using them as indexes for the GeoCQEngineDataStore

Signed-off-by: Rodolfo Totaro <rodolfo_totaro@yahoo.it>

