### PR TITLE
GEOMESA-2755 Initial implementation of CassandraSpatialRDDProvider

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
+++ b/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
@@ -94,7 +94,7 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
 
         // From sc.newAPIHadoopRDD
         // Add necessary security credentials to the JobConf. Required to access secure HDFS.
-        val jconf = new JobConf(conf)
+        val jconf: JobConf = new JobConf(conf)
         SparkHadoopUtil.get.addCredentials(jconf)
 
         // Get username from params

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/test/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreTest.scala
@@ -108,6 +108,9 @@ class CassandraDataStoreTest extends Specification {
 
       val toAdd = (0 until 10).map { i =>
         val sf = new ScalaSimpleFeature(sft, i.toString)
+
+        sf.getDefaultGeometry
+
         sf.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
         sf.setAttribute(0, s"name$i")
         sf.setAttribute(1, f"2014-01-${i + 1}%02dT00:00:01.000Z")

--- a/geomesa-cassandra/geomesa-cassandra-jobs/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-jobs/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>geomesa-cassandra_2.11</artifactId>
+        <groupId>org.locationtech.geomesa</groupId>
+        <version>2.4.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-cassandra-jobs_2.11</artifactId>
+    <name>GeoMesa Cassandra Jobs</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-process-vector_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-cassandra-datastore_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-mapping</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/geomesa-cassandra/geomesa-cassandra-jobs/src/main/scala/org/locationtech/geomesa/cassandra/jobs/CassandraJobUtils.scala
+++ b/geomesa-cassandra/geomesa-cassandra-jobs/src/main/scala/org/locationtech/geomesa/cassandra/jobs/CassandraJobUtils.scala
@@ -1,0 +1,34 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.cassandra.jobs
+
+import org.geotools.data.Query
+import org.locationtech.geomesa.cassandra.data.{CassandraDataStore, EmptyPlan, StatementPlan}
+
+object CassandraJobUtils {
+  /**
+   * Gets (potentially) multiple scan plans. Each plan will only scan a single table
+   *
+   * @param ds data store
+   * @param query query
+   * @throws java.lang.IllegalArgumentException if query can't be answered with scan plans
+   * @return
+   */
+  @throws(classOf[IllegalArgumentException])
+  def getMultiStatementPlans(ds: CassandraDataStore, query: Query): Seq[StatementPlan] = {
+    ds.getQueryPlan(query).flatMap {
+      case p: StatementPlan if p.tables.lengthCompare(1) == 0 => Seq(p)
+      case p: StatementPlan => p.tables.map(table => p.copy(tables = Seq(table)))
+      case _: EmptyPlan => Seq.empty
+      case p =>
+        throw new IllegalArgumentException("Query requires a scan which is not supported through " +
+          s"the input format: ${p.getClass.getName}")
+    }
+  }
+}

--- a/geomesa-cassandra/geomesa-cassandra-spark/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-spark/pom.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>geomesa-cassandra_2.11</artifactId>
+        <groupId>org.locationtech.geomesa</groupId>
+        <version>2.4.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-cassandra-spark_2.11</artifactId>
+    <name>GeoMesa Cassandra Spark</name>
+
+    <dependencies>
+        <!--  External dependencies -->
+        <dependency>
+            <groupId>org.apache.cassandra</groupId>
+            <artifactId>cassandra-all</artifactId>
+            <version>3.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-mapping</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-main</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools.jdbc</groupId>
+            <artifactId>gt-jdbc-postgis</artifactId>
+        </dependency>
+
+        <!-- GeoMesa dependencies -->
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-process-vector_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-cassandra-datastore_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-cassandra-jobs_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-jobs_${scala.binary.version}</artifactId>
+        </dependency>
+
+        <!-- Spark Dependencies -->
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-gt-spark_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-spark-core_${scala.binary.version}</artifactId>
+        </dependency>
+
+        <!-- test deps -->
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.cassandraunit</groupId>
+            <artifactId>cassandra-unit</artifactId>
+            <version>2.2.2.1</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.datastax.cassandra</groupId>
+                    <artifactId>cassandra-driver-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.cassandra</groupId>
+                    <artifactId>cassandra-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hectorclient</groupId>
+                    <artifactId>hector-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/geomesa-cassandra/geomesa-cassandra-spark/src/main/resources/META-INF/services/org.locationtech.geomesa.spark.SpatialRDDProvider
+++ b/geomesa-cassandra/geomesa-cassandra-spark/src/main/resources/META-INF/services/org.locationtech.geomesa.spark.SpatialRDDProvider
@@ -1,0 +1,1 @@
+org.locationtech.geomesa.cassandra.spark.CassandraSpatialRDDProvider

--- a/geomesa-cassandra/geomesa-cassandra-spark/src/main/scala/org/locationtech/geomesa/cassandra/spark/CassandraSpatialRDDProvider.scala
+++ b/geomesa-cassandra/geomesa-cassandra-spark/src/main/scala/org/locationtech/geomesa/cassandra/spark/CassandraSpatialRDDProvider.scala
@@ -1,0 +1,139 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.cassandra.spark
+
+import com.datastax.driver.core.RegularStatement
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.cassandra.hadoop.ConfigHelper
+import org.apache.cassandra.hadoop.cql3.CqlConfigHelper
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.io.Text
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.geotools.data.{Query, Transaction}
+import org.opengis.feature.simple.SimpleFeature
+import org.locationtech.geomesa.cassandra.data.{CassandraDataStore, CassandraDataStoreFactory, CassandraQueryPlan, EmptyPlan}
+import org.locationtech.geomesa.cassandra.data.CassandraDataStoreFactory.Params
+import org.locationtech.geomesa.cassandra.jobs.CassandraJobUtils
+import org.locationtech.geomesa.index.conf.QueryHints._
+import org.locationtech.geomesa.jobs.GeoMesaConfigurator
+import org.locationtech.geomesa.spark.{DataStoreConnector, SpatialRDD, SpatialRDDProvider}
+import org.locationtech.geomesa.utils.geotools.FeatureUtils
+import org.locationtech.geomesa.utils.io.{WithClose, WithStore}
+
+class CassandraSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
+
+  override def canProcess(params: java.util.Map[String, _ <: java.io.Serializable]): Boolean = {
+    CassandraDataStoreFactory.canProcess(params)
+  }
+
+  def rdd(
+      conf: Configuration,
+      sc: SparkContext,
+      dsParams: Map[String, String],
+      origQuery: Query): SpatialRDD = {
+
+    val ds = DataStoreConnector[CassandraDataStore](dsParams)
+    lazy val sft = ds.getSchema(origQuery.getTypeName)
+
+    def queryPlanToRdd(qp: CassandraQueryPlan) : RDD[SimpleFeature] = {
+      /*
+       * Map function from query plan to RDD.
+       */
+      val config = new Configuration(conf)
+      if (ds == null || sft == null || qp.isInstanceOf[EmptyPlan]) {
+        sc.emptyRDD[SimpleFeature]
+      }
+
+      // BEGIN: Attempting to set CQL
+      // We attempt to set Cql from the ranges field from the query plan. However, the CQL from the
+      // query plan is not in the format expected by the delegate of the GeoMesaCassandraInputFormat.
+      // See CassandraRecordReader in GeoMesaCassandraInputFormat for more information.
+      //
+      // Commenting out this section will allow the CassandraSparkProviderTest to pass but we are
+      // unsure if the implementation will generalize to all queries.
+      if (qp.ranges.size == 1) {
+        qp.ranges.head match {
+          case stmt: RegularStatement => CqlConfigHelper.setInputCql(
+            config,
+            stmt.getQueryString
+          )
+          case _ => throw new IllegalArgumentException
+        }
+      } else {
+        throw new IndexOutOfBoundsException
+      }
+      // END: Attempting to set CQL
+
+      ConfigHelper.setInputInitialAddress(config, dsParams("geomesa.cassandra.host"))
+      ConfigHelper.setInputColumnFamily(config, dsParams(Params.KeySpaceParam.getName), qp.tables.head)
+      ConfigHelper.setInputPartitioner(config, "Murmur3Partitioner")
+
+      GeoMesaConfigurator.setFilter(config, qp.filter.toString)
+      GeoMesaConfigurator.setResultsToFeatures(config, qp.resultsToFeatures)
+
+      qp.reducer.foreach(GeoMesaConfigurator.setReducer(config,_))
+      qp.projection.foreach(GeoMesaConfigurator.setProjection(config,_))
+      qp.sort.foreach(GeoMesaConfigurator.setSorting(config,_))
+
+      sc.newAPIHadoopRDD(config, classOf[GeoMesaCassandraInputFormat], classOf[Text], classOf[SimpleFeature]).map(_._2)
+    }
+
+    try {
+      lazy val rddSft = origQuery.getHints.getTransformSchema.getOrElse(sft)
+
+      lazy val qps = {
+        CassandraJobUtils.getMultiStatementPlans(ds, origQuery)
+      }
+
+      if (ds == null || sft == null || qps.isEmpty) {
+        SpatialRDD(sc.emptyRDD[SimpleFeature], rddSft)
+      } else {
+        val rdd = qps.map(queryPlanToRdd) match {
+          case Seq(head) => head
+          case seq => sc.union(seq)
+        }
+        SpatialRDD(rdd, rddSft)
+      }
+
+    } finally {
+      if (ds != null) {
+        ds.dispose()
+      }
+    }
+
+  }
+
+  /**
+    * Writes this RDD to a GeoMesa table.
+    * The type must exist in the data store, and all of the features in the RDD must be of this type.
+    *
+    * @param rdd rdd
+    * @param writeDataStoreParams params
+    * @param writeTypeName type name
+    */
+  def save(rdd: RDD[SimpleFeature], writeDataStoreParams: Map[String, String], writeTypeName: String): Unit = {
+
+    // Base implementation from GeoToolsSpatialRDDProvider
+    val params = writeDataStoreParams
+    val typeName = writeTypeName
+    WithStore[CassandraDataStore](params) { ds =>
+      require(ds != null, "Could not load data store with the provided parameters")
+      require(ds.getSchema(typeName) != null, "Schema must exist before calling save - use `DataStore.createSchema`")
+    }
+
+    rdd.foreachPartition { iter =>
+      WithStore[CassandraDataStore](params) { ds =>
+        WithClose(ds.getFeatureWriterAppend(typeName, Transaction.AUTO_COMMIT)) { writer =>
+          iter.foreach(FeatureUtils.write(writer, _, useProvidedFid = true))
+        }
+      }
+    }
+  }
+}

--- a/geomesa-cassandra/geomesa-cassandra-spark/src/main/scala/org/locationtech/geomesa/cassandra/spark/GeoMesaCassandraInputFormat.scala
+++ b/geomesa-cassandra/geomesa-cassandra-spark/src/main/scala/org/locationtech/geomesa/cassandra/spark/GeoMesaCassandraInputFormat.scala
@@ -1,0 +1,75 @@
+package org.locationtech.geomesa.cassandra.spark
+
+import java.util
+
+import com.typesafe.scalalogging.LazyLogging
+import org.opengis.feature.simple.SimpleFeature
+import org.apache.cassandra.hadoop.cql3.CqlInputFormat
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.mapreduce.{InputFormat, InputSplit, JobContext, RecordReader, TaskAttemptContext}
+import com.datastax.driver.core.Row
+import org.locationtech.geomesa.jobs.GeoMesaConfigurator
+import org.locationtech.geomesa.index.api.QueryPlan.ResultsToFeatures
+
+class GeoMesaCassandraInputFormat extends InputFormat[Text, SimpleFeature] with LazyLogging{
+  private val delegate = new CqlInputFormat
+
+  override def getSplits(context: JobContext): util.List[InputSplit] = {
+    val splits = delegate.getSplits(context)
+    splits
+  }
+
+  override def createRecordReader(inputSplit: InputSplit, taskAttemptContext: TaskAttemptContext): RecordReader[Text, SimpleFeature] = {
+    val toFeatures = GeoMesaConfigurator.getResultsToFeatures[Row](taskAttemptContext.getConfiguration)
+    new CassandraRecordReader(toFeatures, delegate.createRecordReader(inputSplit, taskAttemptContext))
+  }
+
+
+  /**
+   * Record reader that delegates to Cassandra record readers and transforms the key/values coming back into
+   * simple features.
+   *
+   * @param toFeatures results to features
+   * @param reader delegate reader
+   */
+  class CassandraRecordReader(toFeatures: ResultsToFeatures[Row], reader: RecordReader[java.lang.Long, Row])
+      extends RecordReader[Text, SimpleFeature] {
+
+    private val key = new Text()
+
+    private var currentFeature: SimpleFeature = _
+
+    override def initialize(inputSplit: InputSplit, taskAttemptContext: TaskAttemptContext): Unit =
+      // This line attempts to initialize an instance of org/apache/cassandra/hadoop/cql3/CqlRecordReader.java
+      //
+      // On the version from org/apache/cassandra/cassandra-all/3.0.0/cassandra-all-3.0.0-sources.jar this
+      // currently fails when running the CassandraSparkProviderTest. On line 271 in the CqlRecordReader, the
+      // function expects a query with a where clause must include an expression of the form:
+      // token(partition_key1 ... partition_keyn) > ? and token(partition_key1 ... partition_keyn) >= ?
+      //
+      // The CQL set from the CassandraQueryPlan does not conform to this constraint resulting in the following error:
+      // com.datastax.driver.core.exceptions.InvalidQueryException: Invalid amount of bind variables.
+      //
+      // Letting the CqlRecordReader
+      // infer the query from context and not explicitly setting the CQL allows the CassandraSparkProviderTest to
+      // pass, but we are unsure if that method will generalize to all queries.
+      reader.initialize(inputSplit, taskAttemptContext)
+
+    override def getProgress: Float = reader.getProgress
+
+    override def nextKeyValue(): Boolean = {
+      if (reader.nextKeyValue()) {
+        currentFeature = toFeatures.apply(reader.getCurrentValue)
+        key.set(currentFeature.getID)
+        true
+      } else
+        false
+    }
+
+    override def getCurrentKey: Text = key
+
+    override def getCurrentValue: SimpleFeature = currentFeature
+
+    override def close(): Unit = reader.close()
+  }
+}

--- a/geomesa-cassandra/geomesa-cassandra-spark/src/test/resources/cassandra-config.yaml
+++ b/geomesa-cassandra/geomesa-cassandra-spark/src/test/resources/cassandra-config.yaml
@@ -1,0 +1,586 @@
+# Cassandra storage config YAML
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+cluster_name: 'Test Cluster'
+
+# You should always specify InitialToken when setting up a production
+# cluster for the first time, and often when adding capacity later.
+# The principle is that each node should be given an equal slice of
+# the token ring; see http://wiki.apache.org/cassandra/Operations
+# for more details.
+#
+# If blank, Cassandra will request a token bisecting the range of
+# the heaviest-loaded existing node.  If there is no load information
+# available, such as is the case with a new cluster, it will pick
+# a random token, which will lead to hot spots.
+#initial_token:
+
+# See http://wiki.apache.org/cassandra/HintedHandoff
+hinted_handoff_enabled: true
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+max_hint_window_in_ms: 10800000 # 3 hours
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+hinted_handoff_throttle_in_kb: 1024
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+max_hints_delivery_threads: 2
+
+# The following setting populates the page cache on memtable flush and compaction
+# WARNING: Enable this setting only when the whole node's data fits in memory.
+# Defaults to: false
+# populate_io_cache_on_flush: false
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+authenticator: AllowAllAuthenticator
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+authorizer: AllowAllAuthorizer
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+permissions_validity_in_ms: 2000
+
+
+# The partitioner is responsible for distributing rows (by key) across
+# nodes in the cluster.  Any IPartitioner may be used, including your
+# own as long as it is on the classpath.  Out of the box, Cassandra
+# provides org.apache.cassandra.dht.{Murmur3Partitioner, RandomPartitioner
+# ByteOrderedPartitioner, OrderPreservingPartitioner (deprecated)}.
+#
+# - RandomPartitioner distributes rows across the cluster evenly by md5.
+#   This is the default prior to 1.2 and is retained for compatibility.
+# - Murmur3Partitioner is similar to RandomPartioner but uses Murmur3_128
+#   Hash Function instead of md5.  When in doubt, this is the best option.
+# - ByteOrderedPartitioner orders rows lexically by key bytes.  BOP allows
+#   scanning rows in key order, but the ordering can generate hot spots
+#   for sequential insertion workloads.
+# - OrderPreservingPartitioner is an obsolete form of BOP, that stores
+# - keys in a less-efficient format and only works with keys that are
+#   UTF8-encoded Strings.
+# - CollatingOPP collates according to EN,US rules rather than lexical byte
+#   ordering.  Use this as an example if you need custom collation.
+#
+# See http://wiki.apache.org/cassandra/Operations for more on
+# partitioners and token selection.
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# directories where Cassandra should store data on disk.
+data_file_directories:
+    - target/embeddedCassandra/data
+
+# commit log
+commitlog_directory: target/embeddedCassandra/commitlog
+
+# policy for data disk failures:
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# best_effort: stop using the failed disk and respond to requests based on
+#              remaining available sstables.  This means you WILL see obsolete
+#              data at CL.ONE!
+# ignore: ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+disk_failure_policy: stop
+
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must store the whole values of
+# its rows, so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# safe the keys cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+key_cache_save_period: 14400
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Maximum size of the row cache in memory.
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is 0, to disable row caching.
+row_cache_size_in_mb: 0
+
+# Duration in seconds after which Cassandra should
+# safe the row cache. Caches are saved to saved_caches_directory as specified
+# in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+row_cache_save_period: 0
+
+# Number of keys from the row cache to save
+# Disabled by default, meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# saved caches
+saved_caches_directory: target/embeddedCassandra/saved_caches
+
+# commitlog_sync may be either "periodic" or "batch."
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been fsynced to disk.  It will wait up to
+# commitlog_sync_batch_window_in_ms milliseconds for other writes, before
+# performing the sync.
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 50
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+seed_provider:
+    # Addresses of hosts that are deemed contact points.
+    # Cassandra nodes use this list of hosts to find each other and learn
+    # the topology of the ring.  You must change this if you are running
+    # multiple nodes!
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          # seeds is actually a comma-delimited list of addresses.
+          # Ex: "<ip1>,<ip2>,<ip3>"
+          - seeds: "localhost"
+
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: 32
+concurrent_writes: 32
+
+# Total memory to use for memtables.  Cassandra will flush the largest
+# memtable when this much memory is used.
+# If omitted, Cassandra will set it to 1/3 of the heap.
+# memtable_total_space_in_mb: 2048
+
+# Total space to use for commitlogs.
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Cassandra will flush every dirty CF in the oldest
+# segment and remove it.
+# commitlog_total_space_in_mb: 4096
+
+# This sets the amount of memtable flush writer threads.  These will
+# be blocked by disk io, and each one will hold a memtable in memory
+# while blocked. If you have a large heap and many data directories,
+# you can increase this value for better flush performance.
+# By default this will be set to the amount of data directories defined.
+#memtable_flush_writers: 1
+
+# the number of full memtables to allow pending flush, that is,
+# waiting for a writer thread.  At a minimum, this should be set to
+# the maximum number of secondary indexes created on a single CF.
+#memtable_flush_queue_size: 4
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSD:s; not
+# necessarily on platters.
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
+
+# TCP port, for commands and data
+storage_port: 0
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+ssl_storage_port: 0
+
+# Address to bind to and tell other Cassandra nodes to connect to. You
+# _must_ change this if you want multiple nodes to be able to
+# communicate!
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing *if* the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be).
+#
+# Setting this to 0.0.0.0 is always wrong.
+listen_address: localhost
+
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+native_transport_port: 9042
+
+# Whether to start the thrift rpc server.
+start_rpc: true
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+# The address to bind the Thrift RPC service to -- clients connect
+# here. Unlike ListenAddress above, you *can* specify 0.0.0.0 here if
+# you want Thrift to listen on all interfaces.
+#
+# Leaving this blank has the same effect it does for ListenAddress,
+# (i.e. it will be based on the configured hostname of the node).
+rpc_address: localhost
+# port for Thrift to listen for clients on
+rpc_port: 0
+
+# enable or disable keepalive on rpc connections
+rpc_keepalive: true
+
+# Cassandra provides three options for the RPC Server:
+#
+# sync  -> One connection per thread in the rpc pool (see below).
+#          For a very large number of clients, memory will be your limiting
+#          factor; on a 64 bit JVM, 128KB is the minimum stack size per thread.
+#          Connection pooling is very, very strongly recommended.
+#
+# async -> Nonblocking server implementation with one thread to serve
+#          rpc connections.  This is not recommended for high throughput use
+#          cases. Async has been tested to be about 50% slower than sync
+#          or hsha and is deprecated: it will be removed in the next major release.
+#
+# hsha  -> Stands for "half synchronous, half asynchronous." The rpc thread pool
+#          (see below) is used to manage requests, but the threads are multiplexed
+#          across the different clients.
+#
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+rpc_server_type: sync
+
+# Uncomment rpc_min|max|thread to set request pool size.
+# You would primarily set max for the sync server to safeguard against
+# misbehaved clients; if you do hit the max, Cassandra will block until one
+# disconnects before accepting more.  The defaults for sync are min of 16 and max
+# unlimited.
+#
+# For the Hsha server, the min and max both default to quadruple the number of
+# CPU cores.
+#
+# This configuration is ignored by the async server.
+#
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
+
+# uncomment to set socket buffer sizes on rpc connections
+# rpc_send_buff_size_in_bytes:
+# rpc_recv_buff_size_in_bytes:
+
+# Frame size for thrift (maximum field length).
+# 0 disables TFramedTransport in favor of TSocket. This option
+# is deprecated; we strongly recommend using Framed mode.
+thrift_framed_transport_size_in_mb: 15
+
+# The max length of a thrift message, including all fields and
+# internal thrift overhead.
+thrift_max_message_length_in_mb: 16
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# Keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: false
+
+# Add column indexes to a row after its contents reach this size.
+# Increase if your column values are large, or if you have a very large
+# number of columns.  The competing causes are, Cassandra has to
+# deserialize this much of the row to read a single column, so you want
+# it to be small - at least if you do many partial-row reads - but all
+# the index data is read for each access, so you don't want to generate
+# that wastefully either.
+column_index_size_in_kb: 64
+
+# Size limit for rows being compacted in memory.  Larger rows will spill
+# over to disk and use a slower two-pass compaction process.  A message
+# will be logged specifying the row key.
+#in_memory_compaction_limit_in_mb: 64
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# This setting has no effect on LeveledCompactionStrategy.
+#
+# concurrent_compactors defaults to the number of cores.
+# Uncomment to make compaction mono-threaded, the pre-0.8 default.
+#concurrent_compactors: 1
+
+# Multi-threaded compaction. When enabled, each compaction will use
+# up to one thread per core, plus one thread per sstable being merged.
+# This is usually only useful for SSD-based hardware: otherwise,
+# your concern is usually to get compaction to do LESS i/o (see:
+# compaction_throughput_mb_per_sec), not more.
+#multithreaded_compaction: false
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+compaction_throughput_mb_per_sec: 16
+
+# Track cached row keys during compaction, and re-cache their new
+# positions in the compacted sstable.  Disable if you use really large
+# key caches.
+#compaction_preheat_key_cache: true
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+# How long the coordinator should wait for seq or index scans to complete
+range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+request_timeout_in_ms: 10000
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing
+# already-timed-out requests.
+#
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+cross_node_timeout: false
+
+# Enable socket timeout for streaming operation.
+# When a timeout occurs during streaming, streaming is retried from the start
+# of the current file. This _can_ involve re-streaming an important amount of
+# data, so you should avoid setting the value too low.
+# Default value is 0, which never timeout streams.
+# streaming_socket_timeout_in_ms: 0
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Cassandra provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This improves cache locality
+#    when disabling read repair, which can further improve throughput.
+#    Only appropriate for single-datacenter deployments.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's
+#    IP address, respectively.  Unless this happens to match your
+#    deployment conventions (as it did Facebook's), this is best used
+#    as an example of writing a custom Snitch class.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region.  Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the Datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: SimpleSnitch
+
+# controls how often to perform the more expensive part of host score
+# calculation
+dynamic_snitch_update_interval_in_ms: 100
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+dynamic_snitch_reset_interval_in_ms: 600000
+# if set greater than zero and read_repair_chance is < 1.0, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
+
+# request_scheduler -- Set this to a class that implements
+# RequestScheduler, which will schedule incoming client requests
+# according to the specific policy. This is useful for multi-tenancy
+# with a single Cassandra cluster.
+# NOTE: This is specifically for requests from the client and does
+# not affect inter node communication.
+# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
+# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
+# client requests to a node with a separate queue for each
+# request_scheduler_id. The scheduler is further customized by
+# request_scheduler_options as described below.
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+
+# Scheduler Options vary based on the type of scheduler
+# NoScheduler - Has no options
+# RoundRobin
+#  - throttle_limit -- The throttle_limit is the number of in-flight
+#                      requests per client.  Requests beyond
+#                      that limit are queued up until
+#                      running requests can complete.
+#                      The value of 80 here is twice the number of
+#                      concurrent_reads + concurrent_writes.
+#  - default_weight -- default_weight is optional and allows for
+#                      overriding the default which is 1.
+#  - weights -- Weights are optional and will default to 1 or the
+#               overridden default_weight. The weight translates into how
+#               many requests are handled during each turn of the
+#               RoundRobin, based on the scheduler id.
+#
+# request_scheduler_options:
+#    throttle_limit: 80
+#    default_weight: 5
+#    weights:
+#      Keyspace1: 1
+#      Keyspace2: 5
+
+# request_scheduler_id -- An identifer based on which to perform
+# the request scheduling. Currently the only valid option is keyspace.
+# request_scheduler_id: keyspace
+
+# index_interval controls the sampling of entries from the primrary
+# row index in terms of space versus time.  The larger the interval,
+# the smaller and less effective the sampling will be.  In technicial
+# terms, the interval coresponds to the number of index entries that
+# are skipped between taking each sample.  All the sampled entries
+# must fit in memory.  Generally, a value between 128 and 512 here
+# coupled with a large key cache size on CFs results in the best trade
+# offs.  This value is not often changed, however if you have many
+# very small rows (many to an OS page), then increasing this will
+# often lower memory usage without a impact on performance.
+index_interval: 128
+
+# Enable or disable inter-node encryption
+# Default settings are TLS v1, RSA 1024-bit keys (it is imperative that
+# users generate their own keys) TLS_RSA_WITH_AES_128_CBC_SHA as the cipher
+# suite for authentication, key exchange and encryption of the actual data transfers.
+# NOTE: No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
+#
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
+#
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+#
+encryption_options:
+    internode_encryption: none
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    truststore: conf/.truststore
+    truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]

