### PR TITLE
GEOMESA-2743 FSDS - Custom file callbacks

### DIFF
--- a/docs/user/filesystem/index_config.rst
+++ b/docs/user/filesystem/index_config.rst
@@ -157,7 +157,7 @@ which will be invoked for each new file that is created. Observer factories must
 
   package org.locationtech.geomesa.fs.storage.common.observer
 
-  trait FileSystemObserverFactory {
+  trait FileSystemObserverFactory extends Closeable {
     def apply(sft: SimpleFeatureType, partition: String, path: Path): FileSystemObserver
   }
 

--- a/docs/user/filesystem/index_config.rst
+++ b/docs/user/filesystem/index_config.rst
@@ -158,7 +158,7 @@ which will be invoked for each new file that is created. Observer factories must
   package org.locationtech.geomesa.fs.storage.common.observer
 
   trait FileSystemObserverFactory extends Closeable {
-    def apply(sft: SimpleFeatureType, partition: String, path: Path): FileSystemObserver
+    def apply(fc: FileContext, conf: Configuration, sft: SimpleFeatureType, path: Path): FileSystemObserver
   }
 
 .. note::

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/java/org/locationtech/geomesa/fs/storage/common/interop/ConfigurationUtils.java
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/java/org/locationtech/geomesa/fs/storage/common/interop/ConfigurationUtils.java
@@ -13,6 +13,7 @@ import com.typesafe.config.ConfigRenderOptions;
 import com.typesafe.config.ConfigValueFactory;
 import org.opengis.feature.simple.SimpleFeatureType;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -40,6 +41,10 @@ public class ConfigurationUtils {
 
     public static void setMetadata(SimpleFeatureType sft, String name, Map<String, String> options) {
         sft.getUserData().put("geomesa.fs.metadata", serialize(name, options));
+    }
+
+    public static void setObservers(SimpleFeatureType sft, List<String> observers) {
+        sft.getUserData().put("geomesa.fs.observers", String.join(",", observers));
     }
 
     private static String serialize(String name, Map<String, String> options) {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/AbstractFileSystemStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/AbstractFileSystemStorage.scala
@@ -246,7 +246,7 @@ abstract class AbstractFileSystemStorage(
     override def flush(): Unit = FlushQuietly(modifiers.values.toSeq ++ deleters.values).foreach(e => throw e)
 
     override def close(): Unit =
-      CloseQuietly(Seq(reader) ++ modifiers.values ++ deleters.values).foreach(e => throw e)
+      CloseQuietly(Seq(reader) ++ modifiers.values ++ deleters.values ++ observers).foreach(e => throw e)
   }
 
   /**

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/AbstractFileSystemStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/AbstractFileSystemStorage.scala
@@ -145,7 +145,7 @@ abstract class AbstractFileSystemStorage(
         def threaded = FileSystemThreadedReader(Iterator.single(reader -> toCompact), threads)
         val compactObserver = new CompactObserver(partition, path, toCompact)
         val observer = if (observers.isEmpty) { compactObserver } else {
-          new CompositeObserver(observers.map(_.apply(metadata.sft, partition, path)).+:(compactObserver))
+          new CompositeObserver(observers.map(_.apply(context.fc, context.conf, metadata.sft, path)).+:(compactObserver))
         }
 
         WithClose(createWriter(path, observer), threaded) { case (writer, features) =>
@@ -194,7 +194,7 @@ abstract class AbstractFileSystemStorage(
     PathCache.register(context.fc, path)
     val updateObserver = new UpdateObserver(partition, path, action)
     val observer = if (observers.isEmpty) { updateObserver } else {
-      new CompositeObserver(observers.map(_.apply(metadata.sft, partition, path)).+:(updateObserver))
+      new CompositeObserver(observers.map(_.apply(context.fc, context.conf, metadata.sft, path)).+:(updateObserver))
     }
     createWriter(path, observer)
   }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/AbstractFileSystemStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/AbstractFileSystemStorage.scala
@@ -17,7 +17,9 @@ import org.locationtech.geomesa.fs.storage.api.FileSystemStorage.{FileSystemUpda
 import org.locationtech.geomesa.fs.storage.api.StorageMetadata.StorageFileAction.StorageFileAction
 import org.locationtech.geomesa.fs.storage.api.StorageMetadata._
 import org.locationtech.geomesa.fs.storage.api._
-import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage.{FileSystemPathReader, WriterCallback}
+import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage.{FileSystemPathReader, MetadataObserver}
+import org.locationtech.geomesa.fs.storage.common.observer.FileSystemObserverFactory.CompositeObserver
+import org.locationtech.geomesa.fs.storage.common.observer.{FileSystemObserver, FileSystemObserverFactory}
 import org.locationtech.geomesa.fs.storage.common.utils.StorageUtils.FileType
 import org.locationtech.geomesa.fs.storage.common.utils.{PathCache, StorageUtils}
 import org.locationtech.geomesa.index.planning.QueryRunner
@@ -31,15 +33,17 @@ import org.opengis.filter.Filter
 import scala.collection.mutable.ListBuffer
 
 /**
-  * Base class storage implementations
-  *
-  * @param context file system context
-  * @param metadata metadata
-  * @param extension file extension
-  */
+ * Base class storage implementations
+ *
+ * @param context file system context
+ * @param metadata metadata
+ * @param observers observers for file callback hooks
+ * @param extension file extension
+ */
 abstract class AbstractFileSystemStorage(
     val context: FileSystemContext,
     val metadata: StorageMetadata,
+    observers: Seq[FileSystemObserverFactory],
     extension: String
   ) extends FileSystemStorage with MethodProfiling with LazyLogging {
 
@@ -47,10 +51,10 @@ abstract class AbstractFileSystemStorage(
     * Create a writer for the given file
     *
     * @param file file to write to
-    * @param callback callback to report stats on the data written
+    * @param observer observer to report stats on the data written
     * @return
     */
-  protected def createWriter(file: Path, callback: WriterCallback): FileSystemWriter
+  protected def createWriter(file: Path, observer: FileSystemObserver): FileSystemWriter
 
   /**
     * Create a path reader with the given filter and transform
@@ -139,9 +143,12 @@ abstract class AbstractFileSystemStorage(
 
         val reader = createReader(None, None)
         def threaded = FileSystemThreadedReader(Iterator.single(reader -> toCompact), threads)
-        val callback = new CompactCallback(partition, path, toCompact)
+        val compactObserver = new CompactObserver(partition, path, toCompact)
+        val observer = if (observers.isEmpty) { compactObserver } else {
+          new CompositeObserver(observers.map(_.apply(metadata.sft, partition, path)).+:(compactObserver))
+        }
 
-        WithClose(createWriter(path, callback), threaded) { case (writer, features) =>
+        WithClose(createWriter(path, observer), threaded) { case (writer, features) =>
           while (features.hasNext) {
             writer.write(features.next())
             written += 1
@@ -185,7 +192,11 @@ abstract class AbstractFileSystemStorage(
     }
     val path = StorageUtils.nextFile(context.root, partition, metadata.leafStorage, extension, fileType)
     PathCache.register(context.fc, path)
-    createWriter(path, new MetadataCallback(partition, path, action))
+    val updateObserver = new UpdateObserver(partition, path, action)
+    val observer = if (observers.isEmpty) { updateObserver } else {
+      new CompositeObserver(observers.map(_.apply(metadata.sft, partition, path)).+:(updateObserver))
+    }
+    createWriter(path, observer)
   }
 
   /**
@@ -245,8 +256,8 @@ abstract class AbstractFileSystemStorage(
     * @param file file being written
     * @param action file type
     */
-  class MetadataCallback(partition: String, file: Path, action: StorageFileAction) extends WriterCallback {
-    override def onClose(bounds: Envelope, count: Long): Unit = {
+  class UpdateObserver(partition: String, file: Path, action: StorageFileAction) extends MetadataObserver {
+    override protected def onClose(bounds: Envelope, count: Long): Unit = {
       val files = Seq(StorageFile(file.getName, System.currentTimeMillis(), action))
       metadata.addPartition(PartitionMetadata(partition, files, PartitionBounds(bounds), count))
     }
@@ -259,8 +270,8 @@ abstract class AbstractFileSystemStorage(
     * @param file compacted file being written
     * @param replaced files being replaced
     */
-  class CompactCallback(partition: String, file: Path, replaced: Seq[StorageFilePath]) extends WriterCallback {
-    override def onClose(bounds: Envelope, count: Long): Unit = {
+  class CompactObserver(partition: String, file: Path, replaced: Seq[StorageFilePath]) extends MetadataObserver {
+    override protected def onClose(bounds: Envelope, count: Long): Unit = {
       val partitionBounds = PartitionBounds(bounds)
       metadata.removePartition(PartitionMetadata(partition, replaced.map(_.file), partitionBounds, count))
       val added = Seq(StorageFile(file.getName, System.currentTimeMillis(), StorageFileAction.Append))
@@ -271,31 +282,34 @@ abstract class AbstractFileSystemStorage(
 
 object AbstractFileSystemStorage {
 
-  trait WriterCallback {
-    def onClose(bounds: Envelope, count: Long): Unit
-  }
-
+  /**
+   * Reader trait
+   */
   trait FileSystemPathReader {
     def read(path: Path): CloseableIterator[SimpleFeature]
   }
 
-  trait MetadataObservingFileSystemWriter extends FileSystemWriter {
-
-    def callback: WriterCallback
+  /**
+   * Tracks metadata during writes
+   */
+  abstract class MetadataObserver extends FileSystemObserver {
 
     private var count: Long = 0L
     private val bounds: Envelope = new Envelope()
 
-    abstract override def write(feature: SimpleFeature): Unit = {
-      super.write(feature)
+    override def write(feature: SimpleFeature): Unit = {
       // Update internal count/bounds/etc
       count += 1L
-      bounds.expandToInclude(feature.getDefaultGeometry.asInstanceOf[Geometry].getEnvelopeInternal)
+      val geom = feature.getDefaultGeometry.asInstanceOf[Geometry]
+      if (geom != null) {
+        bounds.expandToInclude(geom.getEnvelopeInternal)
+      }
     }
 
-    abstract override def close(): Unit = {
-      super.close()
-      callback.onClose(bounds, count)
-    }
+    override def flush(): Unit = {}
+
+    override def close(): Unit = onClose(bounds, count)
+
+    protected def onClose(bounds: Envelope, count: Long): Unit
   }
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/observer/FileSystemObserver.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/observer/FileSystemObserver.scala
@@ -1,0 +1,16 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.storage.common.observer
+
+import org.locationtech.geomesa.fs.storage.api.FileSystemStorage.FileSystemWriter
+
+/**
+ * Marker trait for writer hooks
+ */
+trait FileSystemObserver extends FileSystemWriter

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/observer/FileSystemObserverFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/observer/FileSystemObserverFactory.scala
@@ -11,7 +11,8 @@ package observer
 
 import java.io.Closeable
 
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileContext, Path}
 import org.locationtech.geomesa.utils.io.{CloseQuietly, FlushQuietly}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
@@ -19,7 +20,7 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
  * Factory for observing file writes
  */
 trait FileSystemObserverFactory extends Closeable {
-  def apply(sft: SimpleFeatureType, partition: String, path: Path): FileSystemObserver
+  def apply(fc: FileContext, conf: Configuration, sft: SimpleFeatureType, path: Path): FileSystemObserver
 }
 
 object FileSystemObserverFactory {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/observer/FileSystemObserverFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/observer/FileSystemObserverFactory.scala
@@ -9,6 +9,8 @@
 package org.locationtech.geomesa.fs.storage.common
 package observer
 
+import java.io.Closeable
+
 import org.apache.hadoop.fs.Path
 import org.locationtech.geomesa.utils.io.{CloseQuietly, FlushQuietly}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -16,7 +18,7 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 /**
  * Factory for observing file writes
  */
-trait FileSystemObserverFactory {
+trait FileSystemObserverFactory extends Closeable {
   def apply(sft: SimpleFeatureType, partition: String, path: Path): FileSystemObserver
 }
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/observer/FileSystemObserverFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/observer/FileSystemObserverFactory.scala
@@ -1,0 +1,44 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.storage.common
+package observer
+
+import org.apache.hadoop.fs.Path
+import org.locationtech.geomesa.utils.io.{CloseQuietly, FlushQuietly}
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+
+/**
+ * Factory for observing file writes
+ */
+trait FileSystemObserverFactory {
+  def apply(sft: SimpleFeatureType, partition: String, path: Path): FileSystemObserver
+}
+
+object FileSystemObserverFactory {
+
+  def apply(sft: SimpleFeatureType): Seq[FileSystemObserverFactory] =
+    sft.getObservers.map(o => Class.forName(o).newInstance().asInstanceOf[FileSystemObserverFactory])
+
+  object NoOpObserver extends FileSystemObserver {
+    override def write(feature: SimpleFeature): Unit = {}
+    override def flush(): Unit = {}
+    override def close(): Unit = {}
+  }
+
+  /**
+   * Composite observer
+   *
+   * @param observers observers
+   */
+  class CompositeObserver(observers: Seq[FileSystemObserver]) extends FileSystemObserver {
+    override def write(feature: SimpleFeature): Unit = observers.foreach(_.write(feature))
+    override def flush(): Unit = FlushQuietly(observers).foreach(e => throw e)
+    override def close(): Unit = CloseQuietly(observers).foreach(e => throw e)
+  }
+}

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/test/scala/org/locationtech/geomesa/fs/storage/common/ConfigurationTest.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/test/scala/org/locationtech/geomesa/fs/storage/common/ConfigurationTest.scala
@@ -79,5 +79,18 @@ class ConfigurationTest extends Specification with AllExpectations {
         sft.removeLeafStorage() must beNone
       }
     }
+
+    "configure observers in user data" >> {
+      val sft = SimpleFeatureTypes.createType("test", "name:String,age:Int,foo:Date,*bar:Point:srid=4326")
+      val setters = Seq(
+        () => ConfigurationUtils.setObservers(sft, java.util.Arrays.asList("foo.bar", "foo.baz")),
+        () => sft.setObservers(Seq("foo.bar", "foo.baz")))
+      foreach(setters) { setter =>
+        setter.apply()
+        sft.getObservers mustEqual Seq("foo.bar", "foo.baz")
+        sft.getUserData.remove(StorageKeys.ObserversKey)
+        sft.getObservers must beEmpty
+      }
+    }
   }
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
@@ -13,14 +13,15 @@ import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.fs.storage.api.FileSystemStorage.FileSystemWriter
 import org.locationtech.geomesa.fs.storage.api.StorageMetadata.{StorageFile, StorageFilePath}
 import org.locationtech.geomesa.fs.storage.api._
-import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage
-import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage.{FileSystemPathReader, WriterCallback}
+import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage.FileSystemPathReader
 import org.locationtech.geomesa.fs.storage.common.utils.PathCache
+import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage
+import org.locationtech.geomesa.fs.storage.common.observer.FileSystemObserver
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
 class ConverterStorage(context: FileSystemContext, metadata: StorageMetadata, converter: SimpleFeatureConverter)
-    extends AbstractFileSystemStorage(context, metadata, "") {
+    extends AbstractFileSystemStorage(context, metadata, Seq.empty, "") {
 
   // TODO close converter...
   // the problem is that we aggressively cache storage instances for performance (in FileSystemStorageManager),
@@ -29,7 +30,7 @@ class ConverterStorage(context: FileSystemContext, metadata: StorageMetadata, co
   // actually need to be closed, and since they will only open a single connection per converter, the
   // impact should be low
 
-  override protected def createWriter(file: Path, callback: WriterCallback): FileSystemWriter =
+  override protected def createWriter(file: Path, observer: FileSystemObserver): FileSystemWriter =
     throw new NotImplementedError()
 
   override protected def createReader(

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/OrcFileSystemStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/OrcFileSystemStorage.scala
@@ -9,7 +9,6 @@
 
 package org.locationtech.geomesa.fs.storage.orc
 
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.fs.Path
 import org.apache.orc.TypeDescription
 import org.locationtech.geomesa.features.serialization.ObjectType
@@ -17,8 +16,9 @@ import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.filter.factory.FastFilterFactory
 import org.locationtech.geomesa.fs.storage.api.FileSystemStorage.FileSystemWriter
 import org.locationtech.geomesa.fs.storage.api._
+import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage.FileSystemPathReader
+import org.locationtech.geomesa.fs.storage.common.observer.{FileSystemObserver, FileSystemObserverFactory}
 import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage
-import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage.{FileSystemPathReader, MetadataObservingFileSystemWriter, WriterCallback}
 import org.locationtech.jts.geom.Geometry
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType
@@ -29,13 +29,14 @@ import org.opengis.filter.Filter
   *
   * @param metadata metadata
   */
-class OrcFileSystemStorage(context: FileSystemContext, metadata: StorageMetadata)
-    extends AbstractFileSystemStorage(context, metadata, OrcFileSystemStorage.FileExtension) with LazyLogging {
+class OrcFileSystemStorage(
+    context: FileSystemContext,
+    metadata: StorageMetadata,
+    observers: Seq[FileSystemObserverFactory] = Seq.empty
+  ) extends AbstractFileSystemStorage(context, metadata, observers, OrcFileSystemStorage.FileExtension) {
 
-  override protected def createWriter(file: Path, cb: WriterCallback): FileSystemWriter =
-    new OrcFileSystemWriter(metadata.sft, context.conf, file) with MetadataObservingFileSystemWriter {
-      override def callback: WriterCallback = cb
-    }
+  override protected def createWriter(file: Path, observer: FileSystemObserver): FileSystemWriter =
+    new OrcFileSystemWriter(metadata.sft, context.conf, file, observer)
 
   override protected def createReader(
       filter: Option[Filter],

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/OrcFileSystemStorageFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/OrcFileSystemStorageFactory.scala
@@ -10,6 +10,7 @@ package org.locationtech.geomesa.fs.storage.orc
 
 import org.apache.orc.OrcConf
 import org.locationtech.geomesa.fs.storage.api._
+import org.locationtech.geomesa.fs.storage.common.observer.FileSystemObserverFactory
 
 class OrcFileSystemStorageFactory extends FileSystemStorageFactory {
 
@@ -20,6 +21,6 @@ class OrcFileSystemStorageFactory extends FileSystemStorageFactory {
         context.conf.get(OrcConf.USE_ZEROCOPY.getHiveConfName) == null) {
       OrcConf.USE_ZEROCOPY.setBoolean(context.conf, true)
     }
-    new OrcFileSystemStorage(context, metadata)
+    new OrcFileSystemStorage(context, metadata, FileSystemObserverFactory(metadata.sft))
   }
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/OrcFileSystemWriter.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/OrcFileSystemWriter.scala
@@ -12,10 +12,20 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.orc.OrcFile
 import org.locationtech.geomesa.fs.storage.api.FileSystemStorage.FileSystemWriter
+import org.locationtech.geomesa.fs.storage.common.observer.FileSystemObserver
+import org.locationtech.geomesa.fs.storage.common.observer.FileSystemObserverFactory.NoOpObserver
 import org.locationtech.geomesa.fs.storage.orc.utils.OrcAttributeWriter
+import org.locationtech.geomesa.utils.io.CloseQuietly
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
-class OrcFileSystemWriter(sft: SimpleFeatureType, config: Configuration, file: Path) extends FileSystemWriter {
+import scala.util.control.NonFatal
+
+class OrcFileSystemWriter(
+    sft: SimpleFeatureType,
+    config: Configuration,
+    file: Path,
+    observer: FileSystemObserver = NoOpObserver
+  ) extends FileSystemWriter {
 
   private val schema = OrcFileSystemStorage.createTypeDescription(sft)
 
@@ -33,17 +43,25 @@ class OrcFileSystemWriter(sft: SimpleFeatureType, config: Configuration, file: P
       writer.addRowBatch(batch)
       batch.reset()
     }
+    observer.write(sf)
   }
 
   override def flush(): Unit = {
+    flushBatch()
+    observer.flush()
+  }
+
+  override def close(): Unit = {
+    try { flushBatch() } catch {
+      case NonFatal(e) => CloseQuietly(Seq(writer, observer)).foreach(e.addSuppressed); throw e
+    }
+    CloseQuietly(Seq(writer, observer)).foreach(e => throw e)
+  }
+
+  private def flushBatch(): Unit = {
     if (batch.size != 0) {
       writer.addRowBatch(batch)
       batch.reset()
     }
-  }
-
-  override def close(): Unit = {
-    flush()
-    writer.close()
   }
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/test/scala/org/locationtech/geomesa/fs/storage/orc/TestObserverFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/test/scala/org/locationtech/geomesa/fs/storage/orc/TestObserverFactory.scala
@@ -23,6 +23,7 @@ class TestObserverFactory extends FileSystemObserverFactory {
     TestObserverFactory.observers += observer
     observer
   }
+  override def close(): Unit = {}
 }
 
 object TestObserverFactory {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/test/scala/org/locationtech/geomesa/fs/storage/orc/TestObserverFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/test/scala/org/locationtech/geomesa/fs/storage/orc/TestObserverFactory.scala
@@ -1,0 +1,44 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.storage.orc
+
+import java.util.Collections
+
+import org.apache.hadoop.fs.Path
+import org.locationtech.geomesa.fs.storage.common.observer.{FileSystemObserver, FileSystemObserverFactory}
+import org.locationtech.geomesa.fs.storage.orc.TestObserverFactory.TestObserver
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+
+import scala.collection.mutable.ArrayBuffer
+
+class TestObserverFactory extends FileSystemObserverFactory {
+  override def apply(sft: SimpleFeatureType, partition: String, path: Path): FileSystemObserver = {
+    val observer = new TestObserver(partition, path)
+    TestObserverFactory.observers += observer
+    observer
+  }
+}
+
+object TestObserverFactory {
+
+  import scala.collection.JavaConverters._
+
+  val observers: scala.collection.mutable.Set[TestObserver] =
+    Collections.synchronizedSet(new java.util.HashSet[TestObserver]()).asScala
+
+  class TestObserver(val partition: String, val path: Path) extends FileSystemObserver {
+
+    val features = ArrayBuffer.empty[SimpleFeature]
+    var closed = false
+
+    override def write(feature: SimpleFeature): Unit = features += feature
+    override def flush(): Unit = {}
+    override def close(): Unit = closed = true
+  }
+}

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/test/scala/org/locationtech/geomesa/fs/storage/orc/TestObserverFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/test/scala/org/locationtech/geomesa/fs/storage/orc/TestObserverFactory.scala
@@ -10,7 +10,8 @@ package org.locationtech.geomesa.fs.storage.orc
 
 import java.util.Collections
 
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileContext, Path}
 import org.locationtech.geomesa.fs.storage.common.observer.{FileSystemObserver, FileSystemObserverFactory}
 import org.locationtech.geomesa.fs.storage.orc.TestObserverFactory.TestObserver
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -18,8 +19,8 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import scala.collection.mutable.ArrayBuffer
 
 class TestObserverFactory extends FileSystemObserverFactory {
-  override def apply(sft: SimpleFeatureType, partition: String, path: Path): FileSystemObserver = {
-    val observer = new TestObserver(partition, path)
+  override def apply(fc: FileContext, conf: Configuration, sft: SimpleFeatureType, path: Path): FileSystemObserver = {
+    val observer = new TestObserver(path)
     TestObserverFactory.observers += observer
     observer
   }
@@ -33,7 +34,7 @@ object TestObserverFactory {
   val observers: scala.collection.mutable.Set[TestObserver] =
     Collections.synchronizedSet(new java.util.HashSet[TestObserver]()).asScala
 
-  class TestObserver(val partition: String, val path: Path) extends FileSystemObserver {
+  class TestObserver(val path: Path) extends FileSystemObserver {
 
     val features = ArrayBuffer.empty[SimpleFeature]
     var closed = false

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/ParquetFileSystemStorageFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/ParquetFileSystemStorageFactory.scala
@@ -9,6 +9,7 @@
 package org.locationtech.geomesa.parquet
 
 import org.locationtech.geomesa.fs.storage.api._
+import org.locationtech.geomesa.fs.storage.common.observer.FileSystemObserverFactory
 import org.locationtech.geomesa.parquet.ParquetFileSystemStorage.ParquetCompressionOpt
 
 class ParquetFileSystemStorageFactory extends FileSystemStorageFactory {
@@ -20,6 +21,6 @@ class ParquetFileSystemStorageFactory extends FileSystemStorageFactory {
       Option(System.getProperty(ParquetCompressionOpt)).foreach(context.conf.set(ParquetCompressionOpt, _))
     }
     context.conf.set("parquet.filter.dictionary.enabled", "true")
-    new ParquetFileSystemStorage(context, metadata)
+    new ParquetFileSystemStorage(context, metadata, FileSystemObserverFactory(metadata.sft))
   }
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/ParquetStorageTest.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/ParquetStorageTest.scala
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.fs.storage.api.FileSystemStorage.FileSystemWriter
 import org.locationtech.geomesa.fs.storage.api._
+import org.locationtech.geomesa.fs.storage.common.StorageKeys
 import org.locationtech.geomesa.fs.storage.common.metadata.FileBasedMetadataFactory
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
@@ -45,7 +46,7 @@ class ParquetStorageTest extends Specification with AllExpectations with LazyLog
 
   "ParquetFileSystemStorage" should {
     "read and write features" in {
-      val sft = SimpleFeatureTypes.createType("orc-test", "*geom:Point:srid=4326,name:String,age:Int,dtg:Date")
+      val sft = SimpleFeatureTypes.createType("parquet-test", "*geom:Point:srid=4326,name:String,age:Int,dtg:Date")
 
       val features = (0 until 10).map { i =>
         val sf = new ScalaSimpleFeature(sft, i.toString)
@@ -61,7 +62,7 @@ class ParquetStorageTest extends Specification with AllExpectations with LazyLog
         val context = FileSystemContext(FileContext.getFileContext(dir.toUri), config, dir)
         val metadata =
           new FileBasedMetadataFactory()
-              .create(context, Map.empty, Metadata(sft, "orc", scheme, leafStorage = true))
+              .create(context, Map.empty, Metadata(sft, "parquet", scheme, leafStorage = true))
         val storage = new ParquetFileSystemStorageFactory().apply(context, metadata)
 
         storage must not(beNull)
@@ -107,7 +108,7 @@ class ParquetStorageTest extends Specification with AllExpectations with LazyLog
     }
 
     "read and write complex features" in {
-      val sft = SimpleFeatureTypes.createType("orc-test-complex",
+      val sft = SimpleFeatureTypes.createType("parquet-test-complex",
         "name:String,age:Int,time:Long,height:Float,weight:Double,bool:Boolean," +
             "uuid:UUID,bytes:Bytes,list:List[Int],map:Map[String,Long]," +
             "line:LineString,mpt:MultiPoint,poly:Polygon,mline:MultiLineString,mpoly:MultiPolygon," +
@@ -147,7 +148,7 @@ class ParquetStorageTest extends Specification with AllExpectations with LazyLog
         val context = FileSystemContext(FileContext.getFileContext(dir.toUri), config, dir)
         val metadata =
           new FileBasedMetadataFactory()
-              .create(context, Map.empty, Metadata(sft, "orc", scheme, leafStorage = true))
+              .create(context, Map.empty, Metadata(sft, "parquet", scheme, leafStorage = true))
         val storage = new ParquetFileSystemStorageFactory().apply(context, metadata)
 
         storage must not(beNull)
@@ -188,7 +189,7 @@ class ParquetStorageTest extends Specification with AllExpectations with LazyLog
     }
 
     "modify and delete features" in {
-      val sft = SimpleFeatureTypes.createType("orc-test", "*geom:Point:srid=4326,name:String,age:Int,dtg:Date")
+      val sft = SimpleFeatureTypes.createType("parquet-test", "*geom:Point:srid=4326,name:String,age:Int,dtg:Date")
 
       val features = (0 until 10).map { i =>
         val sf = new ScalaSimpleFeature(sft, i.toString)
@@ -204,7 +205,7 @@ class ParquetStorageTest extends Specification with AllExpectations with LazyLog
         val context = FileSystemContext(FileContext.getFileContext(dir.toUri), config, dir)
         val metadata =
           new FileBasedMetadataFactory()
-              .create(context, Map.empty, Metadata(sft, "orc", scheme, leafStorage = true))
+              .create(context, Map.empty, Metadata(sft, "parquet", scheme, leafStorage = true))
         val storage = new ParquetFileSystemStorageFactory().apply(context, metadata)
 
         storage must not(beNull)
@@ -247,6 +248,71 @@ class ParquetStorageTest extends Specification with AllExpectations with LazyLog
       }
     }
 
+    "use custom file observers" in {
+      val userData = s"${StorageKeys.ObserversKey}=${classOf[TestObserverFactory].getName}"
+      val sft = SimpleFeatureTypes.createType("parquet-test",
+        s"*geom:Point:srid=4326,name:String,age:Int,dtg:Date;$userData")
+
+      val features = (0 until 10).map { i =>
+        val sf = new ScalaSimpleFeature(sft, i.toString)
+        sf.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+        sf.setAttribute(1, s"name$i")
+        sf.setAttribute(2, s"$i")
+        sf.setAttribute(3, f"2014-01-${i + 1}%02dT00:00:01.000Z")
+        sf.setAttribute(0, s"POINT(4$i 5$i)")
+        sf
+      }
+
+      withTestDir { dir =>
+        val context = FileSystemContext(FileContext.getFileContext(dir.toUri), config, dir)
+        val metadata =
+          new FileBasedMetadataFactory()
+              .create(context, Map.empty, Metadata(sft, "parquet", scheme, leafStorage = true))
+        val storage = new ParquetFileSystemStorageFactory().apply(context, metadata)
+
+        storage must not(beNull)
+
+        val writers = scala.collection.mutable.Map.empty[String, FileSystemWriter]
+
+        features.foreach { f =>
+          val partition = storage.metadata.scheme.getPartitionName(f)
+          val writer = writers.getOrElseUpdate(partition, storage.getWriter(partition))
+          writer.write(f)
+        }
+
+        TestObserverFactory.observers must haveSize(3) // 3 partitions due to our data and scheme
+        forall(TestObserverFactory.observers)(_.closed must beFalse)
+
+        writers.foreach(_._2.close())
+        forall(TestObserverFactory.observers)(_.closed must beTrue)
+        TestObserverFactory.observers.flatMap(_.features) must containTheSameElementsAs(features)
+        TestObserverFactory.observers.clear()
+
+        logger.debug(s"wrote to ${writers.size} partitions for ${features.length} features")
+
+        val updater = storage.getWriter(Filter.INCLUDE)
+
+        updater.hasNext must beTrue
+        while (updater.hasNext) {
+          val feature = updater.next
+          if (feature.getID == "0") {
+            updater.remove()
+          } else if (feature.getID == "1") {
+            feature.setAttribute(1, "name-updated")
+            updater.write()
+          }
+        }
+
+        TestObserverFactory.observers must haveSize(2) // 2 partitions were updated
+        forall(TestObserverFactory.observers)(_.closed must beFalse)
+
+        updater.close()
+
+        forall(TestObserverFactory.observers)(_.closed must beTrue)
+        TestObserverFactory.observers.flatMap(_.features) must haveLength(2)
+      }
+    }
+
     "read old files" in {
       val url = getClass.getClassLoader.getResource("data/2.3.0/example-csv/")
       url must not(beNull)
@@ -266,7 +332,7 @@ class ParquetStorageTest extends Specification with AllExpectations with LazyLog
   }
 
   def withTestDir[R](code: Path => R): R = {
-    val file = new Path(Files.createTempDirectory("gm-orc-test").toUri)
+    val file = new Path(Files.createTempDirectory("gm-parquet-test").toUri)
     try { code(file) } finally {
       file.getFileSystem(new Configuration).delete(file, true)
     }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/TestObserverFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/TestObserverFactory.scala
@@ -23,6 +23,7 @@ class TestObserverFactory extends FileSystemObserverFactory {
     TestObserverFactory.observers += observer
     observer
   }
+  override def close(): Unit = {}
 }
 
 object TestObserverFactory {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/TestObserverFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/TestObserverFactory.scala
@@ -1,0 +1,44 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.parquet
+
+import java.util.Collections
+
+import org.apache.hadoop.fs.Path
+import org.locationtech.geomesa.fs.storage.common.observer.{FileSystemObserver, FileSystemObserverFactory}
+import org.locationtech.geomesa.parquet.TestObserverFactory.TestObserver
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+
+import scala.collection.mutable.ArrayBuffer
+
+class TestObserverFactory extends FileSystemObserverFactory {
+  override def apply(sft: SimpleFeatureType, partition: String, path: Path): FileSystemObserver = {
+    val observer = new TestObserver(partition, path)
+    TestObserverFactory.observers += observer
+    observer
+  }
+}
+
+object TestObserverFactory {
+
+  import scala.collection.JavaConverters._
+
+  val observers: scala.collection.mutable.Set[TestObserver] =
+    Collections.synchronizedSet(new java.util.HashSet[TestObserver]()).asScala
+
+  class TestObserver(val partition: String, val path: Path) extends FileSystemObserver {
+
+    val features = ArrayBuffer.empty[SimpleFeature]
+    var closed = false
+
+    override def write(feature: SimpleFeature): Unit = features += feature
+    override def flush(): Unit = {}
+    override def close(): Unit = closed = true
+  }
+}

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/TestObserverFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/TestObserverFactory.scala
@@ -10,7 +10,8 @@ package org.locationtech.geomesa.parquet
 
 import java.util.Collections
 
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileContext, Path}
 import org.locationtech.geomesa.fs.storage.common.observer.{FileSystemObserver, FileSystemObserverFactory}
 import org.locationtech.geomesa.parquet.TestObserverFactory.TestObserver
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -18,8 +19,8 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import scala.collection.mutable.ArrayBuffer
 
 class TestObserverFactory extends FileSystemObserverFactory {
-  override def apply(sft: SimpleFeatureType, partition: String, path: Path): FileSystemObserver = {
-    val observer = new TestObserver(partition, path)
+  override def apply(fc: FileContext, conf: Configuration, sft: SimpleFeatureType, path: Path): FileSystemObserver = {
+    val observer = new TestObserver(path)
     TestObserverFactory.observers += observer
     observer
   }
@@ -33,7 +34,7 @@ object TestObserverFactory {
   val observers: scala.collection.mutable.Set[TestObserver] =
     Collections.synchronizedSet(new java.util.HashSet[TestObserver]()).asScala
 
-  class TestObserver(val partition: String, val path: Path) extends FileSystemObserver {
+  class TestObserver(val path: Path) extends FileSystemObserver {
 
     val features = ArrayBuffer.empty[SimpleFeature]
     var closed = false


### PR DESCRIPTION
* SimpleFeatureTypes can define file writer callbacks
  * User data key is `geomesa.fs.observers`
  * Trait is `org.locationtech.geomesa.fs.storage.common.observer.FileSystemObserverFactory`

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>