### PR TITLE
GEOMESA-2748  Add support for dsParams which contains hbase Connection when creatin…

### DIFF
--- a/geomesa-hbase/geomesa-hbase-spark/src/main/scala/org/locationtech/geomesa/spark/hbase/HBaseSpatialRDDProvider.scala
+++ b/geomesa-hbase/geomesa-hbase-spark/src/main/scala/org/locationtech/geomesa/spark/hbase/HBaseSpatialRDDProvider.scala
@@ -29,10 +29,12 @@ class HBaseSpatialRDDProvider extends SpatialRDDProvider {
   override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean =
     HBaseDataStoreFactory.canProcess(params)
 
-  def rdd(
+  def rdd(conf: Configuration, sc: SparkContext, params: Map[String, String], query: Query): SpatialRDD = createRdd(conf, sc, params, query)
+
+  override def createRdd(
       conf: Configuration,
       sc: SparkContext,
-      dsParams: Map[String, String],
+      dsParams: Map[String, Object],
       origQuery: Query): SpatialRDD = {
 
     val ds = DataStoreConnector[HBaseDataStore](dsParams)

--- a/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/DataStoreConnector.scala
+++ b/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/DataStoreConnector.scala
@@ -18,11 +18,11 @@ object DataStoreConnector {
 
   import scala.collection.JavaConverters._
 
-  def apply[T <: DataStore](params: Map[String, String]): T = loadingMap.get(params).asInstanceOf[T]
+  def apply[T <: DataStore](params: Map[String, Object]): T = loadingMap.get(params).asInstanceOf[T]
 
-  private val loadingMap = Caffeine.newBuilder().build[Map[String, String], DataStore](
-    new CacheLoader[Map[String, String], DataStore] {
-      override def load(key: Map[String, String]): DataStore = DataStoreFinder.getDataStore(key.asJava)
+  private val loadingMap = Caffeine.newBuilder().build[Map[String, Object], DataStore](
+    new CacheLoader[Map[String, Object], DataStore] {
+      override def load(key: Map[String, Object]): DataStore = DataStoreFinder.getDataStore(key.asJava)
     }
   )
 }

--- a/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/SpatialRDDProvider.scala
+++ b/geomesa-spark/geomesa-spark-core/src/main/scala/org/locationtech/geomesa/spark/SpatialRDDProvider.scala
@@ -41,6 +41,7 @@ trait SpatialRDDProvider {
     * @return
     */
   def rdd(conf: Configuration, sc: SparkContext, params: Map[String, String], query: Query) : SpatialRDD
+  def createRdd(conf: Configuration, sc: SparkContext, params: Map[String, Object], query: Query) : SpatialRDD = null
 
   /**
     * Persist an RDD to long-term storage.


### PR DESCRIPTION
Sometimes, our dsParams contains hbase connection, as shown below.
 val dsParams = Map(
      "hbase.connection"  -> connection,
      "hbase.catalog"     -> "xxx"
    )
For instance, we have to create a special hbase connection for kerberos . We use  "hbase.connection" rather than  "hbase.zookeepers", so that we can set related configuration files. 
However，we cannot create a rdd through "spatialRDDProvider.rdd(conf, sc, dsParams, query)" , for there is only Map[String, String] is allowed as a dsParams. 
Since we have this type of dsParams which contains hbase connection，we'd better add support for these dsParams to create rdd. Aimed at this case, I add a function createRdd, so that we can use "createRdd(conf, sc, dsParams, query) " to create rdd.