### PR TITLE
Updates for GEOMESA-2747 Include GeoTools functions as UDF for Spark

### DIFF
--- a/docs/user/spark/spark_jts.rst
+++ b/docs/user/spark/spark_jts.rst
@@ -125,6 +125,21 @@ also achievable with the following code:
     import spark.implicits. _
     chicagoDF.where(st_contains(st_makeBBOX(0.0, 0.0, 90.0, 90.0), $"geom"))
 
+
+Note that there are two GeoTools derived UDFs and those are:
+
+ * ``st_distanceSpheroid``
+ * ``st_lengthSpheroid``
+
+These are available in the geomesa-spark-sql jar, but also bundled by default in the spark-runtime.
+Example usage is as follows:
+
+.. code::
+
+    import org.locationtech.geomesa.spark.geotools._
+    chicagoDF.where(st_contains(st_distanceSpheroid(st_point(0.0,0.0), col("geom")) > 10)
+
+
 A complete list of the implemented UDFs is given in the next section (:doc:`./sparksql_functions`).
 
 .. _classes representing geometry objects: http://docs.geotools.org/stable/userguide/library/jts/geometry.html
@@ -132,6 +147,13 @@ A complete list of the implemented UDFs is given in the next section (:doc:`./sp
 .. _OpenGIS Simple feature access common architecture: http://www.opengeospatial.org/standards/sfa
 
 .. _OpenGIS Simple feature access SQL option: http://www.opengeospatial.org/standards/sfs
+
+.. code::
+
+    import org.locationtech.geomesa.spark.jts._
+    import spark.implicits. _
+    chicagoDF.where(st_contains(st_makeBBOX(0.0, 0.0, 90.0, 90.0), $"geom"))
+
 
 Building
 ^^^^^^^^

--- a/docs/user/spark/spark_jts.rst
+++ b/docs/user/spark/spark_jts.rst
@@ -125,6 +125,8 @@ also achievable with the following code:
     import spark.implicits. _
     chicagoDF.where(st_contains(st_makeBBOX(0.0, 0.0, 90.0, 90.0), $"geom"))
 
+GeoTools User-defined Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Note that there are two GeoTools derived UDFs and those are:
 

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/DataFrameFunctions.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/DataFrameFunctions.scala
@@ -1,0 +1,46 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.spark
+
+import java.lang
+
+import org.apache.spark.sql.{Column, Encoder, Encoders, TypedColumn}
+import org.locationtech.geomesa.spark.jts.encoders.SpatialEncoders
+import org.locationtech.geomesa.spark.jts.util.SQLFunctionHelper._
+
+
+/**
+ * DataFrame DSL functions for working with GeoTools
+ */
+object DataFrameFunctions extends SpatialEncoders {
+
+  implicit def integerEncoder: Encoder[Integer] = Encoders.INT
+  implicit def doubleEncoder: Encoder[Double] = Encoders.scalaDouble
+  implicit def jDoubleEncoder: Encoder[lang.Double] = Encoders.DOUBLE
+
+  /**
+   * Group of DataFrame DSL functions associated with determining the relationship
+   * between geometries using GeoTools.
+   */
+  trait SpatialRelations {
+
+    import org.locationtech.geomesa.spark.jts.udf.SpatialRelationFunctions._
+
+    def st_distanceSpheroid(left: Column, right: Column): TypedColumn[Any, lang.Double] =
+      udfToColumn(ST_DistanceSphere, relationNames, left, right)
+
+    def st_lengthSphere(line: Column): TypedColumn[Any, lang.Double] =
+      udfToColumn(ST_LengthSphere, relationNames, line)
+  }
+
+  /** Stack of all DataFrame DSL functions. */
+  trait Library extends SpatialRelations
+
+
+}

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/DataFrameFunctions.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/DataFrameFunctions.scala
@@ -1,9 +1,5 @@
 /***********************************************************************
- * Copyright (c) 2019 The MITRE Corporation
- * This software was produced for the U. S. Government under Basic
- * Contract No. W56KGU-18-D-0004, and is subject to the Rights in
- * Noncommercial Computer Software and Noncommercial Computer
- * Software Documentation Clause 252.227-7014 (FEB 2012).
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/DataFrameFunctions.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/DataFrameFunctions.scala
@@ -1,5 +1,9 @@
 /***********************************************************************
- * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * Copyright (c) 2019 The MITRE Corporation
+ * This software was produced for the U. S. Government under Basic
+ * Contract No. W56KGU-18-D-0004, and is subject to the Rights in
+ * Noncommercial Computer Software and Noncommercial Computer
+ * Software Documentation Clause 252.227-7014 (FEB 2012).
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/package.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/package.scala
@@ -1,15 +1,10 @@
 /***********************************************************************
- * Copyright (c) 2019 The MITRE Corporation
- * This software was produced for the U. S. Government under Basic
- * Contract No. W56KGU-18-D-0004, and is subject to the Rights in
- * Noncommercial Computer Software and Noncommercial Computer
- * Software Documentation Clause 252.227-7014 (FEB 2012).
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at
  * http://www.opensource.org/licenses/apache2.0.php.
  ***********************************************************************/
-
 
 package org.locationtech.geomesa.spark
 

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/package.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/package.scala
@@ -1,10 +1,15 @@
 /***********************************************************************
- * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * Copyright (c) 2019 The MITRE Corporation
+ * This software was produced for the U. S. Government under Basic
+ * Contract No. W56KGU-18-D-0004, and is subject to the Rights in
+ * Noncommercial Computer Software and Noncommercial Computer
+ * Software Documentation Clause 252.227-7014 (FEB 2012).
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at
  * http://www.opensource.org/licenses/apache2.0.php.
  ***********************************************************************/
+
 
 package org.locationtech.geomesa.spark
 

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/package.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/package.scala
@@ -1,5 +1,9 @@
 /***********************************************************************
- * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * Copyright (c) 2019 The MITRE Corporation
+ * This software was produced for the U. S. Government under Basic
+ * Contract No. W56KGU-18-D-0004, and is subject to the Rights in
+ * Noncommercial Computer Software and Noncommercial Computer
+ * Software Documentation Clause 252.227-7014 (FEB 2012).
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/package.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/package.scala
@@ -1,0 +1,27 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.spark
+
+import org.apache.spark.sql.functions.udf
+import org.locationtech.geomesa.spark.jts.encoders.SpatialEncoders
+import org.locationtech.jts.geom.{Geometry, LineString}
+
+
+/**
+ * User-facing module imports
+ */
+package object geotools extends DataFrameFunctions.Library with SpatialEncoders {
+
+  def st_distanceSpheroid = udf((g1: Geometry, g2: Geometry) =>
+    GeometricDistanceFunctions.ST_DistanceSpheroid(g1, g2))
+
+  def st_lengthSpheroid = udf((l1: LineString) =>
+    GeometricDistanceFunctions.ST_LengthSpheroid(l1))
+
+}


### PR DESCRIPTION
New code and documentation updates to enable GeoTools functions to be available in Spark.