### PR TITLE
GEOMESA-2850 HBase - clean up data store params

### DIFF
--- a/docs/user/hbase/configuration.rst
+++ b/docs/user/hbase/configuration.rst
@@ -6,6 +6,12 @@ HBase Configuration
 This section details HBase specific configuration properties. For general properties,
 see :ref:`geomesa_site_xml`.
 
+geomesa.hbase.client.scanner.caching.size
++++++++++++++++++++++++++++++++++++++++++
+
+Set the number of rows that scanners will read ahead. If not set, the default caching will apply as configured in
+``hbase-site.xml``. Higher caching values will enable faster scanners but will use more memory.
+
 geomesa.hbase.config.paths
 ++++++++++++++++++++++++++
 
@@ -31,6 +37,18 @@ geomesa.hbase.coprocessor.density.enable
 Disable coprocessor scans for density queries, and use local processing instead. This property will be overridden by
 the data store configuration parameter, if both are specified.
 
+geomesa.hbase.coprocessor.maximize.threads
+++++++++++++++++++++++++++++++++++++++++++
+
+Create a listener thread for each region when making coprocessor calls. If disabled, the number of listener threads
+will be based on the data store configuration parameter ``hbase.coprocessor.threads``.
+
+geomesa.hbase.coprocessor.url
++++++++++++++++++++++++++++++
+
+Path to the GeoMesa jar containing coprocessors, for auto registration. This property will be overridden by
+the data store configuration parameter, if both are specified.
+
 geomesa.hbase.coprocessor.stats.enable
 ++++++++++++++++++++++++++++++++++++++
 
@@ -51,6 +69,18 @@ Disable remote filtering. Remote filtering and coprocessors speed up queries, ho
 of custom JARs in HBase. Since this is not always possible, they can be disabled by setting this to ``false``.
 This property will be overridden by the data store configuration parameter, if both are specified.
 
+geomesa.hbase.scan.buffer
++++++++++++++++++++++++++
+
+Specify the maximum number of results to pre-buffer in local memory when executing a scan, if the client is not
+consuming the results as fast as they are being returned.
+
+geomesa.hbase.table.availability.timeout
+++++++++++++++++++++++++++++++++++++++++
+
+Specify the amount of time to wait for a table to become available after it has been created. The timeout
+is specified as a duration, e.g. ``5 minutes``.
+
 geomesa.hbase.wal.durability
 ++++++++++++++++++++++++++++
 
@@ -66,11 +96,10 @@ ingests where performance is of more concern than reliability. Available setting
 For addtional information see `HBase documentation
 <https://hbase.apache.org/apidocs/org/apache/hadoop/hbase/client/Durability.html>`__.
 
-geomesa.hbase.client.scanner.caching.size
-+++++++++++++++++++++++++++++++++++++++++
+geomesa.hbase.write.batch
++++++++++++++++++++++++++
 
-Set the number of rows that scanners will read ahead. If not set, the default caching will apply as configured in
-``hbase-site.xml``. Higher caching values will enable faster scanners but will use more memory.
+Specify the number of bytes that will be buffered before flushing to disk during write operations.
 
 geomesa.hbase.query.block.caching.enabled
 +++++++++++++++++++++++++++++++++++++++++

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreFactory.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreFactory.scala
@@ -64,7 +64,6 @@ class HBaseDataStoreFactory extends DataStoreFactorySpi with LazyLogging {
       enabled = enabledCoprocessors,
       threads = CoprocessorThreadsParam.lookup(params),
       yieldPartialResults = YieldPartialResultsParam.lookup(params),
-      parallel = CoprocessorParallelScanParam.lookup(params).booleanValue,
       maxRangesPerExtendedScan = MaxRangesPerCoprocessorScanParam.lookup(params),
       url = CoprocessorUrlParam.lookupOpt(params)
     )
@@ -155,7 +154,6 @@ object HBaseDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
       DensityCoprocessorParam,
       StatsCoprocessorParam,
       YieldPartialResultsParam,
-      CoprocessorParallelScanParam,
       EnableSecurityParam,
       GenerateStatsParam,
       AuditQueriesParam,
@@ -196,7 +194,6 @@ object HBaseDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
       enabled: EnabledCoprocessors,
       threads: Int,
       yieldPartialResults: Boolean,
-      parallel: Boolean,
       maxRangesPerExtendedScan: Int,
       url: Option[Path]
     )

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreParams.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreParams.scala
@@ -52,13 +52,6 @@ object HBaseDataStoreParams extends GeoMesaDataStoreParams with SecurityParams {
       default = Int.box(16),
       supportsNiFiExpressions = true)
 
