### PR TITLE
GEOMESA-2832: include guava in install

### DIFF
--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -134,9 +134,9 @@ org.apache.commons:commons-dbcp2	2.6.0	compile
 org.apache.commons:commons-lang3	3.7	compile
 org.apache.commons:commons-pool2	2.6.1	compile
 org.apache.commons:commons-text	1.6	compile
-org.apache.curator:curator-client	4.0.1	compile
-org.apache.curator:curator-framework	4.0.1	compile
-org.apache.curator:curator-recipes	4.0.1	compile
+org.apache.curator:curator-client	4.3.0	compile
+org.apache.curator:curator-framework	4.3.0	compile
+org.apache.curator:curator-recipes	4.3.0	compile
 org.apache.hbase:hbase-client	1.4.12	compile
 org.apache.hbase:hbase-client	2.2.3	compile
 org.apache.hbase:hbase-common	1.4.12	compile

--- a/geomesa-kafka/geomesa-kafka-tools/bin/install-kafka.sh
+++ b/geomesa-kafka/geomesa-kafka-tools/bin/install-kafka.sh
@@ -9,6 +9,7 @@
 zookeeper_version="%%zookeeper.version.recommended%%"
 
 # kafka versions
+guava_version="%%guava.version%%"
 kafka_version="%%kafka.version%%"
 zkclient_version="%%zkclient.version%%"
 jopt_version="%%kafka.jopt.version%%"
@@ -40,6 +41,11 @@ zk_bug_ver="$(expr match "$zookeeper_version" '[0-9][0-9]*\.[0-9][0-9]*\.\([0-9]
 # compare the version of zookeeper to determine if we need zookeeper-jute (version >= 3.5.5)
 if [[ "$zk_maj_ver" -ge 3 && "$zk_min_ver" -ge 5 && "$zk_bug_ver" -ge 5 ]]; then
   urls+=("${base_url}org/apache/zookeeper/zookeeper-jute/$zookeeper_version/zookeeper-jute-$zookeeper_version.jar")
+fi
+
+# if there's already a guava jar (e.g. geoserver) don't install guava to avoid conflicts
+if [ -z "$(find -L $install_dir -maxdepth 1 -name 'guava-*' -print -quit)" ]; then
+  urls+=("${base_url}com/google/guava/guava/${guava_version}/guava-${guava_version}.jar")
 fi
 
 downloadUrls "$install_dir" urls[@]

--- a/pom.xml
+++ b/pom.xml
@@ -1661,17 +1661,17 @@
             <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-client</artifactId>
-                <version>4.0.1</version>
+                <version>4.3.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-framework</artifactId>
-                <version>4.0.1</version>
+                <version>4.3.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-recipes</artifactId>
-                <version>4.0.1</version>
+                <version>4.3.0</version>
             </dependency>
             <!-- standardize httpcomponents version, used by various libraries including hadoop and thrift -->
             <dependency>
@@ -2283,7 +2283,7 @@
             <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-test</artifactId>
-                <version>4.0.1</version>
+                <version>4.3.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2850,3 +2850,4 @@
     </repositories>
 
 </project>
+


### PR DESCRIPTION
Signed-off-by: Jeffrey Klassen <jeffrey.s.klassen@gmail.com>

We are still experiencing a bug with the zookeeper jar included in the classpath if KAFKA_HOME is included on the geomesa-kafka path and zookeeper version is 2.4.0.