### PR TITLE
GEOMESA-2815 Add option to disable coprocessors

### DIFF
--- a/docs/user/hbase/usage.rst
+++ b/docs/user/hbase/usage.rst
@@ -52,6 +52,10 @@ Parameter                                 Type    Description
 ``geomesa.query.loose-bounding-box``      Boolean Use loose bounding boxes - queries will be faster but may return extraneous results
 ``hbase.ranges.max-per-extended-scan``    Integer Max ranges per extended scan. Ranges will be grouped into scans based on this setting
 ``hbase.ranges.max-per-coprocessor-scan`` Integer Max ranges per coprocessor scan. Ranges will be grouped into scans based on this setting
+``hbase.coprocessor.arrow.enable``        Boolean Disable coprocessor scans for Arrow queries, and use local encoding instead
+``hbase.coprocessor.bin.enable``          Boolean Disable coprocessor scans for Bin queries, and use local encoding instead
+``hbase.coprocessor.density.enable``      Boolean Disable coprocessor scans for density queries, and use local processing instead
+``hbase.coprocessor.stats.enable``        Boolean Disable coprocessor scans for stat queries, and use local processing instead
 ``geomesa.stats.generate``                Boolean Toggle collection of statistics (currently not implemented)
 ``geomesa.query.caching``                 Boolean Toggle caching of results
 ========================================= ======= ========================================================================================

--- a/docs/user/hbase/usage.rst
+++ b/docs/user/hbase/usage.rst
@@ -60,5 +60,7 @@ Parameter                                 Type    Description
 ``geomesa.query.caching``                 Boolean Toggle caching of results
 ========================================= ======= ========================================================================================
 
+Note: the ``hbase.coprocessor.*.enable`` parameters will be superseded by ``hbase.remote.filtering=false``.
+
 More information on using GeoTools can be found in the `GeoTools user guide
 <http://docs.geotools.org/stable/userguide/>`__.

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -20,22 +20,19 @@ import org.geotools.data.Query
 import org.locationtech.geomesa.accumulo._
 import org.locationtech.geomesa.accumulo.audit.AccumuloAuditService
 import org.locationtech.geomesa.accumulo.data.AccumuloBackedMetadata.SingleRowAccumuloMetadata
-import org.locationtech.geomesa.accumulo.data.AccumuloDataStore.AccumuloDataStoreConfig
+import org.locationtech.geomesa.accumulo.data.AccumuloDataStoreFactory.AccumuloDataStoreConfig
 import org.locationtech.geomesa.accumulo.data.stats._
 import org.locationtech.geomesa.accumulo.index._
 import org.locationtech.geomesa.accumulo.iterators.{AgeOffIterator, DtgAgeOffIterator, ProjectVersionIterator}
 import org.locationtech.geomesa.accumulo.util.TableUtils
 import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
-import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDataStoreConfig
 import org.locationtech.geomesa.index.index.attribute.AttributeIndex
 import org.locationtech.geomesa.index.index.id.IdIndex
 import org.locationtech.geomesa.index.index.z2.{XZ2Index, Z2Index}
 import org.locationtech.geomesa.index.index.z3.{XZ3Index, Z3Index}
 import org.locationtech.geomesa.index.metadata.{GeoMesaMetadata, MetadataStringSerializer}
 import org.locationtech.geomesa.index.utils.Explainer
-import org.locationtech.geomesa.security.AuthorizationsProvider
-import org.locationtech.geomesa.utils.audit.{AuditProvider, AuditReader, AuditWriter}
 import org.locationtech.geomesa.utils.conf.FeatureExpiration.{FeatureTimeExpiration, IngestTimeExpiration}
 import org.locationtech.geomesa.utils.conf.IndexId
 import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
