### PR TITLE
GEOMESA-2769 Add expiry for cached filters in distributed runtimes

### DIFF
--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -94,6 +94,16 @@ comparison. This property controls the threshold for switching to a hash lookup.
 Note that for datastores with distributed filtering (e.g. HBase and Accumulo), this property needs to be set
 on the distributed processing nodes.
 
+geomesa.filter.remote.cache.expiry
+++++++++++++++++++++++++++++++++++
+
+This property controls how long query filters will be cached in memory in remote processes (i.e. HBase region servers
+and Accumulo tablet servers). For repeated queries, caching the filter can improve query times. However, complex
+filters can require a substantial amount of memory overhead. The expiry is specified as a duration, e.g.
+``10 minutes`` or ``1 hour``. The default is ``10 minutes``.
+
+Note that to take effect, the property must be set on each region or tablet server.
+
 geomesa.force.count
 +++++++++++++++++++
 
@@ -222,6 +232,13 @@ This property provides a rough upper-limit for the number of row ranges that wil
 query. It is specified as a number. In general, more ranges will result in fewer false-positive rows being
 scanned, which will speed up most queries. However, too many ranges can take a long time to generate, and
 overwhelm clients, causing slowdowns. The optimal value depends on the environment.
+
+geomesa.serializer.cache.expiry
++++++++++++++++++++++++++++++++
+
+This property controls how long simple feature serializers will be cached in memory. Lowering this value may
+reduce the memory footprint of your application, at the cost of increased processing time. The expiry is specified
+as a duration, e.g. ``10 minutes`` or ``1 hour``. The default is ``1 hour``.
 
 geomesa.sft.config.urls
 +++++++++++++++++++++++

--- a/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/ScalaSimpleFeatureFactory.scala
+++ b/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/ScalaSimpleFeatureFactory.scala
@@ -9,10 +9,9 @@
 package org.locationtech.geomesa.features
 
 import org.geotools.factory.CommonFactoryFinder
-import org.geotools.util.factory.Hints
 import org.geotools.feature.AbstractFeatureFactoryImpl
 import org.geotools.feature.simple.SimpleFeatureBuilder