-  val CoprocessorParallelScanParam =
-    new GeoMesaParam[java.lang.Boolean](
-      "hbase.coprocessor.scan.parallel",
-      "Invoke all coprocessor RPC calls in parallel",
-      default = java.lang.Boolean.TRUE,
-      supportsNiFiExpressions = true)
-
   val RemoteFilteringParam =
     new GeoMesaParam[java.lang.Boolean](
       "hbase.remote.filtering",
@@ -106,7 +99,7 @@ object HBaseDataStoreParams extends GeoMesaDataStoreParams with SecurityParams {
     new GeoMesaParam[java.lang.Boolean](
       "hbase.coprocessor.arrow.enable",
       "Processes Arrow encoding in HBase region servers as a coprocessor call",
-      default = java.lang.Boolean.FALSE,
+      default = java.lang.Boolean.TRUE,
       systemProperty = Some(SystemPropertyBooleanParam(HBaseDataStoreFactory.RemoteArrowProperty))
     )
 

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
@@ -24,7 +24,8 @@ import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding
 import org.apache.hadoop.hbase.regionserver.BloomType
 import org.apache.hadoop.hbase.security.visibility.CellVisibility
 import org.locationtech.geomesa.hbase.HBaseSystemProperties
-import org.locationtech.geomesa.hbase.HBaseSystemProperties.{CoprocessorPath, TableAvailabilityTimeout}
+// noinspection ScalaDeprecation
+import org.locationtech.geomesa.hbase.HBaseSystemProperties.{CoprocessorPath, CoprocessorUrl, TableAvailabilityTimeout}
 import org.locationtech.geomesa.hbase.aggregators.HBaseArrowAggregator.HBaseArrowResultsToFeatures
 import org.locationtech.geomesa.hbase.aggregators.HBaseBinAggregator.HBaseBinResultsToFeatures
 import org.locationtech.geomesa.hbase.aggregators.HBaseDensityAggregator.HBaseDensityResultsToFeatures
@@ -85,8 +86,10 @@ class HBaseIndexAdapter(ds: HBaseDataStore) extends IndexAdapter[HBaseDataStore]
         val bloom = Some(BloomType.NONE)
         val encoding = if (index.name == IdIndex.name) { None } else { Some(DataBlockEncoding.FAST_DIFF) }
 
+        // noinspection ScalaDeprecation
         val coprocessor = if (!ds.config.remoteFilter) { None } else {
-          lazy val coprocessorUrl = ds.config.coprocessors.url.orElse(CoprocessorPath.option.map(new Path(_))).orElse {
+          def urlFromSysProp: Option[Path] = CoprocessorUrl.option.orElse(CoprocessorPath.option).map(new Path(_))
+          lazy val coprocessorUrl = ds.config.coprocessors.url.orElse(urlFromSysProp).orElse {
             try {
               // the jar should be under hbase.dynamic.jars.dir to enable filters, so look there
               val dir = new Path(conf.get("hbase.dynamic.jars.dir"))

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/package.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/package.scala
@@ -13,12 +13,16 @@ import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemPropert
 package object hbase {
 
   object HBaseSystemProperties {
-    val CoprocessorPath = SystemProperty("geomesa.hbase.coprocessor.path")
-    val WriteBatchSize = SystemProperty("geomesa.hbase.write.batch")
-    val WalDurability = SystemProperty("geomesa.hbase.wal.durability")
-    val ScannerCaching = SystemProperty("geomesa.hbase.client.scanner.caching.size")
-    val ScannerBlockCaching = SystemProperty("geomesa.hbase.query.block.caching.enabled", "true")
-    val ScanBufferSize = SystemProperty("geomesa.hbase.scan.buffer", "100000")
-    val TableAvailabilityTimeout = SystemProperty("geomesa.hbase.table.availability.timeout", "30 minutes")
+    val CoprocessorUrl           : SystemProperty = SystemProperty("geomesa.hbase.coprocessor.url")
+    val CoprocessorMaxThreads    : SystemProperty = SystemProperty("geomesa.hbase.coprocessor.maximize.threads", "true")
+    val WriteBatchSize           : SystemProperty = SystemProperty("geomesa.hbase.write.batch")
+    val WalDurability            : SystemProperty = SystemProperty("geomesa.hbase.wal.durability")
+    val ScannerCaching           : SystemProperty = SystemProperty("geomesa.hbase.client.scanner.caching.size")
+    val ScannerBlockCaching      : SystemProperty = SystemProperty("geomesa.hbase.query.block.caching.enabled", "true")
+    val ScanBufferSize           : SystemProperty = SystemProperty("geomesa.hbase.scan.buffer", "100000")
+    val TableAvailabilityTimeout : SystemProperty = SystemProperty("geomesa.hbase.table.availability.timeout", "30 minutes")
+
+    @deprecated("Use coprocessor url")
+    val CoprocessorPath: SystemProperty = SystemProperty("geomesa.hbase.coprocessor.path")
   }
 }

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseArrowTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseArrowTest.scala
@@ -43,8 +43,7 @@ class HBaseArrowTest extends Specification with LazyLogging  {
 
   lazy val params = Map(
     HBaseDataStoreParams.ConnectionParam.getName   -> MiniCluster.connection,
-    HBaseDataStoreParams.HBaseCatalogParam.getName -> HBaseArrowTest.this.getClass.getSimpleName,
-    HBaseDataStoreParams.ArrowCoprocessorParam.key -> true
+    HBaseDataStoreParams.HBaseCatalogParam.getName -> HBaseArrowTest.this.getClass.getSimpleName
   )
 
   lazy val ds = DataStoreFinder.getDataStore(params.asJava).asInstanceOf[HBaseDataStore]

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseColumnGroupsTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBaseColumnGroupsTest.scala
@@ -49,11 +49,7 @@ class HBaseColumnGroupsTest extends Specification with LazyLogging  {
 
   lazy val params = Map(
     HBaseDataStoreParams.ConnectionParam.getName     -> MiniCluster.connection,
-    HBaseDataStoreParams.HBaseCatalogParam.getName   -> getClass.getSimpleName,
-    HBaseDataStoreParams.ArrowCoprocessorParam.key   -> true,
-    HBaseDataStoreParams.BinCoprocessorParam.key     -> true,
-    HBaseDataStoreParams.DensityCoprocessorParam.key -> true,
-    HBaseDataStoreParams.StatsCoprocessorParam.key   -> true
+    HBaseDataStoreParams.HBaseCatalogParam.getName   -> getClass.getSimpleName
   )
 
   lazy val semiLocalParams = params ++ Map(


### PR DESCRIPTION
* Default arrow coprocessor scans to true
* Move coprocessor scan threads to sys prop
* Rename coprocessor url sys prop to match data store

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>