@@ -362,35 +359,6 @@ object AccumuloDataStore extends LazyLogging {
   import scala.collection.JavaConverters._
 
   private val DeprecatedSchemaVersionKey = "geomesa.version"
-
-  /**
-    * Configuration options for AccumuloDataStore
-    *
-    * @param catalog table in Accumulo used to store feature type metadata
-    * @param defaultVisibilities default visibilities applied to any data written
-    * @param generateStats write stats on data during ingest
-    * @param authProvider provides the authorizations used to access data
-    * @param audit optional implementations to audit queries
-    * @param queryTimeout optional timeout (in millis) before a long-running query will be terminated
-    * @param looseBBox sacrifice some precision for speed
-    * @param caching cache feature results - WARNING can use large amounts of memory
-    * @param writeThreads numer of threads used for writing
-    * @param queryThreads number of threads used per-query
-    * @param recordThreads number of threads used to join against the record table. Because record scans
-    *                      are single-row ranges, increasing this too much can cause performance to decrease
-    */
-  case class AccumuloDataStoreConfig(catalog: String,
-                                     defaultVisibilities: String,
-                                     generateStats: Boolean,
-                                     authProvider: AuthorizationsProvider,
-                                     audit: Option[(AuditWriter with AuditReader, AuditProvider, String)],
-                                     queryTimeout: Option[Long],
-                                     looseBBox: Boolean,
-                                     caching: Boolean,
-                                     writeThreads: Int,
-                                     queryThreads: Int,
-                                     recordThreads: Int,
-                                     namespace: Option[String]) extends GeoMesaDataStoreConfig
 
   /**
     * Converts the old 'index schema' into the appropriate index identifiers

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloIndexAdapter.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloIndexAdapter.scala
@@ -124,7 +124,7 @@ class AccumuloIndexAdapter(ds: AccumuloDataStore) extends IndexAdapter[AccumuloD
     tables.par.foreach { table =>
       if (tableOps.exists(table)) {
         val config = GeoMesaBatchWriterConfig().setMaxWriteThreads(ds.config.writeThreads)
-        WithClose(ds.connector.createBatchDeleter(table, auths, ds.config.queryThreads, config)) { deleter =>
+        WithClose(ds.connector.createBatchDeleter(table, auths, ds.config.queries.threads, config)) { deleter =>
           val range = prefix.map(p => Range.prefix(new Text(p))).getOrElse(new Range())
           deleter.setRanges(Collections.singletonList(range))
           deleter.delete()
@@ -149,7 +149,7 @@ class AccumuloIndexAdapter(ds: AccumuloDataStore) extends IndexAdapter[AccumuloD
       case SingleRowByteRange(row) =>
         new Range(new Text(row))
     }
-    val numThreads = if (index.name == IdIndex.name) { ds.config.recordThreads } else { ds.config.queryThreads }
+    val numThreads = if (index.name == IdIndex.name) { ds.config.queries.recordThreads } else { ds.config.queries.threads }
     val tables = index.getTablesForQuery(filter.filter)
     val (colFamily, schema) = {
       val (cf, s) = groups.group(index.sft, hints.getTransformDefinition, ecql)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloJoinIndex.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/index/AccumuloJoinIndex.scala
@@ -284,7 +284,7 @@ trait AccumuloJoinIndex extends GeoMesaFeatureIndex[AttributeIndexValues[Any], A
     val reducer = new LocalTransformReducer(resultSft, None, None, None, hints, hook)
 
     val recordTables = recordIndex.getTablesForQuery(filter.filter)
-    val recordThreads = ds.asInstanceOf[AccumuloDataStore].config.recordThreads
+    val recordThreads = ds.asInstanceOf[AccumuloDataStore].config.queries.recordThreads
 
     // function to join the attribute index scan results to the record table
     // have to pull the feature id from the row

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreTest.scala
@@ -415,9 +415,9 @@ class AccumuloDataStoreTest extends Specification with TestWithMultipleSfts {
 
     "allow caching to be configured" in {
       DataStoreFinder.getDataStore(dsParams ++ Map(AccumuloDataStoreParams.CachingParam.key -> false))
-          .asInstanceOf[AccumuloDataStore].config.caching must beFalse
+          .asInstanceOf[AccumuloDataStore].config.queries.caching must beFalse
       DataStoreFinder.getDataStore(dsParams ++ Map(AccumuloDataStoreParams.CachingParam.key -> true))
-          .asInstanceOf[AccumuloDataStore].config.caching must beTrue
+          .asInstanceOf[AccumuloDataStore].config.queries.caching must beTrue
     }
 
     "support caching for improved WFS performance due to count/getFeatures" in {

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraIndexAdapter.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraIndexAdapter.scala
@@ -92,7 +92,7 @@ class CassandraIndexAdapter(ds: CassandraDataStore) extends IndexAdapter[Cassand
       val ks = ds.session.getLoggedKeyspace
       val statements = tables.flatMap(table => ranges.map(r => CassandraIndexAdapter.statement(ks, table, r.clauses)))
       val rowsToFeatures = new CassandraResultsToFeatures(strategy.index, strategy.index.sft)
-      val threads = ds.config.queryThreads
+      val threads = ds.config.queries.threads
       val sort = hints.getSortFields
       val max = hints.getMaxFeatures
       val project = hints.getProjection

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStore.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStore.scala
@@ -75,7 +75,7 @@ class HBaseDataStore(val connection: Connection, override val config: HBaseDataS
             if (connection.getAdmin.tableExists(name)) {
               val options = HBaseVersionAggregator.configure(sft, index)
               val scan = new Scan().setFilter(new FilterList())
-              val pool = new CachedThreadPool(config.coprocessorThreads)
+              val pool = new CachedThreadPool(config.coprocessors.threads)
               try {
                 WithClose(GeoMesaCoprocessor.execute(connection, name, scan, options, pool)) { bytes =>
                   bytes.map(_.toStringUtf8).toList.iterator // force evaluation of the iterator before closing it

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreParams.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreParams.scala
@@ -1,0 +1,127 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.hbase.data
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.hbase.client.Connection
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDataStoreParams
+import org.locationtech.geomesa.security.SecurityParams
+import org.locationtech.geomesa.utils.geotools.GeoMesaParam
+
+object HBaseDataStoreParams extends GeoMesaDataStoreParams with SecurityParams {
+
+  val HBaseCatalogParam =
+    new GeoMesaParam[String](
+      "hbase.catalog",
+      "Catalog table name",
+      optional = false,
+      deprecatedKeys = Seq("bigtable.table.name"),
+      supportsNiFiExpressions = true)
+
+  val ConnectionParam =
+    new GeoMesaParam[Connection](
+      "hbase.connection",
+      "Connection",
+      deprecatedKeys = Seq("connection"))
+
+  val ZookeeperParam =
+    new GeoMesaParam[String](
+      "hbase.zookeepers",
+      "List of HBase Zookeeper ensemble servers, comma-separated. " +
+          "Prefer including a valid 'hbase-site.xml' on the classpath over setting this parameter",
+      supportsNiFiExpressions = true)
+
+  val CoprocessorUrlParam =
+    new GeoMesaParam[Path](
+      "hbase.coprocessor.url",
+      "Coprocessor Url",
+      deprecatedKeys = Seq("coprocessor.url"),
+      supportsNiFiExpressions = true)
+
+  val CoprocessorThreadsParam =
+    new GeoMesaParam[Integer](
+      "hbase.coprocessor.threads",
+      "The number of HBase RPC threads to use per coprocessor query",
+      default = Int.box(16),
+      supportsNiFiExpressions = true)
+
+  val RemoteFilteringParam =
+    new GeoMesaParam[java.lang.Boolean](
+      "hbase.remote.filtering",
+      "Remote filtering",
+      default = true,
+      deprecatedKeys = Seq("remote.filtering"))
+
+  val MaxRangesPerExtendedScanParam =
+    new GeoMesaParam[java.lang.Integer](
+      "hbase.ranges.max-per-extended-scan",
+      "Max ranges per extended scan. Ranges will be grouped into scans based on this setting",
+      default = 100,
+      deprecatedKeys = Seq("max.ranges.per.extended.scan"),
+      supportsNiFiExpressions = true)
+
+  val MaxRangesPerCoprocessorScanParam =
+    new GeoMesaParam[java.lang.Integer](
+      "hbase.ranges.max-per-coprocessor-scan",
+      "Max ranges per coprocessor scan. Ranges will be grouped into scans based on this setting",
+      default = Int.MaxValue,
+      supportsNiFiExpressions = true)
+
+  val EnableSecurityParam =
+    new GeoMesaParam[java.lang.Boolean](
+      "hbase.security.enabled",
+      "Enable HBase Security (Visibilities)",
+      default = false,
+      deprecatedKeys = Seq("security.enabled"))
+
+  val ConfigPathsParam =
+    new GeoMesaParam[String](
+      "hbase.config.paths",
+      "Additional HBase configuration resource files (comma-delimited)",
+      supportsNiFiExpressions = true)
+
+  val ConfigsParam =
+    new GeoMesaParam[String](
+      "hbase.config.xml",
+      "Additional HBase configuration properties, as a standard XML `<configuration>` element",
+      largeText = true,
+      supportsNiFiExpressions = true)
+
+  val ArrowCoprocessorParam =
+    new GeoMesaParam[java.lang.Boolean](
+      "hbase.coprocessor.arrow.enable",
+      "Processes Arrow encoding in HBase region servers as a coprocessor call",
+      default = Boolean.box(false),
+      supportsNiFiExpressions = true
+    )
+
+  val BinCoprocessorParam =
+    new GeoMesaParam[java.lang.Boolean](
+      "hbase.coprocessor.bin.enable",
+      "Processes binary encoding in HBase region servers as a coprocessor call",
+      default = Boolean.box(true),
+      supportsNiFiExpressions = true
+    )
+
+  val DensityCoprocessorParam =
+    new GeoMesaParam[java.lang.Boolean](
+      "hbase.coprocessor.density.enable",
+      "Processes heatmap encoding in HBase region servers as a coprocessor call",
+      default = Boolean.box(true),
+      supportsNiFiExpressions = true
+    )
+
+  val StatsCoprocessorParam =
+    new GeoMesaParam[java.lang.Boolean](
+      "hbase.coprocessor.stats.enable",
+      "Processes statistical calculations in HBase region servers as a coprocessor call",
+      default = Boolean.box(true),
+      supportsNiFiExpressions = true
+    )
+}

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreParams.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreParams.scala
@@ -13,6 +13,7 @@ import org.apache.hadoop.hbase.client.Connection
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDataStoreParams
 import org.locationtech.geomesa.security.SecurityParams
 import org.locationtech.geomesa.utils.geotools.GeoMesaParam
+import org.locationtech.geomesa.utils.geotools.GeoMesaParam.SystemPropertyBooleanParam
 
 object HBaseDataStoreParams extends GeoMesaDataStoreParams with SecurityParams {
 
@@ -55,8 +56,9 @@ object HBaseDataStoreParams extends GeoMesaDataStoreParams with SecurityParams {
     new GeoMesaParam[java.lang.Boolean](
       "hbase.remote.filtering",
       "Remote filtering",
-      default = true,
-      deprecatedKeys = Seq("remote.filtering"))
+      default = java.lang.Boolean.TRUE,
+      deprecatedKeys = Seq("remote.filtering"),
+      systemProperty = Some(SystemPropertyBooleanParam(HBaseDataStoreFactory.RemoteFilterProperty)))
 
   val MaxRangesPerExtendedScanParam =
     new GeoMesaParam[java.lang.Integer](
@@ -77,7 +79,7 @@ object HBaseDataStoreParams extends GeoMesaDataStoreParams with SecurityParams {
     new GeoMesaParam[java.lang.Boolean](
       "hbase.security.enabled",
       "Enable HBase Security (Visibilities)",
-      default = false,
+      default = java.lang.Boolean.FALSE,
       deprecatedKeys = Seq("security.enabled"))
 
   val ConfigPathsParam =
@@ -97,7 +99,7 @@ object HBaseDataStoreParams extends GeoMesaDataStoreParams with SecurityParams {
     new GeoMesaParam[java.lang.Boolean](
       "hbase.coprocessor.arrow.enable",
       "Processes Arrow encoding in HBase region servers as a coprocessor call",
-      default = Boolean.box(false),
+      default = java.lang.Boolean.FALSE,
       supportsNiFiExpressions = true
     )
 
@@ -105,7 +107,7 @@ object HBaseDataStoreParams extends GeoMesaDataStoreParams with SecurityParams {
     new GeoMesaParam[java.lang.Boolean](
       "hbase.coprocessor.bin.enable",
       "Processes binary encoding in HBase region servers as a coprocessor call",
-      default = Boolean.box(true),
+      default = java.lang.Boolean.TRUE,
       supportsNiFiExpressions = true
     )
 
@@ -113,7 +115,7 @@ object HBaseDataStoreParams extends GeoMesaDataStoreParams with SecurityParams {
     new GeoMesaParam[java.lang.Boolean](
       "hbase.coprocessor.density.enable",
       "Processes heatmap encoding in HBase region servers as a coprocessor call",
-      default = Boolean.box(true),
+      default = java.lang.Boolean.TRUE,
       supportsNiFiExpressions = true
     )
 
@@ -121,7 +123,7 @@ object HBaseDataStoreParams extends GeoMesaDataStoreParams with SecurityParams {
     new GeoMesaParam[java.lang.Boolean](
       "hbase.coprocessor.stats.enable",
       "Processes statistical calculations in HBase region servers as a coprocessor call",
-      default = Boolean.box(true),
+      default = java.lang.Boolean.TRUE,
       supportsNiFiExpressions = true
     )
 }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseQueryPlan.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseQueryPlan.scala
@@ -114,7 +114,7 @@ object HBaseQueryPlan {
     override type Results = Result
 
     override protected def singleTableScan(ds: HBaseDataStore, scan: TableScan): CloseableIterator[Result] =
-      HBaseBatchScan(ds.connection, scan.table, scan.scans, ds.config.queryThreads)
+      HBaseBatchScan(ds.connection, scan.table, scan.scans, ds.config.queries.threads)
   }
 
   case class CoprocessorPlan(
@@ -134,7 +134,7 @@ object HBaseQueryPlan {
 
     override protected def singleTableScan(ds: HBaseDataStore, scan: TableScan): CloseableIterator[Array[Byte]] = {
       // send out all requests at once, but restrict the total rpc threads used
-      CoprocessorBatchScan(ds.connection, scan.table, scan.scans, coprocessorOptions, ds.config.coprocessorThreads)
+      CoprocessorBatchScan(ds.connection, scan.table, scan.scans, coprocessorOptions, ds.config.coprocessors.threads)
     }
 
     override protected def explain(explainer: Explainer): Unit =

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/resources/log4j.xml
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/resources/log4j.xml
@@ -19,6 +19,9 @@
     <category name="org.mortbay.log">
         <priority value="error"/>
     </category>
+    <category name="org.eclipse.jetty">
+        <priority value="error"/>
+    </category>
     <category name="BlockStateChange">
         <priority value="error"/>
     </category>

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseArrowTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseArrowTest.scala
@@ -17,8 +17,7 @@ import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.arrow.io.SimpleFeatureArrowFileReader
 import org.locationtech.geomesa.features.ScalaSimpleFeature
-import org.locationtech.geomesa.hbase.data.HBaseDataStoreParams.{ConnectionParam, HBaseCatalogParam}
-import org.locationtech.geomesa.hbase.data.HBaseQueryPlan.CoprocessorPlan
+import org.locationtech.geomesa.hbase.data.HBaseQueryPlan.{CoprocessorPlan, ScanPlan}
 import org.locationtech.geomesa.hbase.rpc.filter.Z3HBaseFilter
 import org.locationtech.geomesa.index.conf.QueryHints
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
@@ -33,108 +32,129 @@ class HBaseArrowTest extends Specification with LazyLogging  {
 
   import scala.collection.JavaConverters._
 
-  val sft = SimpleFeatureTypes.createType("arrow", "name:String,age:Int,dtg:Date,*geom:Point:srid=4326")
+  lazy val sft = SimpleFeatureTypes.createType("arrow", "name:String,age:Int,dtg:Date,*geom:Point:srid=4326")
 
-  val features = (0 until 10).map { i =>
+  lazy val features = (0 until 10).map { i =>
     ScalaSimpleFeature.create(sft, s"$i", s"name${i % 2}", s"${i % 5}", s"2017-02-03T00:0$i:01.000Z", s"POINT(40 6$i)")
   }
 
-  var ds: HBaseDataStore = _
+  lazy val params = Map(
+    HBaseDataStoreParams.ConnectionParam.getName   -> MiniCluster.connection,
+    HBaseDataStoreParams.HBaseCatalogParam.getName -> HBaseArrowTest.this.getClass.getSimpleName,
+    HBaseDataStoreParams.ArrowCoprocessorParam.key -> true
+  )
+
+  lazy val ds = DataStoreFinder.getDataStore(params.asJava).asInstanceOf[HBaseDataStore]
+  lazy val dsSemiLocal = DataStoreFinder.getDataStore((params ++ Map(HBaseDataStoreParams.ArrowCoprocessorParam.key -> false)).asJava).asInstanceOf[HBaseDataStore]
+  lazy val dsFullLocal = DataStoreFinder.getDataStore((params ++ Map(HBaseDataStoreParams.RemoteFilteringParam.key -> false)).asJava).asInstanceOf[HBaseDataStore]
 
   step {
     logger.info("Starting HBase Arrow Test")
-    import scala.collection.JavaConversions._
-    val params = Map(
-      ConnectionParam.getName -> MiniCluster.connection,
-      HBaseCatalogParam.getName -> HBaseArrowTest.this.getClass.getSimpleName
-    )
-    ds = DataStoreFinder.getDataStore(params).asInstanceOf[HBaseDataStore]
     ds.createSchema(sft)
     val writer = ds.getFeatureWriterAppend(sft.getTypeName, Transaction.AUTO_COMMIT)
     features.foreach(FeatureUtils.write(writer, _, useProvidedFid = true))
     writer.close()
   }
 
+  "HBaseDataStoreFactory" should {
+    "enable coprocessors" in {
+      ds.config.remoteFilter must beTrue
+      ds.config.coprocessors.enabled.arrow must beTrue
+      dsSemiLocal.config.remoteFilter must beTrue
+      dsSemiLocal.config.coprocessors.enabled.arrow must beFalse
+      dsFullLocal.config.remoteFilter must beFalse
+    }
+  }
+
   "ArrowFileCoprocessor" should {
     "return arrow dictionary encoded data" in {
-      val query = new Query(sft.getTypeName, Filter.INCLUDE)
-      query.getHints.put(QueryHints.ARROW_ENCODE, true)
-      query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "name,age")
-      query.getHints.put(QueryHints.ARROW_MULTI_FILE, true)
-      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
-      val out = new ByteArrayOutputStream
-      results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
-      def in() = new ByteArrayInputStream(out.toByteArray)
-      WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
-        // sft name gets dropped, so we can't compare directly
-        SelfClosingIterator(reader.features()).map(f => (f.getID, f.getAttributes)).toSeq must
-            containTheSameElementsAs(features.map(f => (f.getID, f.getAttributes)))
+      foreach(Seq(ds, dsSemiLocal, dsFullLocal)) { ds =>
+        val query = new Query(sft.getTypeName, Filter.INCLUDE)
+        query.getHints.put(QueryHints.ARROW_ENCODE, true)
+        query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "name,age")
+        query.getHints.put(QueryHints.ARROW_MULTI_FILE, true)
+        val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
+        val out = new ByteArrayOutputStream
+        results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
+        def in() = new ByteArrayInputStream(out.toByteArray)
+        WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
+          // sft name gets dropped, so we can't compare directly
+          SelfClosingIterator(reader.features()).map(f => (f.getID, f.getAttributes)).toSeq must
+              containTheSameElementsAs(features.map(f => (f.getID, f.getAttributes)))
+        }
       }
     }
   }
 
   "ArrowBatchCoprocessor" should {
     "return arrow encoded data" in {
-      val query = new Query(sft.getTypeName, Filter.INCLUDE)
-      query.getHints.put(QueryHints.ARROW_ENCODE, true)
-      query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
-      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
-      val out = new ByteArrayOutputStream
-      results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
-      def in() = new ByteArrayInputStream(out.toByteArray)
-      WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
-        SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
-            containTheSameElementsAs(features)
+      foreach(Seq(ds, dsSemiLocal, dsFullLocal)) { ds =>
+        val query = new Query(sft.getTypeName, Filter.INCLUDE)
+        query.getHints.put(QueryHints.ARROW_ENCODE, true)
+        query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
+        val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
+        val out = new ByteArrayOutputStream
+        results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
+        def in() = new ByteArrayInputStream(out.toByteArray)
+        WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
+          SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
+              containTheSameElementsAs(features)
+        }
       }
     }
     "return arrow dictionary encoded data" in {
-      val query = new Query(sft.getTypeName, Filter.INCLUDE)
-      query.getHints.put(QueryHints.ARROW_ENCODE, true)
-      query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "name,age")
-      query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
-      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
-      val out = new ByteArrayOutputStream
-      results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
-      def in() = new ByteArrayInputStream(out.toByteArray)
-      WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
-        SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
-            containTheSameElementsAs(features)
+      foreach(Seq(ds, dsSemiLocal, dsFullLocal)) { ds =>
+        val query = new Query(sft.getTypeName, Filter.INCLUDE)
+        query.getHints.put(QueryHints.ARROW_ENCODE, true)
+        query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "name,age")
+        query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
+        val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
+        val out = new ByteArrayOutputStream
+        results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
+        def in() = new ByteArrayInputStream(out.toByteArray)
+        WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
+          SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
+              containTheSameElementsAs(features)
+        }
       }
     }
     "return arrow dictionary encoded data with provided dictionaries" in {
-      val query = new Query(sft.getTypeName, Filter.INCLUDE)
-      query.getHints.put(QueryHints.ARROW_ENCODE, true)
-      query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "name")
-      query.getHints.put(QueryHints.ARROW_DICTIONARY_VALUES, "name,name0")
-      query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
-      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
-      val out = new ByteArrayOutputStream
-      results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
-      def in() = new ByteArrayInputStream(out.toByteArray)
-      WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
-        val expected = features.map {
-          case f if f.getAttribute(0) != "name1" => f
-          case f =>
-            val e = ScalaSimpleFeature.copy(sft, f)
-            e.setAttribute(0, "[other]")
-            e
+      foreach(Seq(ds, dsSemiLocal, dsFullLocal)) { ds =>
+        val query = new Query(sft.getTypeName, Filter.INCLUDE)
+        query.getHints.put(QueryHints.ARROW_ENCODE, true)
+        query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "name")
+        query.getHints.put(QueryHints.ARROW_DICTIONARY_VALUES, "name,name0")
+        query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
+        val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
+        val out = new ByteArrayOutputStream
+        results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
+        def in() = new ByteArrayInputStream(out.toByteArray)
+        WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
+          val expected = features.map {
+            case f if f.getAttribute(0) != "name1" => f
+            case f =>
+              val e = ScalaSimpleFeature.copy(sft, f)
+              e.setAttribute(0, "[other]")
+              e
+          }
+          SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
+              containTheSameElementsAs(expected)
         }
-        SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
-            containTheSameElementsAs(expected)
       }
     }
     "return arrow encoded projections" in {
-      import scala.collection.JavaConverters._
-      val query = new Query(sft.getTypeName, Filter.INCLUDE, Array("dtg", "geom"))
-      query.getHints.put(QueryHints.ARROW_ENCODE, true)
-      query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
-      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
-      val out = new ByteArrayOutputStream
-      results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
-      def in() = new ByteArrayInputStream(out.toByteArray)
-      WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
-        SelfClosingIterator(reader.features()).map(_.getAttributes.asScala).toSeq must
-            containTheSameElementsAs(features.map(f => List(f.getAttribute("dtg"), f.getAttribute("geom"))))
+      foreach(Seq(ds, dsSemiLocal, dsFullLocal)) { ds =>
+        val query = new Query(sft.getTypeName, Filter.INCLUDE, Array("dtg", "geom"))
+        query.getHints.put(QueryHints.ARROW_ENCODE, true)
+        query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
+        val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
+        val out = new ByteArrayOutputStream
+        results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
+        def in() = new ByteArrayInputStream(out.toByteArray)
+        WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
+          SelfClosingIterator(reader.features()).map(_.getAttributes.asScala).toSeq must
+              containTheSameElementsAs(features.map(f => List(f.getAttribute("dtg"), f.getAttribute("geom"))))
+        }
       }
     }
     "return sorted batches" in {
@@ -145,55 +165,78 @@ class HBaseArrowTest extends Specification with LazyLogging  {
         "bbox(geom,38,65.5,42,69.5)" -> features.slice(6, 10),
         "bbox(geom,38,65.5,42,69.5) and dtg DURING 2017-02-03T00:00:00.000Z/2017-02-03T00:08:00.000Z" -> features.slice(6, 8)
       )
-      foreach(filters) { case (ecql, expected) =>
-        val query = new Query(sft.getTypeName, ECQL.toFilter(ecql))
+      val transforms = Seq(Array("name", "dtg", "geom"), null)
+      foreach(Seq(ds, dsSemiLocal, dsFullLocal)) { ds =>
+        foreach(filters) { case (ecql, expected) =>
+          foreach(transforms) { transform =>
+            val query = new Query(sft.getTypeName, ECQL.toFilter(ecql), transform)
+            query.getHints.put(QueryHints.ARROW_ENCODE, true)
+            query.getHints.put(QueryHints.ARROW_SORT_FIELD, "dtg")
+            query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "name")
+            query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
+            val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
+            val out = new ByteArrayOutputStream
+            results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
+            def in() = new ByteArrayInputStream(out.toByteArray)
+            WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
+              if (transform == null) {
+                SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toList mustEqual expected
+              } else {
+                SelfClosingIterator(reader.features()).map(f => f.getID -> f.getAttributes.asScala).toList mustEqual
+                    expected.map(f => f.getID -> transform.map(f.getAttribute).toSeq)
+              }
+            }
+          }
+        }
+      }
+    }
+    "return sampled arrow encoded data" in {
+      foreach(Seq(ds, dsSemiLocal, dsFullLocal)) { ds =>
+        val query = new Query(sft.getTypeName, Filter.INCLUDE)
         query.getHints.put(QueryHints.ARROW_ENCODE, true)
-        query.getHints.put(QueryHints.ARROW_SORT_FIELD, "dtg")
+        query.getHints.put(QueryHints.SAMPLING, 0.2f)
         query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
         val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
         val out = new ByteArrayOutputStream
         results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
         def in() = new ByteArrayInputStream(out.toByteArray)
         WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
-          SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toList mustEqual expected
+          val results = SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq
+          results.length must beLessThan(10)
+          foreach(results)(features must contain(_))
         }
-      }
-    }
-    "return sampled arrow encoded data" in {
-      val query = new Query(sft.getTypeName, Filter.INCLUDE)
-      query.getHints.put(QueryHints.ARROW_ENCODE, true)
-      query.getHints.put(QueryHints.SAMPLING, 0.2f)
-      query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
-      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
-      val out = new ByteArrayOutputStream
-      results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
-      def in() = new ByteArrayInputStream(out.toByteArray)
-      WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
-        val results = SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq
-        results must haveLength(4) // TODO this seems to indicate two region servers?
-        foreach(results)(features must contain(_))
       }
     }
     "return arrow dictionary encoded data without caching and with z-values" in {
       val filter = ECQL.toFilter("bbox(geom, 38, 59, 42, 70) and dtg DURING 2017-02-03T00:00:00.000Z/2017-02-03T01:00:00.000Z")
-      val query = new Query(sft.getTypeName, filter)
-      query.getHints.put(QueryHints.ARROW_ENCODE, true)
-      query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "name")
-      query.getHints.put(QueryHints.ARROW_DICTIONARY_CACHED, java.lang.Boolean.FALSE)
-      query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
-      foreach(ds.getQueryPlan(query)) { plan =>
-        plan must beAnInstanceOf[CoprocessorPlan]
-        plan.scans.head.scans.head.getFilter must beAnInstanceOf[FilterList]
-        val filters = plan.scans.head.scans.head.getFilter.asInstanceOf[FilterList].getFilters
-        filters.asScala.map(_.getClass) must contain(classOf[Z3HBaseFilter])
-      }
-      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
-      val out = new ByteArrayOutputStream
-      results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
-      def in() = new ByteArrayInputStream(out.toByteArray)
-      WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
-        SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
-            containTheSameElementsAs(features.filter(filter.evaluate))
+      foreach(Seq(ds, dsSemiLocal, dsFullLocal)) { ds =>
+        val query = new Query(sft.getTypeName, filter)
+        query.getHints.put(QueryHints.ARROW_ENCODE, true)
+        query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "name")
+        query.getHints.put(QueryHints.ARROW_DICTIONARY_CACHED, java.lang.Boolean.FALSE)
+        query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 5)
+        foreach(ds.getQueryPlan(query)) { plan =>
+          if (ds.config.remoteFilter) {
+            if (ds.config.coprocessors.enabled.arrow) {
+              plan must beAnInstanceOf[CoprocessorPlan]
+            } else {
+              plan must beAnInstanceOf[ScanPlan]
+            }
+            plan.scans.head.scans.head.getFilter must beAnInstanceOf[FilterList]
+            val filters = plan.scans.head.scans.head.getFilter.asInstanceOf[FilterList].getFilters
+            filters.asScala.map(_.getClass) must contain(classOf[Z3HBaseFilter])
+          } else {
+            plan must beAnInstanceOf[ScanPlan]
+          }
+        }
+        val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
+        val out = new ByteArrayOutputStream
+        results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
+        def in() = new ByteArrayInputStream(out.toByteArray)
+        WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
+          SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
+              containTheSameElementsAs(features.filter(filter.evaluate))
+        }
       }
     }
   }
@@ -201,5 +244,7 @@ class HBaseArrowTest extends Specification with LazyLogging  {
   step {
     logger.info("Cleaning up HBase Arrow Test")
     ds.dispose()
+    dsSemiLocal.dispose()
+    dsFullLocal.dispose()
   }
 }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseBinAggregatorTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseBinAggregatorTest.scala
@@ -11,18 +11,16 @@ package org.locationtech.geomesa.hbase.data
 import java.util.Date
 
 import com.typesafe.scalalogging.LazyLogging
-import org.locationtech.jts.geom.Point
 import org.geotools.data._
-import org.geotools.data.simple.SimpleFeatureStore
 import org.geotools.util.factory.Hints
-import org.geotools.feature.DefaultFeatureCollection
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.process.transform.BinConversionProcess
 import org.locationtech.geomesa.utils.bin.BinaryOutputEncoder
 import org.locationtech.geomesa.utils.bin.BinaryOutputEncoder.EncodedValues
-import org.locationtech.geomesa.hbase.data.HBaseDataStoreParams._
-import org.locationtech.geomesa.process.transform.BinConversionProcess
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.{FeatureUtils, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.io.WithClose
+import org.locationtech.jts.geom.Point
 import org.opengis.filter.Filter
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -41,12 +39,14 @@ class HBaseBinAggregatorTest extends Specification with LazyLogging {
   var sft = SimpleFeatureTypes.createType(sftName, spec)
 
   lazy val params = Map(
-    ConnectionParam.getName -> MiniCluster.connection,
-    HBaseCatalogParam.getName -> getClass.getSimpleName
+    HBaseDataStoreParams.ConnectionParam.getName   -> MiniCluster.connection,
+    HBaseDataStoreParams.HBaseCatalogParam.getName -> getClass.getSimpleName,
+    HBaseDataStoreParams.BinCoprocessorParam.key   -> true
   )
 
   lazy val ds = DataStoreFinder.getDataStore(params).asInstanceOf[HBaseDataStore]
-  var fs: SimpleFeatureStore = _
+  lazy val dsSemiLocal = DataStoreFinder.getDataStore(params ++ Map(HBaseDataStoreParams.BinCoprocessorParam.key -> false)).asInstanceOf[HBaseDataStore]
+  lazy val dsFullLocal = DataStoreFinder.getDataStore(params ++ Map(HBaseDataStoreParams.RemoteFilteringParam.key -> false)).asInstanceOf[HBaseDataStore]
 
   lazy val features = (0 until 10).map { i =>
     val sf = new ScalaSimpleFeature(sft, s"0$i")
@@ -74,15 +74,9 @@ class HBaseBinAggregatorTest extends Specification with LazyLogging {
     ds.getSchema(sftName) must beNull
     ds.createSchema(SimpleFeatureTypes.createType(sftName, spec))
     sft = ds.getSchema(sftName)
-    fs = ds.getFeatureSource(sftName).asInstanceOf[SimpleFeatureStore]
-
-    val featureCollection = new DefaultFeatureCollection(sftName, sft)
-    features.foreach { f =>
-      f.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
-      featureCollection.add(f)
+    WithClose(ds.getFeatureWriterAppend(sftName, Transaction.AUTO_COMMIT)) { writer =>
+      features.foreach(FeatureUtils.write(writer, _, useProvidedFid = true))
     }
-    // write the feature to the store
-    fs.addFeatures(featureCollection)
   }
 
   def toTuples(value: EncodedValues): Any = value match {
@@ -90,26 +84,45 @@ class HBaseBinAggregatorTest extends Specification with LazyLogging {
     case EncodedValues(trackId, lat, lon, dtg, label) => (((trackId, dtg), (lat, lon)), label)
   }
 
+  "HBaseDataStoreFactory" should {
+    "enable coprocessors" in {
+      ds.config.remoteFilter must beTrue
+      ds.config.coprocessors.enabled.bin must beTrue
+      dsSemiLocal.config.remoteFilter must beTrue
+      dsSemiLocal.config.coprocessors.enabled.bin must beFalse
+      dsFullLocal.config.remoteFilter must beFalse
+    }
+  }
+
   "BinConversionProcess" should {
-    "encode an accumulo feature collection in distributed fashion" in {
-      val bytes = process.execute(fs.getFeatures(Filter.INCLUDE), "name", null, null, null, "lonlat").toList
-      bytes.length must beLessThan(10)
-      val decoded = bytes.reduceLeft(_ ++ _).grouped(16).toSeq.map(BinaryOutputEncoder.decode).map(toTuples)
-      decoded must containTheSameElementsAs(names.zip(dates).zip(lonlat))
+    "encode a feature collection in distributed fashion" in {
+      foreach(Seq(ds, dsSemiLocal, dsFullLocal)) { ds =>
+        val fc = ds.getFeatureSource(sftName).getFeatures(Filter.INCLUDE)
+        val bytes = process.execute(fc, "name", null, null, null, "lonlat").toList
+        bytes.length must beLessThan(10)
+        val decoded = bytes.reduceLeft(_ ++ _).grouped(16).toSeq.map(BinaryOutputEncoder.decode).map(toTuples)
+        decoded must containTheSameElementsAs(names.zip(dates).zip(lonlat))
+      }
     }
 
-    "encode an HBase feature collection in distributed fashion with alternate values" in {
-      val bytes = process.execute(fs.getFeatures(Filter.INCLUDE), "name", "geom2", "dtg2", null, "lonlat").toList
-      bytes.length must beLessThan(10)
-      val decoded = bytes.reduceLeft(_ ++ _).grouped(16).toSeq.map(BinaryOutputEncoder.decode).map(toTuples)
-      decoded must containTheSameElementsAs(names.zip(dates2).zip(lonlat2))
+    "encode a feature collection in distributed fashion with alternate values" in {
+      foreach(Seq(ds, dsSemiLocal, dsFullLocal)) { ds =>
+        val fc = ds.getFeatureSource(sftName).getFeatures(Filter.INCLUDE)
+        val bytes = process.execute(fc, "name", "geom2", "dtg2", null, "lonlat").toList
+        bytes.length must beLessThan(10)
+        val decoded = bytes.reduceLeft(_ ++ _).grouped(16).toSeq.map(BinaryOutputEncoder.decode).map(toTuples)
+        decoded must containTheSameElementsAs(names.zip(dates2).zip(lonlat2))
+      }
     }
 
-    "encode an HBase feature collection in distributed fashion with labels" in {
-      val bytes = process.execute(fs.getFeatures(Filter.INCLUDE), "name", null, null, "track", "lonlat").toList
-      bytes.length must beLessThan(10)
-      val decoded = bytes.reduceLeft(_ ++ _).grouped(24).toSeq.map(BinaryOutputEncoder.decode).map(toTuples)
-      decoded must containTheSameElementsAs(names.zip(dates).zip(lonlat).zip(tracks))
+    "encode a feature collection in distributed fashion with labels" in {
+      foreach(Seq(ds, dsSemiLocal, dsFullLocal)) { ds =>
+        val fc = ds.getFeatureSource(sftName).getFeatures(Filter.INCLUDE)
+        val bytes = process.execute(fc, "name", null, null, "track", "lonlat").toList
+        bytes.length must beLessThan(10)
+        val decoded = bytes.reduceLeft(_ ++ _).grouped(24).toSeq.map(BinaryOutputEncoder.decode).map(toTuples)
+        decoded must containTheSameElementsAs(names.zip(dates).zip(lonlat).zip(tracks))
+      }
     }
   }
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreFactory.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreFactory.scala
@@ -90,8 +90,12 @@ object GeoMesaDataStoreFactory {
   trait GeoMesaDataStoreConfig extends NamespaceConfig {
     def audit: Option[(AuditWriter, AuditProvider, String)]
     def generateStats: Boolean
-    def queryThreads: Int
-    def queryTimeout: Option[Long]
+    def queries: DataStoreQueryConfig
+  }
+
+  trait DataStoreQueryConfig {
+    def threads: Int
+    def timeout: Option[Long]
     def looseBBox: Boolean
     def caching: Boolean
   }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
@@ -45,7 +45,7 @@ abstract class MetadataBackedDataStore(config: NamespaceConfig) extends DataStor
   // TODO: GEOMESA-2360 - Remove global axis order hint from MetadataBackedDataStore
   Hints.putSystemDefault(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, true)
 
-  protected [geomesa] val interceptors = QueryInterceptorFactory(this)
+  protected [geomesa] val interceptors: QueryInterceptorFactory = QueryInterceptorFactory(this)
 
   // hooks to allow extended functionality
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/S2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/S2IndexKeySpace.scala
@@ -200,7 +200,7 @@ class S2IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, g
     // don't need to apply the filter on top of it. this may cause some minor errors at extremely
     // fine resolutions, but the performance is worth it
     // if we have a complicated geometry predicate, we need to pass it through to be evaluated
-    val looseBBox = Option(hints.get(LOOSE_BBOX)).map(Boolean.unbox).getOrElse(config.forall(_.looseBBox))
+    val looseBBox = Option(hints.get(LOOSE_BBOX)).map(Boolean.unbox).getOrElse(config.forall(_.queries.looseBBox))
     lazy val simpleGeoms = values.toSeq.flatMap(_.geometries.values).forall(GeometryUtils.isRectangular)
 
     !looseBBox || !simpleGeoms

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/Z2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/Z2IndexKeySpace.scala
@@ -131,7 +131,7 @@ class Z2IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, g
     // don't need to apply the filter on top of it. this may cause some minor errors at extremely
     // fine resolutions, but the performance is worth it
     // if we have a complicated geometry predicate, we need to pass it through to be evaluated
-    val looseBBox = Option(hints.get(LOOSE_BBOX)).map(Boolean.unbox).getOrElse(config.forall(_.looseBBox))
+    val looseBBox = Option(hints.get(LOOSE_BBOX)).map(Boolean.unbox).getOrElse(config.forall(_.queries.looseBBox))
     lazy val simpleGeoms = values.toSeq.flatMap(_.geometries.values).forall(GeometryUtils.isRectangular)
 
     !looseBBox || !simpleGeoms

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3IndexKeySpace.scala
@@ -242,7 +242,7 @@ class Z3IndexKeySpace(val sft: SimpleFeatureType,
     // if the spatial predicate is rectangular (e.g. a bbox), the index is fine enough that we
     // don't need to apply the filter on top of it. this may cause some minor errors at extremely
     // fine resolutions, but the performance is worth it
-    val looseBBox = Option(hints.get(LOOSE_BBOX)).map(Boolean.unbox).getOrElse(config.forall(_.looseBBox))
+    val looseBBox = Option(hints.get(LOOSE_BBOX)).map(Boolean.unbox).getOrElse(config.forall(_.queries.looseBBox))
     def unboundedDates: Boolean = values.exists(_.temporalUnbounded.nonEmpty)
     def complexGeoms: Boolean = values.exists(_.geometries.values.exists(g => !GeometryUtils.isRectangular(g)))
     !looseBBox || unboundedDates || complexGeoms

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/TestGeoMesaDataStore.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/TestGeoMesaDataStore.scala
@@ -19,7 +19,7 @@ import org.locationtech.geomesa.index.api.QueryPlan.{FeatureReducer, ResultsToFe
 import org.locationtech.geomesa.index.api.WritableFeature.FeatureWrapper
 import org.locationtech.geomesa.index.api.{WritableFeature, _}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
-import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDataStoreConfig
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.{GeoMesaDataStoreConfig, DataStoreQueryConfig}
 import org.locationtech.geomesa.index.metadata.GeoMesaMetadata
 import org.locationtech.geomesa.index.stats.MetadataBackedStats.WritableStat
 import org.locationtech.geomesa.index.stats._
@@ -211,9 +211,12 @@ object TestGeoMesaDataStore {
     override val catalog: String = "test"
     override val audit: Option[(AuditWriter, AuditProvider, String)] = None
     override val generateStats: Boolean = true
-    override val queryThreads: Int = 1
-    override val queryTimeout: Option[Long] = None
-    override val caching: Boolean = false
+    override val queries: DataStoreQueryConfig = new DataStoreQueryConfig() {
+      override val threads: Int = 1
+      override val timeout: Option[Long] = None
+      override val caching: Boolean = false
+      override def looseBBox: Boolean = TestConfig.this.looseBBox
+    }
     override val namespace: Option[String] = None
   }
 

--- a/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/data/KuduIndexAdapter.scala
+++ b/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/data/KuduIndexAdapter.scala
@@ -119,7 +119,7 @@ class KuduIndexAdapter(ds: KuduDataStore) extends IndexAdapter[KuduDataStore] {
       val sort = hints.getSortFields
       val max = hints.getMaxFeatures
       val project = hints.getProjection
-      val threads = ds.config.queryThreads
+      val threads = ds.config.queries.threads
       ScanPlan(filter, tables, ranges, predicates, ecql, adapter, sort, max, project, threads)
     }
   }

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/RedisDataStore.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/RedisDataStore.scala
@@ -10,15 +10,12 @@ package org.locationtech.geomesa.redis.data
 
 import org.geotools.data.Query
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
-import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDataStoreConfig
 import org.locationtech.geomesa.index.metadata.{GeoMesaMetadata, MetadataStringSerializer}
 import org.locationtech.geomesa.index.stats.GeoMesaStats
 import org.locationtech.geomesa.index.utils._
-import org.locationtech.geomesa.redis.data.RedisDataStore.RedisDataStoreConfig
+import org.locationtech.geomesa.redis.data.RedisDataStoreFactory.RedisDataStoreConfig
 import org.locationtech.geomesa.redis.data.index.{RedisAgeOff, RedisIndexAdapter, RedisQueryPlan}
 import org.locationtech.geomesa.redis.data.util.{RedisBackedMetadata, RedisGeoMesaStats, RedisLocking}
-import org.locationtech.geomesa.security.AuthorizationsProvider
-import org.locationtech.geomesa.utils.audit.{AuditProvider, AuditWriter}
 import org.locationtech.geomesa.utils.index.VisibilityLevel
 import org.locationtech.geomesa.utils.io.CloseWithLogging
 import org.opengis.feature.simple.SimpleFeatureType
@@ -90,19 +87,4 @@ class RedisDataStore(val connection: JedisPool, override val config: RedisDataSt
     CloseWithLogging(aging)
     super.dispose()
   }
-}
-
-object RedisDataStore {
-
-  case class RedisDataStoreConfig(
-      catalog: String,
-      generateStats: Boolean,
-      audit: Option[(AuditWriter, AuditProvider, String)],
-      pipeline: Boolean,
-      queryThreads: Int,
-      queryTimeout: Option[Long],
-      looseBBox: Boolean,
-      caching: Boolean,
-      authProvider: AuthorizationsProvider,
-      namespace: Option[String]) extends GeoMesaDataStoreConfig
 }

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/RedisDataStoreFactory.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/RedisDataStoreFactory.scala
@@ -17,11 +17,11 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig
 import org.geotools.data.DataAccessFactory.Param
 import org.geotools.data.{DataStore, DataStoreFactorySpi}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
-import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDataStoreInfo
-import org.locationtech.geomesa.redis.data.RedisDataStore.RedisDataStoreConfig
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.{DataStoreQueryConfig, GeoMesaDataStoreConfig, GeoMesaDataStoreInfo}
 import org.locationtech.geomesa.redis.data.index.RedisAgeOff
 import org.locationtech.geomesa.security
-import org.locationtech.geomesa.utils.audit.{AuditLogger, AuditProvider, NoOpAuditProvider}
+import org.locationtech.geomesa.security.AuthorizationsProvider
+import org.locationtech.geomesa.utils.audit.{AuditLogger, AuditProvider, AuditWriter, NoOpAuditProvider}
 import org.locationtech.geomesa.utils.geotools.GeoMesaParam
 import redis.clients.jedis.JedisPool
 import redis.clients.jedis.util.JedisURIHelper
@@ -119,10 +119,6 @@ object RedisDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
     val catalog = RedisCatalogParam.lookup(params)
     val generateStats = GenerateStatsParam.lookup(params)
     val pipeline = PipelineParam.lookup(params)
-    val queryThreads = QueryThreadsParam.lookup(params)
-    val queryTimeout = QueryTimeoutParam.lookupOpt(params).map(_.toMillis)
-    val looseBBox = LooseBBoxParam.lookup(params).booleanValue()
-    val caching = CachingParam.lookup(params)
 
     val audit = if (!AuditQueriesParam.lookup(params)) { None } else {
       Some((AuditLogger, Option(AuditProvider.Loader.load(params)).getOrElse(NoOpAuditProvider), "redis"))
@@ -131,12 +127,35 @@ object RedisDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
     val authProvider = security.getAuthorizationsProvider(params,
       AuthsParam.lookupOpt(params).map(_.split(",").toSeq.filterNot(_.isEmpty)).getOrElse(Seq.empty))
 
+    val queries = RedisQueryConfig(
+      threads = QueryThreadsParam.lookup(params),
+      timeout = QueryTimeoutParam.lookupOpt(params).map(_.toMillis),
+      looseBBox = LooseBBoxParam.lookup(params).booleanValue(),
+      caching = CachingParam.lookup(params)
+    )
+
     val ns = Option(NamespaceParam.lookUp(params).asInstanceOf[String])
 
-    RedisDataStoreConfig(
-      catalog, generateStats, audit, pipeline, queryThreads, queryTimeout, looseBBox, caching, authProvider, ns)
+    RedisDataStoreConfig(catalog, generateStats, audit, authProvider, queries, pipeline, ns)
   }
 
   private def parse(url: String): Try[URI] = Try(new URI(url)).filter(JedisURIHelper.isValid)
+
+  case class RedisDataStoreConfig(
+      catalog: String,
+      generateStats: Boolean,
+      audit: Option[(AuditWriter, AuditProvider, String)],
+      authProvider: AuthorizationsProvider,
+      queries: RedisQueryConfig,
+      pipeline: Boolean,
+      namespace: Option[String]
+    ) extends GeoMesaDataStoreConfig
+
+  case class RedisQueryConfig(
+      threads: Int,
+      timeout: Option[Long],
+      looseBBox: Boolean,
+      caching: Boolean
+    ) extends DataStoreQueryConfig
 }
 

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/index/RedisQueryPlan.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/index/RedisQueryPlan.scala
@@ -132,7 +132,7 @@ object RedisQueryPlan {
         }
         result.result.iterator.flatMap(_.get.iterator().asScala)
       } else {
-        RedisBatchScan(ds.connection, table, ranges, ds.config.queryThreads)
+        RedisBatchScan(ds.connection, table, ranges, ds.config.queries.threads)
       }
     }
   }

--- a/geomesa-security/src/test/java/org/locationtech/geomesa/security/SecurityUtilsTest.java
+++ b/geomesa-security/src/test/java/org/locationtech/geomesa/security/SecurityUtilsTest.java
@@ -9,7 +9,6 @@
 package org.locationtech.geomesa.security;
 
 import org.geotools.feature.simple.SimpleFeatureBuilder;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes;
@@ -25,7 +24,7 @@ public class SecurityUtilsTest {
         SimpleFeature f = buildFeature();
         SecurityUtils.setFeatureVisibility(f, TEST_VIS);
 
-        Assert.assertThat(f.getUserData().get(SecurityUtils.FEATURE_VISIBILITY), CoreMatchers.equalTo((Object) TEST_VIS));
+        Assert.assertEquals(TEST_VIS, f.getUserData().get(SecurityUtils.FEATURE_VISIBILITY));
     }
 
     @Test
@@ -33,7 +32,7 @@ public class SecurityUtilsTest {
         SimpleFeature f = buildFeature();
         SecurityUtils.setFeatureVisibilities(f, "admin", "user");
 
-        Assert.assertThat(f.getUserData().get(SecurityUtils.FEATURE_VISIBILITY), CoreMatchers.equalTo((Object) TEST_VIS));
+        Assert.assertEquals(TEST_VIS, f.getUserData().get(SecurityUtils.FEATURE_VISIBILITY));
     }
 
     @Test
@@ -41,14 +40,14 @@ public class SecurityUtilsTest {
         SimpleFeature f = buildFeature();
         f.getUserData().put(SecurityUtils.FEATURE_VISIBILITY, TEST_VIS);
 
-        Assert.assertThat(SecurityUtils.getVisibility(f), CoreMatchers.equalTo("admin&user"));
+        Assert.assertEquals("admin&user", SecurityUtils.getVisibility(f));
     }
 
     @Test
     public void testGetFeatureVisibilityWhenNone() {
         SimpleFeature f = buildFeature();
 
-        Assert.assertThat(SecurityUtils.getVisibility(f), CoreMatchers.is(CoreMatchers.nullValue()));
+        Assert.assertNull(SecurityUtils.getVisibility(f));
     }
 
     @Test
@@ -58,12 +57,12 @@ public class SecurityUtilsTest {
 
         SecurityUtils.setFeatureVisibility(src, "src_vis");
 
-        Assert.assertThat(SecurityUtils.getVisibility(src), CoreMatchers.equalTo("src_vis"));
-        Assert.assertThat(SecurityUtils.getVisibility(dest), CoreMatchers.is(CoreMatchers.nullValue()));
+        Assert.assertEquals("src_vis", SecurityUtils.getVisibility(src));
+        Assert.assertNull(SecurityUtils.getVisibility(dest));
 
         SecurityUtils.copyVisibility(src, dest);
 
-        Assert.assertThat(SecurityUtils.getVisibility(dest), CoreMatchers.equalTo("src_vis"));
+        Assert.assertEquals("src_vis", SecurityUtils.getVisibility(dest));
     }
 
     private SimpleFeature buildFeature() {


### PR DESCRIPTION
* New HBase datastore params:
  * `hbase.coprocessor.arrow.enable` default false
  * `hbase.coprocessor.bin.enable` default true
  * `hbase.coprocessor.density.enable` default true
  * `hbase.coprocessor.stats.enable` default true
* Standardize data store config classes

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>