### PR TITLE
GEOMESA-2902 Arrow dictionary encoding for list-type attributes

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoVisibilityRowEncoder.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/KryoVisibilityRowEncoder.scala
@@ -13,12 +13,11 @@ import org.apache.accumulo.core.client.IteratorSetting
 import org.apache.accumulo.core.data.{Key, Value}
 import org.apache.accumulo.core.iterators.user.RowEncodingIterator
 import org.apache.accumulo.core.iterators.{IteratorEnvironment, SortedKeyValueIterator}
-import org.locationtech.geomesa.features.kryo.{KryoFeatureSerializer, Metadata}
 import org.locationtech.geomesa.features.kryo.impl.KryoFeatureDeserialization
-import org.locationtech.geomesa.features.serialization.ObjectType
+import org.locationtech.geomesa.features.kryo.{KryoFeatureSerializer, Metadata}
 import org.locationtech.geomesa.index.iterators.IteratorCache
 import org.locationtech.geomesa.utils.collection.IntBitSet
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.{ObjectType, SimpleFeatureTypes}
 import org.opengis.feature.simple.SimpleFeatureType
 
 /**

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/ArrowBatchIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/ArrowBatchIteratorTest.scala
@@ -46,6 +46,7 @@ class ArrowBatchIteratorTest extends TestWithMultipleSfts with Mockito {
 
   lazy val pointSft = createNewSchema("name:String:index=join,team:String:index-value=true,age:Int,weight:Int,dtg:Date,*geom:Point:srid=4326")
   lazy val lineSft = createNewSchema("name:String:index=join,team:String:index-value=true,age:Int,weight:Int,dtg:Date,*geom:LineString:srid=4326")
+  lazy val listSft = createNewSchema("names:List[String],team:String,dtg:Date,*geom:Point:srid=4326")
 
   implicit val allocator: BufferAllocator = new DirtyRootAllocator(Long.MaxValue, 6.toByte)
 
@@ -66,15 +67,23 @@ class ArrowBatchIteratorTest extends TestWithMultipleSfts with Mockito {
     ScalaSimpleFeature.create(lineSft, s"$i", name, team, age, weight, s"2017-02-03T00:0$i:01.000Z", geom)
   }
 
+  val listFeatures = (0 until 10).map { i =>
+    val names = Seq.tabulate(i % 3)(j => s"name0$j").asJava
+    val team = s"team$i"
+    ScalaSimpleFeature.create(listSft, s"$i", names, team, s"2017-02-03T00:0$i:01.000Z", s"POINT(40 6$i)")
+  }
+
   // hit all major indices
   val filters = Seq(
     "bbox(geom, 38, 59, 42, 70)",
     "bbox(geom, 38, 59, 42, 70) and dtg DURING 2017-02-03T00:00:00.000Z/2017-02-03T01:00:00.000Z",
-    "name IN('name0', 'name1')",
-    s"IN(${pointFeatures.map(_.getID).mkString("'", "', '", "'")})").map(ECQL.toFilter)
+    s"IN(${pointFeatures.map(_.getID).mkString("'", "', '", "'")})",
+    "name IN('name0', 'name1')"
+  ).map(ECQL.toFilter)
 
   addFeatures(pointFeatures)
   addFeatures(lineFeatures)
+  addFeatures(listFeatures)
 
   val sfts = Seq((pointSft, pointFeatures), (lineSft, lineFeatures))
 
@@ -392,6 +401,29 @@ class ArrowBatchIteratorTest extends TestWithMultipleSfts with Mockito {
               reader.dictionaries.keySet mustEqual Set("team", "weight")
               reader.dictionaries.apply("weight").iterator.toSeq must contain(null: AnyRef)
             }
+          }
+        }
+      }
+      ok
+    }
+    "return sorted, dictionary encoded projections list type attributes" in {
+      dataStores.foreach { ds =>
+        filters.dropRight(1).foreach { filter =>
+          val transform = Array("names", "dtg", "geom")
+          val query = new Query(listSft.getTypeName, filter, transform)
+          query.getHints.put(QueryHints.ARROW_ENCODE, true)
+          query.getHints.put(QueryHints.ARROW_DICTIONARY_FIELDS, "names")
+          query.getHints.put(QueryHints.ARROW_SORT_FIELD, "dtg")
+          query.getHints.put(QueryHints.ARROW_BATCH_SIZE, 100)
+          val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT))
+          val out = new ByteArrayOutputStream
+          results.foreach(sf => out.write(sf.getAttribute(0).asInstanceOf[Array[Byte]]))
+          def in() = new ByteArrayInputStream(out.toByteArray)
+          WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
+            compare(reader.features(), listFeatures, transform.toSeq)
+            reader.dictionaries.keySet mustEqual Set("names")
+            reader.dictionaries.apply("names").iterator.toSeq must
+                containTheSameElementsAs(Seq.tabulate(2)(i => s"name0$i"))
           }
         }
       }

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DeltaWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DeltaWriter.scala
@@ -10,13 +10,13 @@ package org.locationtech.geomesa.arrow.io
 
 import java.io.{ByteArrayOutputStream, Closeable, OutputStream}
 import java.nio.channels.Channels
-import java.util.PriorityQueue
 import java.util.concurrent.ThreadLocalRandom
+import java.util.{Collections, PriorityQueue}
 
 import com.google.common.collect.HashBiMap
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.complex.StructVector
+import org.apache.arrow.vector.complex.{ListVector, StructVector}
 import org.apache.arrow.vector.dictionary.DictionaryProvider.MapDictionaryProvider
 import org.apache.arrow.vector.ipc.ArrowStreamWriter
 import org.apache.arrow.vector.ipc.message.IpcOption
@@ -25,12 +25,11 @@ import org.apache.arrow.vector.util.TransferPair
 import org.apache.arrow.vector.{FieldVector, IntVector}
 import org.locationtech.geomesa.arrow.ArrowAllocator
 import org.locationtech.geomesa.arrow.io.records.{RecordBatchLoader, RecordBatchUnloader}
-import org.locationtech.geomesa.arrow.vector.ArrowAttributeReader.ArrowDateReader
+import org.locationtech.geomesa.arrow.vector.ArrowAttributeReader.{ArrowDateReader, ArrowDictionaryReader, ArrowListDictionaryReader}
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding
 import org.locationtech.geomesa.arrow.vector._
-import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.utils.collection.CloseableIterator
-import org.locationtech.geomesa.utils.geotools.{SimpleFeatureOrdering, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.geotools.{AttributeOrdering, ObjectType, SimpleFeatureOrdering, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.geomesa.utils.io.CloseWithLogging
 import org.locationtech.jts.geom.Geometry
@@ -61,6 +60,7 @@ class DeltaWriter(
   ) extends Closeable with StrictLogging {
 
   import DeltaWriter._
+  import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
 
   import scala.collection.JavaConverters._
 
@@ -74,37 +74,41 @@ class DeltaWriter(
 
   private val vector = StructVector.empty(sft.getTypeName, allocator)
 
-  private val ordering = sort.map { case (field, reverse) =>
-    val o = SimpleFeatureOrdering(sft.indexOf(field))
-    if (reverse) { o.reverse } else { o }
-  }
+  private val ordering = sort.map { case (field, reverse) => SimpleFeatureOrdering(sft, field, reverse) }
 
   private val idWriter = ArrowAttributeWriter.id(sft, encoding, vector)
 
   private val writers = sft.getAttributeDescriptors.asScala.map { descriptor =>
     val name = descriptor.getLocalName
+    val isList = descriptor.isList
     val bindings = ObjectType.selectType(descriptor)
     val metadata = Map(SimpleFeatureVector.DescriptorKey -> SimpleFeatureTypes.encodeDescriptor(sft, descriptor))
-
     if (dictionaryFields.contains(name)) {
-      val dictMetadata = Map(SimpleFeatureVector.DescriptorKey -> s"$name:Integer")
-      val attribute = ArrowAttributeWriter(name, Seq(ObjectType.INT), None, dictMetadata, encoding, VectorFactory(vector))
-      val dictionary = {
-        val attribute = ArrowAttributeWriter(name, bindings, None, metadata, encoding, VectorFactory(allocator))
-        val writer = new BatchWriter(attribute.vector, ipcOpts)
-        attribute.vector.setInitialCapacity(initialCapacity)
-        attribute.vector.allocateNew()
-        Some(DictionaryWriter(sft.indexOf(name), attribute, writer, scala.collection.mutable.Map.empty))
+      // for list types, we encode the list items, not the whole list
+      val attribute = {
+        val desc = if (isList) { s"$name:List[Integer]" } else { s"$name:Integer" }
+        val encodedMetadata = Map(SimpleFeatureVector.DescriptorKey -> desc)
+        val encodedBindings = if (isList) { Seq(ObjectType.LIST, ObjectType.INT) } else { Seq(ObjectType.INT) }
+        ArrowAttributeWriter(name, encodedBindings, None, encodedMetadata, encoding, VectorFactory(vector))
       }
-      FieldWriter(name, sft.indexOf(name), attribute, dictionary)
+      val dictBindings = if (isList) { bindings.tail } else { bindings }
+      val ordering = AttributeOrdering(dictBindings)
+      val dict = ArrowAttributeWriter(name, dictBindings, None, metadata, encoding, VectorFactory(allocator))
+      dict.vector.setInitialCapacity(initialCapacity)
+      dict.vector.allocateNew()
+      if (isList) {
+        new DictionaryListFieldWriter(sft.indexOf(name), attribute, dict, ordering, ipcOpts)
+      } else {
+        new DictionaryFieldWriter(sft.indexOf(name), attribute, dict, ordering, ipcOpts)
+      }
     } else {
       val attribute = ArrowAttributeWriter(name, bindings, None, metadata, encoding, VectorFactory(vector))
-      FieldWriter(name, sft.indexOf(name), attribute, None)
+      new AttributeFieldWriter(sft.indexOf(name), attribute)
     }
   }
 
   // writer per-dictionary
-  private val dictionaryWriters = dictionaryFields.map(f => writers.find(_.name == f).get.dictionary.get)
+  private val dictionaryWriters = writers.collect { case d: DictionaryFieldWriter => d }
 
   // single writer to write out all vectors at once (not including dictionaries)
   private val writer = new BatchWriter(vector, ipcOpts)
@@ -120,7 +124,7 @@ class DeltaWriter(
     val last = threadingKey
     threadingKey = math.abs(ThreadLocalRandom.current().nextLong)
     logger.trace(s"$last resetting to $threadingKey")
-    writers.foreach(writer => writer.dictionary.foreach(_.values.clear()))
+    dictionaryWriters.foreach(_.resetDictionary())
   }
 
   /**
@@ -149,31 +153,14 @@ class DeltaWriter(
 
     // write out the dictionaries
 
-    // come up with the delta of new dictionary values
-    val delta = new java.util.TreeSet[AnyRef](dictionaryOrdering)
-
     dictionaryWriters.foreach { dictionary =>
       var i = 0
       while (i < count) {
-        val value = features(i).getAttribute(dictionary.index)
-        if (!dictionary.values.contains(value)) {
-          delta.add(value)
-        }
+        dictionary.addDictionaryValue(features(i))
         i += 1
       }
-      val size = dictionary.values.size
-      i = 0
-      // update the dictionary mappings, and write the new values to the vector
-      delta.asScala.foreach { n =>
-        dictionary.values.put(n, i + size)
-        dictionary.attribute.apply(i, n)
-        i += 1
-      }
-      // write out the dictionary batch
-      dictionary.attribute.setValueCount(i)
-      logger.trace(s"$threadingKey writing dictionary delta with $i values")
-      dictionary.writer.writeBatch(i, result)
-      delta.clear()
+      val delta = dictionary.writeDictionaryDelta(result)
+      logger.trace(s"$threadingKey writing dictionary delta with $delta values")
     }
 
     // set feature ids in the vector
@@ -188,16 +175,12 @@ class DeltaWriter(
 
     // set attributes in the vector
     writers.foreach { writer =>
-      val getAttribute: Int => AnyRef = writer.dictionary match {
-        case None =>             i => features(i).getAttribute(writer.index)
-        case Some(dictionary) => i => dictionary.values(features(i).getAttribute(writer.index)) // dictionary encoded value
-      }
       var i = 0
       while (i < count) {
-        writer.attribute.apply(i, getAttribute(i))
+        writer.write(i, features(i))
         i += 1
       }
-      writer.attribute.setValueCount(count)
+      writer.setValueCount(count)
     }
 
     logger.trace(s"$threadingKey writing batch with $count values")
@@ -213,22 +196,19 @@ class DeltaWriter(
     */
   override def close(): Unit = {
     CloseWithLogging(writer) // also closes `vector`
-    dictionaryWriters.foreach(w => CloseWithLogging(w.writer)) // also closes dictionary vectors
+    CloseWithLogging(dictionaryWriters) // also closes dictionary vectors
     CloseWithLogging(allocator)
   }
 }
 
 object DeltaWriter extends StrictLogging {
 
+  import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
+
   import scala.collection.JavaConverters._
 
   // empty provider
-  private val provider = new MapDictionaryProvider()
-
-  private val dictionaryOrdering: Ordering[AnyRef] = new Ordering[AnyRef] {
-    override def compare(x: AnyRef, y: AnyRef): Int =
-      SimpleFeatureOrdering.nullCompare(x.asInstanceOf[Comparable[Any]], y)
-  }
+  private val Provider = new MapDictionaryProvider()
 
   /**
    * Reduce function for delta records created by DeltaWriter
@@ -289,16 +269,38 @@ object DeltaWriter extends StrictLogging {
           val name = fromVector.getField.getName
           val toVector = result.underlying.getChild(name)
           val transfer: (Int, Int, java.util.Map[Integer, Integer]) => Unit =
-            if (fromVector.getField.getDictionary != null) {
-              val from = fromVector.asInstanceOf[IntVector]
-              val to = toVector.asInstanceOf[IntVector]
-              (fromIndex: Int, toIndex: Int, mapping: java.util.Map[Integer, Integer]) => {
-                val n = from.getObject(fromIndex)
-                if (n == null) {
-                  to.setNull(toIndex)
-                } else {
-                  to.setSafe(toIndex, mapping.get(n))
-                }
+            if (mergedDictionaries.dictionaries.contains(name)) {
+              (fromVector, toVector) match {
+                case (from: IntVector, to: IntVector) =>
+                  (fromIndex: Int, toIndex: Int, mapping: java.util.Map[Integer, Integer]) => {
+                    val n = from.getObject(fromIndex)
+                    if (n == null) {
+                      to.setNull(toIndex)
+                    } else {
+                      to.setSafe(toIndex, mapping.get(n))
+                    }
+                  }
+
+                case (from: ListVector, to: ListVector) =>
+                  val innerTo = to.getDataVector.asInstanceOf[IntVector]
+                  (fromIndex: Int, toIndex: Int, mapping: java.util.Map[Integer, Integer]) => {
+                    // note: should not be nulls as they are converted to empty list
+                    val list = from.getObject(fromIndex).asInstanceOf[java.util.List[Integer]]
+                    if (to.getLastSet >= toIndex) {
+                      to.setLastSet(toIndex - 1)
+                    }
+                    val start = to.startNewValue(toIndex)
+                    var offset = 0
+                    while (offset < list.size()) {
+                      // note: nulls get encoded in the dictionary
+                      innerTo.setSafe(start + offset, mapping.get(list.get(offset)))
+                      offset += 1
+                    }
+                    to.endValue(toIndex, offset)
+                  }
+
+                case _ =>
+                  throw new IllegalStateException(s"Encountered unexpected dictionary vector: $fromVector")
               }
             } else if (sft.indexOf(name) != -1 &&
                 classOf[Geometry].isAssignableFrom(sft.getDescriptor(name).getType.getBinding)) {
@@ -460,16 +462,39 @@ object DeltaWriter extends StrictLogging {
           val transfers: Seq[(Int, Int) => Unit] = toLoad.underlying.getChildrenFromFields.asScala.map { fromVector =>
             val name = fromVector.getField.getName
             val toVector = result.underlying.getChild(name)
-            if (fromVector.getField.getDictionary != null) {
+            if (dictionaries.contains(name)) {
               val mapping = mappings(name)
-              val to = toVector.asInstanceOf[IntVector]
-              (fromIndex: Int, toIndex: Int) => {
-                val n = fromVector.getObject(fromIndex).asInstanceOf[Integer]
-                if (n == null) {
-                  to.setNull(toIndex)
-                } else {
-                  to.setSafe(toIndex, mapping.get(n))
-                }
+              (fromVector, toVector) match {
+                case (from: IntVector, to: IntVector) =>
+                  (fromIndex: Int, toIndex: Int) => {
+                    val n = from.getObject(fromIndex)
+                    if (n == null) {
+                      to.setNull(toIndex)
+                    } else {
+                      to.setSafe(toIndex, mapping.get(n))
+                    }
+                  }
+
+                case (from: ListVector, to: ListVector) =>
+                  val innerTo = to.getDataVector.asInstanceOf[IntVector]
+                  (fromIndex: Int, toIndex: Int) => {
+                    // note: should not be nulls as they are converted to empty list
+                    val list = from.getObject(fromIndex).asInstanceOf[java.util.List[Integer]]
+                    if (to.getLastSet >= toIndex) {
+                      to.setLastSet(toIndex - 1)
+                    }
+                    val start = to.startNewValue(toIndex)
+                    var offset = 0
+                    while (offset < list.size()) {
+                      // note: nulls get encoded in the dictionary
+                      innerTo.setSafe(start + offset, mapping.get(list.get(offset)))
+                      offset += 1
+                    }
+                    to.endValue(toIndex, offset)
+                  }
+
+                case _ =>
+                  throw new IllegalStateException(s"Encountered unexpected dictionary vector: $fromVector")
               }
             } else if (sft.indexOf(name) != -1 &&
                 classOf[Geometry].isAssignableFrom(sft.getDescriptor(name).getType.getBinding)) {
@@ -484,10 +509,12 @@ object DeltaWriter extends StrictLogging {
           }
           val mapVector = toLoad.underlying
           val dict = dictionaries.get(sortBy)
-          val merger = ArrowAttributeReader(sft.getDescriptor(sortBy), mapVector.getChild(sortBy), dict, encoding) match {
+          val descriptor = sft.getDescriptor(sortBy)
+          val merger = ArrowAttributeReader(descriptor, mapVector.getChild(sortBy), dict, encoding) match {
             case r: ArrowDictionaryReader => new DictionaryBatchMerger(toLoad, transfers, r, mappings.get(sortBy).orNull)
+            case r: ArrowListDictionaryReader => new DictionaryListBatchMerger(toLoad, transfers, r, mappings.get(sortBy).orNull)
             case r: ArrowDateReader => new DateBatchMerger(toLoad, transfers, r)
-            case r => new AttributeBatchMerger(toLoad, transfers, r)
+            case r => new AttributeBatchMerger(toLoad, transfers, r, AttributeOrdering(descriptor))
           }
           queue.add(merger.asInstanceOf[BatchMerger[Any]])
         }
@@ -572,20 +599,29 @@ object DeltaWriter extends StrictLogging {
     // calculate our vector bindings/metadata once up front
     val vectorMetadata = dictionaryFields.toArray.map { name =>
       val descriptor = sft.getDescriptor(name)
-      val bindings = ObjectType.selectType(descriptor)
-      val metadata = Map(SimpleFeatureVector.DescriptorKey -> SimpleFeatureTypes.encodeDescriptor(sft, descriptor))
+      val bindings = {
+        val base = ObjectType.selectType(descriptor)
+        if (descriptor.isList) { base.tail } else { base }
+      }
+      val ordering = AttributeOrdering(bindings)
+      val desc = if (descriptor.isList) { s"$name:${descriptor.getListType().getSimpleName}" } else {
+        SimpleFeatureTypes.encodeDescriptor(sft, descriptor)
+      }
+      val metadata = Map(SimpleFeatureVector.DescriptorKey -> desc)
       val factory = VectorFactory(allocator)
-      (name, bindings, metadata, factory)
+      (name, bindings, ordering, metadata, factory)
     }
 
     // create a vector for each dictionary field
     def createNewVectors: Array[ArrowAttributeReader] = {
-      vectorMetadata.map { case (name, bindings, metadata, factory) =>
+      vectorMetadata.map { case (name, bindings, _, metadata, factory) =>
         // use the writer to create the appropriate child vector
         val vector = ArrowAttributeWriter(name, bindings, None, metadata, encoding, factory).vector
         ArrowAttributeReader(bindings, vector, None, encoding)
       }
     }
+
+    val orderings = vectorMetadata.map(_._3)
 
     // final results
     val results = createNewVectors
@@ -632,7 +668,7 @@ object DeltaWriter extends StrictLogging {
           v.vector.makeTransferPair(dictionaries(j).vector)
         }
 
-        new DictionaryMerger(vectors, transfers, off, null, -1) // we don't care about the batch number here
+        new DictionaryMerger(vectors, transfers, off, orderings, null, -1) // we don't care about the batch number here
       }
 
       val transfers = Array.ofDim[TransferPair](dictionaries.length)
@@ -662,7 +698,7 @@ object DeltaWriter extends StrictLogging {
         i += 1
       }
 
-      new DictionaryMerger(dictionaries, transfers, Array.empty, mappings, batch)
+      new DictionaryMerger(dictionaries, transfers, Array.empty, orderings, mappings, batch)
     }
 
     // now merge the separate threads together
@@ -705,7 +741,7 @@ object DeltaWriter extends StrictLogging {
     val mappingsBuilder = Map.newBuilder[String, Array[java.util.Map[Integer, Integer]]]
     mappingsBuilder.sizeHint(dictionaryFields.length)
 
-    vectorMetadata.foreachIndex { case ((name, bindings, _, _), i) =>
+    vectorMetadata.foreachIndex { case ((name, bindings, _, _, _), i) =>
       logger.trace("merged dictionary: " + Seq.tabulate(results(i).getValueCount)(results(i).apply).mkString(","))
       val enc = new DictionaryEncoding(i, true, new ArrowType.Int(32, true))
       dictionaryBuilder += name -> ArrowDictionary.create(enc, results(i).vector, bindings, encoding)
@@ -731,19 +767,86 @@ object DeltaWriter extends StrictLogging {
     }
   }
 
-  private case class FieldWriter(
-      name: String,
-      index: Int,
-      attribute: ArrowAttributeWriter,
-      dictionary: Option[DictionaryWriter] = None
-    )
+  private sealed abstract class FieldWriter(attribute: ArrowAttributeWriter) {
+    def write(i: Int, f: SimpleFeature): Unit
+    def setValueCount(i: Int): Unit = attribute.setValueCount(i)
+  }
 
-  private case class DictionaryWriter(
+  private class AttributeFieldWriter(index: Int, attribute: ArrowAttributeWriter) extends FieldWriter(attribute) {
+    override def write(i: Int, f: SimpleFeature): Unit = attribute.apply(i, f.getAttribute(index))
+  }
+
+  private class DictionaryFieldWriter(
       index: Int,
       attribute: ArrowAttributeWriter,
-      writer: BatchWriter,
-      values: scala.collection.mutable.Map[AnyRef, Integer]
-    )
+      dict: ArrowAttributeWriter,
+      ordering: Ordering[AnyRef],
+      ipcOpts: IpcOption
+    ) extends FieldWriter(attribute) with Closeable {
+
+    protected val values = scala.collection.mutable.Map.empty[AnyRef, Integer]
+    protected val delta  = new java.util.TreeSet[AnyRef](ordering)
+    protected val writer = new BatchWriter(dict.vector, ipcOpts)
+
+    override def write(i: Int, f: SimpleFeature): Unit = attribute.apply(i, values(f.getAttribute(index)))
+
+    def addDictionaryValue(f: SimpleFeature): Unit = {
+      val value = f.getAttribute(index)
+      if (!values.contains(value)) {
+        delta.add(value)
+      }
+    }
+
+    def writeDictionaryDelta(out: ByteArrayOutputStream): Int = {
+      val size = values.size
+      var i = 0
+      // update the dictionary mappings, and write the new values to the vector
+      delta.asScala.foreach { n =>
+        values.put(n, i + size)
+        dict.apply(i, n)
+        i += 1
+      }
+      // write out the dictionary batch
+      dict.setValueCount(i)
+      writer.writeBatch(i, out)
+      delta.clear()
+      i
+    }
+
+    def resetDictionary(): Unit = values.clear()
+
+    override def close(): Unit = writer.close()
+  }
+
+  private class DictionaryListFieldWriter(
+      index: Int,
+      attribute: ArrowAttributeWriter,
+      dict: ArrowAttributeWriter,
+      ordering: Ordering[AnyRef],
+      ipcOpts: IpcOption
+    ) extends DictionaryFieldWriter(index, attribute, dict, ordering, ipcOpts) {
+
+    override def write(i: Int, f: SimpleFeature): Unit = {
+      val list = f.getAttribute(index).asInstanceOf[java.util.List[AnyRef]]
+      val encoded = if (list == null) { Collections.emptyList() } else {
+        val e = new java.util.ArrayList[Integer](list.size)
+        list.asScala.foreach(v => e.add(values(v)))
+        e
+      }
+      attribute.apply(i, encoded)
+    }
+
+    override def addDictionaryValue(f: SimpleFeature): Unit = {
+      val value = f.getAttribute(index).asInstanceOf[java.util.List[AnyRef]]
+      if (value != null) {
+        value.asScala.foreach { v =>
+          if (!values.contains(v)) {
+            delta.add(v)
+          }
+        }
+      }
+    }
+  }
 
   private object BatchMergerOrdering extends Ordering[BatchMerger[Any]] {
     override def compare(x: BatchMerger[Any], y: BatchMerger[Any]): Int = x.compare(y)
@@ -803,6 +906,45 @@ object DeltaWriter extends StrictLogging {
   }
 
   /**
+   * Batch merger for dictionary-encoded values
+   *
+   * @param vector vector for this batch
+   * @param transfers transfer functions to the result batch
+   * @param sort vector holding the values being sorted on
+   * @param dictionaryMappings mappings from the batch to the global dictionary
+   */
+  private class DictionaryListBatchMerger(
+      vector: SimpleFeatureVector,
+      transfers: Seq[(Int, Int) => Unit],
+      sort: ArrowListDictionaryReader,
+      dictionaryMappings: java.util.Map[Integer, Integer]
+    ) extends BatchMerger[DictionaryListBatchMerger](vector, transfers) {
+
+    private var value: java.util.List[Integer] = {
+      val list = sort.getEncoded(0)
+      var i = 0
+      while (i < list.size) {
+        list.set(i, dictionaryMappings.get(list.get(i)))
+        i += 1
+      }
+      list
+    }
+
+    override protected def load(): Unit = {
+      // since we've sorted the dictionaries, we can just compare the encoded index values
+      value = sort.getEncoded(index)
+      var i = 0
+      while (i < value.size) {
+        value.set(i, dictionaryMappings.get(value.get(i)))
+        i += 1
+      }
+    }
+
+    override def compare(that: DictionaryListBatchMerger): Int =
+      AttributeOrdering.IntListOrdering.compare(value, that.value)
+  }
+
+  /**
    * Merger for date values. We can avoid allocating a Date object and just compare the millisecond timestamp
    *
    * @param vector vector for this batch
@@ -832,14 +974,15 @@ object DeltaWriter extends StrictLogging {
   private class AttributeBatchMerger(
       vector: SimpleFeatureVector,
       transfers: Seq[(Int, Int) => Unit],
-      sort: ArrowAttributeReader
+      sort: ArrowAttributeReader,
+      ordering: Ordering[AnyRef]
     ) extends BatchMerger[AttributeBatchMerger](vector, transfers) {
 
-    private var value: Comparable[Any] = sort.apply(0).asInstanceOf[Comparable[Any]]
+    private var value: AnyRef = sort.apply(0)
 
-    override protected def load(): Unit = value = sort.apply(index).asInstanceOf[Comparable[Any]]
+    override protected def load(): Unit = value = sort.apply(index)
 
-    override def compare(that: AttributeBatchMerger): Int = SimpleFeatureOrdering.nullCompare(value, that.value)
+    override def compare(that: AttributeBatchMerger): Int = ordering.compare(value, that.value)
   }
 
   /**
@@ -849,6 +992,7 @@ object DeltaWriter extends StrictLogging {
    * @param readers attribute readers for the dictionary values
    * @param transfers transfers for the dictionary vectors
    * @param offsets dictionary offsets based on the number of threaded delta batches
+   * @param orderings orderings for sorting the dictionary values
    * @param mappings mappings from the local threaded batch dictionary to the global dictionary
    * @param batch the batch number
    */
@@ -856,13 +1000,14 @@ object DeltaWriter extends StrictLogging {
       readers: Array[ArrowAttributeReader],
       transfers: Array[TransferPair],
       offsets: Array[Int],
+      orderings: Array[Ordering[AnyRef]],
       val mappings: Array[HashBiMap[Integer, Integer]],
       val batch: Int
     ) extends Ordered[DictionaryMerger] {
 
     private var current: Int = 0
     private var _index: Int = 0
-    private var _value: Comparable[Any] = _
+    private var _value: AnyRef = _
 
     /**
      * The read position of the current dictionary
@@ -876,7 +1021,7 @@ object DeltaWriter extends StrictLogging {
      *
      * @return
      */
-    def value: Comparable[Any] = _value
+    def value: AnyRef = _value
 
     /**
      * The global offset of the current dictionary, based on the batch threading and the current read position
@@ -919,7 +1064,7 @@ object DeltaWriter extends StrictLogging {
     def advance(): Boolean = {
       _index += 1
       if (readers(current).getValueCount > _index) {
-        _value = readers(current).apply(_index).asInstanceOf[Comparable[Any]]
+        _value = readers(current).apply(_index)
         true
       } else {
         _value = null
@@ -928,7 +1073,7 @@ object DeltaWriter extends StrictLogging {
       }
     }
 
-    override def compare(that: DictionaryMerger): Int = SimpleFeatureOrdering.nullCompare(_value, that._value)
+    override def compare(that: DictionaryMerger): Int = orderings(current).compare(_value, that._value)
   }
 
   /**
@@ -940,7 +1085,7 @@ object DeltaWriter extends StrictLogging {
 
     private val root = createRoot(vector)
     private val os = new ByteArrayOutputStream()
-    private val writer = new ArrowStreamWriter(root, provider, Channels.newChannel(os), ipcOpts)
+    private val writer = new ArrowStreamWriter(root, Provider, Channels.newChannel(os), ipcOpts)
     writer.start() // start the writer - we'll discard the metadata later, as we only care about the record batches
 
     logger.trace(s"write schema: ${vector.getField}")

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DeltaWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DeltaWriter.scala
@@ -91,6 +91,7 @@ class DeltaWriter(
         val encodedBindings = if (isList) { Seq(ObjectType.LIST, ObjectType.INT) } else { Seq(ObjectType.INT) }
         ArrowAttributeWriter(name, encodedBindings, None, encodedMetadata, encoding, VectorFactory(vector))
       }
+      // for list types, get the list item binding (which is the tail of the bindings)
       val dictBindings = if (isList) { bindings.tail } else { bindings }
       val ordering = AttributeOrdering(dictBindings)
       val dict = ArrowAttributeWriter(name, dictBindings, None, metadata, encoding, VectorFactory(allocator))
@@ -601,6 +602,7 @@ object DeltaWriter extends StrictLogging {
       val descriptor = sft.getDescriptor(name)
       val bindings = {
         val base = ObjectType.selectType(descriptor)
+        // for list types, get the list item binding (which is the tail of the bindings)
         if (descriptor.isList) { base.tail } else { base }
       }
       val ordering = AttributeOrdering(bindings)

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/SimpleFeatureArrowFileReader.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/SimpleFeatureArrowFileReader.scala
@@ -104,6 +104,7 @@ object SimpleFeatureArrowFileReader {
         val descriptor = SimpleFeatureTypes.createDescriptor(field.getMetadata.get(DescriptorKey))
         val bindings = {
           val main = ObjectType.selectType(descriptor)
+          // for list types, get the list item binding (which is the tail of the bindings)
           if (descriptor.isList) { main.tail } else { main }
         }
         val vector = provider.lookup(encoding.getId).getVector

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/package.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/package.scala
@@ -9,8 +9,6 @@
 package org.locationtech.geomesa
 
 import org.apache.arrow.memory.{BufferAllocator, RootAllocator}
-import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.io.CloseWithLogging
@@ -43,6 +41,4 @@ package object arrow {
   object ArrowProperties {
     val BatchSize: SystemProperty = SystemProperty("geomesa.arrow.batch.size", "10000")
   }
-
-  case class TypeBindings(bindings: Seq[ObjectType], encoding: SimpleFeatureEncoding)
 }

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeReader.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeReader.scala
@@ -12,17 +12,17 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicLong
 import java.util.{Date, UUID}
 
-import org.locationtech.jts.geom._
 import org.apache.arrow.vector._
 import org.apache.arrow.vector.complex.{BaseRepeatedValueVector, FixedSizeListVector, ListVector, StructVector}
 import org.apache.arrow.vector.holders._
-import org.locationtech.geomesa.arrow.TypeBindings
+import org.apache.arrow.vector.types.Types.MinorType
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding.Encoding
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding.Encoding.Encoding
 import org.locationtech.geomesa.arrow.vector.impl.{AbstractLineStringVector, AbstractPointVector}
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
+import org.locationtech.jts.geom._
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType
 
@@ -53,18 +53,9 @@ trait ArrowAttributeReader {
   def getValueCount: Int = vector.getValueCount
 }
 
-trait ArrowDictionaryReader extends ArrowAttributeReader {
-
-  /**
-    * Gets the raw underlying value without dictionary decoding it
-    *
-    * @param i index of the feature to read
-    * @return
-    */
-  def getEncoded(i: Int): Integer
-}
-
 object ArrowAttributeReader {
+
+  import scala.collection.JavaConverters._
 
   /**
     * Reads an ID
@@ -74,12 +65,13 @@ object ArrowAttributeReader {
     * @param encoding encoding options
     * @return
     */
-  def id(sft: SimpleFeatureType,
-         vector: StructVector,
-         encoding: SimpleFeatureEncoding = SimpleFeatureEncoding.Min): ArrowAttributeReader = {
+  def id(
+      sft: SimpleFeatureType,
+      vector: StructVector,
+      encoding: SimpleFeatureEncoding = SimpleFeatureEncoding.Min): ArrowAttributeReader = {
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
-    def child = vector.getChild(SimpleFeatureVector.FeatureIdField)
+    def child: FieldVector = vector.getChild(SimpleFeatureVector.FeatureIdField)
 
     encoding.fids match {
       case None                             => ArrowAttributeReader.ArrowFeatureIdIncrementingReader
@@ -103,8 +95,7 @@ object ArrowAttributeReader {
             vector: StructVector,
             dictionaries: Map[String, ArrowDictionary],
             encoding: SimpleFeatureEncoding = SimpleFeatureEncoding.Min): Seq[ArrowAttributeReader] = {
-    import scala.collection.JavaConversions._
-    sft.getAttributeDescriptors.map { descriptor =>
+    sft.getAttributeDescriptors.asScala.map { descriptor =>
       val name = descriptor.getLocalName
       val dictionary = dictionaries.get(name).orElse(dictionaries.get(descriptor.getLocalName))
       apply(descriptor, vector.getChild(name), dictionary, encoding)
@@ -150,22 +141,65 @@ object ArrowAttributeReader {
         }
 
       case Some(dict) =>
-        val dictionaryType = TypeBindings(bindings, encoding)
         vector match {
-          case v: TinyIntVector  => new ArrowDictionaryByteReader(v, dict, dictionaryType)
-          case v: SmallIntVector => new ArrowDictionaryShortReader(v, dict, dictionaryType)
-          case v: IntVector      => new ArrowDictionaryIntReader(v, dict, dictionaryType)
+          case v: TinyIntVector  => new ArrowDictionaryByteReader(v, dict)
+          case v: SmallIntVector => new ArrowDictionaryShortReader(v, dict)
+          case v: IntVector      => new ArrowDictionaryIntReader(v, dict)
+
+          case v: ListVector =>
+            val nested = v.getField.getChildren.get(0).getType
+            if (nested == MinorType.TINYINT.getType) {
+              new ArrowListDictionaryByteReader(v, dict)
+            } else if (nested == MinorType.SMALLINT.getType) {
+              new ArrowListDictionaryShortReader(v, dict)
+            } else if (nested == MinorType.INT.getType) {
+              new ArrowListDictionaryIntReader(v, dict)
+            } else {
+              throw new IllegalArgumentException(s"Unexpected dictionary vector: $vector")
+            }
+
           case _ => throw new IllegalArgumentException(s"Unexpected dictionary vector: $vector")
         }
     }
   }
 
   /**
-    * Reads dictionary encoded bytes and converts them to the actual values
-    */
-  class ArrowDictionaryByteReader(override val vector: TinyIntVector,
-                                  val dictionary: ArrowDictionary,
-                                  val dictionaryType: TypeBindings) extends ArrowDictionaryReader {
+   * Transparently reads dictionary encoded values
+   */
+  trait ArrowDictionaryReader extends ArrowAttributeReader {
+
+    /**
+     * Gets the raw underlying value without dictionary decoding it
+     *
+     * @param i index of the feature to read
+     * @return
+     */
+    def getEncoded(i: Int): Integer
+  }
+
+  /**
+   * Transparently reads lists of dictionary encoded values
+   */
+  trait ArrowListDictionaryReader extends ArrowAttributeReader {
+
+    /**
+     * Gets the raw underlying value without dictionary decoding it
+     *
+     * @param i index of the feature to read
+     * @return
+     */
+    def getEncoded(i: Int): java.util.List[Integer]
+  }
+
+  /**
+   * Reads dictionary encoded bytes and converts them to the actual values
+   *
+   * @param vector encoded vector to read
+   * @param dictionary dictionary values
+   */
+  class ArrowDictionaryByteReader(override val vector: TinyIntVector, dictionary: ArrowDictionary)
+      extends ArrowDictionaryReader {
+
     private val holder = new NullableTinyIntHolder
 
     override def apply(i: Int): AnyRef = {
@@ -182,12 +216,57 @@ object ArrowAttributeReader {
   }
 
   /**
-    * Reads dictionary encoded shorts and converts them to the actual values
-    *
-    */
-  class ArrowDictionaryShortReader(override val vector: SmallIntVector,
-                                   val dictionary: ArrowDictionary,
-                                   val dictionaryType: TypeBindings) extends ArrowDictionaryReader {
+   * Reads lists of dictionary encoded bytes and converts them to the actual values
+   *
+   * @param vector encoded vector to read
+   * @param dictionary dictionary values
+   */
+  class ArrowListDictionaryByteReader(override val vector: ListVector, dictionary: ArrowDictionary)
+      extends ArrowListDictionaryReader {
+
+    private val inner = vector.getDataVector.asInstanceOf[TinyIntVector]
+    private val holder = new NullableTinyIntHolder
+
+    override def apply(i: Int): AnyRef = {
+      if (vector.isNull(i)) { null } else {
+        // note: the offset buffer can be swapped out, so don't hold on to any references to it
+        var offset = vector.getOffsetBuffer.getInt(i * BaseRepeatedValueVector.OFFSET_WIDTH)
+        val end = vector.getOffsetBuffer.getInt((i + 1) * BaseRepeatedValueVector.OFFSET_WIDTH)
+        val list = new java.util.ArrayList[AnyRef](end - offset)
+        while (offset < end) {
+          inner.get(offset, holder)
+          list.add(dictionary.lookup(holder.value))
+          offset += 1
+        }
+        list
+      }
+    }
+
+    override def getEncoded(i: Int): java.util.List[Integer] = {
+      if (vector.isNull(i)) { null } else {
+        // note: the offset buffer can be swapped out, so don't hold on to any references to it
+        var offset = vector.getOffsetBuffer.getInt(i * BaseRepeatedValueVector.OFFSET_WIDTH)
+        val end = vector.getOffsetBuffer.getInt((i + 1) * BaseRepeatedValueVector.OFFSET_WIDTH)
+        val list = new java.util.ArrayList[Integer](end - offset)
+        while (offset < end) {
+          inner.get(offset, holder)
+          list.add(holder.value)
+          offset += 1
+        }
+        list
+      }
+    }
+  }
+
+  /**
+   * Reads dictionary encoded shorts and converts them to the actual values
+   *
+   * @param vector encoded vector to read
+   * @param dictionary dictionary values
+   */
+  class ArrowDictionaryShortReader(override val vector: SmallIntVector, dictionary: ArrowDictionary)
+      extends ArrowDictionaryReader {
+
     private val holder = new NullableSmallIntHolder
 
     override def apply(i: Int): AnyRef = {
@@ -204,12 +283,57 @@ object ArrowAttributeReader {
   }
 
   /**
-    * Reads dictionary encoded ints and converts them to the actual values
-    *
-    */
-  class ArrowDictionaryIntReader(override val vector: IntVector,
-                                 val dictionary: ArrowDictionary,
-                                 val dictionaryType: TypeBindings) extends ArrowDictionaryReader {
+   * Reads lists of dictionary encoded shorts and converts them to the actual values
+   *
+   * @param vector encoded vector to read
+   * @param dictionary dictionary values
+   */
+  class ArrowListDictionaryShortReader(override val vector: ListVector, dictionary: ArrowDictionary)
+      extends ArrowListDictionaryReader {
+
+    private val inner = vector.getDataVector.asInstanceOf[SmallIntVector]
+    private val holder = new NullableSmallIntHolder
+
+    override def apply(i: Int): AnyRef = {
+      if (vector.isNull(i)) { null } else {
+        // note: the offset buffer can be swapped out, so don't hold on to any references to it
+        var offset = vector.getOffsetBuffer.getInt(i * BaseRepeatedValueVector.OFFSET_WIDTH)
+        val end = vector.getOffsetBuffer.getInt((i + 1) * BaseRepeatedValueVector.OFFSET_WIDTH)
+        val list = new java.util.ArrayList[AnyRef](end - offset)
+        while (offset < end) {
+          inner.get(offset, holder)
+          list.add(dictionary.lookup(holder.value))
+          offset += 1
+        }
+        list
+      }
+    }
+
+    override def getEncoded(i: Int): java.util.List[Integer] = {
+      if (vector.isNull(i)) { null } else {
+        // note: the offset buffer can be swapped out, so don't hold on to any references to it
+        var offset = vector.getOffsetBuffer.getInt(i * BaseRepeatedValueVector.OFFSET_WIDTH)
+        val end = vector.getOffsetBuffer.getInt((i + 1) * BaseRepeatedValueVector.OFFSET_WIDTH)
+        val list = new java.util.ArrayList[Integer](end - offset)
+        while (offset < end) {
+          inner.get(offset, holder)
+          list.add(holder.value)
+          offset += 1
+        }
+        list
+      }
+    }
+  }
+
+  /**
+   * Reads dictionary encoded ints and converts them to the actual values
+   *
+   * @param vector encoded vector to read
+   * @param dictionary dictionary values
+   */
+  class ArrowDictionaryIntReader(override val vector: IntVector, dictionary: ArrowDictionary)
+      extends ArrowDictionaryReader {
+
     private val holder = new NullableIntHolder
 
     override def apply(i: Int): AnyRef = {
@@ -222,6 +346,49 @@ object ArrowAttributeReader {
     override def getEncoded(i: Int): Integer = {
       vector.get(i, holder)
       if (holder.isSet == 0) { null } else { Int.box(holder.value) }
+    }
+  }
+
+  /**
+   * Reads lists of dictionary encoded ints and converts them to the actual values
+   *
+   * @param vector encoded vector to read
+   * @param dictionary dictionary values
+   */
+  class ArrowListDictionaryIntReader(override val vector: ListVector, dictionary: ArrowDictionary)
+      extends ArrowListDictionaryReader {
+
+    private val inner = vector.getDataVector.asInstanceOf[IntVector]
+    private val holder = new NullableIntHolder
+
+    override def apply(i: Int): AnyRef = {
+      if (vector.isNull(i)) { null } else {
+        // note: the offset buffer can be swapped out, so don't hold on to any references to it
+        var offset = vector.getOffsetBuffer.getInt(i * BaseRepeatedValueVector.OFFSET_WIDTH)
+        val end = vector.getOffsetBuffer.getInt((i + 1) * BaseRepeatedValueVector.OFFSET_WIDTH)
+        val list = new java.util.ArrayList[AnyRef](end - offset)
+        while (offset < end) {
+          inner.get(offset, holder)
+          list.add(dictionary.lookup(holder.value))
+          offset += 1
+        }
+        list
+      }
+    }
+
+    override def getEncoded(i: Int): java.util.List[Integer] = {
+      if (vector.isNull(i)) { null } else {
+        // note: the offset buffer can be swapped out, so don't hold on to any references to it
+        var offset = vector.getOffsetBuffer.getInt(i * BaseRepeatedValueVector.OFFSET_WIDTH)
+        val end = vector.getOffsetBuffer.getInt((i + 1) * BaseRepeatedValueVector.OFFSET_WIDTH)
+        val list = new java.util.ArrayList[Integer](end - offset)
+        while (offset < end) {
+          inner.get(offset, holder)
+          list.add(holder.value)
+          offset += 1
+        }
+        list
+      }
     }
   }
 

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowAttributeWriter.scala
@@ -20,10 +20,9 @@ import org.apache.arrow.vector.types.pojo.{ArrowType, FieldType}
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding.Encoding
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding.Encoding.Encoding
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.filter.function.ProxyIdFunction
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
+import org.locationtech.geomesa.utils.geotools.{ObjectType, SimpleFeatureTypes}
 import org.locationtech.jts.geom._
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -180,7 +179,7 @@ object ArrowAttributeWriter {
       factory: VectorFactory): ArrowAttributeWriter = {
     dictionary match {
       case Some(dict) =>
-        ArrowAttributeWriter.dictionary(name, dict, metadata, factory)
+        ArrowAttributeWriter.dictionary(name, dict, bindings.head == ObjectType.LIST, metadata, factory)
 
       case None =>
         bindings.head match {
@@ -204,13 +203,17 @@ object ArrowAttributeWriter {
   private def dictionary(
       name: String,
       dictionary: ArrowDictionary,
+      isList: Boolean,
       metadata: Map[String, String],
       factory: VectorFactory): ArrowAttributeWriter = {
-    dictionary.encoding.getIndexType.getBitWidth match {
-      case 8  => new ArrowDictionaryByteWriter(name, dictionary, metadata, factory)
-      case 16 => new ArrowDictionaryShortWriter(name, dictionary, metadata, factory)
-      case 32 => new ArrowDictionaryIntWriter(name, dictionary, metadata, factory)
-      case w  => throw new IllegalArgumentException(s"Unsupported dictionary encoding width: $w")
+    (dictionary.encoding.getIndexType.getBitWidth, isList) match {
+      case (8,  false) => new ArrowDictionaryByteWriter(name, dictionary, metadata, factory)
+      case (16, false) => new ArrowDictionaryShortWriter(name, dictionary, metadata, factory)
+      case (32, false) => new ArrowDictionaryIntWriter(name, dictionary, metadata, factory)
+      case (8,  true)  => new ArrowListDictionaryByteWriter(name, dictionary, metadata, factory)
+      case (16, true)  => new ArrowListDictionaryShortWriter(name, dictionary, metadata, factory)
+      case (32, true)  => new ArrowListDictionaryIntWriter(name, dictionary, metadata, factory)
+      case (w, _)      => throw new IllegalArgumentException(s"Unsupported dictionary encoding width: $w")
     }
   }
 
@@ -271,8 +274,13 @@ object ArrowAttributeWriter {
   }
 
   /**
-    * Converts a value into a dictionary byte and writes it
-    */
+   * Converts a value into a dictionary encoded byte and writes it
+   *
+   * @param name attribute/field name
+   * @param dictionary dictionary values
+   * @param metadata field metadata
+   * @param factory vector factory
+   */
   class ArrowDictionaryByteWriter(
       name: String,
       val dictionary: ArrowDictionary,
@@ -280,16 +288,61 @@ object ArrowAttributeWriter {
       factory: VectorFactory
     ) extends ArrowDictionaryWriter {
 
-    override val vector: TinyIntVector =
-      factory.apply(name, new FieldType(true, MinorType.TINYINT.getType, dictionary.encoding, metadata.asJava))
+    override val vector: TinyIntVector = factory.apply(name, MinorType.TINYINT, dictionary.encoding, metadata)
 
     // note: nulls get encoded in the dictionary
     override def apply(i: Int, value: AnyRef): Unit = vector.setSafe(i, dictionary.index(value).toByte)
   }
 
   /**
-    * Converts a value into a dictionary short and writes it
-    */
+   * Converts a list value into a list of dictionary bytes and writes it
+   *
+   * @param name attribute/field name
+   * @param dictionary dictionary values
+   * @param metadata field metadata
+   * @param factory vector factory
+   */
+  class ArrowListDictionaryByteWriter(
+      name: String,
+      val dictionary: ArrowDictionary,
+      metadata: Map[String, String],
+      factory: VectorFactory
+    ) extends ArrowDictionaryWriter {
+
+    override val vector: ListVector = factory.apply(name, MinorType.LIST, metadata)
+
+    private val inner: TinyIntVector =
+      FromList(vector).apply(null, MinorType.TINYINT, dictionary.encoding, Map.empty)
+
+    override def apply(i: Int, value: AnyRef): Unit = {
+      if (vector.getLastSet >= i) {
+        vector.setLastSet(i - 1)
+      }
+      val start = vector.startNewValue(i)
+      // note: null gets converted to empty list
+      if (value == null) {
+        vector.endValue(i, 0)
+      } else {
+        val list = value.asInstanceOf[java.util.List[AnyRef]]
+        var offset = 0
+        while (offset < list.size()) {
+          // note: nulls get encoded in the dictionary
+          inner.setSafe(start + offset, dictionary.index(list.get(offset)).toByte)
+          offset += 1
+        }
+        vector.endValue(i, offset)
+      }
+    }
+  }
+
+  /**
+   * Converts a value into a dictionary encoded short and writes it
+   *
+   * @param name attribute/field name
+   * @param dictionary dictionary values
+   * @param metadata field metadata
+   * @param factory vector factory
+   */
   class ArrowDictionaryShortWriter(
       name: String,
       val dictionary: ArrowDictionary,
@@ -297,16 +350,61 @@ object ArrowAttributeWriter {
       factory: VectorFactory
     ) extends ArrowDictionaryWriter {
 
-    override val vector: SmallIntVector =
-      factory.apply(name, new FieldType(true, MinorType.SMALLINT.getType, dictionary.encoding, metadata.asJava))
+    override val vector: SmallIntVector = factory.apply(name, MinorType.SMALLINT, dictionary.encoding, metadata)
 
     // note: nulls get encoded in the dictionary
     override def apply(i: Int, value: AnyRef): Unit = vector.setSafe(i, dictionary.index(value).toShort)
   }
 
   /**
-    * Converts a value into a dictionary int and writes it
-    */
+   * Converts a list value into a list of dictionary shorts and writes it
+   *
+   * @param name attribute/field name
+   * @param dictionary dictionary values
+   * @param metadata field metadata
+   * @param factory vector factory
+   */
+  class ArrowListDictionaryShortWriter(
+      name: String,
+      val dictionary: ArrowDictionary,
+      metadata: Map[String, String],
+      factory: VectorFactory
+    ) extends ArrowDictionaryWriter {
+
+    override val vector: ListVector = factory.apply(name, MinorType.LIST, metadata)
+
+    private val inner: SmallIntVector =
+      FromList(vector).apply(null, MinorType.SMALLINT, dictionary.encoding, Map.empty)
+
+    override def apply(i: Int, value: AnyRef): Unit = {
+      if (vector.getLastSet >= i) {
+        vector.setLastSet(i - 1)
+      }
+      val start = vector.startNewValue(i)
+      // note: null gets converted to empty list
+      if (value == null) {
+        vector.endValue(i, 0)
+      } else {
+        val list = value.asInstanceOf[java.util.List[AnyRef]]
+        var offset = 0
+        while (offset < list.size()) {
+          // note: nulls get encoded in the dictionary
+          inner.setSafe(start + offset, dictionary.index(list.get(offset)).toShort)
+          offset += 1
+        }
+        vector.endValue(i, offset)
+      }
+    }
+  }
+
+  /**
+   * Converts a value into a dictionary encoded int and writes it
+   *
+   * @param name attribute/field name
+   * @param dictionary dictionary values
+   * @param metadata field metadata
+   * @param factory vector factory
+   */
   class ArrowDictionaryIntWriter(
       name: String,
       val dictionary: ArrowDictionary,
@@ -314,11 +412,50 @@ object ArrowAttributeWriter {
       factory: VectorFactory
     ) extends ArrowDictionaryWriter {
 
-    override val vector: IntVector =
-      factory.apply(name, new FieldType(true, MinorType.INT.getType, dictionary.encoding, metadata.asJava))
+    override val vector: IntVector = factory.apply(name, MinorType.INT, dictionary.encoding, metadata)
 
     // note: nulls get encoded in the dictionary
     override def apply(i: Int, value: AnyRef): Unit = vector.setSafe(i, dictionary.index(value))
+  }
+
+  /**
+   * Converts a list value into a list of dictionary ints and writes it
+   *
+   * @param name attribute/field name
+   * @param dictionary dictionary values
+   * @param metadata field metadata
+   * @param factory vector factory
+   */
+  class ArrowListDictionaryIntWriter(
+      name: String,
+      val dictionary: ArrowDictionary,
+      metadata: Map[String, String],
+      factory: VectorFactory
+    ) extends ArrowDictionaryWriter {
+
+    override val vector: ListVector = factory.apply(name, MinorType.LIST, metadata)
+
+    private val inner: IntVector = FromList(vector).apply(null, MinorType.INT, dictionary.encoding, Map.empty)
+
+    override def apply(i: Int, value: AnyRef): Unit = {
+      if (vector.getLastSet >= i) {
+        vector.setLastSet(i - 1)
+      }
+      val start = vector.startNewValue(i)
+      // note: null gets converted to empty list
+      if (value == null) {
+        vector.endValue(i, 0)
+      } else {
+        val list = value.asInstanceOf[java.util.List[AnyRef]]
+        var offset = 0
+        while (offset < list.size()) {
+          // note: nulls get encoded in the dictionary
+          inner.setSafe(start + offset, dictionary.index(list.get(offset)))
+          offset += 1
+        }
+        vector.endValue(i, offset)
+      }
+    }
   }
 
   /**
@@ -538,6 +675,9 @@ object ArrowAttributeWriter {
       ArrowAttributeWriter(null, Seq(binding), None, Map.empty[String, String], encoding, FromList(vector))
 
     override def apply(i: Int, value: AnyRef): Unit = {
+      if (vector.getLastSet >= i) {
+        vector.setLastSet(i - 1)
+      }
       val start = vector.startNewValue(i)
       // note: null gets converted to empty list
       if (value == null) {

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowDictionary.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/ArrowDictionary.scala
@@ -16,8 +16,8 @@ import org.apache.arrow.vector.dictionary.Dictionary
 import org.apache.arrow.vector.types.pojo.{ArrowType, DictionaryEncoding}
 import org.locationtech.geomesa.arrow.ArrowAllocator
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.io.CloseWithLogging
 import org.opengis.feature.`type`.AttributeDescriptor
 
@@ -161,7 +161,7 @@ object ArrowDictionary {
 
     override def toDictionary(precision: SimpleFeatureEncoding): Dictionary with Closeable = {
       val allocator = ArrowAllocator("dictionary-array")
-      val name = s"dictionary-${id}"
+      val name = s"dictionary-$id"
       val bindings = ObjectType.selectType(binding)
       val writer = ArrowAttributeWriter(name, bindings, None, Map.empty, precision, VectorFactory(allocator))
       var i = 0

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/package.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/vector/package.scala
@@ -11,7 +11,7 @@ package org.locationtech.geomesa.arrow
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.complex.{ListVector, StructVector}
 import org.apache.arrow.vector.types.Types.MinorType
-import org.apache.arrow.vector.types.pojo.FieldType
+import org.apache.arrow.vector.types.pojo.{DictionaryEncoding, FieldType}
 import org.apache.arrow.vector.{FieldVector, ZeroVector}
 
 package object vector {
@@ -33,7 +33,26 @@ package object vector {
      * @return
      */
     def apply[T <: FieldVector](name: String, minorType: MinorType, metadata: Map[String, String]): T =
-      apply(name, new FieldType(true, minorType.getType, null, if (metadata.isEmpty) { null } else { metadata.asJava }))
+      apply(name, minorType, null, metadata)
+
+    /**
+     * Create a vector based on a minor type
+     *
+     * @param name vector name
+     * @param minorType vector type
+     * @param encoding dictionary encoding
+     * @param metadata field metadata
+     * @tparam T vector type
+     * @return
+     */
+    def apply[T <: FieldVector](
+        name: String,
+        minorType: MinorType,
+        encoding: DictionaryEncoding,
+        metadata: Map[String, String]): T = {
+      val m = if (metadata.isEmpty) { null } else { metadata.asJava }
+      apply(name, new FieldType(true, minorType.getType, encoding, m))
+    }
 
     /**
      * Create a vector based on a field

--- a/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/io/DeltaWriterTest.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/io/DeltaWriterTest.scala
@@ -26,8 +26,11 @@ import scala.collection.mutable.ArrayBuffer
 @RunWith(classOf[JUnitRunner])
 class DeltaWriterTest extends Specification {
 
+  import scala.collection.JavaConverters._
+
   val sft = SimpleFeatureTypes.createType("test", "name:String,age:Int,dtg:Date,*geom:Point:srid=4326")
   val lineSft = SimpleFeatureTypes.createType("test", "name:String,team:String,age:Int,weight:Int,dtg:Date,*geom:LineString:srid=4326")
+  val listSft = SimpleFeatureTypes.createType("test", "names:List[String],age:Int,dtg:Date,*geom:Point:srid=4326")
 
   val features = (0 until 20).map { i =>
     ScalaSimpleFeature.create(sft, s"0$i", s"name0${i % 2}", s"${i % 5}", f"2017-03-15T00:$i%02d:00.000Z", s"POINT (4${i % 10} 5${i % 10})")
@@ -39,6 +42,11 @@ class DeltaWriterTest extends Specification {
     val weight = Option(i % 3).filter(_ != 0).map(Int.box).orNull
     val geom = s"LINESTRING(40 6$i, 40.1 6$i, 40.2 6$i, 40.3 6$i)"
     ScalaSimpleFeature.create(lineSft, s"$i", name, team, age, weight, s"2017-02-03T00:0$i:01.000Z", geom)
+  }
+  val listFeatures = (0 until 20).map { i =>
+    val names = Seq.tabulate(i / 3)(j => s"name0$j").asJava
+    val dtg = f"2017-03-15T00:$i%02d:00.000Z"
+    ScalaSimpleFeature.create(listSft, s"0$i", names, s"${i % 5}", dtg, s"POINT (4${i % 10} 5${i % 10})")
   }
 
   val ipcOpts = new IpcOption() // TODO test legacy opts
@@ -101,6 +109,34 @@ class DeltaWriterTest extends Specification {
         reader.dictionaries("age").iterator.toSeq must containTheSameElementsAs(0 until 5)
 
         WithClose(reader.features())(f => f.map(ScalaSimpleFeature.copy).toVector mustEqual features)
+      }
+    }
+    "dynamically encode list-type dictionary values with sorting" >> {
+      val dictionaries = Seq("names")
+      val encoding = SimpleFeatureEncoding.min(includeFids = true)
+      val sort = Some(("dtg", false))
+      val result = ArrayBuffer.empty[Array[Byte]]
+
+      WithClose(new DeltaWriter(listSft, dictionaries, encoding, ipcOpts, sort, 10)) { writer =>
+        result.append(writer.encode(listFeatures.drop(0).toArray, 3))
+        result.append(writer.encode(listFeatures.drop(3).toArray, 5))
+        result.append(writer.encode(listFeatures.drop(8).toArray, 2))
+      }
+      WithClose(new DeltaWriter(listSft, dictionaries, encoding, ipcOpts, sort, 10)) { writer =>
+        result.append(writer.encode(listFeatures.drop(15).toArray, 5))
+        result.append(writer.encode(listFeatures.drop(10).toArray, 5))
+      }
+
+      val bytes = WithClose(DeltaWriter.reduce(listSft, dictionaries, encoding, ipcOpts, sort, sorted = false, 5, result.iterator)) { iter =>
+        iter.foldLeft(Array.empty[Byte])(_ ++ _)
+      }
+
+      WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
+        reader.dictionaries must haveSize(1)
+        reader.dictionaries.get("names") must beSome
+        reader.dictionaries("names").iterator.toSeq must containTheSameElementsAs(Seq.tabulate(6)(i => s"name0$i"))
+
+        WithClose(reader.features())(f => f.map(ScalaSimpleFeature.copy).toVector mustEqual listFeatures)
       }
     }
     "work with line strings" >> {

--- a/geomesa-convert/geomesa-convert-avro/src/main/scala/org/locationtech/geomesa/convert/avro/AvroConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-avro/src/main/scala/org/locationtech/geomesa/convert/avro/AvroConverterFactory.scala
@@ -22,7 +22,7 @@ import org.locationtech.geomesa.convert2.TypeInference.{FunctionTransform, Infer
 import org.locationtech.geomesa.convert2.transforms.Expression
 import org.locationtech.geomesa.convert2.{AbstractConverterFactory, TypeInference}
 import org.locationtech.geomesa.features.avro._
-import org.locationtech.geomesa.features.serialization.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType
 import org.locationtech.geomesa.utils.io.WithClose
 import org.opengis.feature.simple.SimpleFeatureType
 import pureconfig.ConfigObjectCursor

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/AbstractConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/AbstractConverterFactory.scala
@@ -12,16 +12,16 @@ import java.lang.reflect.InvocationTargetException
 import java.nio.charset.Charset
 import java.util.Collections
 
-import com.typesafe.config.{Config, ConfigFactory, ConfigObject, ConfigUtil, ConfigValueFactory}
+import com.typesafe.config._
 import com.typesafe.scalalogging.{LazyLogging, Logger}
 import org.locationtech.geomesa.convert.Modes.{ErrorMode, ParseMode}
 import org.locationtech.geomesa.convert2.AbstractConverter.{BasicConfig, BasicField, BasicOptions}
 import org.locationtech.geomesa.convert2.AbstractConverterFactory.{ConverterConfigConvert, ConverterOptionsConvert, FieldConvert}
 import org.locationtech.geomesa.convert2.transforms.Expression
 import org.locationtech.geomesa.convert2.validators.{HasDtgValidatorFactory, HasGeoValidatorFactory}
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.opengis.feature.simple.SimpleFeatureType
 import pureconfig._
 import pureconfig.error.{CannotConvert, ConfigReaderFailures}

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/TypeInference.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/TypeInference.scala
@@ -11,12 +11,11 @@ package org.locationtech.geomesa.convert2
 import java.lang.{Boolean => jBoolean, Double => jDouble, Float => jFloat, Long => jLong}
 import java.util.{Date, Locale}
 
-import org.locationtech.jts.geom._
 import org.locationtech.geomesa.convert2.transforms.DateFunctionFactory.StandardDateParser
 import org.locationtech.geomesa.convert2.transforms.TransformerFunction
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.utils.geotools.{FeatureUtils, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.geotools.{FeatureUtils, ObjectType, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.text.{DateParsing, WKTUtils}
+import org.locationtech.jts.geom._
 import org.opengis.feature.simple.SimpleFeatureType
 
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}

--- a/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert2/TypeInferenceTest.scala
+++ b/geomesa-convert/geomesa-convert-common/src/test/scala/org/locationtech/geomesa/convert2/TypeInferenceTest.scala
@@ -20,7 +20,7 @@ import org.specs2.runner.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class TypeInferenceTest extends Specification with LazyLogging {
 
-  import org.locationtech.geomesa.features.serialization.ObjectType._
+  import org.locationtech.geomesa.utils.geotools.ObjectType._
 
   val uuidString = "28a12c18-e5ae-4c04-ae7b-bf7cdbfaf234"
   val uuid = java.util.UUID.fromString(uuidString)

--- a/geomesa-convert/geomesa-convert-json/src/main/scala/org/locationtech/geomesa/convert/json/JsonConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-json/src/main/scala/org/locationtech/geomesa/convert/json/JsonConverterFactory.scala
@@ -23,9 +23,8 @@ import org.locationtech.geomesa.convert2.AbstractConverterFactory.{BasicOptionsC
 import org.locationtech.geomesa.convert2.TypeInference.{IdentityTransform, InferredType}
 import org.locationtech.geomesa.convert2.transforms.Expression
 import org.locationtech.geomesa.convert2.{AbstractConverterFactory, TypeInference}
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
-import org.locationtech.geomesa.utils.geotools.FeatureUtils
+import org.locationtech.geomesa.utils.geotools.{FeatureUtils, ObjectType}
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.opengis.feature.simple.SimpleFeatureType
 import pureconfig.ConfigObjectCursor
 import pureconfig.error.{CannotConvert, ConfigReaderFailures}

--- a/geomesa-convert/geomesa-convert-parquet/src/main/scala/org/locationtech/geomesa/convert/parquet/ParquetConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-parquet/src/main/scala/org/locationtech/geomesa/convert/parquet/ParquetConverterFactory.scala
@@ -23,8 +23,8 @@ import org.locationtech.geomesa.convert2.AbstractConverterFactory.{BasicConfigCo
 import org.locationtech.geomesa.convert2.TypeInference.{FunctionTransform, InferredType}
 import org.locationtech.geomesa.convert2.transforms.Expression
 import org.locationtech.geomesa.convert2.{AbstractConverterFactory, TypeInference}
-import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.parquet.io.SimpleFeatureParquetSchema
+import org.locationtech.geomesa.utils.geotools.ObjectType
 import org.locationtech.geomesa.utils.io.PathUtils
 import org.opengis.feature.simple.SimpleFeatureType
 

--- a/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterFactory.scala
@@ -24,8 +24,7 @@ import org.locationtech.geomesa.convert2.transforms.Expression
 import org.locationtech.geomesa.convert2.transforms.Expression.{LiteralNull, TryExpression}
 import org.locationtech.geomesa.convert2.validators.SimpleFeatureValidator
 import org.locationtech.geomesa.convert2.{AbstractConverterFactory, TypeInference}
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.{ObjectType, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.io.WithClose
 import org.opengis.feature.simple.SimpleFeatureType
 import pureconfig.error.ConfigReaderFailures

--- a/geomesa-features/geomesa-feature-avro/src/main/scala/org/locationtech/geomesa/features/avro/FeatureSpecificReader.scala
+++ b/geomesa-features/geomesa-feature-avro/src/main/scala/org/locationtech/geomesa/features/avro/FeatureSpecificReader.scala
@@ -18,7 +18,7 @@ import org.locationtech.geomesa.features.avro.FeatureSpecificReader.AttributeRea
 import org.locationtech.geomesa.features.avro.serde.{ASFDeserializer, Version1Deserializer, Version2Deserializer}
 // noinspection ScalaDeprecation
 import org.locationtech.geomesa.features.avro.serialization.{AvroUserDataSerialization, AvroUserDataSerializationV4}
-import org.locationtech.geomesa.features.serialization.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 /**

--- a/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/serialization/GeoJsonSerializer.scala
+++ b/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/serialization/GeoJsonSerializer.scala
@@ -13,7 +13,7 @@ import java.util.{Base64, Date, UUID}
 
 import com.google.gson.stream.JsonWriter
 import com.typesafe.scalalogging.LazyLogging
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.text.DateParsing
 import org.locationtech.jts.geom.Geometry
@@ -87,6 +87,8 @@ class GeoJsonSerializer(sft: SimpleFeatureType) extends LazyLogging {
 }
 
 object GeoJsonSerializer extends LazyLogging {
+
+  import org.locationtech.geomesa.utils.geotools.ObjectType
 
   private val geometryWriter = {
     val writer = new org.locationtech.jts.io.geojson.GeoJsonWriter()

--- a/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/serialization/GeoJsonSerializer.scala
+++ b/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/serialization/GeoJsonSerializer.scala
@@ -13,7 +13,6 @@ import java.util.{Base64, Date, UUID}
 
 import com.google.gson.stream.JsonWriter
 import com.typesafe.scalalogging.LazyLogging
-import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.text.DateParsing
 import org.locationtech.jts.geom.Geometry
@@ -89,6 +88,7 @@ class GeoJsonSerializer(sft: SimpleFeatureType) extends LazyLogging {
 object GeoJsonSerializer extends LazyLogging {
 
   import org.locationtech.geomesa.utils.geotools.ObjectType
+  import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 
   private val geometryWriter = {
     val writer = new org.locationtech.jts.io.geojson.GeoJsonWriter()

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserialization.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserialization.scala
@@ -18,9 +18,9 @@ import org.locationtech.geomesa.features.SimpleFeatureSerializer
 import org.locationtech.geomesa.features.kryo.impl.KryoFeatureDeserialization.KryoAttributeReader
 import org.locationtech.geomesa.features.kryo.json.KryoJsonSerialization
 import org.locationtech.geomesa.features.kryo.serialization.KryoGeometrySerialization
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.cache.{CacheKeyGenerator, SoftThreadLocal, ThreadLocalCache}
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.kryo.NonMutatingInput
 import org.locationtech.jts.geom.Geometry
 import org.opengis.feature.`type`.AttributeDescriptor

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserializationV2.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureDeserializationV2.scala
@@ -17,9 +17,9 @@ import com.typesafe.scalalogging.LazyLogging
 import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer.NullByte
 import org.locationtech.geomesa.features.kryo.json.KryoJsonSerialization
 import org.locationtech.geomesa.features.kryo.serialization.KryoGeometrySerialization
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.cache.ThreadLocalCache
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType
 

--- a/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureSerialization.scala
+++ b/geomesa-features/geomesa-feature-kryo/src/main/scala/org/locationtech/geomesa/features/kryo/impl/KryoFeatureSerialization.scala
@@ -17,11 +17,11 @@ import com.typesafe.scalalogging.LazyLogging
 import org.locationtech.geomesa.features.SimpleFeatureSerializer
 import org.locationtech.geomesa.features.kryo.json.KryoJsonSerialization
 import org.locationtech.geomesa.features.kryo.serialization.{KryoGeometrySerialization, KryoUserDataSerialization}
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.cache.{CacheKeyGenerator, SoftThreadLocal, ThreadLocalCache}
 import org.locationtech.geomesa.utils.collection.IntBitSet
 import org.locationtech.geomesa.utils.geometry.GeometryPrecision
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.jts.geom.Geometry
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/OrcFileSystemReader.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/OrcFileSystemReader.scala
@@ -12,12 +12,12 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.orc.storage.ql.io.sarg.SearchArgument
 import org.apache.orc.{OrcFile, Reader}
-import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.features.{ScalaSimpleFeature, TransformSimpleFeature}
 import org.locationtech.geomesa.filter.FilterHelper
 import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage.FileSystemPathReader
 import org.locationtech.geomesa.fs.storage.orc.utils.{OrcAttributeReader, OrcSearchArguments}
 import org.locationtech.geomesa.utils.collection.CloseableIterator
+import org.locationtech.geomesa.utils.geotools.ObjectType
 import org.locationtech.geomesa.utils.geotools.Transform.Transforms
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/OrcFileSystemStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/OrcFileSystemStorage.scala
@@ -11,14 +11,14 @@ package org.locationtech.geomesa.fs.storage.orc
 
 import org.apache.hadoop.fs.Path
 import org.apache.orc.TypeDescription
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.filter.factory.FastFilterFactory
 import org.locationtech.geomesa.fs.storage.api.FileSystemStorage.FileSystemWriter
 import org.locationtech.geomesa.fs.storage.api._
 import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage
 import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage.FileSystemPathReader
 import org.locationtech.geomesa.fs.storage.common.observer.FileSystemObserver
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.jts.geom.Geometry
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/utils/OrcAttributeReader.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/utils/OrcAttributeReader.scala
@@ -13,9 +13,9 @@ import java.util.UUID
 import org.apache.orc.storage.ql.exec.vector._
 import org.geotools.filter.identity.FeatureIdImpl
 import org.geotools.geometry.jts.JTSFactoryFinder
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.fs.storage.orc.OrcFileSystemStorage
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.text.WKBUtils
 import org.locationtech.jts.geom._
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/utils/OrcAttributeWriter.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/utils/OrcAttributeWriter.scala
@@ -12,9 +12,9 @@ import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import org.apache.orc.storage.ql.exec.vector._
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.fs.storage.orc.OrcFileSystemStorage
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.text.WKBUtils
 import org.locationtech.jts.geom._
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/utils/OrcInputFormatReader.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/utils/OrcInputFormatReader.scala
@@ -10,15 +10,15 @@ package org.locationtech.geomesa.fs.storage.orc.utils
 
 import java.util.UUID
 
-import org.locationtech.jts.geom.{Coordinate, LineString, LinearRing, Polygon}
 import org.apache.hadoop.io._
 import org.apache.orc.mapred.{OrcList, OrcMap, OrcStruct, OrcTimestamp}
 import org.geotools.filter.identity.FeatureIdImpl
 import org.geotools.geometry.jts.JTSFactoryFinder
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.fs.storage.orc.OrcFileSystemStorage
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.text.WKBUtils
+import org.locationtech.jts.geom.{Coordinate, LineString, LinearRing, Polygon}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 trait OrcInputFormatReader {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/utils/OrcOutputFormatWriter.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/main/scala/org/locationtech/geomesa/fs/storage/orc/utils/OrcOutputFormatWriter.scala
@@ -14,9 +14,9 @@ import java.util.UUID
 import org.apache.hadoop.io._
 import org.apache.orc.TypeDescription
 import org.apache.orc.mapred.{OrcList, OrcMap, OrcStruct, OrcTimestamp}
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.fs.storage.orc.OrcFileSystemStorage
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.text.WKBUtils
 import org.locationtech.jts.geom._
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/FilterConverter.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/FilterConverter.scala
@@ -11,11 +11,10 @@ package org.locationtech.geomesa.parquet
 import org.apache.parquet.filter2.predicate.Operators._
 import org.apache.parquet.filter2.predicate.{FilterApi, FilterPredicate}
 import org.apache.parquet.io.api.Binary
-import org.locationtech.geomesa.features.serialization.ObjectType
 import org.locationtech.geomesa.filter.FilterHelper
 import org.locationtech.geomesa.filter.visitor.FilterExtractingVisitor
 import org.locationtech.geomesa.index.strategies.SpatialFilterStrategy
-import org.locationtech.geomesa.utils.geotools.GeometryUtils
+import org.locationtech.geomesa.utils.geotools.{GeometryUtils, ObjectType}
 import org.locationtech.geomesa.utils.text.StringSerialization
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/io/SimpleFeatureParquetSchema.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/io/SimpleFeatureParquetSchema.scala
@@ -16,11 +16,10 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.apache.parquet.schema.Type.Repetition
 import org.apache.parquet.schema.Types.BasePrimitiveBuilder
 import org.apache.parquet.schema._
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.features.serialization.TwkbSerialization.GeometryBytes
 import org.locationtech.geomesa.fs.storage.common.jobs.StorageConfiguration
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
+import org.locationtech.geomesa.utils.geotools.{ObjectType, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.text.StringSerialization
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/io/SimpleFeatureParquetSchemaV0.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/io/SimpleFeatureParquetSchemaV0.scala
@@ -11,8 +11,8 @@ package org.locationtech.geomesa.parquet.io
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.apache.parquet.schema.Type.Repetition
 import org.apache.parquet.schema.{MessageType, OriginalType, Type, Types}
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/io/SimpleFeatureReadSupport.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/io/SimpleFeatureReadSupport.scala
@@ -19,9 +19,9 @@ import org.apache.parquet.io.api._
 import org.apache.parquet.schema.MessageType
 import org.geotools.geometry.jts.JTSFactoryFinder
 import org.locationtech.geomesa.features.ScalaSimpleFeature
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.parquet.io.SimpleFeatureReadSupport.SimpleFeatureRecordMaterializer
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.text.WKBUtils
 import org.locationtech.jts.geom.Coordinate
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/io/SimpleFeatureWriteSupport.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/io/SimpleFeatureWriteSupport.scala
@@ -15,8 +15,8 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.hadoop.api.WriteSupport
 import org.apache.parquet.hadoop.api.WriteSupport.WriteContext
 import org.apache.parquet.io.api.{Binary, RecordConsumer}
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.text.WKBUtils
 import org.locationtech.jts.geom._
 import org.opengis.feature.`type`.AttributeDescriptor

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/attribute/AttributeIndexKey.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/attribute/AttributeIndexKey.scala
@@ -12,7 +12,7 @@ import java.sql.Timestamp
 
 import org.calrissian.mango.types.encoders.lexi.LongEncoder
 import org.calrissian.mango.types.{LexiTypeEncoders, TypeEncoder, TypeRegistry}
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureOrdering
+import org.locationtech.geomesa.utils.geotools.AttributeOrdering
 import org.locationtech.geomesa.utils.geotools.converters.FastConverter
 import org.locationtech.geomesa.utils.index.ByteArrays
 import org.opengis.feature.`type`.AttributeDescriptor
@@ -24,7 +24,7 @@ case class AttributeIndexKey(i: Short, value: String, inclusive: Boolean = true)
     val indexOrder = Ordering.Short.compare(i, that.i)
     if (indexOrder != 0) { indexOrder } else {
       // if i is the same, then value must be of the same type
-      val valueOrder = SimpleFeatureOrdering.nullCompare(value.asInstanceOf[Comparable[Any]], that.value)
+      val valueOrder = AttributeOrdering.StringOrdering.compare(value, that.value)
       if (valueOrder != 0) { valueOrder } else {
         Ordering.Boolean.compare(inclusive, that.inclusive)
       }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/iterators/ArrowScan.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/iterators/ArrowScan.scala
@@ -13,8 +13,8 @@ import java.util.Objects
 
 import org.apache.arrow.vector.ipc.message.IpcOption
 import org.geotools.util.factory.Hints
-import org.locationtech.geomesa.arrow.io.records.RecordBatchUnloader
 import org.locationtech.geomesa.arrow.io._
+import org.locationtech.geomesa.arrow.io.records.RecordBatchUnloader
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding.Encoding
 import org.locationtech.geomesa.arrow.vector.{ArrowDictionary, SimpleFeatureVector}
@@ -26,7 +26,7 @@ import org.locationtech.geomesa.index.iterators.ArrowScan._
 import org.locationtech.geomesa.index.stats.GeoMesaStats
 import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
-import org.locationtech.geomesa.utils.geotools.{GeometryUtils, SimpleFeatureOrdering, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.geotools._
 import org.locationtech.geomesa.utils.io.CloseWithLogging
 import org.locationtech.geomesa.utils.stats.{EnumerationStat, Stat, TopK}
 import org.locationtech.geomesa.utils.text.StringSerialization
@@ -81,6 +81,9 @@ trait ArrowScan extends AggregatingScan[ArrowAggregate] {
 object ArrowScan {
 
   import org.locationtech.geomesa.index.conf.QueryHints.RichHints
+  import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
+
+  import scala.collection.JavaConverters._
 
   object Configuration {
 
@@ -103,11 +106,6 @@ object ArrowScan {
   }
 
   val DictionaryTopK: SystemProperty = SystemProperty("geomesa.arrow.dictionary.top", "1000")
-
-  val DictionaryOrdering: Ordering[AnyRef] = new Ordering[AnyRef] {
-    override def compare(x: AnyRef, y: AnyRef): Int =
-      SimpleFeatureOrdering.nullCompare(x.asInstanceOf[Comparable[Any]], y)
-  }
 
   /**
     * Configure the iterator
@@ -203,21 +201,28 @@ object ArrowScan {
     * @param provided provided dictionary values, if any, keyed by attribute name
     * @return
     */
-  def createDictionaries(stats: GeoMesaStats,
-                         sft: SimpleFeatureType,
-                         filter: Option[Filter],
-                         attributes: Seq[String],
-                         provided: Map[String, Array[AnyRef]],
-                         cached: Map[String, TopK[AnyRef]]): Map[String, ArrowDictionary] = {
-    def sort(values: Array[AnyRef]): Unit = java.util.Arrays.sort(values, DictionaryOrdering)
+  def createDictionaries(
+      stats: GeoMesaStats,
+      sft: SimpleFeatureType,
+      filter: Option[Filter],
+      attributes: Seq[String],
+      provided: Map[String, Array[AnyRef]],
+      cached: Map[String, TopK[AnyRef]]): Map[String, ArrowDictionary] = {
 
     if (attributes.isEmpty) { Map.empty } else {
       var id = -1L
       // note: sort values to return same dictionary cache
       val providedDictionaries = provided.map { case (k, v) =>
         id += 1
-        sort(v)
-        k -> ArrowDictionary.create(id, v)(ClassTag[AnyRef](sft.getDescriptor(k).getType.getBinding))
+        val descriptor = sft.getDescriptor(k)
+        val bindings = ObjectType.selectType(descriptor)
+        val (binding, order) = if (descriptor.isList) {
+          (descriptor.getListType(), AttributeOrdering(bindings.tail))
+        } else {
+          (descriptor.getType.getBinding, AttributeOrdering(bindings))
+        }
+        java.util.Arrays.sort(v, order)
+        k -> ArrowDictionary.create(id, v)(ClassTag[AnyRef](binding))
       }
       val toLookup = attributes.filterNot(provided.contains)
       if (toLookup.isEmpty) { providedDictionaries } else {
@@ -225,9 +230,18 @@ object ArrowScan {
         val queried = if (toLookup.forall(cached.contains)) {
           cached.map { case (name, k) =>
             id += 1
-            val values = k.topK(DictionaryTopK.get.toInt).map(_._1).toArray
-            sort(values)
-            name -> ArrowDictionary.create(id, values)(ClassTag[AnyRef](sft.getDescriptor(name).getType.getBinding))
+            val descriptor = sft.getDescriptor(name)
+            val bindings = ObjectType.selectType(descriptor)
+            val (values, binding, order) = if (descriptor.isList) {
+              val lists = k.topK(DictionaryTopK.get.toInt).asInstanceOf[Iterator[(java.util.List[AnyRef], Long)]]
+              val values = lists.flatMap(_._1.asScala).toArray
+              (values, descriptor.getListType(), AttributeOrdering(bindings.tail))
+            } else {
+              val values = k.topK(DictionaryTopK.get.toInt).map(_._1).toArray
+              (values, descriptor.getType.getBinding, AttributeOrdering(bindings))
+            }
+            java.util.Arrays.sort(values, order)
+            name -> ArrowDictionary.create(id, values)(ClassTag[AnyRef](binding))
           }
         } else {
           // if we have to run a query, might as well generate all values
@@ -241,9 +255,17 @@ object ArrowScan {
           enumerations.map { e =>
             id += 1
             val name = nameIter.next
-            val values = e.values.toArray[AnyRef]
-            sort(values)
-            name -> ArrowDictionary.create(id, values)(ClassTag[AnyRef](sft.getDescriptor(name).getType.getBinding))
+            val descriptor = sft.getDescriptor(name)
+            val bindings = ObjectType.selectType(descriptor)
+            val (values, binding, order) = if (descriptor.isList) {
+              val values = e.values.flatMap(_.asInstanceOf[java.util.List[AnyRef]].asScala).toArray[AnyRef]
+              (values, descriptor.getListType(), AttributeOrdering(bindings.tail))
+            } else {
+              val values = e.values.toArray[AnyRef]
+              (values, descriptor.getType.getBinding, AttributeOrdering(bindings))
+            }
+            java.util.Arrays.sort(values, order)
+            name -> ArrowDictionary.create(id, values)(ClassTag[AnyRef](binding))
           }.toMap
         }
         queried ++ providedDictionaries
@@ -352,10 +374,7 @@ object ArrowScan {
     private var writer: DictionaryBuildingWriter = _
     private val os = new ByteArrayOutputStream()
 
-    private val ordering = {
-      val o = SimpleFeatureOrdering(sft.indexOf(sortBy))
-      if (reverse) { o.reverse } else { o }
-    }
+    private val ordering = SimpleFeatureOrdering(sft, sortBy, reverse)
 
     override def init(): Unit = {
       writer = new DictionaryBuildingWriter(sft, dictionaryFields, encoding, ipcOpts)
@@ -525,10 +544,7 @@ object ArrowScan {
 
     private var index = 0
 
-    private val ordering = {
-      val o = SimpleFeatureOrdering(sft.indexOf(sortField))
-      if (reverse) { o.reverse } else { o }
-    }
+    private val ordering = SimpleFeatureOrdering(sft, sortField, reverse)
 
     override def init(): Unit = {
       vector = SimpleFeatureVector.create(sft, dictionaries, encoding)

--- a/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/schema/KuduColumnAdapter.scala
+++ b/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/schema/KuduColumnAdapter.scala
@@ -19,12 +19,11 @@ import org.apache.kudu.{ColumnSchema, Type}
 import org.geotools.geometry.jts.JTSFactoryFinder
 import org.locationtech.geomesa.features.kryo.impl.{KryoFeatureDeserialization, KryoFeatureSerialization}
 import org.locationtech.geomesa.features.kryo.serialization.KryoGeometrySerialization
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.filter.{Bounds, FilterHelper}
 import org.locationtech.geomesa.kudu.schema.KuduSimpleFeatureSchema.KuduFilter
 import org.locationtech.geomesa.kudu.utils.ColumnConfiguration
-import org.locationtech.geomesa.utils.geotools.GeometryUtils
+import org.locationtech.geomesa.utils.geotools.{GeometryUtils, ObjectType}
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.jts.geom.{Coordinate, Geometry, Point}
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType

--- a/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/utils/ColumnConfiguration.scala
+++ b/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/utils/ColumnConfiguration.scala
@@ -10,9 +10,9 @@ package org.locationtech.geomesa.kudu.utils
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kudu.ColumnSchema.{ColumnSchemaBuilder, CompressionAlgorithm, Encoding}
-import org.locationtech.geomesa.features.serialization.ObjectType
-import org.locationtech.geomesa.features.serialization.ObjectType.ObjectType
 import org.locationtech.geomesa.kudu.KuduSystemProperties
+import org.locationtech.geomesa.utils.geotools.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 
 /**
   * Configures a column before building. Currently supports encoding and compression

--- a/geomesa-kudu/geomesa-kudu-datastore/src/test/scala/org/locationtech/geomesa/kudu/utils/ColumnConfigurationTest.scala
+++ b/geomesa-kudu/geomesa-kudu-datastore/src/test/scala/org/locationtech/geomesa/kudu/utils/ColumnConfigurationTest.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.kudu.utils
 
 import org.apache.kudu.ColumnSchema.{CompressionAlgorithm, Encoding}
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.features.serialization.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType
 import org.locationtech.geomesa.kudu.KuduSystemProperties
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.specs2.mock.Mockito

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/transform/ArrowConversionProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/transform/ArrowConversionProcess.scala
@@ -252,10 +252,7 @@ object ArrowConversionProcess {
       }
 
       val ordering = if (preSorted) { None } else {
-        sort.map { case (field, reverse) =>
-          val o = SimpleFeatureOrdering(sft.indexOf(field))
-          if (reverse) { o.reverse } else { o }
-        }
+        sort.map { case (field, reverse) => SimpleFeatureOrdering(sft, field, reverse) }
       }
       val sorted = ordering match {
         case None    => features.iterator

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/SparkUtils.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/SparkUtils.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.types.{DataTypes, StructField, StructType, Timestamp
 import org.geotools.factory.CommonFactoryFinder
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.locationtech.geomesa.features.ScalaSimpleFeature
-import org.locationtech.geomesa.features.serialization.ObjectType
+import org.locationtech.geomesa.utils.geotools.ObjectType
 import org.locationtech.geomesa.utils.uuid.TimeSortedUuidGenerator
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/AttributeOrdering.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/AttributeOrdering.scala
@@ -1,0 +1,147 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.geotools
+
+import java.util.{Date, UUID}
+
+import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
+import org.locationtech.jts.geom.Geometry
+import org.opengis.feature.`type`.AttributeDescriptor
+
+import scala.math.Ordering
+
+/**
+ * Ordering of simple feature attributes
+ */
+object AttributeOrdering {
+
+  /**
+   * An ordering for a particular attribute. Note that although the signature is AnyRef for ease of use
+   * with the simple feature API, the actual values being sorted must correspond to the type of the attribute
+   *
+   * @param descriptor descriptor
+   * @return
+   */
+  def apply(descriptor: AttributeDescriptor): Ordering[AnyRef] = apply(ObjectType.selectType(descriptor))
+
+  /**
+   * An ordering for a particular attribute. Note that although the signature is AnyRef for ease of use
+   * with the simple feature API, the actual values being sorted must correspond to the type of the attribute
+   *
+   * @param bindings type bindings
+   * @return
+   */
+  def apply(bindings: Seq[ObjectType]): Ordering[AnyRef] = {
+    val ordering = bindings.head match {
+      case ObjectType.STRING   => StringOrdering
+      case ObjectType.INT      => IntOrdering
+      case ObjectType.LONG     => LongOrdering
+      case ObjectType.FLOAT    => FloatOrdering
+      case ObjectType.DOUBLE   => DoubleOrdering
+      case ObjectType.BOOLEAN  => BooleanOrdering
+      case ObjectType.DATE     => DateOrdering
+      case ObjectType.UUID     => UuidOrdering
+      case ObjectType.GEOMETRY => GeometryOrdering
+      case ObjectType.BYTES    => BytesOrdering
+      case ObjectType.LIST     => list(bindings.last)
+      case ObjectType.MAP      => throw new NotImplementedError("Ordering for Map-type attributes is not supported")
+      case b                   => throw new NotImplementedError(s"Unexpected attribute type: $b")
+    }
+    ordering.asInstanceOf[Ordering[AnyRef]]
+  }
+
+  private def list(binding: ObjectType): Ordering[AnyRef] = {
+    val ordering = binding match {
+      case ObjectType.STRING   => StringListOrdering
+      case ObjectType.INT      => IntListOrdering
+      case ObjectType.LONG     => LongListOrdering
+      case ObjectType.FLOAT    => FloatListOrdering
+      case ObjectType.DOUBLE   => DoubleListOrdering
+      case ObjectType.BOOLEAN  => BooleanListOrdering
+      case ObjectType.DATE     => DateListOrdering
+      case ObjectType.UUID     => UuidListOrdering
+      case ObjectType.GEOMETRY => GeometryListOrdering
+      case ObjectType.BYTES    => BytesListOrdering
+      case b                   => throw new NotImplementedError(s"Unexpected attribute type: List[$b]")
+    }
+    ordering.asInstanceOf[Ordering[AnyRef]]
+  }
+
+  val StringOrdering   : Ordering[String]            = new NullOrdering(Ordering.String)
+  val IntOrdering      : Ordering[Integer]           = new NullOrdering(Ordering.ordered[Integer])
+  val LongOrdering     : Ordering[java.lang.Long]    = new NullOrdering(Ordering.ordered[java.lang.Long])
+  val FloatOrdering    : Ordering[java.lang.Float]   = new NullOrdering(Ordering.ordered[java.lang.Float])
+  val DoubleOrdering   : Ordering[java.lang.Double]  = new NullOrdering(Ordering.ordered[java.lang.Double])
+  val BooleanOrdering  : Ordering[java.lang.Boolean] = new NullOrdering(Ordering.ordered[java.lang.Boolean])
+  val DateOrdering     : Ordering[Date]              = new NullOrdering(Ordering.ordered[Date])
+  val UuidOrdering     : Ordering[UUID]              = new NullOrdering(Ordering.ordered[UUID])
+  val GeometryOrdering : Ordering[Geometry]          = new NullOrdering(new GeometryOrdering())
+  val BytesOrdering    : Ordering[Array[Byte]]       = new NullOrdering(new BytesOrdering())
+
+  val StringListOrdering   : Ordering[java.util.List[String]]            = ListOrdering(StringOrdering)
+  val IntListOrdering      : Ordering[java.util.List[Integer]]           = ListOrdering(IntOrdering)
+  val LongListOrdering     : Ordering[java.util.List[java.lang.Long]]    = ListOrdering(LongOrdering)
+  val FloatListOrdering    : Ordering[java.util.List[java.lang.Float]]   = ListOrdering(FloatOrdering)
+  val DoubleListOrdering   : Ordering[java.util.List[java.lang.Double]]  = ListOrdering(DoubleOrdering)
+  val BooleanListOrdering  : Ordering[java.util.List[java.lang.Boolean]] = ListOrdering(BooleanOrdering)
+  val DateListOrdering     : Ordering[java.util.List[Date]]              = ListOrdering(DateOrdering)
+  val UuidListOrdering     : Ordering[java.util.List[UUID]]              = ListOrdering(UuidOrdering)
+  val GeometryListOrdering : Ordering[java.util.List[Geometry]]          = ListOrdering(GeometryOrdering)
+  val BytesListOrdering    : Ordering[java.util.List[Array[Byte]]]       = ListOrdering(BytesOrdering)
+
+  private class GeometryOrdering extends Ordering[Geometry] {
+    override def compare(x: Geometry, y: Geometry): Int = x.compareTo(y)
+  }
+
+  private class BytesOrdering extends Ordering[Array[Byte]] {
+    override def compare(x: Array[Byte], y: Array[Byte]): Int = {
+      val len = math.min(x.length, y.length)
+      var i = 0
+      while (i < len) {
+        val res = java.lang.Byte.compare(x(i), y(i))
+        if (res != 0) {
+          return res
+        }
+        i += 1
+      }
+      Integer.compare(x.length, y.length)
+    }
+  }
+
+  private object ListOrdering {
+    def apply[T](delegate: Ordering[T]): Ordering[java.util.List[T]] = new NullOrdering(new ListOrdering(delegate))
+  }
+
+  private class ListOrdering[T](delegate: Ordering[T]) extends Ordering[java.util.List[T]] {
+    override def compare(x: java.util.List[T], y: java.util.List[T]): Int = {
+      val len = math.min(x.size, y.size)
+      var i = 0
+      while (i < len) {
+        val res = delegate.compare(x.get(i), y.get(i))
+        if (res != 0) {
+          return res
+        }
+        i += 1
+      }
+      Integer.compare(x.size, y.size)
+    }
+  }
+
+  private class NullOrdering[T](delegate: Ordering[T]) extends Ordering[T] {
+    override def compare(x: T, y: T): Int = {
+      if (x == null) {
+        if (y == null) { 0 } else { -1 }
+      } else if (y == null) {
+        1
+      } else {
+        delegate.compare(x, y)
+      }
+    }
+  }
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -168,11 +168,8 @@ object RichAttributeDescriptors extends Conversions {
 
     private def tryClass(value: AnyRef): Class[_] = Try(Class.forName(value.asInstanceOf[String])).getOrElse(null)
 
-    def isList: Boolean = ad.getUserData.containsKey(UserDataListType)
-
-    def isMap: Boolean =
-      ad.getUserData.containsKey(UserDataMapKeyType) && ad.getUserData.containsKey(UserDataMapValueType)
-
+    def isList: Boolean = classOf[java.util.List[_]].isAssignableFrom(ad.getType.getBinding)
+    def isMap: Boolean = classOf[java.util.Map[_, _]].isAssignableFrom(ad.getType.getBinding)
     def isMultiValued: Boolean = isList || isMap
 
     def getPrecision: GeometryPrecision = {
@@ -271,6 +268,8 @@ object RichSimpleFeatureType extends Conversions {
     @deprecated("table sharing no longer supported")
     def getTableSharingPrefix: String = userData[String](TableSharingPrefix).getOrElse("")
 
+    // noinspection ScalaDeprecation
+    @deprecated("table sharing no longer supported")
     def getTableSharingBytes: Array[Byte] = if (sft.isTableSharing) {
       sft.getTableSharingPrefix.getBytes(StandardCharsets.UTF_8)
     } else {

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/ObjectType.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/ObjectType.scala
@@ -6,16 +6,15 @@
  * http://www.opensource.org/licenses/apache2.0.php.
  ***********************************************************************/
 
-package org.locationtech.geomesa.features.serialization
+package org.locationtech.geomesa.utils.geotools
 
 import java.util.{UUID, Collections => jCollections, List => jList, Map => jMap}
 
-import org.locationtech.jts.geom._
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.AttributeConfigs.{UserDataListType, UserDataMapKeyType, UserDataMapValueType}
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.AttributeOptions._
+import org.locationtech.jts.geom._
 import org.opengis.feature.`type`.AttributeDescriptor
 
-@deprecated("Replaced with org.locationtech.geomesa.utils.geotools.ObjectType")
 object ObjectType extends Enumeration {
 
   type ObjectType = Value
@@ -29,30 +28,30 @@ object ObjectType extends Enumeration {
   val JSON = Value
 
   /**
-    * @see selectType(clazz: Class[_], metadata: java.util.Map[_, _])
-    *
-    * @param descriptor attribute descriptor
-    * @return
-    */
+   * @see selectType(clazz: Class[_], metadata: java.util.Map[_, _])
+   *
+   * @param descriptor attribute descriptor
+   * @return
+   */
   def selectType(descriptor: AttributeDescriptor): Seq[ObjectType] =
     selectType(descriptor.getType.getBinding, descriptor.getUserData)
 
   /**
-    * Turns a SimpleFeatureType attribute class binding into an enumeration.
-    *
-    * The first element in the result will be the primary binding. For geometries, lists and maps,
-    * the result will also contain secondary types.
-    *
-    * Lists will contain the type of the list elements.
-    * Maps will contain the type of the map keys, then the type of the map values.
-    * Geometries will contain the specific geometry type.
-    *
-    * Note: geometries will always return GEOMETRY as the primary type to allow for generic matching.
-    *
-    * @param clazz class, must be valid for a SimpleFeatureType attribute
-    * @param metadata attribute metadata (user data)
-    * @return binding
-    */
+   * Turns a SimpleFeatureType attribute class binding into an enumeration.
+   *
+   * The first element in the result will be the primary binding. For geometries, lists and maps,
+   * the result will also contain secondary types.
+   *
+   * Lists will contain the type of the list elements.
+   * Maps will contain the type of the map keys, then the type of the map values.
+   * Geometries will contain the specific geometry type.
+   *
+   * Note: geometries will always return GEOMETRY as the primary type to allow for generic matching.
+   *
+   * @param clazz class, must be valid for a SimpleFeatureType attribute
+   * @param metadata attribute metadata (user data)
+   * @return binding
+   */
   def selectType(clazz: Class[_], metadata: jMap[_, _] = jCollections.emptyMap()): Seq[ObjectType] = {
     clazz match {
       case c if classOf[java.lang.String].isAssignableFrom(c) =>

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureOrdering.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureOrdering.scala
@@ -10,17 +10,19 @@ package org.locationtech.geomesa.utils.geotools
 
 import org.locationtech.geomesa.utils.collection.TieredOrdering
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
-import org.opengis.filter.expression.PropertyName
 import org.opengis.filter.sort.{SortBy, SortOrder}
 
 import scala.math.Ordering
 
 /**
-  * Ordering for simple features. Assumes that any attributes implement `Comparable`
+  * Ordering for simple features
   */
 object SimpleFeatureOrdering {
 
-  private val cached = Array.tabulate(16)(new AttributeOrdering(_))
+  // noinspection ScalaDeprecation
+  private val ComparableOrdering = new Ordering[AnyRef] {
+    override def compare(x: AnyRef, y: AnyRef): Int = nullCompare(x.asInstanceOf[Comparable[Any]], y)
+  }
 
   /**
     * Sort on the ith attribute of a simple feature
@@ -28,46 +30,46 @@ object SimpleFeatureOrdering {
     * @param i attribute to sort on
     * @return
     */
-  def apply(i: Int): Ordering[SimpleFeature] =
-    if (i < cached.length) { cached(i) } else { new AttributeOrdering(i) }
+  @deprecated("Use attribute name, this method does not work for all attribute types")
+  def apply(i: Int): Ordering[SimpleFeature] = new SimpleFeatureOrdering(i, ComparableOrdering)
 
   /**
-    * Sort on an attribute by name. `null`, `"id"` or an empty string can be used to indicate
-    * 'natural' ordering by feature ID
-    *
-    * @param sft simple feature type
-    * @param sortBy attribute to sort by
-    * @return
-    */
+   * Sort on an attribute by name. `null`, `"id"` or an empty string can be used to indicate
+   * 'natural' ordering by feature ID
+   *
+   * @param sft simple feature type
+   * @param sortBy attribute to sort by
+   * @return
+   */
   def apply(sft: SimpleFeatureType, sortBy: String): Ordering[SimpleFeature] = apply(sft, sortBy, reverse = false)
 
   /**
-    * Sort on an attribute by name. `null`, `"id"` or an empty string can be used to indicate
-    * * 'natural' ordering by feature ID
-    *
-    * @param sft simple feature type
-    * @param sortBy attribute to sort by
-    * @param reverse reverse the sort (from ascending to descending)
-    * @return
-    */
+   * Sort on an attribute by name. `null`, `"id"` or an empty string can be used to indicate
+   * * 'natural' ordering by feature ID
+   *
+   * @param sft simple feature type
+   * @param sortBy attribute to sort by
+   * @param reverse reverse the sort (from ascending to descending)
+   * @return
+   */
   def apply(sft: SimpleFeatureType, sortBy: String, reverse: Boolean): Ordering[SimpleFeature] = {
-    val sort = if (sortBy == null || sortBy.isEmpty || sortBy.equalsIgnoreCase("id")) { fid } else {
+    val sort = if (sortBy == null || sortBy.isEmpty || sortBy.equalsIgnoreCase("id")) { FidOrdering } else {
       val i = sft.indexOf(sortBy)
       if (i == -1) {
         throw new IllegalArgumentException(s"Trying to sort by an attribute that is not in the schema: $sortBy")
       }
-      apply(i)
+      new SimpleFeatureOrdering(i, AttributeOrdering(sft.getDescriptor(i)))
     }
     if (reverse) { sort.reverse } else { sort }
   }
 
   /**
-    * Sort by multiple attributes by name
-    *
-    * @param sft simple feature type
-    * @param sortBy pairs of (attribute name, reverse ordering)
-    * @return
-    */
+   * Sort by multiple attributes by name
+   *
+   * @param sft simple feature type
+   * @param sortBy pairs of (attribute name, reverse ordering)
+   * @return
+   */
   def apply(sft: SimpleFeatureType, sortBy: Seq[(String, Boolean)]): Ordering[SimpleFeature] = {
     if (sortBy.lengthCompare(1) == 0) {
       apply(sft, sortBy.head._1, sortBy.head._2)
@@ -77,24 +79,24 @@ object SimpleFeatureOrdering {
   }
 
   /**
-    * Sort on a geotools SortBy instance
-    *
-    * @param sft simple feature type
-    * @param sortBy sort by
-    * @return
-    */
+   * Sort on a geotools SortBy instance
+   *
+   * @param sft simple feature type
+   * @param sortBy sort by
+   * @return
+   */
   def apply(sft: SimpleFeatureType, sortBy: SortBy): Ordering[SimpleFeature] = {
     val name = Option(sortBy.getPropertyName).map(_.getPropertyName).orNull
     apply(sft, name, sortBy.getSortOrder == SortOrder.DESCENDING)
   }
 
   /**
-    * Sort on a geotools SortBy array
-    *
-    * @param sft simple feature type
-    * @param sortBy sort by
-    * @return
-    */
+   * Sort on a geotools SortBy array
+   *
+   * @param sft simple feature type
+   * @param sortBy sort by
+   * @return
+   */
   def apply(sft: SimpleFeatureType, sortBy: Array[SortBy]): Ordering[SimpleFeature] = {
     if (sortBy.length == 1) {
       apply(sft, sortBy.head)
@@ -103,30 +105,15 @@ object SimpleFeatureOrdering {
     }
   }
 
-  /**
-    * Sort based on the feature ID ('natural' ordering)
-    *
-    * @return
-    */
-  def fid: Ordering[SimpleFeature] = Fid
+  def fid: Ordering[SimpleFeature] = FidOrdering
 
-  private object Fid extends Ordering[SimpleFeature] {
+  object FidOrdering extends Ordering[SimpleFeature] {
     override def compare(x: SimpleFeature, y: SimpleFeature): Int = x.getID.compareTo(y.getID)
   }
 
-  private class AttributeOrdering(i: Int) extends Ordering[SimpleFeature] {
+  private class SimpleFeatureOrdering(i: Int, delegate: Ordering[AnyRef]) extends Ordering[SimpleFeature] {
     override def compare(x: SimpleFeature, y: SimpleFeature): Int =
-      nullCompare(x.getAttribute(i).asInstanceOf[Comparable[Any]], y.getAttribute(i))
-  }
-
-  private class PropertyOrdering(property: PropertyName) extends Ordering[SimpleFeature] {
-    override def compare(x: SimpleFeature, y: SimpleFeature): Int =
-      nullCompare(property.evaluate(x).asInstanceOf[Comparable[Any]], property.evaluate(y))
-  }
-
-  private class UserDataOrdering(key: String) extends Ordering[SimpleFeature] {
-    override def compare(x: SimpleFeature, y: SimpleFeature): Int =
-      nullCompare(x.getUserData.get(key).asInstanceOf[Comparable[Any]], y.getUserData.get(key))
+      delegate.compare(x.getAttribute(i), y.getAttribute(i))
   }
 
   /**
@@ -136,6 +123,7 @@ object SimpleFeatureOrdering {
     * @param y right value
     * @return
     */
+  @deprecated
   def nullCompare(x: Comparable[Any], y: Any): Int = {
     if (x == null) {
       if (y == null) { 0 } else { -1 }

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureOrderingTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureOrderingTest.scala
@@ -13,27 +13,31 @@ import java.util.Date
 import org.geotools.feature.simple.SimpleFeatureImpl
 import org.geotools.filter.identity.FeatureIdImpl
 import org.junit.runner.RunWith
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
 import scala.util.Random
 
 @RunWith(classOf[JUnitRunner])
-class SimpleFeatureOrderingTest extends Specification with Mockito {
+class SimpleFeatureOrderingTest extends Specification {
 
-  val sft = SimpleFeatureTypes.createType("sort", "name:String,age:Int,opt:Int,dtg:Date,*geom:Point:srid=4326")
+  import scala.collection.JavaConverters._
+
+  val sft =
+    SimpleFeatureTypes.createType("sort",
+      "name:String,hobbies:List[String],age:Int,opt:Int,dtg:Date,*geom:Point:srid=4326")
 
   val features = new Random(-1L).shuffle {
     (0 until 10).map { i =>
-      val sf = new SimpleFeatureImpl(Array.ofDim[AnyRef](5), sft, new FeatureIdImpl(s"0$i"), false)
+      val sf = new SimpleFeatureImpl(Array.ofDim[AnyRef](6), sft, new FeatureIdImpl(s"0$i"), false)
       sf.setAttribute(0, s"name${i % 2}")
-      sf.setAttribute(1, Int.box(i + 20))
+      sf.setAttribute(1, Seq.tabulate(i % 5)(t => s"name$t$i").asJava)
+      sf.setAttribute(2, Int.box(i + 20))
       if (i % 2 != 0) {
-        sf.setAttribute(2, Int.box(i + 10))
+        sf.setAttribute(3, Int.box(i + 10))
       }
-      sf.setAttribute(3, f"2017-02-20T00:00:$i%02d.000Z")
-      sf.setAttribute(4, s"POINT(40 ${50 + i})")
+      sf.setAttribute(4, f"2017-02-20T00:00:$i%02d.000Z")
+      sf.setAttribute(5, s"POINT(40 ${50 + i})")
       sf
     }
   }
@@ -41,23 +45,28 @@ class SimpleFeatureOrderingTest extends Specification with Mockito {
   "SimpleFeatureOrdering" should {
 
     "sort by feature ID" >> {
-      features.sorted(SimpleFeatureOrdering.fid) mustEqual features.sortBy(_.getID)
+      features.sorted(SimpleFeatureOrdering.FidOrdering) mustEqual features.sortBy(_.getID)
     }
 
     "sort by string attributes" >> {
-      features.sorted(SimpleFeatureOrdering(0)) mustEqual features.sortBy(f => Option(f.getAttribute(0).asInstanceOf[String]))
+      features.sorted(SimpleFeatureOrdering(sft, "name")) mustEqual features.sortBy(f => Option(f.getAttribute(0).asInstanceOf[String]))
     }
 
     "sort by int attributes" >> {
-      features.sorted(SimpleFeatureOrdering(1)) mustEqual features.sortBy(_.getAttribute(1).asInstanceOf[Int])
+      features.sorted(SimpleFeatureOrdering(sft, "age")) mustEqual features.sortBy(_.getAttribute(2).asInstanceOf[Int])
     }
 
     "sort by null attributes" >> {
-      features.sorted(SimpleFeatureOrdering(2)) mustEqual features.sortBy(f => Option(f.getAttribute(2).asInstanceOf[Integer]))
+      features.sorted(SimpleFeatureOrdering(sft, "opt")) mustEqual features.sortBy(f => Option(f.getAttribute(3).asInstanceOf[Integer]))
     }
 
     "sort by date attributes" >> {
-      features.sorted(SimpleFeatureOrdering(3)) mustEqual features.sortBy(_.getAttribute(3).asInstanceOf[Date])
+      features.sorted(SimpleFeatureOrdering(sft, "dtg")) mustEqual features.sortBy(_.getAttribute(4).asInstanceOf[Date])
+    }
+
+    "sort by list attributes" >> {
+      val sorted = features.sortBy(_.getAttribute(1).asInstanceOf[java.util.List[String]].asScala.mkString)
+      features.sorted(SimpleFeatureOrdering(sft, "hobbies")) mustEqual sorted
     }
   }
 }


### PR DESCRIPTION
* List items are dictionary encoded, not the list itself
* Add sorting for list-type attributes
* Move ObjectType to geomesa-utils

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>