### PR TITLE
GEOMESA-2769 Add expiry for cached filters in distributed runtimes

### DIFF
--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -94,6 +94,16 @@ comparison. This property controls the threshold for switching to a hash lookup.
 Note that for datastores with distributed filtering (e.g. HBase and Accumulo), this property needs to be set
 on the distributed processing nodes.
 
+geomesa.filter.remote.cache.expiry
+++++++++++++++++++++++++++++++++++
+
+This property controls how long query filters will be cached in memory in remote processes (i.e. HBase region servers
+and Accumulo tablet servers). For repeated queries, caching the filter can improve query times. However, complex
+filters can require a substantial amount of memory overhead. The expiry is specified as a duration, e.g.
+``10 minutes`` or ``1 hour``. The default is ``10 minutes``.
+
+Note that to take effect, the property must be set on each region or tablet server.
+
 geomesa.force.count
 +++++++++++++++++++
 
@@ -215,6 +225,13 @@ This property provides a rough upper-limit for the number of row ranges that wil
 query. It is specified as a number. In general, more ranges will result in fewer false-positive rows being
 scanned, which will speed up most queries. However, too many ranges can take a long time to generate, and
 overwhelm clients, causing slowdowns. The optimal value depends on the environment.
+
+geomesa.serializer.cache.expiry
++++++++++++++++++++++++++++++++
+
+This property controls how long simple feature serializers will be cached in memory. Lowering this value may
+reduce the memory footprint of your application, at the cost of increased processing time. The expiry is specified
+as a duration, e.g. ``10 minutes`` or ``1 hour``. The default is ``1 hour``.
 
 geomesa.sft.config.urls
 +++++++++++++++++++++++

