### PR TITLE
 reset metedata cache when delete catalog

### DIFF
--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStore.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStore.scala
@@ -68,6 +68,10 @@ class HBaseDataStore(con: ConnectionWrapper, override val config: HBaseDataStore
 
   override def dispose(): Unit = try { super.dispose() } finally { con.close() }
 
+  override def delete():Unit={
+    super.delete()
+    metadata.asInstanceOf[HBaseBackedMetadata[String]].resetCache()
+  }
   override protected def loadIteratorVersions: Set[String] = {
     import org.locationtech.geomesa.utils.conversions.ScalaImplicits.RichIterator
 

--- a/geomesa-hbase/geomesa-hbase-rpc/src/main/scala/org/locationtech/geomesa/hbase/rpc/filter/CqlTransformFilter.scala
+++ b/geomesa-hbase/geomesa-hbase-rpc/src/main/scala/org/locationtech/geomesa/hbase/rpc/filter/CqlTransformFilter.scala
@@ -275,7 +275,7 @@ object CqlTransformFilter extends StrictLogging with SamplingIterator {
       var offset = 0
       val sftLength = ByteArrays.readInt(bytes, offset)
       offset += 4
-      val spec = new String(bytes, offset, sftLength)
+      val spec = new String(bytes, offset, sftLength,StandardCharsets.UTF_8)
       offset += sftLength
 
       val sft = IteratorCache.sft(spec)
@@ -305,12 +305,12 @@ object CqlTransformFilter extends StrictLogging with SamplingIterator {
         }
       } else {
         offset += 4
-        val tdefs = new String(bytes, offset, tdefsLength)
+        val tdefs = new String(bytes, offset, tdefsLength,StandardCharsets.UTF_8)
         offset += tdefsLength
 
         val tsftLength = ByteArrays.readInt(bytes, offset)
         offset += 4
-        val tsft = IteratorCache.sft(new String(bytes, offset, tsftLength))
+        val tsft = IteratorCache.sft(new String(bytes, offset, tsftLength,StandardCharsets.UTF_8))
 
         feature.setTransforms(tdefs, tsft)
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStore.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStore.scala
@@ -85,7 +85,11 @@ abstract class GeoMesaDataStore[DS <: GeoMesaDataStore[DS]](val config: GeoMesaD
     * (index tables and catalog table)
     * NB: We are *not* currently deleting the query table and/or query information.
     */
-  def delete(): Unit = adapter.deleteTables(getTypeNames.flatMap(getAllTableNames).distinct)
+  def delete(): Unit = {
+    val types = getTypeNames
+    val tables = if (types.length == 0) Array(config.catalog) else types
+    adapter.deleteTables(types.flatMap(getAllTableNames).distinct)
+  }
 
   // hooks to allow extended functionality
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/TableBasedMetadata.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/metadata/TableBasedMetadata.scala
@@ -99,7 +99,7 @@ trait TableBasedMetadata[T] extends GeoMesaMetadata[T] with LazyLogging {
   protected def scanKeys(): CloseableIterator[(String, String)]
 
   // only synchronize if table doesn't exist - otherwise it's ready only and we can avoid synchronization
-  private val tableExists: MaybeSynchronized[Boolean] =
+  private var tableExists: MaybeSynchronized[Boolean] =
     if (checkIfTableExists) { new NotSynchronized(true) } else { new IsSynchronized(false) }
 
   private val expiry = TableBasedMetadata.Expiry.toDuration.get.toMillis
@@ -231,6 +231,11 @@ trait TableBasedMetadata[T] extends GeoMesaMetadata[T] with LazyLogging {
   // checks that the table is already created, and creates it if not
   def ensureTableExists(): Unit = tableExists.set(true, false, createTable())
 
+
+  def resetCache():Unit={
+    tableExists = if (checkIfTableExists) { new NotSynchronized[Boolean](true)} else {new IsSynchronized[Boolean](false)}
+    metaDataCache.invalidateAll()
+  }
   /**
     * Invalidate all keys for the given feature type
     *


### PR DESCRIPTION
The original logic will cause the failure to delete the catalog after calling HBaseDataStore.delete() after removing all schemas through datastore.remove(), and failing to create a new typename through datastore.create() after calling HBaseDataStore.delete() 