### PR TITLE
GEOMESA-2914 Provide simplified schema management

### DIFF
--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterHelperTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterHelperTest.scala
@@ -258,8 +258,7 @@ class FilterHelperTest extends Specification {
     "evaluate functions with large IN predicate" >> {
       val string = (0 to 4000).mkString("IN(", ",", ")")
       val filter = ECQL.toFilter(string)
-      updateFilter(filter)
-      ok
+      updateFilter(filter) must not(throwAn[Exception])
     }
 
     "evaluate functions with large number of ORs" >> {
@@ -269,8 +268,7 @@ class FilterHelperTest extends Specification {
       (1 until count).foreach { i =>
         filter = ff.or(filter, ff.equal(a, ff.literal(i)))
       }
-      updateFilter(filter)
-      ok
+      updateFilter(filter) must not(throwAn[Exception])
     }
 
     "evaluate functions with large number of ANDs" >> {
@@ -280,9 +278,7 @@ class FilterHelperTest extends Specification {
       (1 until count).foreach { i =>
         filter = ff.and(filter, ff.equal(a, ff.literal(i)))
       }
-      val updated = updateFilter(filter)
-      println(s"Updated filter $updated")
-      ok
+      updateFilter(filter) must not(throwAn[Exception])
     }
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStore.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStore.scala
@@ -33,7 +33,6 @@ import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.{AttributeOpti
 import org.locationtech.geomesa.utils.geotools.converters.FastConverter
 import org.locationtech.geomesa.utils.index.IndexMode
 import org.locationtech.geomesa.utils.io.CloseWithLogging
-import org.locationtech.geomesa.utils.stats.IndexCoverage
 import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
@@ -506,7 +505,7 @@ abstract class GeoMesaDataStore[DS <: GeoMesaDataStore[DS]](val config: GeoMesaD
   def checkSchemaCompatibility(typeName: String, sft: SimpleFeatureType): SchemaCompatibility = {
     val previous = getSchema(typeName)
     if (previous == null) {
-      new SchemaCompatibility.Missing(this, sft)
+      new SchemaCompatibility.DoesNotExist(this, sft)
     } else {
       Try(validateSchemaUpdate(previous, sft)).failed.map(SchemaCompatibility.Incompatible).getOrElse {
         val copy = SimpleFeatureTypes.copy(sft)
@@ -679,12 +678,12 @@ object GeoMesaDataStore extends LazyLogging {
      * @param ds data store
      * @param sft schema
      */
-    class Missing(ds: GeoMesaDataStore[_], val sft: SimpleFeatureType) extends SchemaCompatibility {
+    class DoesNotExist(ds: GeoMesaDataStore[_], val sft: SimpleFeatureType) extends SchemaCompatibility {
       override def apply(): Unit = ds.createSchema(sft)
     }
 
-    object Missing {
-      def unapply(arg: Missing): Option[SimpleFeatureType] = Some(arg.sft)
+    object DoesNotExist {
+      def unapply(arg: DoesNotExist): Option[SimpleFeatureType] = Some(arg.sft)
     }
 
     /**

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStore.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStore.scala
@@ -12,17 +12,16 @@ import java.io.IOException
 import java.util.Collections
 import java.util.concurrent.TimeUnit
 
-import com.github.benmanes.caffeine.cache.{CacheLoader, Caffeine}
+import com.github.benmanes.caffeine.cache.{AsyncCacheLoader, CacheLoader, Caffeine}
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.data._
 import org.locationtech.geomesa.index.FlushableFeatureWriter
 import org.locationtech.geomesa.index.api.{IndexManager, _}
 import org.locationtech.geomesa.index.conf.partition.TablePartition
-import org.locationtech.geomesa.index.geotools.GeoMesaDataStore.VersionKey
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStore.{SchemaCompatibility, VersionKey}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDataStoreConfig
 import org.locationtech.geomesa.index.index.attribute.AttributeIndex
 import org.locationtech.geomesa.index.index.id.IdIndex
-import org.locationtech.geomesa.index.metadata.GeoMesaMetadata.AttributesKey
 import org.locationtech.geomesa.index.planning.QueryPlanner
 import org.locationtech.geomesa.index.stats.HasGeoMesaStats
 import org.locationtech.geomesa.index.utils.{ExplainLogging, Explainer}
@@ -35,9 +34,11 @@ import org.locationtech.geomesa.utils.geotools.converters.FastConverter
 import org.locationtech.geomesa.utils.index.IndexMode
 import org.locationtech.geomesa.utils.io.CloseWithLogging
 import org.locationtech.geomesa.utils.stats.IndexCoverage
+import org.opengis.feature.`type`.AttributeDescriptor
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
+import scala.util.Try
 import scala.util.control.NonFatal
 
 /**
@@ -162,34 +163,13 @@ abstract class GeoMesaDataStore[DS <: GeoMesaDataStore[DS]](val config: GeoMesaD
 
   @throws(classOf[IllegalArgumentException])
   override protected def preSchemaUpdate(sft: SimpleFeatureType, previous: SimpleFeatureType): Unit = {
-    // check for attributes flagged 'index' and convert them to sft-level user data
-    sft.getAttributeDescriptors.asScala.foreach { d =>
-      val index = d.getUserData.remove(AttributeOptions.OptIndex).asInstanceOf[String]
-      if (index == null || index.equalsIgnoreCase(IndexCoverage.NONE.toString) || index.equalsIgnoreCase("false")) {
-        // no-op
-      } else if (index.equalsIgnoreCase(IndexCoverage.FULL.toString) || java.lang.Boolean.valueOf(index)) {
-        val fields = Seq(d.getLocalName) ++ Option(sft.getGeomField) ++ sft.getDtgField
-        val attribute = IndexId(AttributeIndex.name, AttributeIndex.version, fields, IndexMode.ReadWrite)
-        val existing = sft.getIndices.map(GeoMesaFeatureIndex.identifier)
-        if (!existing.contains(GeoMesaFeatureIndex.identifier(attribute))) {
-          sft.setIndices(sft.getIndices :+ attribute)
-        }
-      } else {
-        throw new IllegalArgumentException(s"Configured index coverage '$index' is not valid: expected " +
-            IndexCoverage.FULL.toString)
-      }
-    }
-
+    updateSchemaUserData(sft, previous)
     // try to create the new indices to ensure they are valid for the sft
-    val previousIndices = previous.getIndices.map(GeoMesaFeatureIndex.identifier)
-    val newIndices = sft.getIndices.filterNot(i => previousIndices.contains(GeoMesaFeatureIndex.identifier(i)))
-    if (newIndices.nonEmpty) {
-      try { GeoMesaFeatureIndexFactory.create(this, sft, newIndices) } catch {
-        case NonFatal(e) => throw new IllegalArgumentException(s"Error configuring new feature index:", e)
-      }
+    try { GeoMesaFeatureIndexFactory.create(this, sft, sft.getIndices) } catch {
+      case NonFatal(e) => throw new IllegalArgumentException(s"Error configuring new feature index:", e)
     }
-
-    sft.getFeatureExpiration // validate any configured age-off
+    // validate any configured age-off
+    sft.getFeatureExpiration
   }
 
   // create the index tables (if not using partitioned tables)
@@ -208,26 +188,17 @@ abstract class GeoMesaDataStore[DS <: GeoMesaDataStore[DS]](val config: GeoMesaD
     val partitioned = TablePartition.partitioned(sft)
 
     // check for column renaming
-    val colMap = previous.getAttributeDescriptors.asScala.zipWithIndex.toMap.flatMap { case (prev, i) =>
-      val cur = sft.getDescriptor(i)
-      if (prev.getLocalName != cur.getLocalName) {
-        Map(prev.getLocalName -> cur.getLocalName)
-      } else {
-        Map.empty[String, String]
-      }
-    }
+    val colMap = getColumnMap(previous, sft).map { case (k, v) => (v, k) }
 
-    val indices = sft.getIndices
-    val indexChange = colMap.nonEmpty && indices.exists(_.attributes.exists(colMap.contains))
-    if (indexChange) {
-      val updated = indices.map { i =>
-        if (!i.attributes.exists(colMap.contains)) { i } else {
-          val update = i.copy(attributes = i.attributes.map(a => colMap.getOrElse(a, a)))
-          // side-effect - rewrite the table name keys for the renamed cols
-          val old = manager.index(previous, GeoMesaFeatureIndex.identifier(i))
-          val index = GeoMesaFeatureIndexFactory.create(this, sft, Seq(update)).headOption.getOrElse {
+    // rewrite the table name keys for the renamed cols
+    if (colMap.nonEmpty) {
+      sft.getIndices.foreach { i =>
+        if (i.attributes.exists(colMap.contains)) {
+          val prev = i.copy(attributes = i.attributes.map(a => colMap.getOrElse(a, a)))
+          val old = manager.index(previous, GeoMesaFeatureIndex.identifier(prev))
+          val index = GeoMesaFeatureIndexFactory.create(this, sft, Seq(i)).headOption.getOrElse {
             throw new IllegalArgumentException(
-              s"Error configuring new feature index: ${GeoMesaFeatureIndex.identifier(update)}")
+              s"Error configuring new feature index: ${GeoMesaFeatureIndex.identifier(i)}")
           }
           val partitions = if (!partitioned) { Seq(None) } else {
             // have to use the old table name key but the new sft name for looking up the partitions
@@ -240,11 +211,8 @@ abstract class GeoMesaDataStore[DS <: GeoMesaDataStore[DS]](val config: GeoMesaD
               metadata.insert(sft.getTypeName, index.tableNameKey(p), v)
             }
           }
-          update
         }
       }
-      sft.setIndices(updated.distinct)
-      metadata.insert(sft.getTypeName, AttributesKey, SimpleFeatureTypes.encodeType(sft, includeUserData = true))
     }
 
     // configure any new indices
@@ -265,7 +233,7 @@ abstract class GeoMesaDataStore[DS <: GeoMesaDataStore[DS]](val config: GeoMesaD
     }
 
     // rename tables to match the new sft name
-    if (sft.getTypeName != previous.getTypeName || indexChange) {
+    if (sft.getTypeName != previous.getTypeName || sft.getIndices != previous.getIndices) {
       if (FastConverter.convertOrElse[java.lang.Boolean](sft.getUserData.get(Configs.UpdateRenameTables), false)) {
         manager.indices(sft).foreach { index =>
           val partitions = if (partitioned) { index.getPartitions.map(Option.apply) } else { Seq(None) }
@@ -528,51 +496,152 @@ abstract class GeoMesaDataStore[DS <: GeoMesaDataStore[DS]](val config: GeoMesaD
     }
   }
 
+  /**
+   * Checks a simple feature type against an existing schema
+   *
+   * @param typeName type name
+   * @param sft udpated simple feature type
+   * @return
+   */
+  def checkSchemaCompatibility(typeName: String, sft: SimpleFeatureType): SchemaCompatibility = {
+    val previous = getSchema(typeName)
+    if (previous == null) {
+      new SchemaCompatibility.Missing(this, sft)
+    } else {
+      Try(validateSchemaUpdate(previous, sft)).failed.map(SchemaCompatibility.Incompatible).getOrElse {
+        val copy = SimpleFeatureTypes.copy(sft)
+        updateSchemaUserData(copy, previous)
+        if (SimpleFeatureTypes.compare(copy, previous) == 0 && copy.getUserData == previous.getUserData) {
+          SchemaCompatibility.Unchanged
+        } else {
+          new SchemaCompatibility.Compatible(this, typeName, sft)
+        }
+      }
+    }
+  }
+
   // end public methods
+
+  /**
+   * Updates the user data for a schema update prior to persistence. Handles converting existing
+   * user data based on new/updated attributes, copying existing user data over, etc. Feature
+   * type will be updated in place
+   *
+   * @param sft schema update
+   * @param previous existing schema
+   * @return
+   */
+  private def updateSchemaUserData(sft: SimpleFeatureType, previous: SimpleFeatureType): Unit = {
+
+    // check for column renaming
+    val colMap = getColumnMap(previous, sft)
+
+    def remapCol(name: String): String = colMap.getOrElse(name, name)
+
+    // check for attributes flagged 'index' and convert them to sft-level user data
+    def indexed(d: AttributeDescriptor): Boolean = {
+      d.getUserData.remove(AttributeOptions.OptIndex) match {
+        case i: String if Seq("true", "full").exists(_.equalsIgnoreCase(i)) => true
+        case i if i == null || Seq("false", "none").exists(_.equalsIgnoreCase(i.toString)) => false
+        case i => throw new IllegalArgumentException(s"Configured index coverage '$i' is not valid: expected 'true'")
+      }
+    }
+    sft.getAttributeDescriptors.asScala.foreach { d =>
+      if (indexed(d)) {
+        val fields = Seq(d.getLocalName) ++ Option(sft.getGeomField) ++ sft.getDtgField
+        val existing = sft.getIndices
+        if (!existing.exists(e => e.name == AttributeIndex.name && e.attributes.map(remapCol) == fields)) {
+          val id = IndexId(AttributeIndex.name, AttributeIndex.version, fields, IndexMode.ReadWrite)
+          sft.setIndices(existing :+ id)
+        }
+      }
+    }
+
+    // check for new indices and 'enabled indices' changes
+    val indices = {
+      val enabled = if (!sft.getUserData.containsKey(Configs.EnabledIndices)) { Seq.empty } else {
+        GeoMesaFeatureIndexFactory.indices(sft)
+      }
+      val remapped = (previous.getIndices ++ sft.getIndices).map(i => i.copy(attributes = i.attributes.map(remapCol)))
+      (remapped ++ enabled).foldLeft(Seq.empty[IndexId]) { (sum, next) =>
+        // note: ignore index version
+        if (sum.exists(i => i.name == next.name && i.attributes == next.attributes)) { sum } else { sum :+ next }
+      }
+    }
+    if (indices != previous.getIndices) {
+      sft.setIndices(indices)
+    }
+
+    // preserve any existing user data but overwrite any keys we redefine
+    val userData = new java.util.HashMap[AnyRef, AnyRef](previous.getUserData)
+    userData.putAll(sft.getUserData)
+    sft.getUserData.putAll(userData)
+    // remove enabled indices as we don't need to persist it
+    sft.getUserData.remove(Configs.EnabledIndices)
+    // remove any null/empty keys as a way to delete existing user data
+    sft.getUserData.asScala.collect { case (k, null | "") => k }.foreach(sft.getUserData.remove)
+  }
+
+  /**
+   * Gets a map of column renames, for use during schema updates
+   *
+   * @param previous previous feature type
+   * @param sft updated feature type
+   * @return map of old name -> new name
+   */
+  private def getColumnMap(previous: SimpleFeatureType, sft: SimpleFeatureType): Map[String, String] = {
+    previous.getAttributeDescriptors.asScala.zipWithIndex.toMap.flatMap { case (prev, i) =>
+      val cur = sft.getDescriptor(i)
+      if (prev.getLocalName != cur.getLocalName) {
+        Map(prev.getLocalName -> cur.getLocalName)
+      } else {
+        Map.empty[String, String]
+      }
+    }
+  }
 }
 
 object GeoMesaDataStore extends LazyLogging {
 
   import org.locationtech.geomesa.index.conf.SchemaProperties.{CheckDistributedVersion, ValidateDistributedClasspath}
 
-  private val loader = new CacheLoader[VersionKey, Either[Exception, Option[SemanticVersion]]]() {
-    override def load(key: VersionKey): Either[Exception, Option[SemanticVersion]] = {
-      if (key.ds.getTypeNames.length == 0) {
-        // short-circuit load - should try again next time cache is accessed
-        throw new RuntimeException("Can't load remote versions if there are no feature types")
-      }
-      if (CheckDistributedVersion.toBoolean.contains(false)) { Right(None) } else {
-        val clientVersion = key.ds.getClientVersion
-        // use lenient parsing to account for versions like 1.3.5.1
-        val iterVersions = key.ds.loadIteratorVersions.map(v => SemanticVersion(v, lenient = true))
+  private val loader: AsyncCacheLoader[VersionKey, Either[Exception, Option[SemanticVersion]]] =
+    new CacheLoader[VersionKey, Either[Exception, Option[SemanticVersion]]]() {
+      override def load(key: VersionKey): Either[Exception, Option[SemanticVersion]] = {
+        if (key.ds.getTypeNames.length == 0) {
+          // short-circuit load - should try again next time cache is accessed
+          throw new RuntimeException("Can't load remote versions if there are no feature types")
+        }
+        if (CheckDistributedVersion.toBoolean.contains(false)) { Right(None) } else {
+          val clientVersion = key.ds.getClientVersion
+          // use lenient parsing to account for versions like 1.3.5.1
+          val iterVersions = key.ds.loadIteratorVersions.map(v => SemanticVersion(v, lenient = true))
 
-        def message: String = "Classpath errors detected: configured server-side iterators do not match " +
-            s"client version. Client version: $clientVersion, server versions: ${iterVersions.mkString(", ")}"
+          def message: String = "Classpath errors detected: configured server-side iterators do not match " +
+              s"client version. Client version: $clientVersion, server versions: ${iterVersions.mkString(", ")}"
 
-        // take the newest one if there are multiple - probably an update went partially awry, so it's
-        // likely to match more tablet servers than the lower version
-        val version = iterVersions.reduceLeftOption((left, right) => if (right > left) { right } else { left })
+          // take the newest one if there are multiple - probably an update went partially awry, so it's
+          // likely to match more tablet servers than the lower version
+          val version = iterVersions.reduceLeftOption((left, right) => if (right > left) { right } else { left })
 
-        // ensure matching versions
-        // return an error if the user has enabled strict checking and it's not a patch/pre-release version mismatch
-        // otherwise just log a warning
-        if (iterVersions.forall(_ == clientVersion)) {
-          Right(version)
-        } else if (ValidateDistributedClasspath.toBoolean.contains(false) ||
-            iterVersions.forall(MinorOrdering.compare(_, clientVersion) == 0)) {
-          logger.warn(message)
-          Right(version)
-        } else {
-          Left(new RuntimeException(s"$message. You may override this check by setting the system property " +
-              s"'-D${ValidateDistributedClasspath.property}=false'"))
+          // ensure matching versions
+          // return an error if the user has enabled strict checking and it's not a patch/pre-release version mismatch
+          // otherwise just log a warning
+          if (iterVersions.forall(_ == clientVersion)) {
+            Right(version)
+          } else if (ValidateDistributedClasspath.toBoolean.contains(false) ||
+              iterVersions.forall(MinorOrdering.compare(_, clientVersion) == 0)) {
+            logger.warn(message)
+            Right(version)
+          } else {
+            Left(new RuntimeException(s"$message. You may override this check by setting the system property " +
+                s"'-D${ValidateDistributedClasspath.property}=false'"))
+          }
         }
       }
     }
-  }
 
-  private val versions =
-    Caffeine.newBuilder().refreshAfterWrite(1, TimeUnit.DAYS)
-      .buildAsync[VersionKey, Either[Exception, Option[SemanticVersion]]](loader)
+  private val versions = Caffeine.newBuilder().refreshAfterWrite(1, TimeUnit.DAYS).buildAsync(loader)
 
   /**
     * Kick off an asynchronous call to load remote iterator versions
@@ -583,6 +652,64 @@ object GeoMesaDataStore extends LazyLogging {
     // can't get remote version if there aren't any tables
     if (ds.getTypeNames.length > 0) {
       versions.get(new VersionKey(ds))
+    }
+  }
+
+  sealed trait SchemaCompatibility {
+
+    /**
+     * Ensures that the schema matches the existing schema in the data store, or throws an error if
+     * the schemas are incompatible
+     */
+    def apply(): Unit
+  }
+
+  object SchemaCompatibility {
+
+    /**
+     * Indicates that the schema is equal to the existing schema in the data store
+     */
+    case object Unchanged extends SchemaCompatibility {
+      override def apply(): Unit = {}
+    }
+
+    /**
+     * Indicates that the schema does not exist in the data store
+     *
+     * @param ds data store
+     * @param sft schema
+     */
+    class Missing(ds: GeoMesaDataStore[_], val sft: SimpleFeatureType) extends SchemaCompatibility {
+      override def apply(): Unit = ds.createSchema(sft)
+    }
+
+    object Missing {
+      def unapply(arg: Missing): Option[SimpleFeatureType] = Some(arg.sft)
+    }
+
+    /**
+     * Indicates that the schema is not equal to the existing schema, but is compatible
+     *
+     * @param ds data store
+     * @param typeName type name
+     * @param update the updated schema with all appropriate metadata
+     */
+    class Compatible(ds: GeoMesaDataStore[_], val typeName: String, val update: SimpleFeatureType)
+        extends SchemaCompatibility {
+      override def apply(): Unit = ds.updateSchema(typeName, update)
+    }
+
+    object Compatible {
+      def unapply(arg: Compatible): Option[(String, SimpleFeatureType)] = Some(arg.typeName, arg.update)
+    }
+
+    /**
+     * Indicates that the schema is not compatible with the existing schema in the data store
+     *
+     * @param error error message
+     */
+    case class Incompatible(error: Throwable) extends SchemaCompatibility {
+      override def apply(): Unit = throw error
     }
   }
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.index.geotools
 
 import java.time.{Instant, ZoneOffset}
-import java.util.{List => jList}
+import java.util.{Locale, List => jList}
 
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.data._
@@ -25,8 +25,8 @@ import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleF
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.Configs
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.InternalConfigs.TableSharingPrefix
 import org.locationtech.geomesa.utils.geotools.converters.FastConverter
-import org.locationtech.geomesa.utils.geotools.{GeoToolsDateFormat, SimpleFeatureTypes}
-import org.locationtech.geomesa.utils.index.GeoMesaSchemaValidator
+import org.locationtech.geomesa.utils.geotools.{FeatureUtils, GeoToolsDateFormat, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.index.{GeoMesaSchemaValidator, ReservedWordCheck}
 import org.locationtech.geomesa.utils.io.CloseWithLogging
 import org.opengis.feature.`type`.Name
 import org.opengis.feature.simple.SimpleFeatureType
@@ -240,26 +240,7 @@ abstract class MetadataBackedDataStore(config: NamespaceConfig) extends DataStor
         throw new IllegalArgumentException(s"Schema '$typeName' does not exist")
       }
 
-      // validate that default geometry and date have not changed (rename is ok)
-      if (schema.getGeomIndex != previousSft.getGeomIndex) {
-        throw new UnsupportedOperationException("Changing the default geometry attribute is not supported")
-      } else if (schema.getDtgIndex != previousSft.getDtgIndex) {
-        throw new UnsupportedOperationException("Changing the default date attribute is not supported")
-      }
-
-      // check that unmodifiable user data has not changed
-      MetadataBackedDataStore.UnmodifiableUserDataKeys.foreach { key =>
-        if (schema.userData[Any](key) != previousSft.userData[Any](key)) {
-          throw new UnsupportedOperationException(s"Updating '$key' is not supported")
-        }
-      }
-
-      // check for column type changes
-      previousSft.getAttributeDescriptors.asScala.zipWithIndex.foreach { case (prev, i) =>
-        if (prev.getType.getBinding != schema.getDescriptor(i).getType.getBinding) {
-          throw new UnsupportedOperationException("Updating schema column types is not allowed")
-        }
-      }
+      validateSchemaUpdate(previousSft, schema)
 
       val sft = SimpleFeatureTypes.mutable(schema)
 
@@ -385,6 +366,51 @@ abstract class MetadataBackedDataStore(config: NamespaceConfig) extends DataStor
   // end methods from org.geotools.data.DataStore
 
   /**
+   * Validate a call to updateSchema, throwing errors on failed validation
+   *
+   * @param existing existing schema
+   * @param schema updated sft
+   */
+  protected def validateSchemaUpdate(existing: SimpleFeatureType, schema: SimpleFeatureType): Unit = {
+    // validate that default geometry and date have not changed (rename is ok)
+    if (schema.getGeomIndex != existing.getGeomIndex) {
+      throw new UnsupportedOperationException("Changing the default geometry attribute is not supported")
+    } else if (schema.getDtgIndex != existing.getDtgIndex) {
+      throw new UnsupportedOperationException("Changing the default date attribute is not supported")
+    }
+
+    // check that unmodifiable user data has not changed
+    MetadataBackedDataStore.UnmodifiableUserDataKeys.foreach { key =>
+      if (schema.userData[Any](key) != existing.userData[Any](key)) {
+        throw new UnsupportedOperationException(s"Updating '$key' is not supported")
+      }
+    }
+
+    // validate that attributes weren't removed
+    if (existing.getAttributeCount > schema.getAttributeCount) {
+      throw new UnsupportedOperationException("Removing attributes from the schema is not supported")
+    }
+
+    // check for column type changes
+    existing.getAttributeDescriptors.asScala.zipWithIndex.foreach { case (prev, i) =>
+      val binding = schema.getDescriptor(i).getType.getBinding
+      if (!binding.isAssignableFrom(prev.getType.getBinding)) {
+        throw new UnsupportedOperationException(
+          s"Incompatible schema column type change: ${schema.getDescriptor(i).getLocalName} " +
+              s"from ${prev.getType.getBinding.getName} to ${binding.getName}")
+      }
+    }
+
+    // check for reserved words - only check for new/renamed attributes
+    val reserved = schema.getAttributeDescriptors.asScala.map(_.getLocalName).exists { name =>
+      existing.getDescriptor(name) == null && FeatureUtils.ReservedWords.contains(name.toUpperCase(Locale.US))
+    }
+    if (reserved) {
+      ReservedWordCheck.validateAttributeNames(schema)
+    }
+  }
+
+  /**
     * Acquires a distributed lock for all data stores sharing this catalog table.
     * Make sure that you 'release' the lock in a finally block.
     */
@@ -407,5 +433,14 @@ object MetadataBackedDataStore {
   import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.Configs._
 
   private val UnmodifiableUserDataKeys =
-    Set(TableSharing, TableSharingPrefix, IndexVisibilityLevel, IndexZ3Interval, IndexXzPrecision)
+    Set(
+      TableSharing,
+      TableSharingPrefix,
+      IndexVisibilityLevel,
+      IndexZ3Interval,
+      IndexXzPrecision,
+      IndexZShards,
+      IndexIdShards,
+      IndexAttributeShards
+    )
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
@@ -438,6 +438,7 @@ object MetadataBackedDataStore {
       TableSharingPrefix,
       IndexVisibilityLevel,
       IndexZ3Interval,
+      S3_INTERVAL_KEY,
       IndexXzPrecision,
       IndexZShards,
       IndexIdShards,

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreTest.scala
@@ -28,7 +28,6 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.index.TestGeoMesaDataStore
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore.SchemaCompatibility
-import org.locationtech.geomesa.index.geotools.GeoMesaDataStore.SchemaCompatibility.Unchanged
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreTest._
 import org.locationtech.geomesa.index.index.attribute.AttributeIndex
 import org.locationtech.geomesa.index.index.id.IdIndex
@@ -240,7 +239,7 @@ class GeoMesaDataStoreTest extends Specification {
           |}""".stripMargin
 
       val missing = ds.checkSchemaCompatibility("test", toSft(missingConfig))
-      missing must beAnInstanceOf[SchemaCompatibility.Missing]
+      missing must beAnInstanceOf[SchemaCompatibility.DoesNotExist]
       missing.apply()
 
       val original = ds.getSchema("test")

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreTest.scala
@@ -10,6 +10,7 @@ package org.locationtech.geomesa.index.geotools
 
 import java.util.Collections
 
+import com.typesafe.config.ConfigFactory
 import org.geotools.data.collection.ListFeatureCollection
 import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureSource}
 import org.geotools.data.store.{ReTypingFeatureCollection, ReprojectingFeatureCollection}
@@ -26,6 +27,8 @@ import org.geotools.util.factory.Hints
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.index.TestGeoMesaDataStore
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStore.SchemaCompatibility
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStore.SchemaCompatibility.Unchanged
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreTest._
 import org.locationtech.geomesa.index.index.attribute.AttributeIndex
 import org.locationtech.geomesa.index.index.id.IdIndex
@@ -216,6 +219,57 @@ class GeoMesaDataStoreTest extends Specification {
         ds.stats.getCount(sft) must beSome(1L)
         ds.stats.getMinMax[String](sft, "n", exact = false).map(_.max) must beSome("name0")
       }
+    }
+    "update compatible schemas from typesafe config changes" in {
+      import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
+      def toSft(config: String): SimpleFeatureType = SimpleFeatureTypes.createType(ConfigFactory.parseString(config))
+
+      val ds = new TestGeoMesaDataStore(true)
+      val missingConfig =
+        """{
+          |  type-name = "test"
+          |  attributes = [
+          |    { name = "type", type = "String"                             }
+          |    { name = "dtg",  type = "Date",  default = true              }
+          |    { name = "geom", type = "Point", default = true, srid = 4326 }
+          |  ]
+          |  user-data = {
+          |    "geomesa.indices.enabled" = "z3:geom:dtg,attr:type:dtg"
+          |  }
+          |}""".stripMargin
+
+      val missing = ds.checkSchemaCompatibility("test", toSft(missingConfig))
+      missing must beAnInstanceOf[SchemaCompatibility.Missing]
+      missing.apply()
+
+      val original = ds.getSchema("test")
+      original must not(beNull)
+
+      ds.checkSchemaCompatibility("test", toSft(missingConfig)) mustEqual SchemaCompatibility.Unchanged
+
+      val addIndexConfig = missingConfig.replace("z3", "id,z3")
+
+      val addIndex = ds.checkSchemaCompatibility("test", toSft(addIndexConfig))
+      addIndex must beAnInstanceOf[SchemaCompatibility.Compatible]
+      addIndex.apply()
+
+      val updateAddIndex = ds.getSchema("test")
+      updateAddIndex.getIndices.map(_.name).toSet mustEqual Set("id", "z3", "attr")
+
+      ds.checkSchemaCompatibility("test", toSft(addIndexConfig)) mustEqual SchemaCompatibility.Unchanged
+
+      val addAttributeConfig = addIndexConfig.replace("]", s"""    { name = "name", type = "String" }${"\n"}]""")
+
+      val addAttribute = ds.checkSchemaCompatibility("test", toSft(addAttributeConfig))
+      addAttribute must beAnInstanceOf[SchemaCompatibility.Compatible]
+      addAttribute.apply()
+
+      val updateAddAttribute = ds.getSchema("test")
+      updateAddAttribute.getAttributeDescriptors.asScala.map(_.getLocalName) mustEqual
+          Seq("type", "dtg", "geom", "name")
+
+      ds.checkSchemaCompatibility("test", toSft(addAttributeConfig)) mustEqual SchemaCompatibility.Unchanged
     }
     "unwrap decorating feature collections" in {
       val fc = ds.getFeatureSource(sft.getTypeName).getFeatures()

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/status/HelpCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/status/HelpCommand.scala
@@ -9,7 +9,8 @@
 package org.locationtech.geomesa.tools.status
 
 import com.beust.jcommander.{JCommander, Parameter, Parameters}
-import org.locationtech.geomesa.tools.{AutocompleteInfo, Command, Runner}
+import org.locationtech.geomesa.tools.Runner.AutocompleteInfo
+import org.locationtech.geomesa.tools.{Command, Runner}
 
 class HelpCommand(runner: Runner, jc: JCommander) extends Command {
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -133,10 +133,9 @@ object RichAttributeDescriptors extends Conversions {
   // noinspection AccessorLikeMethodIsEmptyParen
   implicit class RichAttributeDescriptor(val ad: AttributeDescriptor) extends AnyVal {
 
-    def setKeepStats(enabled: Boolean): Unit = if (enabled) {
-      ad.getUserData.put(OptStats, "true")
-    } else {
-      ad.getUserData.remove(OptStats)
+    def setKeepStats(enabled: Boolean): AttributeDescriptor = {
+      if (enabled) { ad.getUserData.put(OptStats, "true") } else { ad.getUserData.remove(OptStats) }
+      ad
     }
     def isKeepStats(): Boolean = boolean(ad.getUserData.get(OptStats))
 
@@ -145,8 +144,10 @@ object RichAttributeDescriptors extends Conversions {
     def getColumnGroups(): Set[String] =
       Option(ad.getUserData.get(OptColumnGroups).asInstanceOf[String]).map(_.split(",").toSet).getOrElse(Set.empty)
 
-    def setCardinality(cardinality: Cardinality): Unit =
+    def setCardinality(cardinality: Cardinality): AttributeDescriptor = {
       ad.getUserData.put(OptCardinality, cardinality.toString)
+      ad
+    }
 
     def getCardinality(): Cardinality =
       Option(ad.getUserData.get(OptCardinality).asInstanceOf[String])
@@ -154,13 +155,17 @@ object RichAttributeDescriptors extends Conversions {
 
     def isJson(): Boolean = boolean(ad.getUserData.get(OptJson))
 
-    def setListType(typ: Class[_]): Unit = ad.getUserData.put(UserDataListType, typ.getName)
+    def setListType(typ: Class[_]): AttributeDescriptor = {
+      ad.getUserData.put(UserDataListType, typ.getName)
+      ad
+    }
 
     def getListType(): Class[_] = tryClass(ad.getUserData.get(UserDataListType).asInstanceOf[String])
 
-    def setMapTypes(keyType: Class[_], valueType: Class[_]): Unit = {
+    def setMapTypes(keyType: Class[_], valueType: Class[_]): AttributeDescriptor = {
       ad.getUserData.put(UserDataMapKeyType, keyType.getName)
       ad.getUserData.put(UserDataMapValueType, valueType.getName)
+      ad
     }
 
     def getMapTypes(): (Class[_], Class[_]) =

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/ObjectType.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/ObjectType.scala
@@ -10,8 +10,6 @@ package org.locationtech.geomesa.utils.geotools
 
 import java.util.{UUID, Collections => jCollections, List => jList, Map => jMap}
 
-import org.geotools.feature.AttributeTypeBuilder
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.AttributeConfigs
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.AttributeConfigs.{UserDataListType, UserDataMapKeyType, UserDataMapValueType}
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.AttributeOptions._
 import org.locationtech.jts.geom._
@@ -28,17 +26,6 @@ object ObjectType extends Enumeration {
 
   // string sub-types
   val JSON = Value
-
-  private val geometryTypeMap = Map[Class[_], ObjectType](
-    classOf[Point]              -> POINT,
-    classOf[LineString]         -> LINESTRING,
-    classOf[Polygon]            -> POLYGON,
-    classOf[MultiLineString]    -> MULTILINESTRING,
-    classOf[MultiPolygon]       -> MULTIPOLYGON,
-    classOf[MultiPoint]         -> MULTIPOINT,
-    classOf[GeometryCollection] -> GEOMETRY_COLLECTION,
-    classOf[Geometry]           -> GEOMETRY
-  )
 
   /**
    * @see selectType(clazz: Class[_], metadata: java.util.Map[_, _])
@@ -76,7 +63,7 @@ object ObjectType extends Enumeration {
       case c if classOf[java.lang.Boolean].isAssignableFrom(c) => Seq(BOOLEAN)
       case c if classOf[java.util.Date].isAssignableFrom(c) => Seq(DATE)
       case c if classOf[UUID].isAssignableFrom(c) => Seq(UUID)
-      case c if classOf[Geometry].isAssignableFrom(c) => Seq(GEOMETRY, geometryTypeMap(c))
+      case c if classOf[Geometry].isAssignableFrom(c) => geometryType(c.asInstanceOf[Class[_ <: Geometry]])
       case c if classOf[Array[Byte]].isAssignableFrom(c) => Seq(BYTES)
       case c if classOf[jList[_]].isAssignableFrom(c) => listType(metadata)
       case c if classOf[jMap[_, _]].isAssignableFrom(c) => mapType(metadata)
@@ -85,34 +72,18 @@ object ObjectType extends Enumeration {
     }
   }
 
-  /**
-   * Create an attribute descriptor from a type binding
-   *
-   * @param name attribute name
-   * @param bindings bindings
-   * @return
-   */
-  def createDescriptor(name: String, bindings: Seq[ObjectType]): AttributeDescriptor = {
-    val builder = new AttributeTypeBuilder()
-
-    selectBindings(bindings) match {
-      case Seq(c) =>
-        builder.binding(c)
-
-      case Seq(c1, c2) if c1 == classOf[java.util.List[_]] =>
-        builder.binding(c1)
-        builder.userData(AttributeConfigs.UserDataListType, c2.getName)
-
-      case Seq(c1, c2, c3) if c1 == classOf[java.util.Map[_, _]] =>
-        builder.binding(c1)
-        builder.userData(AttributeConfigs.UserDataMapKeyType, c2.getName)
-        builder.userData(AttributeConfigs.UserDataMapValueType, c3.getName)
-
-      case b =>
-        throw new IllegalArgumentException(s"Unexpeced bindings: ${bindings}: $b")
+  private def geometryType(clazz: Class[_ <: Geometry]): Seq[ObjectType] = {
+    val subtype = clazz match {
+      case c if c == classOf[Point]              => POINT
+      case c if c == classOf[LineString]         => LINESTRING
+      case c if c == classOf[Polygon]            => POLYGON
+      case c if c == classOf[MultiLineString]    => MULTILINESTRING
+      case c if c == classOf[MultiPolygon]       => MULTIPOLYGON
+      case c if c == classOf[MultiPoint]         => MULTIPOINT
+      case c if c == classOf[GeometryCollection] => GEOMETRY_COLLECTION
+      case _                                     => GEOMETRY
     }
-
-    builder.buildDescriptor(name)
+    Seq(GEOMETRY, subtype)
   }
 
   private def listType(metadata: jMap[_, _]): Seq[ObjectType] = {
@@ -124,7 +95,7 @@ object ObjectType extends Enumeration {
   }
 
   private def mapType(metadata: jMap[_, _]): Seq[ObjectType] = {
-    val keyClass = Class.forName(metadata.get(UserDataMapKeyType).asInstanceOf[String])
+    val keyClass   = Class.forName(metadata.get(UserDataMapKeyType).asInstanceOf[String])
     val keyType = selectType(keyClass) match {
       case Seq(binding) => binding
       case _ => throw new IllegalArgumentException(s"Can't serialize map key type of ${keyClass.getName}")
@@ -135,24 +106,5 @@ object ObjectType extends Enumeration {
       case _ => throw new IllegalArgumentException(s"Can't serialize map value type of ${valueClass.getName}")
     }
     Seq(MAP, keyType, valueType)
-  }
-
-  private def selectBindings(types: Seq[ObjectType]): Seq[Class[_]] = {
-    types.head match {
-      case STRING   => Seq(classOf[java.lang.String])
-      case INT      => Seq(classOf[java.lang.Integer])
-      case LONG     => Seq(classOf[java.lang.Long])
-      case FLOAT    => Seq(classOf[java.lang.Float])
-      case DOUBLE   => Seq(classOf[java.lang.Double])
-      case BOOLEAN  => Seq(classOf[java.lang.Boolean])
-      case DATE     => Seq(classOf[java.util.Date])
-      case UUID     => Seq(classOf[UUID])
-      case BYTES    => Seq(classOf[Array[Byte]])
-      case GEOMETRY => geometryTypeMap.collectFirst { case (k, v) if v == types.last => k }.toSeq
-      case LIST     => Seq(classOf[java.util.List[_]], selectBindings(types.tail).head)
-      case MAP      => Seq(classOf[java.util.Map[_, _]], selectBindings(types.slice(1, 2)).head, selectBindings(types.slice(2, 3)).head)
-
-      case _ => throw new IllegalArgumentException(s"Unexpected type: ${types.head}")
-    }
   }
 }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
@@ -354,13 +354,23 @@ object SimpleFeatureTypes {
     */
   def mutable(sft: SimpleFeatureType): SimpleFeatureType = {
     if (sft.isInstanceOf[ImmutableSimpleFeatureType] || sft.getAttributeDescriptors.asScala.exists(isImmutable)) {
-      // note: SimpleFeatureTypeBuilder copies attribute user data but not feature user data
-      val copy = SimpleFeatureTypeBuilder.copy(sft)
-      copy.getUserData.putAll(sft.getUserData)
-      copy
+      copy(sft)
     } else {
       sft
     }
+  }
+
+  /**
+   * Copy a simple feature type, returning a mutable implementation
+   *
+   * @param sft simple feature type
+   * @return
+   */
+  def copy(sft: SimpleFeatureType): SimpleFeatureType = {
+    // note: SimpleFeatureTypeBuilder copies attribute user data but not feature user data
+    val copy = SimpleFeatureTypeBuilder.copy(sft)
+    copy.getUserData.putAll(sft.getUserData)
+    copy
   }
 
   private def isImmutable(d: AttributeDescriptor): Boolean =

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/sft/SimpleFeatureSpec.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/sft/SimpleFeatureSpec.scala
@@ -144,7 +144,7 @@ object SimpleFeatureSpec {
       SimpleAttributeSpec(name, binding, options)
     } else if (geometryTypeMap.contains(binding.getSimpleName)) {
       val opts = if (sft != null && sft.getGeometryDescriptor == descriptor) { options + (OptDefault -> "true") } else { options }
-      GeomAttributeSpec(name, binding, opts)
+      GeomAttributeSpec(name, binding.asInstanceOf[Class[_ <: Geometry]], opts)
     } else if (classOf[java.util.List[_]].isAssignableFrom(binding)) {
       val itemClass = Option(descriptor.getListType()).getOrElse(classOf[String])
       ListAttributeSpec(name, itemClass, options)
@@ -166,7 +166,8 @@ object SimpleFeatureSpec {
   /**
     * Geometry attribute
     */
-  case class GeomAttributeSpec(name: String, clazz: Class[_], options: Map[String, String]) extends AttributeSpec {
+  case class GeomAttributeSpec(name: String, clazz: Class[_ <: Geometry], options: Map[String, String])
+      extends AttributeSpec {
 
     val default: Boolean = options.get(OptDefault).exists(_.toBoolean)
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/sft/SimpleFeatureSpec.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/sft/SimpleFeatureSpec.scala
@@ -168,7 +168,7 @@ object SimpleFeatureSpec {
     */
   case class GeomAttributeSpec(name: String, clazz: Class[_], options: Map[String, String]) extends AttributeSpec {
 
-    private val default = options.get(OptDefault).exists(_.toBoolean)
+    val default: Boolean = options.get(OptDefault).exists(_.toBoolean)
 
     override def toSpec: String = if (default) { s"*${super.toSpec}" } else { super.toSpec }
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/sft/SimpleFeatureSpecParser.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/sft/SimpleFeatureSpecParser.scala
@@ -11,6 +11,7 @@ package org.locationtech.geomesa.utils.geotools.sft
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.geotools.sft.SimpleFeatureSpec._
 import org.locationtech.geomesa.utils.text.BasicParser
+import org.locationtech.jts.geom.Geometry
 import org.parboiled.errors.{ErrorUtils, InvalidInputError, ParsingException}
 import org.parboiled.scala.parserunners.{BasicParseRunner, ReportingParseRunner}
 import org.parboiled.scala.{EOI, ParsingResult, Rule1}
@@ -151,7 +152,7 @@ private class SimpleFeatureSpecParser extends BasicParser {
   }
 
   // matches any of the geometry types defined in geometryTypeMap
-  private def geometryType: Rule1[Class[_]] = rule("GeometryTypeBinding") {
+  private def geometryType: Rule1[Class[_ <: Geometry]] = rule("GeometryTypeBinding") {
     ":" ~ geometryTypeMap.keys.toList.sorted.reverse.map(str).reduce(_ | _) ~> geometryTypeMap.apply
   }
 


### PR DESCRIPTION
* `GeoMesaDataStore.checkSchemaCompatibility` can be used to create
  and update schemas with complicated checks

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>