### PR TITLE
GEOMESA-2758 Additional NiFi expression language support

### DIFF
--- a/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/data/FileSystemDataStoreFactory.scala
+++ b/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/data/FileSystemDataStoreFactory.scala
@@ -144,7 +144,8 @@ object FileSystemDataStoreFactory extends GeoMesaDataStoreInfo {
         "fs.config.xml",
         "Additional Hadoop configuration properties, as a standard XML `<configuration>` element",
         largeText = true,
-        deprecatedParams = Seq(DeprecatedConfParam))
+        deprecatedParams = Seq(DeprecatedConfParam),
+        supportsNiFiExpressions = true)
 
     val ReadThreadsParam =
       new GeoMesaParam[Integer](

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreFactory.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreFactory.scala
@@ -251,5 +251,6 @@ object HBaseDataStoreParams extends GeoMesaDataStoreParams with SecurityParams {
     new GeoMesaParam[String](
       "hbase.config.xml",
       "Additional HBase configuration properties, as a standard XML `<configuration>` element",
-      largeText = true)
+      largeText = true,
+      supportsNiFiExpressions = true)
 }

--- a/geomesa-security/src/main/scala/org/locationtech/geomesa/security/package.scala
+++ b/geomesa-security/src/main/scala/org/locationtech/geomesa/security/package.scala
@@ -21,10 +21,32 @@ package object security {
   val GEOMESA_AUDIT_PROVIDER_IMPL = SystemProperty("geomesa.audit.provider.impl")
   val GEOMESA_AUTH_PROVIDER_IMPL  = SystemProperty("geomesa.auth.provider.impl")
 
-  val AuthsParam           = new GeoMesaParam[String]("geomesa.security.auths", "Super-set of authorizations that will be used for queries. The actual authorizations might differ, depending on the authorizations provider, but will be outside this set. Comma-delimited.", deprecatedKeys = Seq("auths"))
-  val ForceEmptyAuthsParam = new GeoMesaParam[java.lang.Boolean]("geomesa.security.auths.force-empty", "Default to using no authorizations during queries, instead of using the connection user's authorizations", default = false, deprecatedKeys = Seq("forceEmptyAuths"))
-  val AuthProviderParam    = new GeoMesaParam[AuthorizationsProvider]("geomesa.security.auths.provider", "Authorizations provider", deprecatedKeys = Seq("authProvider"))
-  val VisibilitiesParam    = new GeoMesaParam[String]("geomesa.security.visibilities", "Default visibilities to apply to all written data", deprecatedKeys = Seq("visibilities"))
+  val AuthsParam =
+    new GeoMesaParam[String](
+      "geomesa.security.auths",
+      "Super-set of authorizations that will be used for queries. The actual authorizations might differ, depending on the authorizations provider, but will be outside this set. Comma-delimited.",
+      deprecatedKeys = Seq("auths"),
+      supportsNiFiExpressions = true)
+
+  val ForceEmptyAuthsParam =
+    new GeoMesaParam[java.lang.Boolean](
+      "geomesa.security.auths.force-empty",
+      "Default to using no authorizations during queries, instead of using the connection user's authorizations",
+      default = false,
+      deprecatedKeys = Seq("forceEmptyAuths"))
+
+  val AuthProviderParam =
+    new GeoMesaParam[AuthorizationsProvider](
+      "geomesa.security.auths.provider",
+      "Authorizations provider",
+      deprecatedKeys = Seq("authProvider"))
+
+  val VisibilitiesParam =
+    new GeoMesaParam[String](
+      "geomesa.security.visibilities",
+      "Default visibilities to apply to all written data",
+      deprecatedKeys = Seq("visibilities"),
+      supportsNiFiExpressions = true)
 
   trait SecurityParams {
     val AuthsParam: GeoMesaParam[String] = org.locationtech.geomesa.security.AuthsParam


### PR DESCRIPTION
* geomesa.security.auths
* geomesa.security.visibilities
* hbase.config.xml
* fs.config.xml

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>