### PR TITLE
GEOMESA-2754 Support intersection and difference of geometries in spark 

### DIFF
--- a/docs/user/spark/sparksql_functions.rst
+++ b/docs/user/spark/sparksql_functions.rst
@@ -670,6 +670,17 @@ st_crosses
 
 Returns true if the supplied geometries have some, but not all, interior points in common.
 
+.. _st_difference:
+
+st_difference
+^^^^^^^^^^^^^^^
+
+::
+
+    Geometry st_difference(Geometry a, Geometry b)
+
+Returns the difference of the input geomtries.
+
 .. _st_disjoint:
 
 st_disjoint
@@ -726,6 +737,17 @@ st_equals
     Boolean st_equals(Geometry a, Geometry b)
 
 Returns true if the given Geometries represent the same logical Geometry. Directionality is ignored.
+
+.. _st_intersection:
+
+st_intersection
+^^^^^^^^^^^^^^^
+
+::
+
+    Geometry st_intersection(Geometry a, Geometry b)
+
+Returns the intersection of the input geomtries.
 
 .. _st_intersects:
 

--- a/docs/user/spark/sparksql_functions.rst
+++ b/docs/user/spark/sparksql_functions.rst
@@ -673,13 +673,13 @@ Returns true if the supplied geometries have some, but not all, interior points 
 .. _st_difference:
 
 st_difference
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^
 
 ::
 
     Geometry st_difference(Geometry a, Geometry b)
 
-Returns the difference of the input geomtries.
+Returns the difference of the input geometries.
 
 .. _st_disjoint:
 
@@ -747,7 +747,7 @@ st_intersection
 
     Geometry st_intersection(Geometry a, Geometry b)
 
-Returns the intersection of the input geomtries.
+Returns the intersection of the input geometries.
 
 .. _st_intersects:
 

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/DataFrameFunctions.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/DataFrameFunctions.scala
@@ -348,6 +348,12 @@ object DataFrameFunctions extends SpatialEncoders {
 
     def st_lengthSphere(line: Column): TypedColumn[Any, jl.Double] =
       udfToColumn(ST_LengthSphere, relationNames, line)
+
+    def st_intersection(geom1:Column, geom2:Column): TypedColumn[Any, Geometry] =
+      udfToColumn(ST_Intersection, relationNames, geom1, geom2)
+
+    def st_difference(geom1:Column, geom2:Column): TypedColumn[Any, Geometry] =
+      udfToColumn(ST_Difference, relationNames, geom1, geom2)
   }
 
   /** Stack of all DataFrame DSL functions. */

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/udf/SpatialRelationFunctions.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/udf/SpatialRelationFunctions.scala
@@ -54,6 +54,10 @@ object SpatialRelationFunctions {
   val ST_LengthSphere: LineString => jl.Double =
     nullableUDF(line => line.getCoordinates.sliding(2).map { case Array(l, r) => fastDistance(l, r) }.sum)
 
+  val ST_Intersection: (Geometry, Geometry) => Geometry = nullableUDF((geom1, geom2) => geom1.intersection(geom2))
+
+  val ST_Difference: (Geometry, Geometry) => Geometry = nullableUDF((geom1, geom2) => geom1.difference(geom2))
+
   private[geomesa] val relationNames = Map(
     ST_Translate -> "st_translate" ,
     ST_Contains -> "st_contains",
@@ -74,7 +78,9 @@ object SpatialRelationFunctions {
     ST_DistanceSphere -> "st_distanceSphere",
     ST_Length -> "st_length",
     ST_AggregateDistanceSphere -> "st_aggregateDistanceSphere",
-    ST_LengthSphere -> "st_lengthSphere"
+    ST_LengthSphere -> "st_lengthSphere",
+    ST_Intersection -> "st_intersection",
+    ST_Difference -> "st_difference"
   )
 
   // Geometry Processing
@@ -111,6 +117,8 @@ object SpatialRelationFunctions {
 
     // Register geometry Processing
     sqlContext.udf.register("st_convexhull", ch)
+    sqlContext.udf.register(relationNames(ST_Intersection),ST_Intersection)
+    sqlContext.udf.register(relationNames(ST_Difference),ST_Difference)
   }
 
   @transient private lazy val spatialContext = JtsSpatialContext.GEO


### PR DESCRIPTION
We've have many methods for geometry in spark.  We can judge if geometies intersects or disjoint. However, getting the intersection or difference part is unsupported in spark now. It is expected to add support for getting intersection and difference geometries are often required.
I add support for getting intersection and difference of geometries in spark. The intersection and difference can be accessed using SQL queries of spark SQL, as follows.
![image](https://user-images.githubusercontent.com/58421556/70403165-05411780-1a71-11ea-9b24-a9ccbaf8c74e.png)
![image](https://user-images.githubusercontent.com/58421556/70403177-0c682580-1a71-11ea-9884-0bdee08159a1.png)