--- a/geomesa-cassandra/geomesa-cassandra-spark/src/test/resources/init.cql
+++ b/geomesa-cassandra/geomesa-cassandra-spark/src/test/resources/init.cql
@@ -1,0 +1,2 @@
+CREATE KEYSPACE IF NOT EXISTS geomesa_cassandra WITH replication={'class' : 'SimpleStrategy', 'replication_factor':1};
+USE geomesa_cassandra;

--- a/geomesa-cassandra/geomesa-cassandra-spark/src/test/resources/log4j.xml
+++ b/geomesa-cassandra/geomesa-cassandra-spark/src/test/resources/log4j.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.EnhancedPatternLayout">
+            <param name="ConversionPattern" value="[%d] %5p %c{1}: %m%n"/>
+        </layout>
+    </appender>
+
+    <category name="org.apache.cassandra">
+        <priority value="warn"/>
+    </category>
+    <category name="com.datastax.driver">
+        <priority value="warn"/>
+    </category>
+
+    <!--<category name="org.locationtech.geomesa.cassandra">
+        <priority value="trace"/>
+    </category>-->
+
+    <root>
+        <priority value="info"/>
+        <appender-ref ref="CONSOLE" />
+    </root>
+</log4j:configuration>

--- a/geomesa-cassandra/geomesa-cassandra-spark/src/test/scala/org/locationtech/geomesa/cassandra/spark/CassandraSparkProviderTest.scala
+++ b/geomesa-cassandra/geomesa-cassandra-spark/src/test/scala/org/locationtech/geomesa/cassandra/spark/CassandraSparkProviderTest.scala
@@ -1,0 +1,120 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.cassandra.spark
+
+import java.nio.file.{Files, Path}
+
+import com.datastax.driver.core.{Cluster, SocketOptions}
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.{SparkConf, SparkContext}
+import org.cassandraunit.CQLDataLoader
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper
+import org.geotools.data.{DataStoreFinder, Query, Transaction}
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.cassandra.data.CassandraDataStore
+import org.locationtech.geomesa.cassandra.data.CassandraDataStoreFactory.Params
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.spark.{GeoMesaSpark, GeoMesaSparkKryoRegistrator}
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
+import org.locationtech.geomesa.utils.geotools.{FeatureUtils, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.io.WithClose
+import org.opengis.feature.simple.SimpleFeature
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class CassandraSparkProviderTest extends Specification {
+
+  sequential
+
+  var storage: Path = _
+  var params: Map[String, String] = _
+  var ds: CassandraDataStore = _
+
+  var sc: SparkContext = _
+
+  step {
+    // cassandra database set up
+    storage = Files.createTempDirectory("cassandra")
+
+    System.setProperty("cassandra.storagedir", storage.toString)
+
+    EmbeddedCassandraServerHelper.startEmbeddedCassandra("cassandra-config.yaml", 1200000L)
+
+    var readTimeout: Int = SystemProperty("cassandraReadTimeout", "12000").get.toInt
+
+    if (readTimeout < 0) {
+      readTimeout = 12000
+    }
+    val host = EmbeddedCassandraServerHelper.getHost
+    val port = EmbeddedCassandraServerHelper.getNativeTransportPort
+    val cluster = new Cluster.Builder().addContactPoints(host).withPort(port)
+      .withSocketOptions(new SocketOptions().setReadTimeoutMillis(readTimeout)).build().init()
+    val session = cluster.connect()
+    val cqlDataLoader = new CQLDataLoader(session)
+    cqlDataLoader.load(new ClassPathCQLDataSet("init.cql", false, false))
+
+    // add parameters to point to Cassandra
+    params = Map(
+      Params.ContactPointParam.getName -> s"$host:$port",
+      Params.KeySpaceParam.getName -> "geomesa_cassandra",
+      Params.CatalogParam.getName -> "test_sft",
+      "geomesa.cassandra.host" -> s"$host"
+    )
+    ds = DataStoreFinder.getDataStore(params).asInstanceOf[CassandraDataStore]
+
+    // Spark set up
+    val conf = new SparkConf().setMaster("local[2]").setAppName("testSpark")
+    conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+    conf.set("spark.kryo.registrator", classOf[GeoMesaSparkKryoRegistrator].getName)
+    sc = SparkContext.getOrCreate(conf)
+  }
+
+  // Define feature schema
+  lazy val chicagoSft =
+    SimpleFeatureTypes.createType("chicago",
+      "arrest:String,case_number:Int,dtg:Date,*geom:Point:srid=4326")
+
+  // Make test features
+  lazy val chicagoFeatures: Seq[SimpleFeature] = Seq(
+    ScalaSimpleFeature.create(chicagoSft, "1", "true", 1, "2016-01-01T00:00:00.000Z", "POINT (-76.5 38.5)"),
+    ScalaSimpleFeature.create(chicagoSft, "2", "true", 2, "2016-01-02T00:00:00.000Z", "POINT (-77.0 38.0)"),
+    ScalaSimpleFeature.create(chicagoSft, "3", "true", 3, "2016-01-03T00:00:00.000Z", "POINT (-78.0 39.0)"),
+    ScalaSimpleFeature.create(chicagoSft, "4", "true", 4, "2016-01-01T00:00:00.000Z", "POINT (-73.5 39.5)"),
+    ScalaSimpleFeature.create(chicagoSft, "5", "true", 5, "2016-01-02T00:00:00.000Z", "POINT (-74.0 35.5)"),
+    ScalaSimpleFeature.create(chicagoSft, "6", "true", 6, "2016-01-03T00:00:00.000Z", "POINT (-79.0 37.5)")
+  )
+
+  "The CassandraSpatialRDDProvider" should {
+    "read from the embedded Cassandra database" in {
+      val ds = DataStoreFinder.getDataStore(params)
+      ds.createSchema(chicagoSft)
+      WithClose(ds.getFeatureWriterAppend("chicago", Transaction.AUTO_COMMIT)) { writer =>
+        chicagoFeatures.take(3).foreach(FeatureUtils.write(writer, _, useProvidedFid = true))
+      }
+
+      val rdd = GeoMesaSpark(params).rdd(new Configuration(), sc, params, new Query("chicago"))
+      rdd.count() mustEqual 3l
+    }
+
+    "write to the embedded Cassandra database" in {
+      val ds = DataStoreFinder.getDataStore(params)
+      ds.createSchema(chicagoSft)
+      val writeRdd = sc.parallelize(chicagoFeatures)
+      GeoMesaSpark(params).save(writeRdd, params, "chicago")
+      // verify write
+      val readRdd = GeoMesaSpark(params).rdd(new Configuration(), sc, params, new Query("chicago"))
+      readRdd.count() mustEqual 6l
+    }
+  }
+
+}

--- a/geomesa-cassandra/pom.xml
+++ b/geomesa-cassandra/pom.xml
@@ -15,7 +15,9 @@
         <module>geomesa-cassandra-datastore</module>
         <module>geomesa-cassandra-dist</module>
         <module>geomesa-cassandra-gs-plugin</module>
+        <module>geomesa-cassandra-spark</module>
         <module>geomesa-cassandra-tools</module>
+        <module>geomesa-cassandra-jobs</module>
     </modules>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,11 @@
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
+                <artifactId>geomesa-cassandra-jobs_${scala.binary.version}</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.locationtech.geomesa</groupId>
                 <artifactId>geomesa-cassandra-tools_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Work done for Cornell CS 5152 class. Contributions by: @rayjzeng @j-mez @lucaschen321

This pull request contains an incomplete implementation of a CassandraSpatialRDDProvider that providers Cassandra Spark support. The work for this integration is contained in two new modules: geomesa-cassandra-jobs and geomesa-cassandra-spark.

Current bugs and issues are documented inline in:
* geomesa-cassandra/geomesa-cassandra-spark/src/main/scala/org/locationtech/geomesa/cassandra/spark/CassandraSpatialRDDProvider.scala
* geomesa-cassandra/geomesa-cassandra-spark/src/main/scala/org/locationtech/geomesa/cassandra/spark/GeoMesaCassandraInputFormat.scala