--- a/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/ScalaSimpleFeatureFactory.scala
+++ b/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/ScalaSimpleFeatureFactory.scala
@@ -35,21 +35,16 @@ object ScalaSimpleFeatureFactory {
   private val hints = new Hints(Hints.FEATURE_FACTORY, classOf[ScalaSimpleFeatureFactory])
   private val featureFactory = CommonFactoryFinder.getFeatureFactory(hints)
 
-  private val cache = new SoftThreadLocalCache[SimpleFeatureType, SimpleFeatureBuilder]()
-
-  private def getFeatureBuilder(sft: SimpleFeatureType) =
-    cache.getOrElseUpdate(sft, new SimpleFeatureBuilder(sft, featureFactory))
-
-  def init() = Hints.putSystemDefault(Hints.FEATURE_FACTORY, classOf[ScalaSimpleFeatureFactory])
+  def init(): Unit = Hints.putSystemDefault(Hints.FEATURE_FACTORY, classOf[ScalaSimpleFeatureFactory])
 
   def buildFeature(sft: SimpleFeatureType, attrs: Seq[AnyRef], id: String): SimpleFeature = {
-    val builder = getFeatureBuilder(sft)
+    val builder = featureBuilder(sft)
     builder.addAll(attrs)
     builder.buildFeature(id)
   }
 
   def copyFeature(sft: SimpleFeatureType, feature: SimpleFeature, id: String): SimpleFeature = {
-    val builder = getFeatureBuilder(sft)
+    val builder = featureBuilder(sft)
     builder.init(feature)
     builder.buildFeature(id)
   }

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserialization.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserialization.scala
@@ -6,7 +6,8 @@
  * http://www.opensource.org/licenses/apache2.0.php.
  ***********************************************************************/
 
-package org.locationtech.geomesa.features.kryo.impl
+package org.locationtech.geomesa.features.kryo
+package impl
 
 import java.io.InputStream
 import java.util
@@ -22,7 +23,7 @@ import org.locationtech.geomesa.features.kryo.json.KryoJsonSerialization
 import org.locationtech.geomesa.features.kryo.serialization.{KryoGeometrySerialization, KryoUserDataSerialization}
 import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
-import org.locationtech.geomesa.utils.cache.{CacheKeyGenerator, SoftThreadLocal, SoftThreadLocalCache}
+import org.locationtech.geomesa.utils.cache.{CacheKeyGenerator, SoftThreadLocal, ThreadLocalCache}
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType
 
@@ -70,7 +71,7 @@ trait KryoFeatureDeserialization extends SimpleFeatureSerializer with LazyLoggin
 object KryoFeatureDeserialization extends LazyLogging {
 
   private[this] val inputs  = new SoftThreadLocal[Input]()
-  private[this] val readers = new SoftThreadLocalCache[String, Array[Input => AnyRef]]()
+  private[this] val readers = new ThreadLocalCache[String, Array[Input => AnyRef]](SerializerCacheExpiry)
 
   def getInput(bytes: Array[Byte], offset: Int, count: Int): Input = {
     val in = inputs.getOrElseUpdate(new Input)

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureSerialization.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureSerialization.scala
@@ -6,7 +6,8 @@
  * http://www.opensource.org/licenses/apache2.0.php.
  ***********************************************************************/
 
-package org.locationtech.geomesa.features.kryo.impl
+package org.locationtech.geomesa.features.kryo
+package impl
 
 import java.io.OutputStream
 import java.util.{Date, UUID}
@@ -19,7 +20,7 @@ import org.locationtech.geomesa.features.kryo.json.KryoJsonSerialization
 import org.locationtech.geomesa.features.kryo.serialization.{KryoGeometrySerialization, KryoUserDataSerialization}
 import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
-import org.locationtech.geomesa.utils.cache.{CacheKeyGenerator, SoftThreadLocal, SoftThreadLocalCache}
+import org.locationtech.geomesa.utils.cache.{CacheKeyGenerator, SoftThreadLocal, ThreadLocalCache}
 import org.locationtech.geomesa.utils.geometry.GeometryPrecision
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -85,8 +86,8 @@ trait KryoFeatureSerialization extends SimpleFeatureSerializer {
 object KryoFeatureSerialization {
 
   private [this] val outputs = new SoftThreadLocal[Output]()
-  private [this] val writers = new SoftThreadLocalCache[String, Array[(Output, AnyRef) => Unit]]()
-  private [this] val offsets = new SoftThreadLocalCache[String, Array[Int]]()
+  private [this] val writers = new ThreadLocalCache[String, Array[(Output, AnyRef) => Unit]](SerializerCacheExpiry)
+  private [this] val offsets = new ThreadLocalCache[String, Array[Int]](SerializerCacheExpiry)
 
   def getOutput(stream: OutputStream): Output = {
     val out = outputs.getOrElseUpdate(new Output(1024, -1))

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/package.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/package.scala
@@ -1,0 +1,18 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.features
+
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
+
+import scala.concurrent.duration.Duration
+
+package object kryo {
+
+  val SerializerCacheExpiry: Duration = SystemProperty("geomesa.serializer.cache.expiry", "1 hour").toDuration.get
+}

--- a/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/SimpleFeatureSerialization.scala
+++ b/geomesa-jobs/src/main/scala/org/locationtech/geomesa/jobs/mapreduce/SimpleFeatureSerialization.scala
@@ -14,7 +14,7 @@ import com.google.common.primitives.Ints
 import org.apache.hadoop.io.serializer.{Deserializer, Serialization, Serializer}
 import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
 import org.locationtech.geomesa.jobs.mapreduce.SimpleFeatureSerialization._
-import org.locationtech.geomesa.utils.cache.SoftThreadLocalCache
+import org.locationtech.geomesa.utils.cache.ThreadLocalCache
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.SimpleFeature
 
@@ -31,8 +31,11 @@ class SimpleFeatureSerialization extends Serialization[SimpleFeature] {
 }
 
 object SimpleFeatureSerialization {
+
+  import org.locationtech.geomesa.features.kryo.SerializerCacheExpiry
+
   // re-usable serializers since they are not thread safe
-  val serializers = new SoftThreadLocalCache[String, KryoFeatureSerializer]()
+  val serializers = new ThreadLocalCache[String, KryoFeatureSerializer](SerializerCacheExpiry)
 
   /**
    * Writes a string to the output stream

--- a/geomesa-utils/pom.xml
+++ b/geomesa-utils/pom.xml
@@ -117,6 +117,10 @@
             <artifactId>parboiled-scala_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
         </dependency>

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/cache/ThreadLocalCache.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/cache/ThreadLocalCache.scala
@@ -1,0 +1,108 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.cache
+
+import java.io.Closeable
+import java.lang.ref.WeakReference
+import java.util.concurrent._
+
+import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
+import com.google.common.util.concurrent.MoreExecutors
+
+import scala.concurrent.duration.Duration
+
+/**
+ * Creates a per-thread cache of values with a timed expiration.
+ *
+ * Since caches are only cleaned up when accessed, uses an asynchronous thread to
+ * actively clean up any orphaned thread local values
+ *
+ * @tparam K key type
+ * @tparam V value type
+ */
+class ThreadLocalCache[K <: AnyRef, V <: AnyRef](
+    expiry: Duration,
+    executor: ScheduledExecutorService = ThreadLocalCache.executor
+  ) extends scala.collection.mutable.Map[K, V]
+    with scala.collection.mutable.MapLike[K, V, ThreadLocalCache[K, V]]
+    with Runnable
+    with Closeable {
+
+  import scala.collection.JavaConverters._
+
+  // weak references to our current caches, to allow cleanup + GC
+  private val references = new ConcurrentLinkedQueue[WeakReference[Cache[K, V]]]()
+
+  private val caches = new ThreadLocal[Cache[K, V]]() {
+    override def initialValue(): Cache[K, V] = {
+      val cache = Caffeine.newBuilder().expireAfterAccess(expiry.toMillis, TimeUnit.MILLISECONDS).build[K, V]()
+      references.offer(new WeakReference(cache)) // this will always succeed as our queue is unbounded
+      cache
+    }
+  }
+
+  private val cleanup = executor.scheduleWithFixedDelay(this, expiry.toMillis, expiry.toMillis, TimeUnit.MILLISECONDS)
+
+  override def get(key: K): Option[V] = Option(caches.get.getIfPresent(key))
+
+  override def getOrElseUpdate(key: K, op: => V): V = {
+    val cached = caches.get.getIfPresent(key)
+    if (cached != null) { cached } else {
+      val value = op
+      caches.get.put(key, value)
+      value
+    }
+  }
+
+  override def +=(kv: (K, V)): this.type = {
+    caches.get.put(kv._1, kv._2)
+    this
+  }
+
+  override def -=(key: K): this.type = {
+    caches.get.invalidate(key)
+    this
+  }
+
+  override def empty: ThreadLocalCache[K, V] = new ThreadLocalCache[K, V](expiry)
+
+  override def iterator: Iterator[(K, V)] = caches.get.asMap.asScala.iterator
+
+  override def run(): Unit = {
+    val iter = references.iterator()
+    while (iter.hasNext) {
+      val cache = iter.next.get
+      if (cache == null) {
+        // cache has been GC'd, remove our reference to it
+        iter.remove()
+      } else {
+        cache.cleanUp()
+      }
+    }
+  }
+
+  override def close(): Unit = {
+    cleanup.cancel(true)
+    val iter = references.iterator()
+    while (iter.hasNext) {
+      val cache = iter.next.get
+      if (cache != null) {
+        cache.asMap().clear()
+      }
+      iter.remove()
+    }
+  }
+}
+
+object ThreadLocalCache {
+  // use a 2 thread executor service for all the caches - we only use a handful across the code base
+  private val executor = MoreExecutors.getExitingScheduledExecutorService {
+    Executors.newScheduledThreadPool(2).asInstanceOf[ScheduledThreadPoolExecutor]
+  }
+}

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/cache/ThreadLocalCacheTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/cache/ThreadLocalCacheTest.scala
@@ -1,0 +1,91 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.cache
+
+import java.util.concurrent.{ScheduledExecutorService, ScheduledFuture, TimeUnit}
+
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.utils.io.WithClose
+import org.mockito.ArgumentMatchers
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ThreadLocalCacheTest extends Specification with Mockito {
+
+  import scala.concurrent.duration._
+
+  "ThreadLocalCache" should {
+    "implement map methods" in {
+      new ThreadLocalCache[String, String](10.minutes) must
+          beAnInstanceOf[scala.collection.mutable.Map[String, String]]
+    }
+
+    "allow getOrElseUpdate" in {
+      WithClose(new ThreadLocalCache[String, String](10.minutes)) { cache =>
+        cache.getOrElseUpdate("k1", "v1") mustEqual "v1"
+        var sideEffect = "1"
+        cache.getOrElseUpdate("k1", { sideEffect = "2"; "v1" }) mustEqual "v1"
+        sideEffect mustEqual "1"
+      }
+    }
+
+    "be thread safe" in {
+      WithClose(new ThreadLocalCache[String, AnyRef](10.minutes)) { cache =>
+        val obj1 = new AnyRef()
+        val obj2 = new AnyRef()
+        val first = cache.getOrElseUpdate("k1", obj1)
+        var second: AnyRef = null
+        val t = new Thread(new Runnable() { override def run(): Unit = second = cache.getOrElseUpdate("k1", obj2) } )
+        t.start()
+        t.join()
+        first must beTheSameAs(obj1)
+        second must beTheSameAs(obj2)
+        first must not beTheSameAs second
+      }
+    }
+
+    "read expired references correctly" in {
+      val es = mock[MockScheduledExecutorService]
+      val future = mock[ScheduledFuture[Unit]]
+      es.scheduleWithFixedDelay(ArgumentMatchers.any(), ArgumentMatchers.eq(100L),
+        ArgumentMatchers.eq(100L), ArgumentMatchers.eq(TimeUnit.MILLISECONDS)) returns future
+      WithClose(new ThreadLocalCache[String, String](100.millis, es)) { cache =>
+        there was one(es).scheduleWithFixedDelay(cache, 100, 100, TimeUnit.MILLISECONDS)
+        cache.put("k1", "v1")
+        cache.get("k1") must beSome("v1")
+        eventually(10, 100.millis)(cache.get("k1") must beNone)
+      }
+      there was one(future).cancel(true)
+    }
+
+    "update expired references correctly" in {
+      val es = mock[MockScheduledExecutorService]
+      val future = mock[ScheduledFuture[Unit]]
+      es.scheduleWithFixedDelay(ArgumentMatchers.any(), ArgumentMatchers.eq(100L),
+        ArgumentMatchers.eq(100L), ArgumentMatchers.eq(TimeUnit.MILLISECONDS)) returns future
+      WithClose(new ThreadLocalCache[String, String](100.millis, es)) { cache =>
+        there was one(es).scheduleWithFixedDelay(cache, 100, 100, TimeUnit.MILLISECONDS)
+        cache.put("k1", "v1")
+        cache.get("k1") must beSome("v1")
+        eventually(10, 100.millis)(cache.get("k1") must beNone)
+        cache.getOrElseUpdate("k1", "v2") mustEqual "v2"
+        cache.get("k1") must beSome("v2")
+        cache("k1") mustEqual "v2"
+      }
+      there was one(future).cancel(true)
+    }
+  }
+
+  // needed to handle mocking the unbound wildcard in the signature for scheduleWithFixedDelay
+  trait MockScheduledExecutorService extends ScheduledExecutorService {
+    override def scheduleWithFixedDelay(command: Runnable, initialDelay: Long, delay: Long, unit: TimeUnit): ScheduledFuture[Unit]
+  }
+}


### PR DESCRIPTION
* `geomesa.filter.remote.cache.expiry` for setting filter expiration
* `geomesa.serializer.cache.expiry` for setting serializer expiration

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>