### PR TITLE
GEOMESA-2956 Set deserialize charset in CqlTransformFilter

### DIFF
--- a/geomesa-hbase/geomesa-hbase-rpc/src/main/scala/org/locationtech/geomesa/hbase/rpc/filter/CqlTransformFilter.scala
+++ b/geomesa-hbase/geomesa-hbase-rpc/src/main/scala/org/locationtech/geomesa/hbase/rpc/filter/CqlTransformFilter.scala
@@ -284,7 +284,7 @@ object CqlTransformFilter extends StrictLogging with SamplingIterator {
       val cqlLength = ByteArrays.readInt(bytes, offset)
       offset += 4
       val cql = if (cqlLength == 0) { null } else {
-        IteratorCache.filter(sft, spec, new String(bytes, offset, cqlLength))
+        IteratorCache.filter(sft, spec, new String(bytes, offset, cqlLength,StandardCharsets.UTF_8))
       }
       offset += cqlLength
 


### PR DESCRIPTION
set the charset to UTF-8 in CqlTransformFilter#deserialize instead of using the JVM's character set as the same
as CqlTransformFilter#serialization.
Signed-off-by: xxxxs <Susheldon@users.noreply.github.com>