### PR TITLE
Change JedisPool to JedisPoolAbstract to allow use Redis Sentinel

### DIFF
--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/RedisDataStore.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/RedisDataStore.scala
@@ -22,7 +22,7 @@ import org.locationtech.geomesa.utils.audit.{AuditProvider, AuditWriter}
 import org.locationtech.geomesa.utils.index.VisibilityLevel
 import org.locationtech.geomesa.utils.io.CloseWithLogging
 import org.opengis.feature.simple.SimpleFeatureType
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.JedisPoolAbstract
 
 /**
   * Data store backed by Redis. Uses Redis SortedSets for range scanning
@@ -30,7 +30,7 @@ import redis.clients.jedis.JedisPool
   * @param connection connection pool
   * @param config datastore configuration
   */
-class RedisDataStore(val connection: JedisPool, override val config: RedisDataStoreConfig)
+class RedisDataStore(val connection: JedisPoolAbstract, override val config: RedisDataStoreConfig)
     extends GeoMesaDataStore[RedisDataStore](config) with RedisLocking {
 
   import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/RedisDataStoreFactory.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/RedisDataStoreFactory.scala
@@ -23,7 +23,7 @@ import org.locationtech.geomesa.redis.data.index.RedisAgeOff
 import org.locationtech.geomesa.security
 import org.locationtech.geomesa.utils.audit.{AuditLogger, AuditProvider, NoOpAuditProvider}
 import org.locationtech.geomesa.utils.geotools.GeoMesaParam
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.{JedisPool, JedisPoolAbstract}
 import redis.clients.jedis.util.JedisURIHelper
 
 import scala.util.Try
@@ -90,7 +90,7 @@ object RedisDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
     * @param params params
     * @return
     */
-  def buildConnection(params: java.util.Map[String, Serializable]): JedisPool = {
+  def buildConnection(params: java.util.Map[String, Serializable]): JedisPoolAbstract = {
     ConnectionPoolParam.lookupOpt(params).getOrElse {
       val url = RedisUrlParam.lookup(params)
       val config = new GenericObjectPoolConfig()

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/index/RedisAgeOff.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/index/RedisAgeOff.scala
@@ -22,7 +22,7 @@ import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemPropert
 import org.locationtech.geomesa.utils.io.WithClose
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.identity.Identifier
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.JedisPoolAbstract
 import redis.clients.jedis.params.ZAddParams
 
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
@@ -139,7 +139,7 @@ object RedisAgeOff extends StrictLogging {
     * @param connection jedis connection
     * @param table ttl table for the feature type
     */
-  class AgeOffWriter(connection: JedisPool, table: Array[Byte]) extends Closeable with Flushable {
+  class AgeOffWriter(connection: JedisPoolAbstract, table: Array[Byte]) extends Closeable with Flushable {
 
     private val writes = new java.util.HashMap[Array[Byte], java.lang.Double]
     private val deletes = ArrayBuffer.empty[Array[Byte]]
@@ -229,7 +229,7 @@ object RedisAgeOff extends StrictLogging {
       throw new IllegalStateException("Invalid age-off lock timeout")
     }
 
-    override def connection: JedisPool = ds.connection
+    override def connection: JedisPoolAbstract = ds.connection
 
     override def run(): Unit = {
       val timestamp = System.currentTimeMillis()

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/index/RedisIndexAdapter.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/index/RedisIndexAdapter.scala
@@ -26,7 +26,7 @@ import org.locationtech.geomesa.redis.data.index.RedisQueryPlan.{EmptyPlan, ZLex
 import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.geomesa.utils.io.WithClose
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.JedisPoolAbstract
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
@@ -206,7 +206,7 @@ object RedisIndexAdapter extends LazyLogging {
     * @param wrapper feature wrapper
     */
   class RedisIndexWriter(
-      jedis: JedisPool,
+      jedis: JedisPoolAbstract,
       indices: Seq[GeoMesaFeatureIndex[_, _]],
       partition: Option[String],
       aging: Option[AgeOffWriter],

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/package.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/package.scala
@@ -13,7 +13,7 @@ import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDa
 import org.locationtech.geomesa.security.SecurityParams
 import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
 import org.locationtech.geomesa.utils.geotools.GeoMesaParam
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.JedisPoolAbstract
 
 import scala.util.control.NonFatal
 
@@ -66,7 +66,7 @@ package object data extends LazyLogging {
             "but restricts queries to a single execution thread",
         default = Boolean.box(false))
 
-    val ConnectionPoolParam = new GeoMesaParam[JedisPool]("redis.connection", "Connection pool") // generally used for testing
+    val ConnectionPoolParam = new GeoMesaParam[JedisPoolAbstract]("redis.connection", "Connection pool") // generally used for testing
   }
 
   object RedisSystemProperties {

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/util/RedisBackedMetadata.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/util/RedisBackedMetadata.scala
@@ -13,7 +13,7 @@ import java.nio.charset.StandardCharsets
 import org.locationtech.geomesa.index.metadata.{KeyValueStoreMetadata, MetadataSerializer}
 import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.locationtech.geomesa.utils.io.WithClose
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.JedisPoolAbstract
 
 /**
   * Redis-backed metadata implementation. Metadata is stored as a redis hashset
@@ -23,7 +23,7 @@ import redis.clients.jedis.JedisPool
   * @param serializer serializer
   * @tparam T type param
   */
-class RedisBackedMetadata[T](connection: JedisPool, table: String, val serializer: MetadataSerializer[T])
+class RedisBackedMetadata[T](connection: JedisPoolAbstract, table: String, val serializer: MetadataSerializer[T])
     extends KeyValueStoreMetadata[T] {
 
   import scala.collection.JavaConverters._

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/util/RedisBatchScan.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/util/RedisBatchScan.scala
@@ -14,10 +14,10 @@ import org.locationtech.geomesa.index.api.BoundedByteRange
 import org.locationtech.geomesa.index.utils.AbstractBatchScan
 import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.locationtech.geomesa.utils.io.WithClose
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.JedisPoolAbstract
 
 private class RedisBatchScan(
-    connection: JedisPool,
+    connection: JedisPoolAbstract,
     table: Array[Byte],
     ranges: Seq[BoundedByteRange],
     threads: Int,
@@ -37,7 +37,7 @@ object RedisBatchScan {
   private val Sentinel = new Array[Byte](0)
 
   def apply(
-      connection: JedisPool,
+      connection: JedisPoolAbstract,
       table: Array[Byte],
       ranges: Seq[BoundedByteRange],
       threads: Int): CloseableIterator[Array[Byte]] =

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/util/RedisLocking.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/util/RedisLocking.scala
@@ -13,7 +13,7 @@ import java.util.UUID
 import org.locationtech.geomesa.index.DistributedLockTimeout
 import org.locationtech.geomesa.index.utils.{DistributedLocking, Releasable}
 import org.locationtech.geomesa.utils.io.WithClose
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.JedisPoolAbstract
 import redis.clients.jedis.params.SetParams
 
 /**
@@ -35,7 +35,7 @@ trait RedisLocking extends DistributedLocking {
     new SetParams().nx().px(timeout.toMillis)
   }
 
-  def connection: JedisPool
+  def connection: JedisPoolAbstract
 
   override protected def acquireDistributedLock(key: String): Releasable =
     acquireDistributedLock(key, Long.MaxValue).orNull


### PR DESCRIPTION
I need to intergate GeoMesa to an exising Redis Sentinel, but by default JedisPool is used.
Which make use Redis Sentinel as data store impossible, so I would like to change JedisPool to JedisPoolAbstract to allow use Redis Sentinel as data store programmatically. 