### PR TITLE
GEOMESA-2809 Upgrade dependencies to mitigate CVE findings

### DIFF
--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -9,10 +9,10 @@ com.conversantmedia:disruptor	1.2.13	compile
 com.drewnoakes:metadata-extractor	2.8.1	compile
 com.esotericsoftware:kryo-shaded	3.0.3	compile
 com.esotericsoftware:minlog	1.3.0	compile
-com.fasterxml.jackson.core:jackson-annotations	2.9.7	compile
-com.fasterxml.jackson.core:jackson-core	2.9.7	compile
-com.fasterxml.jackson.core:jackson-databind	2.9.7	compile
-com.fasterxml.jackson.dataformat:jackson-dataformat-cbor	2.9.7	compile
+com.fasterxml.jackson.core:jackson-annotations	2.9.10	compile
+com.fasterxml.jackson.core:jackson-core	2.9.10	compile
+com.fasterxml.jackson.core:jackson-databind	2.9.10.3	compile
+com.fasterxml.jackson.dataformat:jackson-dataformat-cbor	2.9.10	compile
 com.github.ben-manes.caffeine:caffeine	2.5.6	compile
 com.github.pureconfig:pureconfig_2.11	0.11.1	compile
 com.github.pureconfig:pureconfig-core_2.11	0.11.1	compile
@@ -70,9 +70,9 @@ io.dropwizard.metrics:metrics-ganglia	3.2.6	compile
 io.dropwizard.metrics:metrics-graphite	3.2.6	compile
 io.dropwizard.metrics:metrics-jvm	3.2.6	compile
 io.github.azagniotov:dropwizard-metrics-cloudwatch	1.0.13	compile
-io.netty:netty-all	4.1.17.Final	compile
-io.netty:netty-buffer	4.1.17.Final	compile
-io.netty:netty-common	4.1.17.Final	compile
+io.netty:netty-all	4.1.48.Final	compile
+io.netty:netty-buffer	4.1.48.Final	compile
+io.netty:netty-common	4.1.48.Final	compile
 io.sgr:s2-geometry-library-java	1.0.1	compile
 it.geosolutions.jaiext.affine:jt-affine	1.1.9	compile
 it.geosolutions.jaiext.algebra:jt-algebra	1.1.9	compile
@@ -126,7 +126,7 @@ org.apache.avro:avro	1.7.5	compile
 org.apache.camel:camel-core	2.24.1	compile
 org.apache.camel:camel-scala	2.24.1	compile
 org.apache.commons:commons-collections4	4.4	compile
-org.apache.commons:commons-compress	1.18	compile
+org.apache.commons:commons-compress	1.20	compile
 org.apache.commons:commons-configuration2	2.5	compile
 org.apache.commons:commons-crypto	1.0.0	compile
 org.apache.commons:commons-csv	1.5	compile

--- a/pom.xml
+++ b/pom.xml
@@ -71,15 +71,15 @@
         <avro.version>1.7.5</avro.version> <!-- see also confluent.avro.version -->
         <parquet.version>1.9.0</parquet.version>
         <orc.version>1.5.4</orc.version>
-        <fasterxml.jackson.version>2.9.7</fasterxml.jackson.version> <!-- used by geoserver (2.9.7), spark (2.6.7) and arrow (2.7.1) -->
-        <fasterxml.jackson.databind.version>2.9.7</fasterxml.jackson.databind.version> <!-- used by spark (2.6.7.1) and arrow (2.7.1) -->
+        <fasterxml.jackson.version>2.9.10</fasterxml.jackson.version> <!-- used by geoserver (2.9.7), spark (2.6.7) and arrow (2.7.1) -->
+        <fasterxml.jackson.databind.version>2.9.10.3</fasterxml.jackson.databind.version> <!-- used by spark (2.6.7.1) and arrow (2.7.1) -->
         <codehaus.jackson.version>1.9.3</codehaus.jackson.version>
         <gdal.version>2.0.0</gdal.version>
         <json4s.version>3.5.4</json4s.version>
         <scalatra.version>2.6.3</scalatra.version>
         <kryo.version>3.0.3</kryo.version>
         <arrow.version>0.16.0</arrow.version>
-        <netty.version>4.1.17.Final</netty.version>
+        <netty.version>4.1.48.Final</netty.version>
         <metrics.version>3.2.6</metrics.version>
         <aws.sdk.version>1.11.421</aws.sdk.version>
 
@@ -1487,7 +1487,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.18</version>
+                <version>1.20</version>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>
@@ -1766,7 +1766,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
-                <version>${fasterxml.jackson.databind.version}</version>
+                <version>${fasterxml.jackson.version}</version>
                 <scope>provided</scope> <!-- from spark -->
             </dependency>
             <dependency>


### PR DESCRIPTION
* jackson 2.9.7 -> 2.9.10
* netty 4.1.17 -> 4.1.48
* commons-compress 1.18 -> 1.20

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>