-import org.locationtech.geomesa.utils.cache.SoftThreadLocalCache
+import org.geotools.util.factory.Hints
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
@@ -36,21 +35,16 @@ object ScalaSimpleFeatureFactory {
   private val hints = new Hints(Hints.FEATURE_FACTORY, classOf[ScalaSimpleFeatureFactory])
   private val featureFactory = CommonFactoryFinder.getFeatureFactory(hints)
 
-  private val cache = new SoftThreadLocalCache[SimpleFeatureType, SimpleFeatureBuilder]()
-
-  private def getFeatureBuilder(sft: SimpleFeatureType) =
-    cache.getOrElseUpdate(sft, new SimpleFeatureBuilder(sft, featureFactory))
-
-  def init() = Hints.putSystemDefault(Hints.FEATURE_FACTORY, classOf[ScalaSimpleFeatureFactory])
+  def init(): Unit = Hints.putSystemDefault(Hints.FEATURE_FACTORY, classOf[ScalaSimpleFeatureFactory])
 
   def buildFeature(sft: SimpleFeatureType, attrs: Seq[AnyRef], id: String): SimpleFeature = {
-    val builder = getFeatureBuilder(sft)
+    val builder = featureBuilder(sft)
     builder.addAll(attrs)
     builder.buildFeature(id)
   }
 
   def copyFeature(sft: SimpleFeatureType, feature: SimpleFeature, id: String): SimpleFeature = {
-    val builder = getFeatureBuilder(sft)
+    val builder = featureBuilder(sft)
     builder.init(feature)
     builder.buildFeature(id)
   }

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserialization.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserialization.scala
@@ -6,7 +6,8 @@
  * http://www.opensource.org/licenses/apache2.0.php.
  ***********************************************************************/
 
-package org.locationtech.geomesa.features.kryo.impl
+package org.locationtech.geomesa.features.kryo
+package impl
 
 import java.io.InputStream
 import java.util.{Date, UUID}
@@ -14,13 +15,12 @@ import java.util.{Date, UUID}
 import com.esotericsoftware.kryo.io.Input
 import com.typesafe.scalalogging.LazyLogging
 import org.locationtech.geomesa.features.SimpleFeatureSerializer
-import org.locationtech.geomesa.features.kryo.KryoBufferSimpleFeature
 import org.locationtech.geomesa.features.kryo.impl.KryoFeatureDeserialization.KryoAttributeReader
 import org.locationtech.geomesa.features.kryo.json.KryoJsonSerialization
 import org.locationtech.geomesa.features.kryo.serialization.KryoGeometrySerialization
 import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
-import org.locationtech.geomesa.utils.cache.{CacheKeyGenerator, SoftThreadLocal, SoftThreadLocalCache}
+import org.locationtech.geomesa.utils.cache.{CacheKeyGenerator, SoftThreadLocal, ThreadLocalCache}
 import org.locationtech.jts.geom.Geometry
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType
@@ -48,7 +48,7 @@ trait KryoFeatureDeserialization extends SimpleFeatureSerializer with LazyLoggin
 object KryoFeatureDeserialization extends LazyLogging {
 
   private val inputs  = new SoftThreadLocal[Input]()
-  private val readers = new SoftThreadLocalCache[String, Array[KryoAttributeReader]]()
+  private val readers = new ThreadLocalCache[String, Array[KryoAttributeReader]](SerializerCacheExpiry)
 
   def getInput(bytes: Array[Byte], offset: Int, count: Int): Input = {
     val in = inputs.getOrElseUpdate(new Input)

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserializationV2.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserializationV2.scala
@@ -6,7 +6,8 @@
  * http://www.opensource.org/licenses/apache2.0.php.
  ***********************************************************************/
 
-package org.locationtech.geomesa.features.kryo.impl
+package org.locationtech.geomesa.features.kryo
+package impl
 
 import java.util
 import java.util.{Date, UUID}
@@ -18,7 +19,7 @@ import org.locationtech.geomesa.features.kryo.json.KryoJsonSerialization
 import org.locationtech.geomesa.features.kryo.serialization.KryoGeometrySerialization
 import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
-import org.locationtech.geomesa.utils.cache.SoftThreadLocalCache
+import org.locationtech.geomesa.utils.cache.ThreadLocalCache
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType
 
@@ -38,7 +39,7 @@ import scala.util.control.NonFatal
   */
 object KryoFeatureDeserializationV2 extends LazyLogging {
 
-  private val readers = new SoftThreadLocalCache[String, Array[Input => AnyRef]]()
+  private val readers = new ThreadLocalCache[String, Array[Input => AnyRef]](SerializerCacheExpiry)
 
   private [geomesa] def getReaders(key: String, sft: SimpleFeatureType): Array[Input => AnyRef] = {
     readers.getOrElseUpdate(key, sft.getAttributeDescriptors.toArray.map {

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureSerialization.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureSerialization.scala
@@ -19,7 +19,7 @@ import org.locationtech.geomesa.features.kryo.json.KryoJsonSerialization
 import org.locationtech.geomesa.features.kryo.serialization.{KryoGeometrySerialization, KryoUserDataSerialization}
 import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
-import org.locationtech.geomesa.utils.cache.{CacheKeyGenerator, SoftThreadLocal, SoftThreadLocalCache}
+import org.locationtech.geomesa.utils.cache.{CacheKeyGenerator, SoftThreadLocal, ThreadLocalCache}
 import org.locationtech.geomesa.utils.collection.IntBitSet
 import org.locationtech.geomesa.utils.geometry.GeometryPrecision
 import org.locationtech.jts.geom.Geometry
@@ -119,7 +119,7 @@ object KryoFeatureSerialization extends LazyLogging {
   val MaxUnsignedShort: Int = 65535
 
   private [this] val outputs = new SoftThreadLocal[Output]()
-  private [this] val writers = new SoftThreadLocalCache[String, Array[KryoAttributeWriter]]()
+  private [this] val writers = new ThreadLocalCache[String, Array[KryoAttributeWriter]](SerializerCacheExpiry)
 
   /**
     * Gets a reusable, thread-local output. Don't hold on to the result, as it may be re-used on a per-thread basis

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/package.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/package.scala
@@ -10,8 +10,13 @@ package org.locationtech.geomesa.features
 
 import com.esotericsoftware.kryo.io.{Input, Output}
 import org.locationtech.geomesa.utils.collection.IntBitSet
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
+
+import scala.concurrent.duration.Duration
 
 package object kryo {
+
+  val SerializerCacheExpiry: Duration = SystemProperty("geomesa.serializer.cache.expiry", "1 hour").toDuration.get
 
   /**
     * Metadata for serialized simple features

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/iterators/IteratorCache.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/iterators/IteratorCache.scala
@@ -8,13 +8,16 @@
 
 package org.locationtech.geomesa.index.iterators
 
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 
+import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
+import com.typesafe.scalalogging.StrictLogging
 import org.locationtech.geomesa.features.SerializationOption.SerializationOption
 import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
 import org.locationtech.geomesa.filter.factory.FastFilterFactory
 import org.locationtech.geomesa.index.api.{GeoMesaFeatureIndex, GeoMesaFeatureIndexFactory}
-import org.locationtech.geomesa.utils.cache.SoftThreadLocalCache
+import org.locationtech.geomesa.utils.cache.ThreadLocalCache
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
 import org.locationtech.geomesa.utils.conf.IndexId
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.index.IndexMode
@@ -24,15 +27,18 @@ import org.opengis.filter.Filter
 /**
   * Cache for expensive objects used in iterators
   */
-object IteratorCache {
+object IteratorCache extends StrictLogging {
 
-  // thread safe objects can use a concurrent hashmap
-  private val serializerCache = new ConcurrentHashMap[(String, String), KryoFeatureSerializer]()
-  private val indexCache = new ConcurrentHashMap[(String, String), GeoMesaFeatureIndex[_, _]]()
+  private val expiry = SystemProperty("geomesa.filter.remote.cache.expiry", "10 minutes").toDuration.get
 
-  // non-thread safe objects use thread-locals
-  // note: treating filters as unsafe due to an abundance of caution
-  private val filterCache = new SoftThreadLocalCache[(String, String), Filter]()
+  // thread safe object caches
+  private val serializerCache: Cache[(String, String), KryoFeatureSerializer] =
+    Caffeine.newBuilder().expireAfterAccess(expiry.toMillis, TimeUnit.MILLISECONDS).build()
+  private val indexCache: Cache[(String, String), GeoMesaFeatureIndex[_, _]] =
+    Caffeine.newBuilder().expireAfterAccess(expiry.toMillis, TimeUnit.MILLISECONDS).build()
+
+  // non-thread safe object caches
+  private val filterCache = new ThreadLocalCache[(String, String), Filter](expiry)
 
   /**
     * Returns a cached simple feature type, creating one if necessary. Note: do not modify returned value.
@@ -51,7 +57,7 @@ object IteratorCache {
     */
   def serializer(spec: String, options: Set[SerializationOption]): KryoFeatureSerializer = {
     // note: before the cache is populated, we might end up creating multiple objects, but it is still thread-safe
-    val cached = serializerCache.get((spec, options.mkString))
+    val cached = serializerCache.getIfPresent((spec, options.mkString))
     if (cached != null) { cached } else {
       val serializer = KryoFeatureSerializer(sft(spec), options)
       serializerCache.put((spec, options.mkString), serializer)
@@ -70,8 +76,11 @@ object IteratorCache {
     * @param ecql ecql
     * @return
     */
-  def filter(sft: SimpleFeatureType, spec: String, ecql: String): Filter =
+  def filter(sft: SimpleFeatureType, spec: String, ecql: String): Filter = {
+    logger.debug(s"Filter cache estimated size: ${filterCache.estimatedGlobalSize}")
+    logger.trace(s"Filter cache entries: ${filterCache.globalIterator.map { case (t, (k, v), _) => s"thread $t $k=>$v" }.mkString(", ")}")
     filterCache.getOrElseUpdate((spec, ecql), FastFilterFactory.toFilter(sft, ecql))
+  }
 
   /**
     * Gets a cached feature index instance. Note that the index is not backed by a data store as
@@ -83,7 +92,7 @@ object IteratorCache {
     * @return
     */
   def index(sft: SimpleFeatureType, spec: String, identifier: String): GeoMesaFeatureIndex[_, _] = {
-    val cached = indexCache.get((spec, identifier))
+    val cached = indexCache.getIfPresent((spec, identifier))
     if (cached != null) { cached } else {
       val index = GeoMesaFeatureIndexFactory.create(null, sft, Seq(IndexId.id(identifier))).headOption.getOrElse {
         throw new RuntimeException(s"Index option not configured correctly: $identifier")

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/SimpleFeatureSerialization.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/SimpleFeatureSerialization.scala
@@ -15,7 +15,7 @@ import org.apache.hadoop.io.serializer.{Deserializer, Serialization, Serializer}
 import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
 import org.locationtech.geomesa.jobs.GeoMesaConfigurator
 import org.locationtech.geomesa.jobs.mapreduce.SimpleFeatureSerialization._
-import org.locationtech.geomesa.utils.cache.SoftThreadLocalCache
+import org.locationtech.geomesa.utils.cache.ThreadLocalCache
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.index.ByteArrays
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -38,8 +38,10 @@ class SimpleFeatureSerialization extends Configured with Serialization[SimpleFea
 
 object SimpleFeatureSerialization {
 
+  import org.locationtech.geomesa.features.kryo.SerializerCacheExpiry
+
   // re-usable serializers since they are not thread safe
-  private val serializers = new SoftThreadLocalCache[String, KryoFeatureSerializer]()
+  private val serializers = new ThreadLocalCache[String, KryoFeatureSerializer](SerializerCacheExpiry)
 
   private def serializer(key: String, sft: SimpleFeatureType): KryoFeatureSerializer =
     serializers.getOrElseUpdate(key, KryoFeatureSerializer.builder(sft).withId.withUserData.build())

--- a/geomesa-utils/pom.xml
+++ b/geomesa-utils/pom.xml
@@ -109,6 +109,10 @@
             <artifactId>parboiled-scala_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
         </dependency>

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/cache/ThreadLocalCache.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/cache/ThreadLocalCache.scala
@@ -1,0 +1,146 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.cache
+
+import java.io.Closeable
+import java.lang.ref.WeakReference
+import java.util.concurrent._
+
+import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
+import com.google.common.util.concurrent.MoreExecutors
+
+import scala.concurrent.duration.Duration
+
+/**
+ * Creates a per-thread cache of values with a timed expiration.
+ *
+ * Map operations will only affect/reflect the state of the current thread. Additional methods `globalIterator`
+ * and `estimatedGlobalSize` are provided for global views across all threads, which generally should only be used
+ * for debugging.
+ *
+ * Since caches are only cleaned up when accessed, uses an asynchronous thread to
+ * actively clean up any orphaned thread local values
+ *
+ * @tparam K key type
+ * @tparam V value type
+ */
+class ThreadLocalCache[K <: AnyRef, V <: AnyRef](
+    expiry: Duration,
+    executor: ScheduledExecutorService = ThreadLocalCache.executor
+  ) extends scala.collection.mutable.Map[K, V]
+    with scala.collection.mutable.MapLike[K, V, ThreadLocalCache[K, V]]
+    with Runnable
+    with Closeable {
+
+  import scala.collection.JavaConverters._
+
+  // weak references to our current caches, to allow cleanup + GC
+  private val references = new ConcurrentLinkedQueue[(Long, WeakReference[Cache[K, V]])]()
+
+  private val caches = new ThreadLocal[Cache[K, V]]() {
+    override def initialValue(): Cache[K, V] = {
+      val cache = Caffeine.newBuilder().expireAfterAccess(expiry.toMillis, TimeUnit.MILLISECONDS).build[K, V]()
+      // this will always succeed as our queue is unbounded
+      references.offer((Thread.currentThread().getId, new WeakReference(cache)))
+      cache
+    }
+  }
+
+  private val cleanup = executor.scheduleWithFixedDelay(this, expiry.toMillis, expiry.toMillis, TimeUnit.MILLISECONDS)
+
+  // show the class name for toString
+  override def stringPrefix : String = "ThreadLocalCache"
+
+  override def get(key: K): Option[V] = Option(caches.get.getIfPresent(key))
+
+  override def getOrElseUpdate(key: K, op: => V): V = {
+    val cached = caches.get.getIfPresent(key)
+    if (cached != null) { cached } else {
+      val value = op
+      caches.get.put(key, value)
+      value
+    }
+  }
+
+  override def +=(kv: (K, V)): this.type = {
+    caches.get.put(kv._1, kv._2)
+    this
+  }
+
+  override def -=(key: K): this.type = {
+    caches.get.invalidate(key)
+    this
+  }
+
+  override def empty: ThreadLocalCache[K, V] = new ThreadLocalCache[K, V](expiry)
+
+  override def iterator: Iterator[(K, V)] = caches.get.asMap.asScala.iterator
+
+  /**
+   * Gets an iterator across all thread-local values, not just the current thread
+   *
+   * @return iterator of (thread-id, key, value)
+   */
+  def globalIterator: Iterator[(Long, K, V)] = {
+    references.iterator.asScala.flatMap { case (id, ref) =>
+      val cache = ref.get
+      if (cache == null) { Iterator.empty } else {
+        cache.asMap().asScala.iterator.map { case (k, v) => (id, k, v) }
+      }
+    }
+  }
+
+  /**
+   * Gets the estimated total size across all thread-local values
+   *
+   * @return
+   */
+  def estimatedGlobalSize: Long = {
+    var size = 0L
+    references.iterator.asScala.foreach { case (_, ref) =>
+      val cache = ref.get
+      if (cache != null) {
+        size += cache.estimatedSize()
+      }
+    }
+    size
+  }
+
+  override def run(): Unit = {
+    val iter = references.iterator()
+    while (iter.hasNext) {
+      val cache = iter.next._2.get
+      if (cache == null) {
+        // cache has been GC'd, remove our reference to it
+        iter.remove()
+      } else {
+        cache.cleanUp()
+      }
+    }
+  }
+
+  override def close(): Unit = {
+    cleanup.cancel(true)
+    val iter = references.iterator()
+    while (iter.hasNext) {
+      val cache = iter.next._2.get
+      if (cache != null) {
+        cache.asMap().clear()
+      }
+      iter.remove()
+    }
+  }
+}
+
+object ThreadLocalCache {
+  // use a 2 thread executor service for all the caches - we only use a handful across the code base
+  private val executor = MoreExecutors.getExitingScheduledExecutorService {
+    Executors.newScheduledThreadPool(2).asInstanceOf[ScheduledThreadPoolExecutor]
+  }
+}

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/cache/ThreadLocalCacheTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/cache/ThreadLocalCacheTest.scala
@@ -1,0 +1,91 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.cache
+
+import java.util.concurrent.{ScheduledExecutorService, ScheduledFuture, TimeUnit}
+
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.utils.io.WithClose
+import org.mockito.ArgumentMatchers
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ThreadLocalCacheTest extends Specification with Mockito {
+
+  import scala.concurrent.duration._
+
+  "ThreadLocalCache" should {
+    "implement map methods" in {
+      new ThreadLocalCache[String, String](10.minutes) must
+          beAnInstanceOf[scala.collection.mutable.Map[String, String]]
+    }
+
+    "allow getOrElseUpdate" in {
+      WithClose(new ThreadLocalCache[String, String](10.minutes)) { cache =>
+        cache.getOrElseUpdate("k1", "v1") mustEqual "v1"
+        var sideEffect = "1"
+        cache.getOrElseUpdate("k1", { sideEffect = "2"; "v1" }) mustEqual "v1"
+        sideEffect mustEqual "1"
+      }
+    }
+
+    "be thread safe" in {
+      WithClose(new ThreadLocalCache[String, AnyRef](10.minutes)) { cache =>
+        val obj1 = new AnyRef()
+        val obj2 = new AnyRef()
+        val first = cache.getOrElseUpdate("k1", obj1)
+        var second: AnyRef = null
+        val t = new Thread(new Runnable() { override def run(): Unit = second = cache.getOrElseUpdate("k1", obj2) } )
+        t.start()
+        t.join()
+        first must beTheSameAs(obj1)
+        second must beTheSameAs(obj2)
+        first must not beTheSameAs second
+      }
+    }
+
+    "read expired references correctly" in {
+      val es = mock[MockScheduledExecutorService]
+      val future = mock[ScheduledFuture[Unit]]
+      es.scheduleWithFixedDelay(ArgumentMatchers.any(), ArgumentMatchers.eq(100L),
+        ArgumentMatchers.eq(100L), ArgumentMatchers.eq(TimeUnit.MILLISECONDS)) returns future
+      WithClose(new ThreadLocalCache[String, String](100.millis, es)) { cache =>
+        there was one(es).scheduleWithFixedDelay(cache, 100, 100, TimeUnit.MILLISECONDS)
+        cache.put("k1", "v1")
+        cache.get("k1") must beSome("v1")
+        eventually(10, 100.millis)(cache.get("k1") must beNone)
+      }
+      there was one(future).cancel(true)
+    }
+
+    "update expired references correctly" in {
+      val es = mock[MockScheduledExecutorService]
+      val future = mock[ScheduledFuture[Unit]]
+      es.scheduleWithFixedDelay(ArgumentMatchers.any(), ArgumentMatchers.eq(100L),
+        ArgumentMatchers.eq(100L), ArgumentMatchers.eq(TimeUnit.MILLISECONDS)) returns future
+      WithClose(new ThreadLocalCache[String, String](100.millis, es)) { cache =>
+        there was one(es).scheduleWithFixedDelay(cache, 100, 100, TimeUnit.MILLISECONDS)
+        cache.put("k1", "v1")
+        cache.get("k1") must beSome("v1")
+        eventually(10, 100.millis)(cache.get("k1") must beNone)
+        cache.getOrElseUpdate("k1", "v2") mustEqual "v2"
+        cache.get("k1") must beSome("v2")
+        cache("k1") mustEqual "v2"
+      }
+      there was one(future).cancel(true)
+    }
+  }
+
+  // needed to handle mocking the unbound wildcard in the signature for scheduleWithFixedDelay
+  trait MockScheduledExecutorService extends ScheduledExecutorService {
+    override def scheduleWithFixedDelay(command: Runnable, initialDelay: Long, delay: Long, unit: TimeUnit): ScheduledFuture[Unit]
+  }
+}


### PR DESCRIPTION
* `geomesa.filter.remote.cache.expiry` for setting filter expiration
* `geomesa.serializer.cache.expiry` for setting serializer expiration

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>