### PR TITLE
GEOMESA-2848 Improve query timeout behavior

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloQueryPlan.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloQueryPlan.scala
@@ -21,7 +21,9 @@ import org.locationtech.geomesa.index.api.QueryPlan.{FeatureReducer, ResultsToFe
 import org.locationtech.geomesa.index.api.{FilterStrategy, QueryPlan}
 import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.index.utils.Reprojection.QueryReferenceSystems
+import org.locationtech.geomesa.index.utils.ThreadManagement.{LowLevelScanner, ManagedScan, Timeout}
 import org.locationtech.geomesa.utils.collection.{CloseableIterator, SelfClosingIterator}
+import org.opengis.filter.Filter
 
 /**
   * Accumulo-specific query plan
@@ -91,46 +93,6 @@ object AccumuloQueryPlan extends LazyLogging {
     override def scan(ds: AccumuloDataStore): CloseableIterator[Entry[Key, Value]] = CloseableIterator.empty
   }
 
-  // sequential scan plan
-  case class ScanPlan(
-      filter: FilterStrategy,
-      tables: Seq[String],
-      range: org.apache.accumulo.core.data.Range,
-      iterators: Seq[IteratorSetting],
-      columnFamily: Option[Text],
-      resultsToFeatures: ResultsToFeatures[Entry[Key, Value]],
-      reducer: Option[FeatureReducer],
-      sort: Option[Seq[(String, Boolean)]],
-      maxFeatures: Option[Int],
-      projection: Option[QueryReferenceSystems]
-    ) extends AccumuloQueryPlan {
-
-    override val numThreads = 1
-    override val ranges: Seq[org.apache.accumulo.core.data.Range] = Seq(range)
-
-    override def scan(ds: AccumuloDataStore): CloseableIterator[Entry[Key, Value]] = {
-      // calculate authorizations up front so that multi-threading doesn't mess up auth providers
-      val auths = ds.auths
-      if (PartitionParallelScan.toBoolean.contains(true)) {
-        // kick off all the scans at once
-        tables.map(scanner(ds.connector, _, auths)).foldLeft(CloseableIterator.empty[Entry[Key, Value]])(_ ++ _)
-      } else {
-        // kick off the scans sequentially as they finish
-        SelfClosingIterator(tables.iterator).flatMap(scanner(ds.connector, _, auths))
-      }
-    }
-
-    private def scanner(
-        connector: Connector,
-        table: String,
-        auths: Authorizations): CloseableIterator[Entry[Key, Value]] = {
-      val scanner = connector.createScanner(table, auths)
-      scanner.setRange(range)
-      configure(scanner)
-      SelfClosingIterator(scanner.iterator.asScala, scanner.close())
-    }
-  }
-
   // batch scan plan
   case class BatchScanPlan(
       filter: FilterStrategy,
@@ -146,35 +108,54 @@ object AccumuloQueryPlan extends LazyLogging {
       numThreads: Int
     ) extends AccumuloQueryPlan {
 
-    override def scan(ds: AccumuloDataStore): CloseableIterator[Entry[Key, Value]] =
-      // calculate authorizations up front so that multi-threading doesn't mess up auth providers
-      scan(ds.connector, ds.auths)
+    override def scan(ds: AccumuloDataStore): CloseableIterator[Entry[Key, Value]] = {
+      // convert the relative timeout to an absolute timeout up front
+      val timeout = ds.config.queries.timeout.map(Timeout.apply)
+      // note: calculate authorizations up front so that multi-threading doesn't mess up auth providers
+      scan(ds.connector, ds.auths, timeout)
+    }
 
     /**
-      * Scan with pre-computed auths
-      *
-      * @param connector connector
-      * @param auths auths
-      * @return
-      */
-    def scan(connector: Connector, auths: Authorizations): CloseableIterator[Entry[Key, Value]] = {
+     * Scan with pre-computed auths
+     *
+     * @param connector connector
+     * @param auths auths
+     * @param timeout absolute stop time, as sys time
+     * @return
+     */
+    def scan(
+        connector: Connector,
+        auths: Authorizations,
+        timeout: Option[Timeout]): CloseableIterator[Entry[Key, Value]] = {
       if (PartitionParallelScan.toBoolean.contains(true)) {
         // kick off all the scans at once
-        tables.map(scanner(connector, _, auths)).foldLeft(CloseableIterator.empty[Entry[Key, Value]])(_ ++ _)
+        tables.map(scanner(connector, _, auths, timeout)).foldLeft(CloseableIterator.empty[Entry[Key, Value]])(_ ++ _)
       } else {
         // kick off the scans sequentially as they finish
-        SelfClosingIterator(tables.iterator).flatMap(scanner(connector, _, auths))
+        SelfClosingIterator(tables.iterator).flatMap(scanner(connector, _, auths, timeout))
       }
     }
 
+    /**
+     *
+     * @param connector connector
+     * @param table table
+     * @param auths auths
+     * @param timeout absolute stop time, as sys time
+     * @return
+     */
     private def scanner(
         connector: Connector,
         table: String,
-        auths: Authorizations): CloseableIterator[Entry[Key, Value]] = {
+        auths: Authorizations,
+        timeout: Option[Timeout]): CloseableIterator[Entry[Key, Value]] = {
       val scanner = connector.createBatchScanner(table, auths, numThreads)
       scanner.setRanges(ranges.asJava)
       configure(scanner)
-      SelfClosingIterator(scanner.iterator.asScala, scanner.close())
+      timeout match {
+        case None => new ScanIterator(scanner)
+        case Some(t) => new ManagedScanIterator(t, new AccumuloScanner(scanner), this)
+      }
     }
   }
 
@@ -190,7 +171,7 @@ object AccumuloQueryPlan extends LazyLogging {
       joinQuery: BatchScanPlan
     ) extends AccumuloQueryPlan {
 
-    override val join = Some((joinFunction, joinQuery))
+    override val join: Some[(JoinFunction, BatchScanPlan)] = Some((joinFunction, joinQuery))
     override def resultsToFeatures: ResultsToFeatures[Entry[Key, Value]] = joinQuery.resultsToFeatures
     override def reducer: Option[FeatureReducer] = joinQuery.reducer
     override def sort: Option[Seq[(String, Boolean)]] = joinQuery.sort
@@ -198,16 +179,18 @@ object AccumuloQueryPlan extends LazyLogging {
     override def projection: Option[QueryReferenceSystems] = joinQuery.projection
 
     override def scan(ds: AccumuloDataStore): CloseableIterator[Entry[Key, Value]] = {
+      // convert the relative timeout to an absolute timeout up front
+      val timeout = ds.config.queries.timeout.map(Timeout.apply)
       // calculate authorizations up front so that multi-threading doesn't mess up auth providers
       val auths = ds.auths
       val joinTables = joinQuery.tables.iterator
       if (PartitionParallelScan.toBoolean.contains(true)) {
         // kick off all the scans at once
-        tables.map(scanner(ds.connector, _, joinTables.next, auths))
+        tables.map(scanner(ds.connector, _, joinTables.next, auths, timeout))
             .foldLeft(CloseableIterator.empty[Entry[Key, Value]])(_ ++ _)
       } else {
         // kick off the scans sequentially as they finish
-        SelfClosingIterator(tables.iterator).flatMap(scanner(ds.connector, _, joinTables.next, auths))
+        SelfClosingIterator(tables.iterator).flatMap(scanner(ds.connector, _, joinTables.next, auths, timeout))
       }
     }
 
@@ -215,7 +198,8 @@ object AccumuloQueryPlan extends LazyLogging {
         connector: Connector,
         table: String,
         joinTable: String,
-        auths: Authorizations): CloseableIterator[Entry[Key, Value]] = {
+        auths: Authorizations,
+        timeout: Option[Timeout]): CloseableIterator[Entry[Key, Value]] = {
       val primary = if (ranges.lengthCompare(1) == 0) {
         val scanner = connector.createScanner(table, auths)
         scanner.setRange(ranges.head)
@@ -227,8 +211,28 @@ object AccumuloQueryPlan extends LazyLogging {
       }
       configure(primary)
       val join = joinQuery.copy(tables = Seq(joinTable))
-      val bms = new BatchMultiScanner(connector, primary, join, joinFunction, auths)
-      SelfClosingIterator(bms.iterator, bms.close())
+      new BatchMultiScanner(connector, primary, join, joinFunction, auths, timeout)
     }
+  }
+
+  private class ScanIterator(scanner: ScannerBase) extends CloseableIterator[Entry[Key, Value]] {
+    private val iter = scanner.iterator.asScala
+    override def hasNext: Boolean = iter.hasNext
+    override def next(): Entry[Key, Value] = iter.next()
+    override def close(): Unit = scanner.close()
+  }
+
+  private class ManagedScanIterator(
+      override val timeout: Timeout,
+      override protected val underlying: AccumuloScanner,
+      plan: AccumuloQueryPlan
+    ) extends ManagedScan[Entry[Key, Value]] {
+    override protected def typeName: String = plan.filter.index.sft.getTypeName
+    override protected def filter: Option[Filter] = plan.filter.filter
+  }
+
+  private class AccumuloScanner(scanner: ScannerBase) extends LowLevelScanner[Entry[Key, Value]] {
+    override def iterator: Iterator[Entry[Key, Value]] = scanner.iterator.asScala
+    override def close(): Unit = scanner.close()
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
@@ -479,14 +479,14 @@ class AccumuloDataStoreQueryTest extends Specification with TestWithMultipleSfts
     }
 
     "kill queries after a configurable timeout" in {
-      import scala.concurrent.duration._
-
+      skipped("relies on thread.sleep timing")
       val params = dsParams ++ Map(AccumuloDataStoreParams.QueryTimeoutParam.getName -> "1s")
 
       val dsWithTimeout = DataStoreFinder.getDataStore(params).asInstanceOf[AccumuloDataStore]
       val reader = dsWithTimeout.getFeatureReader(new Query(defaultSft.getTypeName, Filter.INCLUDE), Transaction.AUTO_COMMIT)
-      reader.isClosed must beFalse
-      eventually(20, 200.millis)(reader.isClosed must beTrue)
+      reader.hasNext() must beTrue
+      Thread.sleep(5000) // TODO this is error prone...
+      reader.close() must throwAn[RuntimeException]("Scan terminated due to timeout of 1000ms")
     }
 
     "block full table scans" in {

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/BatchMultiScannerTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/util/BatchMultiScannerTest.scala
@@ -52,9 +52,9 @@ class BatchMultiScannerTest extends TestWithFeatureType {
     val jp = qp.join.get._2.asInstanceOf[BatchScanPlan]
     foreach(jp.tables)(table => ds.connector.tableOperations.exists(table) must beTrue)
 
-    val bms = new BatchMultiScanner(ds.connector, attrScanner, jp, qp.join.get._1, ds.auths, 5, batchSize)
+    val bms = new BatchMultiScanner(ds.connector, attrScanner, jp, qp.join.get._1, ds.auths, None, 5, batchSize)
 
-    val retrieved = bms.iterator.map(jp.resultsToFeatures.apply).toList
+    val retrieved = bms.map(jp.resultsToFeatures.apply).toList
     forall(retrieved)(_.getAttribute(attr) mustEqual value)
 
     retrieved.size

--- a/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
+++ b/geomesa-accumulo/geomesa-accumulo-spark/src/main/scala/org/locationtech/geomesa/spark/accumulo/AccumuloSpatialRDDProvider.scala
@@ -18,7 +18,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.rdd.{NewHadoopRDD, RDD}
 import org.geotools.data.{DataStoreFinder, Query, Transaction}
-import org.locationtech.geomesa.accumulo.data.AccumuloQueryPlan.{BatchScanPlan, EmptyPlan, ScanPlan}
+import org.locationtech.geomesa.accumulo.data.AccumuloQueryPlan.{BatchScanPlan, EmptyPlan}
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloDataStoreFactory, AccumuloQueryPlan}
 import org.locationtech.geomesa.index.conf.QueryHints._
 import org.locationtech.geomesa.jobs.accumulo.AccumuloJobUtils
@@ -99,7 +99,6 @@ class AccumuloSpatialRDDProvider extends SpatialRDDProvider with LazyLogging {
         // flatten and duplicate the query plans so each one only has a single table
         val expanded = qps.flatMap {
           case qp: BatchScanPlan => qp.tables.map(t => qp.copy(tables = Seq(t)))
-          case qp: ScanPlan => qp.tables.map(t => qp.copy(tables = Seq(t)))
           case qp: EmptyPlan => Seq(qp)
           case qp => throw new NotImplementedError(s"Unexpected query plan type: $qp")
         }

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/BatchWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/BatchWriter.scala
@@ -181,8 +181,9 @@ object BatchWriter {
     }
 
     override def close(): Unit = {
-      CloseWithLogging(result, batches)
+      CloseWithLogging(batches)
       inputs.foreach { case (vector, _) => CloseWithLogging(vector) }
+      CloseWithLogging(result)
     }
   }
 }

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DeltaWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DeltaWriter.scala
@@ -12,7 +12,6 @@ import java.io.{ByteArrayOutputStream, Closeable, OutputStream}
 import java.nio.channels.Channels
 import java.util.PriorityQueue
 import java.util.concurrent.ThreadLocalRandom
-import java.util.concurrent.atomic.AtomicBoolean
 
 import com.google.common.collect.HashBiMap
 import com.typesafe.scalalogging.StrictLogging
@@ -39,6 +38,7 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 import scala.math.Ordering
+import scala.util.control.NonFatal
 
 /**
   * Builds up dictionaries and write record batches. Dictionaries are encoded as deltas
@@ -320,9 +320,9 @@ object DeltaWriter extends StrictLogging {
       private var mappings: Map[String, java.util.Map[Integer, Integer]] = _
       private var count = 0 // records read in current batch
 
-      override def hasNext: Boolean = synchronized { count < toLoad.reader.getValueCount || loadNextBatch() }
+      override def hasNext: Boolean = count < toLoad.reader.getValueCount || loadNextBatch()
 
-      override def next(): Array[Byte] = synchronized {
+      override def next(): Array[Byte] = {
         var total = 0
         while (total < batchSize && hasNext) {
           // read the rest of the current vector, up to the batch size
@@ -349,7 +349,7 @@ object DeltaWriter extends StrictLogging {
         }
       }
 
-      override def close(): Unit = synchronized { CloseWithLogging.raise(Seq(toLoad, result, mergedDictionaries)) }
+      override def close(): Unit = CloseWithLogging.raise(Seq(toLoad, result, mergedDictionaries))
 
       /**
         * Read the next batch
@@ -518,12 +518,9 @@ object DeltaWriter extends StrictLogging {
 
     val merged: CloseableIterator[Array[Byte]] = new CloseableIterator[Array[Byte]] {
 
-      // note: we synchronize the hasNext and close methods so that query timeouts don't asynchronously
-      // close any arrow vectors while they're being loaded/unloaded, as that can cause memory leaks
-
       private var batch: Array[Byte] = _
 
-      override def hasNext: Boolean = synchronized {
+      override def hasNext: Boolean = {
         if (batch == null) {
           batch = nextBatch()
         }
@@ -536,7 +533,7 @@ object DeltaWriter extends StrictLogging {
         res
       }
 
-      override def close(): Unit = synchronized {
+      override def close(): Unit = {
         CloseWithLogging(result)
         CloseWithLogging(cleanup)
         CloseWithLogging(mergedDictionaries)
@@ -974,24 +971,32 @@ object DeltaWriter extends StrictLogging {
       deltas: CloseableIterator[Array[Byte]]
     ) extends CloseableIterator[Array[Byte]] {
 
-    private val closed = new AtomicBoolean(false)
-
     private lazy val reduced = {
-      val grouped = scala.collection.mutable.Map.empty[Long, scala.collection.mutable.ArrayBuilder[Array[Byte]]]
-      while (!closed.get && deltas.hasNext) {
-        val delta = deltas.next
-        grouped.getOrElseUpdate(ByteArrays.readLong(delta), Array.newBuilder) += delta
-      }
-      val threaded = Array.ofDim[Array[Array[Byte]]](grouped.size)
-      var i = 0
-      grouped.foreach { case (_, builder) => threaded(i) = builder.result; i += 1 }
-      logger.trace(s"merging delta batches from ${threaded.length} thread(s)")
-      val dictionaries = mergeDictionaries(sft, dictionaryFields, threaded, encoding)
-      if (sorted || sort.isEmpty) {
-        reduceNoSort(sft, dictionaryFields, encoding, dictionaries, sort, batchSize, threaded)
-      } else {
-        val Some((s, r)) = sort
-        reduceWithSort(sft, dictionaryFields, encoding, dictionaries, s, r, batchSize, threaded)
+      try {
+        val grouped = scala.collection.mutable.Map.empty[Long, scala.collection.mutable.ArrayBuilder[Array[Byte]]]
+        while (deltas.hasNext) {
+          val delta = deltas.next
+          grouped.getOrElseUpdate(ByteArrays.readLong(delta), Array.newBuilder) += delta
+        }
+        val threaded = Array.ofDim[Array[Array[Byte]]](grouped.size)
+        var i = 0
+        grouped.foreach { case (_, builder) => threaded(i) = builder.result; i += 1 }
+        logger.trace(s"merging delta batches from ${threaded.length} thread(s)")
+        val dictionaries = mergeDictionaries(sft, dictionaryFields, threaded, encoding)
+        if (sorted || sort.isEmpty) {
+          reduceNoSort(sft, dictionaryFields, encoding, dictionaries, sort, batchSize, threaded)
+        } else {
+          val Some((s, r)) = sort
+          reduceWithSort(sft, dictionaryFields, encoding, dictionaries, s, r, batchSize, threaded)
+        }
+      } catch {
+        case NonFatal(e) =>
+          // if we get an error, re-throw it on next()
+          new CloseableIterator[Array[Byte]] {
+            override def hasNext: Boolean = true
+            override def next(): Array[Byte] = throw e
+            override def close(): Unit = {}
+          }
       }
     }
 
@@ -999,9 +1004,6 @@ object DeltaWriter extends StrictLogging {
 
     override def next(): Array[Byte] = reduced.next()
 
-    override def close(): Unit = {
-      closed.set(true)
-      CloseWithLogging(deltas, reduced)
-    }
+    override def close(): Unit = CloseWithLogging(deltas, reduced)
   }
 }

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraQueryPlan.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraQueryPlan.scala
@@ -15,6 +15,7 @@ import org.locationtech.geomesa.index.api.QueryPlan.{FeatureReducer, ResultsToFe
 import org.locationtech.geomesa.index.api.{FilterStrategy, QueryPlan}
 import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.index.utils.Reprojection.QueryReferenceSystems
+import org.locationtech.geomesa.index.utils.ThreadManagement.Timeout
 import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.opengis.filter.Filter
 
@@ -75,5 +76,5 @@ case class StatementPlan(
   ) extends CassandraQueryPlan {
 
   override def scan(ds: CassandraDataStore): CloseableIterator[Row] =
-    CassandraBatchScan(ds.session, ranges, numThreads)
+    CassandraBatchScan(this, ds.session, ranges, numThreads, ds.config.queries.timeout.map(Timeout.apply))
 }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
@@ -255,9 +255,8 @@ class HBaseIndexAdapter(ds: HBaseDataStore) extends IndexAdapter[HBaseDataStore]
         }
         (cqlFilter ++ indexFilter).sortBy(_._1).map(_._2)
       }
-      lazy val coprocessorOptions: Map[String, String] =
-        Map[String, String](GeoMesaCoprocessor.YieldOpt -> ds.config.coprocessors.yieldPartialResults.toString) ++
-            strategy.index.ds.config.queries.timeout.map(GeoMesaCoprocessor.timeout)
+      lazy val coprocessorOptions =
+        Map(GeoMesaCoprocessor.YieldOpt -> String.valueOf(ds.config.coprocessors.yieldPartialResults))
       lazy val scans = configureScans(tables, ranges, small, colFamily, filters, coprocessor = false)
       lazy val coprocessorScans =
         configureScans(tables, ranges, small, colFamily, indexFilter.toSeq.map(_._2), coprocessor = true)

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseQueryPlan.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseQueryPlan.scala
@@ -20,6 +20,7 @@ import org.locationtech.geomesa.index.api.QueryPlan.{FeatureReducer, ResultsToFe
 import org.locationtech.geomesa.index.api.{FilterStrategy, QueryPlan}
 import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.index.utils.Reprojection.QueryReferenceSystems
+import org.locationtech.geomesa.index.utils.ThreadManagement.Timeout
 import org.locationtech.geomesa.utils.collection.{CloseableIterator, SelfClosingIterator}
 import org.locationtech.geomesa.utils.index.ByteArrays
 
@@ -40,7 +41,9 @@ sealed trait HBaseQueryPlan extends QueryPlan[HBaseDataStore] {
   def scans: Seq[TableScan]
 
   override def scan(ds: HBaseDataStore): CloseableIterator[Results] = {
-    val iter = scans.iterator.map(singleTableScan(ds, _))
+    // convert the relative timeout to an absolute timeout up front
+    val timeout = ds.config.queries.timeout.map(Timeout.apply)
+    val iter = scans.iterator.map(singleTableScan(_, ds.connection, threads(ds), timeout))
     if (PartitionParallelScan.toBoolean.contains(true)) {
       // kick off all the scans at once
       iter.foldLeft(CloseableIterator.empty[Results])(_ ++ _)
@@ -61,7 +64,13 @@ sealed trait HBaseQueryPlan extends QueryPlan[HBaseDataStore] {
     explainer.popLevel()
   }
 
-  protected def singleTableScan(ds: HBaseDataStore, scan: TableScan): CloseableIterator[Results]
+  protected def threads(ds: HBaseDataStore): Int
+
+  protected def singleTableScan(
+      scan: TableScan,
+      connection: Connection,
+      threads: Int,
+      timeout: Option[Timeout]): CloseableIterator[Results]
 
   // additional explaining, if any
   protected def explain(explainer: Explainer): Unit = {}
@@ -96,8 +105,12 @@ object HBaseQueryPlan {
     override val maxFeatures: Option[Int] = None
     override val projection: Option[QueryReferenceSystems] = None
     override def scan(ds: HBaseDataStore): CloseableIterator[Result] = CloseableIterator.empty
-    override protected def singleTableScan(ds: HBaseDataStore, scan: TableScan): CloseableIterator[Result] =
-      CloseableIterator.empty
+    override protected def threads(ds: HBaseDataStore): Int = 0
+    override protected def singleTableScan(
+        scan: TableScan,
+        connection: Connection,
+        threads: Int,
+        timeout: Option[Timeout]): CloseableIterator[Result] = CloseableIterator.empty
   }
 
   case class ScanPlan(
@@ -113,8 +126,15 @@ object HBaseQueryPlan {
 
     override type Results = Result
 
-    override protected def singleTableScan(ds: HBaseDataStore, scan: TableScan): CloseableIterator[Result] =
-      HBaseBatchScan(ds.connection, scan.table, scan.scans, ds.config.queries.threads)
+    override protected def threads(ds: HBaseDataStore): Int = ds.config.queries.threads
+
+    override protected def singleTableScan(
+        scan: TableScan,
+        connection: Connection,
+        threads: Int,
+        timeout: Option[Timeout]): CloseableIterator[Result] = {
+      HBaseBatchScan(this, connection, scan.table, scan.scans, threads, timeout)
+    }
   }
 
   case class CoprocessorPlan(
@@ -132,9 +152,14 @@ object HBaseQueryPlan {
 
     override def sort: Option[Seq[(String, Boolean)]] = None // client side sorting is not relevant for coprocessors
 
-    override protected def singleTableScan(ds: HBaseDataStore, scan: TableScan): CloseableIterator[Array[Byte]] = {
-      // send out all requests at once, but restrict the total rpc threads used
-      CoprocessorBatchScan(ds.connection, scan.table, scan.scans, coprocessorOptions, ds.config.coprocessors.threads)
+    override protected def threads(ds: HBaseDataStore): Int = ds.config.coprocessors.threads
+
+    override protected def singleTableScan(
+        scan: TableScan,
+        connection: Connection,
+        threads: Int,
+        timeout: Option[Timeout]): CloseableIterator[Array[Byte]] = {
+      CoprocessorBatchScan(this, connection, scan.table, scan.scans, coprocessorOptions, threads, timeout)
     }
 
     override protected def explain(explainer: Explainer): Unit =

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryPlanner.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryPlanner.scala
@@ -23,6 +23,7 @@ import org.locationtech.geomesa.utils.cache.SoftThreadLocal
 import org.locationtech.geomesa.utils.collection.{CloseableIterator, SelfClosingIterator}
 import org.locationtech.geomesa.utils.geotools.Transform
 import org.locationtech.geomesa.utils.geotools.Transform.Transforms
+import org.locationtech.geomesa.utils.iterators.ExceptionalIterator
 import org.locationtech.geomesa.utils.stats.{MethodProfiling, StatParser}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.sort.SortOrder
@@ -88,7 +89,8 @@ class QueryPlanner[DS <: GeoMesaDataStore[DS]](ds: DS) extends QueryRunner with 
       iterator = iterator.map(project.apply)
     }
 
-    iterator
+    // wrap in an exceptional iterator to prevent geoserver from suppressing any exceptions
+    ExceptionalIterator(iterator)
   }
 
   /**

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/utils/ThreadManagement.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/utils/ThreadManagement.scala
@@ -11,15 +11,23 @@ package org.locationtech.geomesa.index.utils
 import java.io.Closeable
 import java.util.concurrent.{ScheduledFuture, ScheduledThreadPoolExecutor, TimeUnit}
 
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.Logger
+import org.locationtech.geomesa.filter.filterToString
+import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.locationtech.geomesa.utils.concurrent.ExitingExecutor
+import org.locationtech.geomesa.utils.iterators.ExceptionalIterator
+import org.opengis.filter.Filter
+import org.slf4j.LoggerFactory
 
+import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
 /**
  * Singleton for registering and managing running queries.
  */
-object ThreadManagement extends LazyLogging {
+object ThreadManagement {
+
+  private val logger = Logger(LoggerFactory.getLogger(ThreadManagement.getClass.getName.replace("$", "")))
 
   private val executor = {
     val ex = new ScheduledThreadPoolExecutor(2)
@@ -28,28 +36,120 @@ object ThreadManagement extends LazyLogging {
   }
 
   /**
-   * Register a query with the thread manager
+   * Register a scan with the thread manager
+   *
+   * @param scan scan to terminate
+   * @return
    */
-  def register(query: ManagedQuery): ScheduledFuture[_] =
-    executor.schedule(new QueryKiller(query), query.getTimeout, TimeUnit.MILLISECONDS)
-
-  /**
-    * Trait for classes to be managed for timeouts
-    */
-  trait ManagedQuery extends Closeable {
-    def getTimeout: Long
-    def isClosed: Boolean
-    def debug: String
+  def register(scan: ManagedScan[_]): ScheduledFuture[_] = {
+    val timeout = math.max(1, scan.timeout.absolute - System.currentTimeMillis())
+    executor.schedule(new QueryKiller(scan), timeout, TimeUnit.MILLISECONDS)
   }
 
-  private class QueryKiller(query: ManagedQuery) extends Runnable {
-    override def run(): Unit = {
-      if (!query.isClosed) {
-        logger.warn(s"Stopping ${query.debug} based on timeout of ${query.getTimeout}ms")
-        try { query.close() } catch {
-          case NonFatal(e) => logger.warn("Error cancelling query:", e)
-        }
+  /**
+   * Trait for scans that are managed, i.e. tracked and terminated if they exceed a specified timeout
+   *
+   * @tparam T type
+   */
+  trait ManagedScan[T] extends CloseableIterator[T] {
+
+    /**
+     * Scan timeout
+     *
+     * @return
+     */
+    def timeout: Timeout
+
+    /**
+     * Low-level scan to be stopped
+     *
+     * @return
+     */
+    protected def underlying: LowLevelScanner[T]
+
+    // used for log messages
+    protected def typeName: String
+    protected def filter: Option[Filter]
+
+    // we can use a volatile var since we only update the value with a single thread
+    @volatile
+    private var terminated = timeout.absolute <= System.currentTimeMillis()
+
+    private val iter = ExceptionalIterator(if (terminated) { Iterator.empty } else { underlying.iterator })
+    private val cancel = if (terminated) { None } else { Some(ThreadManagement.register(this)) }
+
+    // note: check iter.hasNext first so we get updated terminated flag
+    override def hasNext: Boolean = iter.hasNext || terminated
+
+    override def next(): T = {
+      if (terminated) {
+        val e = new RuntimeException(s"Scan terminated due to timeout of ${timeout.relative}ms")
+        iter.suppressed.foreach(e.addSuppressed)
+        throw e
+      } else {
+        iter.next()
       }
     }
+
+    /**
+     * Forcibly terminate the scan
+     */
+    def terminate(): Unit = {
+      terminated = true
+      try {
+        logger.warn(
+          s"Stopping scan on schema '$typeName' with filter '${filterToString(filter)}' " +
+              s"based on timeout of ${timeout.relative}ms")
+        underlying.close()
+      } catch {
+        case NonFatal(e) => logger.warn("Error cancelling scan:", e)
+      }
+    }
+
+    /**
+     * Was the scan terminated due to timeout
+     *
+     * @return
+     */
+    def isTerminated: Boolean = terminated
+
+    override def close(): Unit = {
+      cancel.foreach(_.cancel(false))
+      // if terminated, we've already closed the iterator
+      if (!terminated) {
+        underlying.close()
+      }
+    }
+  }
+
+  /**
+   * Low level scanner that can be closed to terminate a scan
+   *
+   * @tparam T type
+   */
+  trait LowLevelScanner[T] extends Closeable {
+    def iterator: Iterator[T]
+  }
+
+  /**
+   * Timeout holder
+   *
+   * @param relative relative timeout, in millis
+   * @param absolute absolute timeout, in system millis since epoch
+   */
+  case class Timeout(relative: Long, absolute: Long)
+
+  object Timeout {
+    def apply(relative: Long): Timeout = Timeout(relative, System.currentTimeMillis() + relative)
+    def apply(relative: String): Timeout = Timeout(Duration(relative).toMillis)
+  }
+
+  /**
+   * Runnable to handle terminating a scan
+   *
+   * @param scan scan to terminate
+   */
+  private class QueryKiller(val scan: ManagedScan[_]) extends Runnable {
+    override def run(): Unit = scan.terminate()
   }
 }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/utils/ThreadManagementTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/utils/ThreadManagementTest.scala
@@ -1,0 +1,75 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.utils
+
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.index.utils.ThreadManagement.{LowLevelScanner, ManagedScan, Timeout}
+import org.opengis.filter.Filter
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ThreadManagementTest extends Specification {
+
+  "ManagedScan" should {
+    "pre-close expired scans" in {
+      val scanner = TestScanner(Seq("foo", "bar", "baz"))
+      val scan = new TestScan(Timeout(0), scanner)
+      scan.isTerminated must beTrue
+      scan.hasNext must beTrue
+      scan.next must throwA[RuntimeException]
+    }
+    "throw exception on next for expired scans" in {
+      val scanner = TestScanner(Seq("foo", "bar", "baz"))
+      val scan = new TestScan(Timeout("10 minutes"), scanner)
+      scan.isTerminated must beFalse
+      scan.hasNext must beTrue
+      scan.next mustEqual "foo"
+      scan.terminate()
+      scanner.closed must beTrue
+      scan.hasNext must beTrue
+      scan.next must throwA[RuntimeException]
+    }
+    "throw exception on next for expired scans even if underlying iterator is empty" in {
+      val scanner = TestScanner(Seq("foo"))
+      val scan = new TestScan(Timeout("10 minutes"), scanner)
+      scan.isTerminated must beFalse
+      scan.hasNext must beTrue
+      scan.next mustEqual "foo"
+      scan.terminate()
+      scanner.closed must beTrue
+      scan.hasNext must beTrue
+      scan.next must throwA[RuntimeException]
+    }
+    "throw exception on next for errors underlying iterator hasNext" in {
+      val scanner = new TestScanner(Seq.empty) {
+        override def iterator: Iterator[String] = new Iterator[String] {
+          override def hasNext: Boolean = throw new RuntimeException("test")
+          override def next(): String = null
+        }
+      }
+      val scan = new TestScan(Timeout("10 minutes"), scanner)
+      scan.isTerminated must beFalse
+      scan.hasNext must beTrue
+      scan.next must throwA[RuntimeException]
+    }
+  }
+
+  class TestScan(override val timeout: Timeout, override protected val underlying: TestScanner)
+      extends ManagedScan[String] {
+    override protected def typeName: String = ""
+    override protected def filter: Option[Filter] = None
+  }
+
+  case class TestScanner(values: Seq[String]) extends LowLevelScanner[String] {
+    var closed = false
+    override def iterator: Iterator[String] = values.iterator
+    override def close(): Unit = closed = true
+  }
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/iterators/ExceptionalIterator.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/iterators/ExceptionalIterator.scala
@@ -1,0 +1,56 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.iterators
+
+import org.locationtech.geomesa.utils.collection.CloseableIterator
+
+import scala.util.control.NonFatal
+
+/**
+ * Delegates an iterator and throws all exceptions through the 'next' method to get around geotools
+ * wrapping iterators that catch and suppress exceptions in hasNext
+ *
+ * @param delegate delegate iterator
+ * @tparam T type bounds
+ */
+class ExceptionalIterator[T](val delegate: Iterator[T]) extends Iterator[T] {
+
+  private var _suppressed: Throwable = _
+
+  override def hasNext: Boolean = {
+    try { delegate.hasNext } catch {
+      case NonFatal(e) =>
+        _suppressed = e
+        true
+    }
+  }
+
+  override def next(): T = {
+    if (_suppressed != null) {
+      throw _suppressed
+    } else {
+      delegate.next()
+    }
+  }
+
+  def suppressed: Option[Throwable] = Option(_suppressed)
+}
+
+object ExceptionalIterator {
+
+  def apply[T](iterator: Iterator[T]): ExceptionalIterator[T] = new ExceptionalIterator(iterator)
+
+  def apply[T](iterator: CloseableIterator[T]): ExceptionalCloseableIterator[T] =
+    new ExceptionalCloseableIterator(iterator)
+
+  class ExceptionalCloseableIterator[T](delegate: CloseableIterator[T])
+      extends ExceptionalIterator(delegate) with CloseableIterator[T] {
+    override def close(): Unit = delegate.close()
+  }
+}


### PR DESCRIPTION
* Move query termination to low-level scans
  * Prevents errors in 'reduce' logic being interrupted
* Throw all exceptions through 'next' method, to prevent geoserver from swallowing them

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>