### PR TITLE
GEOMESA-2969 Align Spark geometry representations with FSDS parquet

### DIFF
--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -90,6 +90,15 @@ Compatibility Matrix
 | Dependencies | N     | N     | Y     |
 +--------------+-------+-------+-------+
 
+Version 3.2.0 Upgrade Guide
++++++++++++++++++++++++++++
+
+Order of Columns in GeoMesa Spark
+---------------------------------
+
+When loading data from a ``SpatialRDDProvider`` in Spark, the ``__fid__`` column has been moved from the first
+element to the last element of the row, in order to better align with other GeoMesa formats.
+
 Version 3.1.0 Upgrade Guide
 +++++++++++++++++++++++++++
 

--- a/geomesa-fs/geomesa-fs-spark-runtime/src/test/scala/org/locationtech/geomesa/fs/spark/FileSystemRDDProviderTest.scala
+++ b/geomesa-fs/geomesa-fs-spark-runtime/src/test/scala/org/locationtech/geomesa/fs/spark/FileSystemRDDProviderTest.scala
@@ -106,7 +106,7 @@ class FileSystemRDDProviderTest extends Specification with LazyLogging {
             "dtg > '2016-01-01T12:00:00Z' AND dtg < '2016-01-02T12:00:00Z'"
         val rows = sc.sql(select).collect()
         rows must haveLength(1)
-        rows.head.get(0) mustEqual "2"
+        rows.head.get(rows.head.fieldIndex("__fid__")) mustEqual "2"
       }
     }
 
@@ -207,8 +207,8 @@ class FileSystemRDDProviderTest extends Specification with LazyLogging {
         }
         val res = sc.sql(s"select * from $format").collect()
         res must haveLength(2)
-        res.map(_.get(0)).toSeq must containTheSameElementsAs(Seq("1", "3"))
-        res.collectFirst { case r if r.get(0) == "1" => r.get(4) } must beSome[Any](WKTUtils.read("POINT (76.5 38.5)"))
+        res.map(r => r.get(r.fieldIndex("__fid__"))).toSeq must containTheSameElementsAs(Seq("1", "3"))
+        res.collectFirst { case r if r.get(r.fieldIndex("__fid__")) == "1" => r.get(r.fieldIndex("geom")) } must beSome[Any](WKTUtils.read("POINT (76.5 38.5)"))
       }
     }
   }

--- a/geomesa-hbase/geomesa-hbase-rpc/src/main/scala/org/locationtech/geomesa/hbase/rpc/filter/CqlTransformFilter.scala
+++ b/geomesa-hbase/geomesa-hbase-rpc/src/main/scala/org/locationtech/geomesa/hbase/rpc/filter/CqlTransformFilter.scala
@@ -275,7 +275,7 @@ object CqlTransformFilter extends StrictLogging with SamplingIterator {
       var offset = 0
       val sftLength = ByteArrays.readInt(bytes, offset)
       offset += 4
-      val spec = new String(bytes, offset, sftLength)
+      val spec = new String(bytes, offset, sftLength,StandardCharsets.UTF_8)
       offset += sftLength
 
       val sft = IteratorCache.sft(spec)
@@ -305,12 +305,12 @@ object CqlTransformFilter extends StrictLogging with SamplingIterator {
         }
       } else {
         offset += 4
-        val tdefs = new String(bytes, offset, tdefsLength)
+        val tdefs = new String(bytes, offset, tdefsLength,StandardCharsets.UTF_8)
         offset += tdefsLength
 
         val tsftLength = ByteArrays.readInt(bytes, offset)
         offset += 4
-        val tsft = IteratorCache.sft(new String(bytes, offset, tsftLength))
+        val tsft = IteratorCache.sft(new String(bytes, offset, tsftLength,StandardCharsets.UTF_8))
 
         feature.setTransforms(tdefs, tsft)
 

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/apache/spark/sql/jts/AbstractGeometryUDT.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/apache/spark/sql/jts/AbstractGeometryUDT.scala
@@ -8,11 +8,8 @@
 
 package org.apache.spark.sql.jts
 
-import org.locationtech.jts.geom.Geometry
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.types._
-import org.locationtech.geomesa.spark.jts.util.WKBUtils
+import org.locationtech.jts.geom.{Geometry, GeometryFactory}
 
 import scala.reflect._
 
@@ -23,21 +20,11 @@ import scala.reflect._
  */
 abstract class AbstractGeometryUDT[T >: Null <: Geometry: ClassTag](override val simpleString: String)
   extends UserDefinedType[T] {
+  protected def gf: GeometryFactory = AbstractGeometryUDT.gf
+  override lazy val pyUDT: String = s"geomesa_pyspark.types.${getClass.getSimpleName}"
+  override lazy val userClass: Class[T] = classTag[T].runtimeClass.asInstanceOf[Class[T]]
+}
 
-  override def pyUDT: String = s"geomesa_pyspark.types.${getClass.getSimpleName}"
-
-  override def serialize(obj: T): InternalRow = {
-    new GenericInternalRow(Array[Any](WKBUtils.write(obj)))
-  }
-
-  override def sqlType: DataType = StructType(Seq(
-    StructField("wkb", DataTypes.BinaryType)
-  ))
-
-  override def userClass: Class[T] = classTag[T].runtimeClass.asInstanceOf[Class[T]]
-
-  override def deserialize(datum: Any): T = {
-    val ir = datum.asInstanceOf[InternalRow]
-    WKBUtils.read(ir.getBinary(0)).asInstanceOf[T]
-  }
+object AbstractGeometryUDT {
+  private val gf = new GeometryFactory()
 }

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/apache/spark/sql/jts/JTSTypes.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/apache/spark/sql/jts/JTSTypes.scala
@@ -19,25 +19,50 @@ import org.locationtech.jts.geom._
 
 object JTSTypes {
 
-  val GeometryTypeInstance          : GeometryUDT = GeometryUDT
-  val PointTypeInstance             : PointUDT = PointUDT
-  val LineStringTypeInstance        : LineStringUDT = LineStringUDT
-  val PolygonTypeInstance           : PolygonUDT = PolygonUDT
-  val MultiPointTypeInstance        : MultiPointUDT = MultiPointUDT
-  val MultiLineStringTypeInstance   : MultiLineStringUDT = MultiLineStringUDT
-  @deprecated("replaced with MultiPolygonTypeInstance")
-  val MultipolygonTypeInstance      : MultiPolygonUDT = MultiPolygonUDT
-  val MultiPolygonTypeInstance      : MultiPolygonUDT = MultiPolygonUDT
+  val GeometryUDT          : GeometryUDT = new GeometryUDT()
+  val PointUDT             : PointUDT = new PointUDT()
+  val LineStringUDT        : LineStringUDT = new LineStringUDT()
+  val PolygonUDT           : PolygonUDT = new PolygonUDT()
+  val MultiPointUDT        : MultiPointUDT = new MultiPointUDT()
+  val MultiLineStringUDT   : MultiLineStringUDT = new MultiLineStringUDT()
+  val MultiPolygonUDT      : MultiPolygonUDT = new MultiPolygonUDT()
+  val GeometryCollectionUDT: GeometryCollectionUDT = new GeometryCollectionUDT()
+
+  @deprecated("replaced with MultiPolygonUDT")
+  val MultipolygonTypeInstance: MultiPolygonUDT = new MultiPolygonUDT()
+  @deprecated("replaced with GeometryUDT")
+  val GeometryTypeInstance: GeometryUDT = GeometryUDT
+  @deprecated("replaced with GeometryUDT")
+  val PointTypeInstance: PointUDT = PointUDT
+  @deprecated("replaced with GeometryUDT")
+  val LineStringTypeInstance: LineStringUDT = LineStringUDT
+  @deprecated("replaced with GeometryUDT")
+  val PolygonTypeInstance: PolygonUDT = PolygonUDT
+  @deprecated("replaced with GeometryUDT")
+  val MultiPointTypeInstance: MultiPointUDT = MultiPointUDT
+  @deprecated("replaced with GeometryUDT")
+  val MultiLineStringTypeInstance: MultiLineStringUDT = MultiLineStringUDT
+  @deprecated("replaced with GeometryUDT")
+  val MultiPolygonTypeInstance: MultiPolygonUDT = MultiPolygonUDT
+  @deprecated("replaced with GeometryUDT")
   val GeometryCollectionTypeInstance: GeometryCollectionUDT = GeometryCollectionUDT
 
   // these constant values conform to WKB values
-  val GeometryType           = 0
-  val PointType              = 1
-  val LineStringType         = 2
-  val PolygonType            = 3
-  val MultiPointType         = 4
-  val MultiLineStringType    = 5
-  val MultiPolygonType       = 6
+  @deprecated("unused")
+  val GeometryType = 0
+  @deprecated("unused")
+  val PointType = 1
+  @deprecated("unused")
+  val LineStringType = 2
+  @deprecated("unused")
+  val PolygonType = 3
+  @deprecated("unused")
+  val MultiPointType = 4
+  @deprecated("unused")
+  val MultiLineStringType = 5
+  @deprecated("unused")
+  val MultiPolygonType = 6
+  @deprecated("unused")
   val GeometryCollectionType = 7
 
   val typeMap: Map[Class[_], Class[_ <: UserDefinedType[_]]] = Map(
@@ -77,8 +102,6 @@ class PointUDT extends AbstractGeometryUDT[Point]("point"){
     }
   }
 }
-
-case object PointUDT extends PointUDT
 
 class MultiPointUDT extends AbstractGeometryUDT[MultiPoint]("multipoint") {
 
@@ -135,8 +158,6 @@ class MultiPointUDT extends AbstractGeometryUDT[MultiPoint]("multipoint") {
   }
 }
 
-case object MultiPointUDT extends MultiPointUDT
-
 class LineStringUDT extends AbstractGeometryUDT[LineString]("linestring") {
 
   // parquet definition:
@@ -189,8 +210,6 @@ class LineStringUDT extends AbstractGeometryUDT[LineString]("linestring") {
     }
   }
 }
-
-case object LineStringUDT extends LineStringUDT
 
 class MultiLineStringUDT extends AbstractGeometryUDT[MultiLineString]("multilinestring") {
 
@@ -261,8 +280,6 @@ class MultiLineStringUDT extends AbstractGeometryUDT[MultiLineString]("multiline
     }
   }
 }
-
-case object MultiLineStringUDT extends MultiLineStringUDT
 
 class PolygonUDT extends AbstractGeometryUDT[Polygon]("polygon") {
 
@@ -339,8 +356,6 @@ class PolygonUDT extends AbstractGeometryUDT[Polygon]("polygon") {
     }
   }
 }
-
-case object PolygonUDT extends PolygonUDT
 
 class MultiPolygonUDT extends AbstractGeometryUDT[MultiPolygon]("multipolygon") {
 
@@ -439,8 +454,6 @@ class MultiPolygonUDT extends AbstractGeometryUDT[MultiPolygon]("multipolygon") 
   }
 }
 
-case object MultiPolygonUDT extends MultiPolygonUDT
-
 class GeometryUDT extends AbstractGeometryUDT[Geometry]("geometry") {
 
   // parquet file metadata:
@@ -448,14 +461,14 @@ class GeometryUDT extends AbstractGeometryUDT[Geometry]("geometry") {
 
   private [sql] override def acceptsType(dataType: DataType): Boolean = {
     super.acceptsType(dataType) ||
-      dataType.getClass == JTSTypes.GeometryTypeInstance.getClass ||
-      dataType.getClass == JTSTypes.PointTypeInstance.getClass ||
-      dataType.getClass == JTSTypes.LineStringTypeInstance.getClass ||
-      dataType.getClass == JTSTypes.PolygonTypeInstance.getClass ||
-      dataType.getClass == JTSTypes.MultiLineStringTypeInstance.getClass ||
-      dataType.getClass == JTSTypes.MultiPointTypeInstance.getClass ||
-      dataType.getClass == JTSTypes.MultipolygonTypeInstance.getClass ||
-      dataType.getClass == JTSTypes.GeometryCollectionTypeInstance.getClass
+      dataType.getClass == classOf[GeometryUDT] ||
+      dataType.getClass == classOf[PointUDT] ||
+      dataType.getClass == classOf[LineStringUDT] ||
+      dataType.getClass == classOf[PolygonUDT] ||
+      dataType.getClass == classOf[MultiLineStringUDT] ||
+      dataType.getClass == classOf[MultiPointUDT] ||
+      dataType.getClass == classOf[MultiPolygonUDT] ||
+      dataType.getClass == classOf[GeometryCollectionUDT]
   }
 
   // Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL)
@@ -480,9 +493,9 @@ class GeometryCollectionUDT
 
   private [sql] override def acceptsType(dataType: DataType): Boolean = {
     super.acceptsType(dataType) ||
-        dataType.getClass == JTSTypes.MultiLineStringTypeInstance.getClass ||
-        dataType.getClass == JTSTypes.MultiPointTypeInstance.getClass ||
-        dataType.getClass == JTSTypes.MultipolygonTypeInstance.getClass
+        dataType.getClass == classOf[MultiLineStringUDT] ||
+        dataType.getClass == classOf[MultiPointUDT] ||
+        dataType.getClass == classOf[MultiPolygonUDT]
   }
 
   override def sqlType: DataType = DataTypes.BinaryType
@@ -498,5 +511,3 @@ class GeometryCollectionUDT
     }
   }
 }
-
-case object GeometryCollectionUDT extends GeometryCollectionUDT

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/apache/spark/sql/jts/JTSTypes.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/apache/spark/sql/jts/JTSTypes.scala
@@ -8,19 +8,27 @@
 
 package org.apache.spark.sql.jts
 
-import org.locationtech.jts.geom._
-import org.apache.spark.sql._
+import java.io.IOException
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.types._
+import org.locationtech.geomesa.spark.jts.util.WKBUtils
+import org.locationtech.jts.geom._
 
 object JTSTypes {
-  val GeometryTypeInstance           = new GeometryUDT
-  val PointTypeInstance              = new PointUDT
-  val LineStringTypeInstance         = new LineStringUDT
-  val PolygonTypeInstance            = new PolygonUDT
-  val MultiPointTypeInstance         = new MultiPointUDT
-  val MultiLineStringTypeInstance    = new MultiLineStringUDT
-  val MultipolygonTypeInstance       = new MultiPolygonUDT
-  val GeometryCollectionTypeInstance = new GeometryCollectionUDT
+
+  val GeometryTypeInstance          : GeometryUDT = GeometryUDT
+  val PointTypeInstance             : PointUDT = PointUDT
+  val LineStringTypeInstance        : LineStringUDT = LineStringUDT
+  val PolygonTypeInstance           : PolygonUDT = PolygonUDT
+  val MultiPointTypeInstance        : MultiPointUDT = MultiPointUDT
+  val MultiLineStringTypeInstance   : MultiLineStringUDT = MultiLineStringUDT
+  @deprecated("replaced with MultiPolygonTypeInstance")
+  val MultipolygonTypeInstance      : MultiPolygonUDT = MultiPolygonUDT
+  val MultiPolygonTypeInstance      : MultiPolygonUDT = MultiPolygonUDT
+  val GeometryCollectionTypeInstance: GeometryCollectionUDT = GeometryCollectionUDT
 
   // these constant values conform to WKB values
   val GeometryType           = 0
@@ -44,26 +52,401 @@ object JTSTypes {
   )
 }
 
-private [spark] class PointUDT extends AbstractGeometryUDT[Point]("point")
-object PointUDT extends PointUDT
+class PointUDT extends AbstractGeometryUDT[Point]("point"){
 
-private [spark] class MultiPointUDT extends AbstractGeometryUDT[MultiPoint]("multipoint")
-object MultiPointUDT extends MultiPointUDT
+  // parquet definition:
+  // group.id(GeometryBytes.TwkbPoint)
+  //  .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnX)
+  //  .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnY)
 
-private [spark] class LineStringUDT extends AbstractGeometryUDT[LineString]("linestring")
-object LineStringUDT extends LineStringUDT
+  override val sqlType: StructType = StructType(Seq(
+    StructField("x", DataTypes.DoubleType, nullable = false),
+    StructField("y", DataTypes.DoubleType, nullable = false)
+  ))
 
-private [spark] class MultiLineStringUDT extends AbstractGeometryUDT[MultiLineString]("multilinestring")
-object MultiLineStringUDT extends MultiLineStringUDT
+  override def serialize(obj: Point): InternalRow = {
+    if (obj == null) { null } else {
+      new GenericInternalRow(Array[Any](obj.getX, obj.getY))
+    }
+  }
 
-private [spark] class PolygonUDT extends AbstractGeometryUDT[Polygon]("polygon")
-object PolygonUDT extends PolygonUDT
+  override def deserialize(datum: Any): Point = {
+    if (datum == null) { null } else {
+      val row = ir(datum)
+      gf.createPoint(new Coordinate(row.getDouble(0), row.getDouble(1)))
+    }
+  }
+}
 
-private [spark] class MultiPolygonUDT extends AbstractGeometryUDT[MultiPolygon]("multipolygon")
-object MultiPolygonUDT extends MultiPolygonUDT
+case object PointUDT extends PointUDT
 
-private [spark] class GeometryUDT extends AbstractGeometryUDT[Geometry]("geometry") {
-  private[sql] override def acceptsType(dataType: DataType): Boolean = {
+class MultiPointUDT extends AbstractGeometryUDT[MultiPoint]("multipoint") {
+
+  // parquet definition:
+  // case ObjectType.MULTIPOINT =>
+  //   group.id(GeometryBytes.TwkbMultiPoint)
+  //     .repeated(PrimitiveTypeName.DOUBLE).named(GeometryColumnX)
+  //     .repeated(PrimitiveTypeName.DOUBLE).named(GeometryColumnY)
+
+  // parquet file metadata:
+  //  mpt:          OPTIONAL F:2
+  //  .x:           OPTIONAL F:1
+  //  ..list:       REPEATED F:1
+  //  ...element:   OPTIONAL DOUBLE R:1 D:4
+  //  .y:           OPTIONAL F:1
+  //  ..list:       REPEATED F:1
+  //  ...element:   OPTIONAL DOUBLE R:1 D:4
+
+  override def sqlType: DataType = StructType(Seq(
+    StructField("x", CoordArray(DataTypes.DoubleType), nullable = false),
+    StructField("y", CoordArray(DataTypes.DoubleType), nullable = false)
+  ))
+
+  // TODO seems like these serialization objects will lead to autoboxing of doubles
+
+  override def serialize(obj: MultiPoint): InternalRow = {
+    if (obj == null) { null } else {
+      val x = new GenericArrayData(Array.ofDim[Any](obj.getNumGeometries))
+      val y = new GenericArrayData(Array.ofDim[Any](obj.getNumGeometries))
+      var i = 0
+      while (i < x.numElements()) {
+        val c = obj.getGeometryN(i).asInstanceOf[Point].getCoordinate
+        x(i) = c.getX
+        y(i) = c.getY
+        i += 1
+      }
+      new GenericInternalRow(Array[Any](x, y))
+    }
+  }
+
+  override def deserialize(datum: Any): MultiPoint = {
+    if (datum == null) { null } else {
+      val row = ir(datum)
+      val x = row.getArray(0)
+      val y = row.getArray(1)
+      val c = Array.ofDim[Coordinate](x.numElements())
+      var i = 0
+      while (i < c.length) {
+        c(i) = new Coordinate(x.getDouble(i), y.getDouble(i))
+        i += 1
+      }
+      gf.createMultiPointFromCoords(c)
+    }
+  }
+}
+
+case object MultiPointUDT extends MultiPointUDT
+
+class LineStringUDT extends AbstractGeometryUDT[LineString]("linestring") {
+
+  // parquet definition:
+  // case ObjectType.LINESTRING =>
+  //   group.id(GeometryBytes.TwkbLineString)
+  //     .repeated(PrimitiveTypeName.DOUBLE).named(GeometryColumnX)
+  //     .repeated(PrimitiveTypeName.DOUBLE).named(GeometryColumnY)
+
+  // parquet file metadata:
+  //  line:         OPTIONAL F:2
+  //  .x:           OPTIONAL F:1
+  //  ..list:       REPEATED F:1
+  //  ...element:   OPTIONAL DOUBLE R:1 D:4
+  //  .y:           OPTIONAL F:1
+  //  ..list:       REPEATED F:1
+  //  ...element:   OPTIONAL DOUBLE R:1 D:4
+
+  override def sqlType: DataType = StructType(Seq(
+    StructField("x", CoordArray(DataTypes.DoubleType), nullable = false),
+    StructField("y", CoordArray(DataTypes.DoubleType), nullable = false)
+  ))
+
+  override def serialize(obj: LineString): InternalRow = {
+    if (obj == null) { null } else {
+      val x = new GenericArrayData(Array.ofDim[Any](obj.getNumPoints))
+      val y = new GenericArrayData(Array.ofDim[Any](obj.getNumPoints))
+      var i = 0
+      while (i < x.numElements()) {
+        val c = obj.getCoordinateN(i)
+        x(i) = c.getX
+        y(i) = c.getY
+        i += 1
+      }
+      new GenericInternalRow(Array[Any](x, y))
+    }
+  }
+
+  override def deserialize(datum: Any): LineString = {
+    if (datum == null) { null } else {
+      val row = ir(datum)
+      val x = row.getArray(0)
+      val y = row.getArray(1)
+      val c = Array.ofDim[Coordinate](x.numElements())
+      var i = 0
+      while (i < c.length) {
+        c(i) = new Coordinate(x.getDouble(i), y.getDouble(i))
+        i += 1
+      }
+      gf.createLineString(c)
+    }
+  }
+}
+
+case object LineStringUDT extends LineStringUDT
+
+class MultiLineStringUDT extends AbstractGeometryUDT[MultiLineString]("multilinestring") {
+
+  // parquet definition:
+  // case ObjectType.MULTILINESTRING =>
+  //   group.id(GeometryBytes.TwkbMultiLineString)
+  //     .requiredList().element(PrimitiveTypeName.DOUBLE, Repetition.REPEATED).named(GeometryColumnX)
+  //     .requiredList().element(PrimitiveTypeName.DOUBLE, Repetition.REPEATED).named(GeometryColumnY)
+
+  // parquet file metadata:
+  //  mline:        OPTIONAL F:2
+  //  .x:           OPTIONAL F:1
+  //  ..list:       REPEATED F:1
+  //  ...element:   OPTIONAL DOUBLE R:1 D:4
+  //  .y:           OPTIONAL F:1
+  //  ..list:       REPEATED F:1
+  //  ...element:   OPTIONAL DOUBLE R:1 D:4
+
+  override def sqlType: DataType = StructType(Seq(
+    StructField("x", CoordArray(CoordArray(DataTypes.DoubleType)), nullable = false),
+    StructField("y", CoordArray(CoordArray(DataTypes.DoubleType)), nullable = false)
+  ))
+
+  override def serialize(obj: MultiLineString): InternalRow = {
+    if (obj == null) { null } else {
+      val x = new GenericArrayData(Array.ofDim[Any](obj.getNumGeometries))
+      val y = new GenericArrayData(Array.ofDim[Any](obj.getNumGeometries))
+      var i = 0
+      while (i < obj.getNumGeometries) {
+        val line = obj.getGeometryN(i).asInstanceOf[LineString]
+        val xx = new GenericArrayData(Array.ofDim[Any](line.getNumPoints))
+        val yy = new GenericArrayData(Array.ofDim[Any](line.getNumPoints))
+        var j = 0
+        while (j < xx.numElements()) {
+          val c = line.getCoordinateN(j)
+          xx(j) = c.getX
+          yy(j) = c.getY
+          j += 1
+        }
+        x(i) = xx
+        y(i) = yy
+        i += 1
+      }
+      new GenericInternalRow(Array[Any](x, y))
+    }
+  }
+
+  override def deserialize(datum: Any): MultiLineString = {
+    if (datum == null) { null } else {
+      val row = ir(datum)
+      val x = row.getArray(0)
+      val y = row.getArray(1)
+      val lines = Array.ofDim[LineString](x.numElements())
+      var i = 0
+      while (i < lines.length) {
+        val xx = x.getArray(i)
+        val yy = y.getArray(i)
+        val c = Array.ofDim[Coordinate](xx.numElements())
+        var j = 0
+        while (j < c.length) {
+          c(j) = new Coordinate(xx.getDouble(j), yy.getDouble(j))
+          j += 1
+        }
+        lines(i) = gf.createLineString(c)
+        i += 1
+      }
+      gf.createMultiLineString(lines)
+    }
+  }
+}
+
+case object MultiLineStringUDT extends MultiLineStringUDT
+
+class PolygonUDT extends AbstractGeometryUDT[Polygon]("polygon") {
+
+  // parquet definition:
+  // case ObjectType.POLYGON =>
+  //   group.id(GeometryBytes.TwkbPolygon)
+  //     .requiredList().element(PrimitiveTypeName.DOUBLE, Repetition.REPEATED).named(GeometryColumnX)
+  //     .requiredList().element(PrimitiveTypeName.DOUBLE, Repetition.REPEATED).named(GeometryColumnY)
+
+  // parquet file metadata:
+  //  poly:         OPTIONAL F:2
+  //  .x:           OPTIONAL F:1
+  //  ..list:       REPEATED F:1
+  //  ...element:   OPTIONAL DOUBLE R:1 D:4
+  //  .y:           OPTIONAL F:1
+  //  ..list:       REPEATED F:1
+  //  ...element:   OPTIONAL DOUBLE R:1 D:4
+
+  override def sqlType: DataType = StructType(Seq(
+    StructField("x", CoordArray(CoordArray(DataTypes.DoubleType)), nullable = false),
+    StructField("y", CoordArray(CoordArray(DataTypes.DoubleType)), nullable = false)
+  ))
+
+  override def serialize(obj: Polygon): InternalRow = {
+    if (obj == null) { null } else {
+      val x = new GenericArrayData(Array.ofDim[Any](obj.getNumInteriorRing + 1))
+      val y = new GenericArrayData(Array.ofDim[Any](obj.getNumInteriorRing + 1))
+      var i = 0
+      while (i < obj.getNumInteriorRing + 1) {
+        val line = if (i == 0) { obj.getExteriorRing} else { obj.getInteriorRingN(i - 1) }
+        val xx = new GenericArrayData(Array.ofDim[Any](line.getNumPoints))
+        val yy = new GenericArrayData(Array.ofDim[Any](line.getNumPoints))
+        var j = 0
+        while (j < xx.numElements()) {
+          val c = line.getCoordinateN(j)
+          xx(j) = c.getX
+          yy(j) = c.getY
+          j += 1
+        }
+        x(i) = xx
+        y(i) = yy
+        i += 1
+      }
+      new GenericInternalRow(Array[Any](x, y))
+    }
+  }
+
+  override def deserialize(datum: Any): Polygon = {
+    if (datum == null) { null } else {
+      val row = ir(datum)
+      val x = row.getArray(0)
+      val y = row.getArray(1)
+      var shell: LinearRing = null
+      val holes = Array.ofDim[LinearRing](x.numElements() - 1)
+      var i = 0
+      while (i < x.numElements()) {
+        val xx = x.getArray(i)
+        val yy = y.getArray(i)
+        val c = Array.ofDim[Coordinate](xx.numElements())
+        var j = 0
+        while (j < c.length) {
+          c(j) = new Coordinate(xx.getDouble(j), yy.getDouble(j))
+          j += 1
+        }
+        val line = gf.createLinearRing(c)
+        if (i == 0) {
+          shell = line
+        } else {
+          holes(i - 1) = line
+        }
+        i += 1
+      }
+      gf.createPolygon(shell, holes)
+    }
+  }
+}
+
+case object PolygonUDT extends PolygonUDT
+
+class MultiPolygonUDT extends AbstractGeometryUDT[MultiPolygon]("multipolygon") {
+
+  // parquet definition:
+  // case ObjectType.MULTIPOLYGON =>
+  //   group.id(GeometryBytes.TwkbMultiPolygon)
+  //     .requiredList().requiredListElement().element(PrimitiveTypeName.DOUBLE, Repetition.REPEATED).named(GeometryColumnX)
+  //     .requiredList().requiredListElement().element(PrimitiveTypeName.DOUBLE, Repetition.REPEATED).named(GeometryColumnY)
+
+  // parquet file metadata:
+  //  mpoly:        OPTIONAL F:2
+  //  .x:           OPTIONAL F:1
+  //  ..list:       REPEATED F:1
+  //  ...element:   OPTIONAL F:1
+  //  ....list:     REPEATED F:1
+  //  .....element: OPTIONAL DOUBLE R:2 D:6
+  //  .y:           OPTIONAL F:1
+  //  ..list:       REPEATED F:1
+  //  ...element:   OPTIONAL F:1
+  //  ....list:     REPEATED F:1
+  //  .....element: OPTIONAL DOUBLE R:2 D:6
+
+  override def sqlType: DataType = StructType(Seq(
+    StructField("x", CoordArray(CoordArray(CoordArray(DataTypes.DoubleType))), nullable = false),
+    StructField("y", CoordArray(CoordArray(CoordArray(DataTypes.DoubleType))), nullable = false)
+  ))
+
+  override def serialize(obj: MultiPolygon): InternalRow = {
+    if (obj == null) { null } else {
+      val x = new GenericArrayData(Array.ofDim[Any](obj.getNumGeometries))
+      val y = new GenericArrayData(Array.ofDim[Any](obj.getNumGeometries))
+      var i = 0
+      while (i < obj.getNumGeometries) {
+        val poly = obj.getGeometryN(i).asInstanceOf[Polygon]
+        val xx = new GenericArrayData(Array.ofDim[Any](poly.getNumInteriorRing + 1))
+        val yy = new GenericArrayData(Array.ofDim[Any](poly.getNumInteriorRing + 1))
+        var j = 0
+        while (j < poly.getNumInteriorRing + 1) {
+          val line = if (j == 0) { poly.getExteriorRing} else { poly.getInteriorRingN(j - 1) }
+          val xxx = new GenericArrayData(Array.ofDim[Any](line.getNumPoints))
+          val yyy = new GenericArrayData(Array.ofDim[Any](line.getNumPoints))
+          var k = 0
+          while (k < xxx.numElements()) {
+            val c = line.getCoordinateN(k)
+            xxx(k) = c.getX
+            yyy(k) = c.getY
+            k += 1
+          }
+          xx(j) = xxx
+          yy(j) = yyy
+          j += 1
+        }
+        x(i) = xx
+        y(i) = yy
+        i += 1
+      }
+      new GenericInternalRow(Array[Any](x, y))
+    }
+  }
+
+  override def deserialize(datum: Any): MultiPolygon = {
+    if (datum == null) { null } else {
+      val row = ir(datum)
+      val x = row.getArray(0)
+      val y = row.getArray(1)
+      val polys = Array.ofDim[Polygon](x.numElements())
+      var i = 0
+      while (i < x.numElements()) {
+        val xx = x.getArray(i)
+        val yy = y.getArray(i)
+        var shell: LinearRing = null
+        val holes = Array.ofDim[LinearRing](xx.numElements() - 1)
+        var j = 0
+        while (j < xx.numElements()) {
+          val xxx = xx.getArray(j)
+          val yyy = yy.getArray(j)
+          val c = Array.ofDim[Coordinate](xxx.numElements())
+          var k = 0
+          while (k < c.length) {
+            c(k) = new Coordinate(xxx.getDouble(k), yyy.getDouble(k))
+            k += 1
+          }
+          val line = gf.createLinearRing(c)
+          if (j == 0) {
+            shell = line
+          } else {
+            holes(j - 1) = line
+          }
+          j += 1
+        }
+        polys(i) = gf.createPolygon(shell, holes)
+        i += 1
+      }
+      gf.createMultiPolygon(polys)
+    }
+  }
+}
+
+case object MultiPolygonUDT extends MultiPolygonUDT
+
+class GeometryUDT extends AbstractGeometryUDT[Geometry]("geometry") {
+
+  // parquet file metadata:
+  //  g:    OPTIONAL BINARY R:0 D:1
+
+  private [sql] override def acceptsType(dataType: DataType): Boolean = {
     super.acceptsType(dataType) ||
       dataType.getClass == JTSTypes.GeometryTypeInstance.getClass ||
       dataType.getClass == JTSTypes.PointTypeInstance.getClass ||
@@ -74,12 +457,46 @@ private [spark] class GeometryUDT extends AbstractGeometryUDT[Geometry]("geometr
       dataType.getClass == JTSTypes.MultipolygonTypeInstance.getClass ||
       dataType.getClass == JTSTypes.GeometryCollectionTypeInstance.getClass
   }
+
+  // Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL)
+  override def sqlType: DataType = DataTypes.BinaryType
+
+  override def serialize(obj: Geometry): Array[Byte] =
+    if (obj == null) { null } else { WKBUtils.write(obj) }
+
+  override def deserialize(datum: Any): Geometry = {
+    datum match {
+      case null => null
+      case a: Array[Byte] => WKBUtils.read(a)
+      case _ => throw new IOException(s"Invalid serialized geometry: $datum")
+    }
+  }
 }
 
 case object GeometryUDT extends GeometryUDT
 
-private [spark] class GeometryCollectionUDT
-  extends AbstractGeometryUDT[GeometryCollection]("geometrycollection")
+class GeometryCollectionUDT
+  extends AbstractGeometryUDT[GeometryCollection]("geometrycollection") {
 
-object GeometryCollectionUDT extends GeometryCollectionUDT
+  private [sql] override def acceptsType(dataType: DataType): Boolean = {
+    super.acceptsType(dataType) ||
+        dataType.getClass == JTSTypes.MultiLineStringTypeInstance.getClass ||
+        dataType.getClass == JTSTypes.MultiPointTypeInstance.getClass ||
+        dataType.getClass == JTSTypes.MultipolygonTypeInstance.getClass
+  }
 
+  override def sqlType: DataType = DataTypes.BinaryType
+
+  override def serialize(obj: GeometryCollection): Array[Byte] =
+    if (obj == null) { null } else { WKBUtils.write(obj) }
+
+  override def deserialize(datum: Any): GeometryCollection = {
+    datum match {
+      case null => null
+      case a: Array[Byte] => WKBUtils.read(a).asInstanceOf[GeometryCollection]
+      case _ => throw new IOException(s"Invalid serialized geometry: $datum")
+    }
+  }
+}
+
+case object GeometryCollectionUDT extends GeometryCollectionUDT

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/apache/spark/sql/jts/package.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/apache/spark/sql/jts/package.scala
@@ -8,7 +8,10 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.sql.types.UDTRegistration
+import java.io.IOException
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.{ArrayType, DataType, UDTRegistration}
 
 package object jts {
   /**
@@ -21,5 +24,14 @@ package object jts {
    */
   private[jts] lazy val registration: Unit = JTSTypes.typeMap.foreach {
     case (l, r) => UDTRegistration.register(l.getCanonicalName, r.getCanonicalName)
+  }
+
+  private[spark] def CoordArray(t: DataType): DataType = ArrayType(t, containsNull = false)
+
+  private[spark] def ir(datum: Any): InternalRow = {
+    datum match {
+      case ir: InternalRow => ir
+      case _ => throw new IOException(s"Invalid serialized geometry: $datum")
+    }
   }
 }

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/DataFrameFunctions.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/DataFrameFunctions.scala
@@ -18,7 +18,6 @@ import org.apache.spark.sql.{Column, Encoder, Encoders, TypedColumn}
 import org.locationtech.geomesa.spark.jts.encoders.SpatialEncoders
 import org.locationtech.geomesa.spark.jts.util.SQLFunctionHelper._
 
-
 /**
  * DataFrame DSL functions for working with JTS types
  */
@@ -39,21 +38,21 @@ object DataFrameFunctions extends SpatialEncoders {
       new Column(Literal.create(u.serialize(t), u)).as[T]
 
     /** Create a generic geometry literal, encoded as a GeometryUDT. */
-    def geomLit(g: Geometry): TypedColumn[Any, Geometry] = udtlit(g, GeometryUDT)
+    def geomLit(g: Geometry): TypedColumn[Any, Geometry] = udtlit(g, JTSTypes.GeometryUDT)
     /** Create a point literal, encoded as a PointUDT. */
-    def pointLit(g: Point): TypedColumn[Any, Point] = udtlit(g, PointUDT)
+    def pointLit(g: Point): TypedColumn[Any, Point] = udtlit(g, JTSTypes.PointUDT)
     /** Create a line literal, encoded as a LineUDT. */
-    def lineLit(g: LineString): TypedColumn[Any, LineString] = udtlit(g, LineStringUDT)
+    def lineLit(g: LineString): TypedColumn[Any, LineString] = udtlit(g, JTSTypes.LineStringUDT)
     /** Create a polygon literal, encoded as a PolygonUDT. */
-    def polygonLit(g: Polygon): TypedColumn[Any, Polygon] = udtlit(g, PolygonUDT)
+    def polygonLit(g: Polygon): TypedColumn[Any, Polygon] = udtlit(g, JTSTypes.PolygonUDT)
     /** Create a multi-point literal, encoded as a MultiPointUDT. */
-    def mPointLit(g: MultiPoint): TypedColumn[Any, MultiPoint] = udtlit(g, MultiPointUDT)
+    def mPointLit(g: MultiPoint): TypedColumn[Any, MultiPoint] = udtlit(g, JTSTypes.MultiPointUDT)
     /** Create a multi-line literal, encoded as a MultiPointUDT. */
-    def mLineLit(g: MultiLineString): TypedColumn[Any, MultiLineString] = udtlit(g, MultiLineStringUDT)
+    def mLineLit(g: MultiLineString): TypedColumn[Any, MultiLineString] = udtlit(g, JTSTypes.MultiLineStringUDT)
     /** Create a multi-polygon literal, encoded as a MultiPolygonUDT. */
-    def mPolygonLit(g: MultiPolygon): TypedColumn[Any, MultiPolygon] = udtlit(g, MultiPolygonUDT)
+    def mPolygonLit(g: MultiPolygon): TypedColumn[Any, MultiPolygon] = udtlit(g, JTSTypes.MultiPolygonUDT)
     /** create a geometry collection literal, encoded as a GeometryCollectionUDT. */
-    def geomCollLit(g: GeometryCollection): TypedColumn[Any, GeometryCollection] = udtlit(g, GeometryCollectionUDT)
+    def geomCollLit(g: GeometryCollection): TypedColumn[Any, GeometryCollection] = udtlit(g, JTSTypes.GeometryCollectionUDT)
 
     def st_geomFromGeoHash(geohash: Column, precision: Column): TypedColumn[Any, Geometry] =
       udfToColumn(ST_GeomFromGeoHash, constructorNames, geohash, precision)

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/rules/GeometryLiteral.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/rules/GeometryLiteral.scala
@@ -8,24 +8,98 @@
 
 package org.locationtech.geomesa.spark.jts.rules
 
-import org.locationtech.jts.geom.Geometry
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.LeafExpression
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.jts.JTSTypes.GeometryTypeInstance
+import org.apache.spark.sql.jts.JTSTypes._
 import org.apache.spark.sql.types.DataType
+import org.locationtech.jts.geom._
 
 /**
  * Catalyst AST expression used during rule rewriting to extract geometry literal values
  * from Catalyst memory and keep a copy in JVM heap space for subsequent use in rule evaluation.
  */
-case class GeometryLiteral(repr: InternalRow, geom: Geometry) extends LeafExpression  with CodegenFallback {
-
+abstract class GeometryLiteral extends LeafExpression with CodegenFallback {
+  def geom: Geometry
+  def repr: Any
   override def foldable: Boolean = true
-
   override def nullable: Boolean = true
-
   override def eval(input: InternalRow): Any = repr
-
-  override def dataType: DataType = GeometryTypeInstance
 }
+
+object GeometryLiteral {
+
+  def unapply(g: GeometryLiteral): Option[(Any, Geometry)] = Some(g.repr, g.geom)
+
+  case class PointLiteral(geom: Point, repr: InternalRow) extends GeometryLiteral {
+    override def dataType: DataType = PointTypeInstance
+  }
+
+  object PointLiteral {
+    def apply(repr: InternalRow): PointLiteral = PointLiteral(PointTypeInstance.deserialize(repr), repr)
+  }
+
+  case class LineStringLiteral(geom: LineString, repr: InternalRow) extends GeometryLiteral {
+    override def dataType: DataType = LineStringTypeInstance
+  }
+
+  object LineStringLiteral {
+    def apply(repr: InternalRow): LineStringLiteral =
+      LineStringLiteral(LineStringTypeInstance.deserialize(repr), repr)
+  }
+
+  case class PolygonLiteral(geom: Polygon, repr: InternalRow) extends GeometryLiteral {
+    override def dataType: DataType = PolygonTypeInstance
+  }
+
+  object PolygonLiteral {
+    def apply(repr: InternalRow): PolygonLiteral =
+      PolygonLiteral(PolygonTypeInstance.deserialize(repr), repr)
+  }
+
+  case class GenericGeometryLiteral(geom: Geometry, repr: Array[Byte]) extends GeometryLiteral {
+    override def dataType: DataType = GeometryTypeInstance
+  }
+
+  object GenericGeometryLiteral {
+    def apply(repr: Array[Byte]): GenericGeometryLiteral =
+      GenericGeometryLiteral(GeometryTypeInstance.deserialize(repr), repr)
+  }
+
+  case class MultiPointLiteral(geom: MultiPoint, repr: InternalRow) extends GeometryLiteral {
+    override def dataType: DataType = MultiPointTypeInstance
+  }
+
+  object MultiPointLiteral {
+    def apply(repr: InternalRow): MultiPointLiteral =
+      MultiPointLiteral(MultiPointTypeInstance.deserialize(repr), repr)
+  }
+
+  case class MultiLineStringLiteral(geom: MultiLineString, repr: InternalRow) extends GeometryLiteral {
+    override def dataType: DataType = MultiLineStringTypeInstance
+  }
+
+  object MultiLineStringLiteral {
+    def apply(repr: InternalRow): MultiLineStringLiteral =
+      MultiLineStringLiteral(MultiLineStringTypeInstance.deserialize(repr), repr)
+  }
+
+  case class MultiPolygonLiteral(geom: MultiPolygon, repr: InternalRow) extends GeometryLiteral {
+    override def dataType: DataType = MultiPolygonTypeInstance
+  }
+
+  object MultiPolygonLiteral {
+    def apply(repr: InternalRow): MultiPolygonLiteral =
+      MultiPolygonLiteral(MultiPolygonTypeInstance.deserialize(repr), repr)
+  }
+
+  case class GeometryCollectionLiteral(geom: GeometryCollection, repr: InternalRow) extends GeometryLiteral {
+    override def dataType: DataType = GeometryCollectionTypeInstance
+  }
+
+  object GeometryCollectionLiteral {
+    def apply(repr: InternalRow): GeometryCollectionLiteral =
+      GeometryCollectionLiteral(GeometryCollectionTypeInstance.deserialize(repr), repr)
+  }
+}
+

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/rules/GeometryLiteral.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/rules/GeometryLiteral.scala
@@ -32,74 +32,74 @@ object GeometryLiteral {
   def unapply(g: GeometryLiteral): Option[(Any, Geometry)] = Some(g.repr, g.geom)
 
   case class PointLiteral(geom: Point, repr: InternalRow) extends GeometryLiteral {
-    override def dataType: DataType = PointTypeInstance
+    override def dataType: DataType = PointUDT
   }
 
   object PointLiteral {
-    def apply(repr: InternalRow): PointLiteral = PointLiteral(PointTypeInstance.deserialize(repr), repr)
+    def apply(repr: InternalRow): PointLiteral = PointLiteral(PointUDT.deserialize(repr), repr)
   }
 
   case class LineStringLiteral(geom: LineString, repr: InternalRow) extends GeometryLiteral {
-    override def dataType: DataType = LineStringTypeInstance
+    override def dataType: DataType = LineStringUDT
   }
 
   object LineStringLiteral {
     def apply(repr: InternalRow): LineStringLiteral =
-      LineStringLiteral(LineStringTypeInstance.deserialize(repr), repr)
+      LineStringLiteral(LineStringUDT.deserialize(repr), repr)
   }
 
   case class PolygonLiteral(geom: Polygon, repr: InternalRow) extends GeometryLiteral {
-    override def dataType: DataType = PolygonTypeInstance
+    override def dataType: DataType = PolygonUDT
   }
 
   object PolygonLiteral {
     def apply(repr: InternalRow): PolygonLiteral =
-      PolygonLiteral(PolygonTypeInstance.deserialize(repr), repr)
+      PolygonLiteral(PolygonUDT.deserialize(repr), repr)
   }
 
   case class GenericGeometryLiteral(geom: Geometry, repr: Array[Byte]) extends GeometryLiteral {
-    override def dataType: DataType = GeometryTypeInstance
+    override def dataType: DataType = GeometryUDT
   }
 
   object GenericGeometryLiteral {
     def apply(repr: Array[Byte]): GenericGeometryLiteral =
-      GenericGeometryLiteral(GeometryTypeInstance.deserialize(repr), repr)
+      GenericGeometryLiteral(GeometryUDT.deserialize(repr), repr)
   }
 
   case class MultiPointLiteral(geom: MultiPoint, repr: InternalRow) extends GeometryLiteral {
-    override def dataType: DataType = MultiPointTypeInstance
+    override def dataType: DataType = MultiPointUDT
   }
 
   object MultiPointLiteral {
     def apply(repr: InternalRow): MultiPointLiteral =
-      MultiPointLiteral(MultiPointTypeInstance.deserialize(repr), repr)
+      MultiPointLiteral(MultiPointUDT.deserialize(repr), repr)
   }
 
   case class MultiLineStringLiteral(geom: MultiLineString, repr: InternalRow) extends GeometryLiteral {
-    override def dataType: DataType = MultiLineStringTypeInstance
+    override def dataType: DataType = MultiLineStringUDT
   }
 
   object MultiLineStringLiteral {
     def apply(repr: InternalRow): MultiLineStringLiteral =
-      MultiLineStringLiteral(MultiLineStringTypeInstance.deserialize(repr), repr)
+      MultiLineStringLiteral(MultiLineStringUDT.deserialize(repr), repr)
   }
 
   case class MultiPolygonLiteral(geom: MultiPolygon, repr: InternalRow) extends GeometryLiteral {
-    override def dataType: DataType = MultiPolygonTypeInstance
+    override def dataType: DataType = MultiPolygonUDT
   }
 
   object MultiPolygonLiteral {
     def apply(repr: InternalRow): MultiPolygonLiteral =
-      MultiPolygonLiteral(MultiPolygonTypeInstance.deserialize(repr), repr)
+      MultiPolygonLiteral(MultiPolygonUDT.deserialize(repr), repr)
   }
 
   case class GeometryCollectionLiteral(geom: GeometryCollection, repr: InternalRow) extends GeometryLiteral {
-    override def dataType: DataType = GeometryCollectionTypeInstance
+    override def dataType: DataType = GeometryCollectionUDT
   }
 
   object GeometryCollectionLiteral {
     def apply(repr: InternalRow): GeometryCollectionLiteral =
-      GeometryCollectionLiteral(GeometryCollectionTypeInstance.deserialize(repr), repr)
+      GeometryCollectionLiteral(GeometryCollectionUDT.deserialize(repr), repr)
   }
 }
 

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/rules/GeometryLiteralRules.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/rules/GeometryLiteralRules.scala
@@ -9,11 +9,13 @@
 package org.locationtech.geomesa.spark.jts.rules
 
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, Literal, ScalaUDF}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, ScalaUDF}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.jts.GeometryUDT
+import org.apache.spark.sql.jts._
+import org.locationtech.geomesa.spark.jts.rules.GeometryLiteral._
 
+import scala.reflect.ClassTag
 import scala.util.Try
 
 object GeometryLiteralRules {
@@ -22,19 +24,27 @@ object GeometryLiteralRules {
     override def apply(plan: LogicalPlan): LogicalPlan = {
       plan.transform {
         case q: LogicalPlan => q.transformExpressionsDown {
-          case s: ScalaUDF =>
-            // TODO: Break down by GeometryType
-            Try {
-                s.eval(null) match {
-                  case row: GenericInternalRow =>
-                    val ret = GeometryUDT.deserialize(row)
-                    GeometryLiteral(row, ret)
-                  case other: Any =>
-                    Literal(other)
-                }
-            }.getOrElse(s)
+          case s: ScalaUDF if s.dataType.isInstanceOf[PointUDT] => eval(s, PointLiteral.apply)
+          case s: ScalaUDF if s.dataType.isInstanceOf[LineStringUDT] => eval(s, LineStringLiteral.apply)
+          case s: ScalaUDF if s.dataType.isInstanceOf[PolygonUDT] => eval(s, PolygonLiteral.apply)
+          case s: ScalaUDF if s.dataType.isInstanceOf[GeometryUDT] => eval(s, GenericGeometryLiteral.apply)
+          case s: ScalaUDF if s.dataType.isInstanceOf[MultiPointUDT] => eval(s, MultiPointLiteral.apply)
+          case s: ScalaUDF if s.dataType.isInstanceOf[MultiLineStringUDT] => eval(s, MultiLineStringLiteral.apply)
+          case s: ScalaUDF if s.dataType.isInstanceOf[MultiPolygonUDT] => eval(s, MultiPolygonLiteral.apply)
+          case s: ScalaUDF if s.dataType.isInstanceOf[GeometryCollectionUDT] => eval(s, GeometryCollectionLiteral.apply)
         }
       }
+    }
+
+    private def eval[T: ClassTag](s: ScalaUDF, lit: T => Expression): Expression = {
+      val t = Try {
+        s.eval(null) match {
+          case null => Literal(null)
+          case t: T => lit(t)
+          case a => Literal(a)
+        }
+      }
+      t.getOrElse(s)
     }
   }
 

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/udaf/ConvexHull.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/udaf/ConvexHull.scala
@@ -16,9 +16,9 @@ import org.apache.spark.sql.jts.JTSTypes
 class ConvexHull extends UserDefinedAggregateFunction {
   import org.apache.spark.sql.types.{DataTypes => DT}
 
-  override val inputSchema = DT.createStructType(Array(DT.createStructField("inputGeom", JTSTypes.GeometryTypeInstance, true)))
-  override val bufferSchema = DT.createStructType(Array(DT.createStructField("convexHull", JTSTypes.GeometryTypeInstance, true)))
-  override val dataType = DT.createStructType(Array(DT.createStructField("convexHull", JTSTypes.GeometryTypeInstance, true)))
+  override val inputSchema = DT.createStructType(Array(DT.createStructField("inputGeom", JTSTypes.GeometryUDT, true)))
+  override val bufferSchema = DT.createStructType(Array(DT.createStructField("convexHull", JTSTypes.GeometryUDT, true)))
+  override val dataType = DT.createStructType(Array(DT.createStructField("convexHull", JTSTypes.GeometryUDT, true)))
   override val deterministic = true
 
   override def initialize(buffer: MutableAggregationBuffer): Unit = {

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/apache/spark/sql/SQLRules.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/apache/spark/sql/SQLRules.scala
@@ -144,9 +144,9 @@ object SQLRules extends LazyLogging {
   object SpatialOptimizationsRule extends Rule[LogicalPlan] with PredicateHelper {
 
     def extractGeometry(e: org.apache.spark.sql.catalyst.expressions.Expression): Option[Geometry] = e match {
-      case GeometryLiteral(_, geom) => Some(geom)
+      case g: GeometryLiteral => Some(g.geom)
       case And(l, r) => extractGeometry(l).orElse(extractGeometry(r))
-      case u: ScalaUDF => u.children.collectFirst { case GeometryLiteral(_, geom) => geom }
+      case u: ScalaUDF => u.children.collectFirst { case g: GeometryLiteral => g.geom }
       case _ => None
     }
 

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/SparkUtils.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/SparkUtils.scala
@@ -96,11 +96,11 @@ object SparkUtils extends LazyLogging {
         case DataTypes.FloatType               => classOf[java.lang.Float]
         case DataTypes.DoubleType              => classOf[java.lang.Double]
         case DataTypes.BooleanType             => classOf[java.lang.Boolean]
-        case JTSTypes.PointTypeInstance        => classOf[org.locationtech.jts.geom.Point]
-        case JTSTypes.LineStringTypeInstance   => classOf[org.locationtech.jts.geom.LineString]
-        case JTSTypes.PolygonTypeInstance      => classOf[org.locationtech.jts.geom.Polygon]
+        case JTSTypes.PointUDT        => classOf[org.locationtech.jts.geom.Point]
+        case JTSTypes.LineStringUDT   => classOf[org.locationtech.jts.geom.LineString]
+        case JTSTypes.PolygonUDT      => classOf[org.locationtech.jts.geom.Polygon]
         case JTSTypes.MultipolygonTypeInstance => classOf[org.locationtech.jts.geom.MultiPolygon]
-        case JTSTypes.GeometryTypeInstance     => classOf[org.locationtech.jts.geom.Geometry]
+        case JTSTypes.GeometryUDT     => classOf[org.locationtech.jts.geom.Geometry]
       }
       builder.add(field.name, binding)
     }
@@ -130,14 +130,14 @@ object SparkUtils extends LazyLogging {
       case ObjectType.MAP      => null // not supported
       case ObjectType.GEOMETRY =>
         bindings.last match {
-          case ObjectType.POINT               => JTSTypes.PointTypeInstance
-          case ObjectType.LINESTRING          => JTSTypes.LineStringTypeInstance
-          case ObjectType.POLYGON             => JTSTypes.PolygonTypeInstance
-          case ObjectType.MULTIPOINT          => JTSTypes.MultiPointTypeInstance
-          case ObjectType.MULTILINESTRING     => JTSTypes.MultiLineStringTypeInstance
+          case ObjectType.POINT               => JTSTypes.PointUDT
+          case ObjectType.LINESTRING          => JTSTypes.LineStringUDT
+          case ObjectType.POLYGON             => JTSTypes.PolygonUDT
+          case ObjectType.MULTIPOINT          => JTSTypes.MultiPointUDT
+          case ObjectType.MULTILINESTRING     => JTSTypes.MultiLineStringUDT
           case ObjectType.MULTIPOLYGON        => JTSTypes.MultipolygonTypeInstance
-          case ObjectType.GEOMETRY_COLLECTION => JTSTypes.GeometryTypeInstance
-          case _                              => JTSTypes.GeometryTypeInstance
+          case ObjectType.GEOMETRY_COLLECTION => JTSTypes.GeometryUDT
+          case _                              => JTSTypes.GeometryUDT
         }
 
       case _ => logger.warn(s"Unexpected bindings for descriptor $ad: ${bindings.mkString(", ")}"); null

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/SparkUtils.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/locationtech/geomesa/spark/SparkUtils.scala
@@ -109,8 +109,9 @@ object SparkUtils extends LazyLogging {
   }
 
   def createStructType(sft: SimpleFeatureType): StructType = {
-    val fields = sft.getAttributeDescriptors.asScala.flatMap(createStructField).toList
-    StructType(StructField("__fid__", DataTypes.StringType, nullable = false) :: fields)
+    val fields = sft.getAttributeDescriptors.asScala.flatMap(createStructField)
+    fields.append(StructField("__fid__", DataTypes.StringType, nullable = false))
+    StructType(fields.toList)
   }
 
   private def createStructField(ad: AttributeDescriptor): Option[StructField] = {

--- a/geomesa-spark/geomesa-spark-sql/src/test/scala/org/locationtech/geomesa/spark/SparkSQLColumnsTest.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/test/scala/org/locationtech/geomesa/spark/SparkSQLColumnsTest.scala
@@ -129,13 +129,13 @@ class SparkSQLColumnsTest extends Specification with LazyLogging {
         "boolean" -> DataTypes.BooleanType,
         "dtg"     -> DataTypes.TimestampType,
         "time"    -> DataTypes.TimestampType,
-        "line"    -> JTSTypes.LineStringTypeInstance,
-        "poly"    -> JTSTypes.PolygonTypeInstance,
-        "points"  -> JTSTypes.MultiPointTypeInstance,
-        "lines"   -> JTSTypes.MultiLineStringTypeInstance,
+        "line"    -> JTSTypes.LineStringUDT,
+        "poly"    -> JTSTypes.PolygonUDT,
+        "points"  -> JTSTypes.MultiPointUDT,
+        "lines"   -> JTSTypes.MultiLineStringUDT,
         "polys"   -> JTSTypes.MultipolygonTypeInstance,
-        "geoms"   -> JTSTypes.GeometryCollectionTypeInstance,
-        "point"   -> JTSTypes.PointTypeInstance,
+        "geoms"   -> JTSTypes.GeometryCollectionUDT,
+        "point"   -> JTSTypes.PointUDT,
         "__fid__" -> DataTypes.StringType
       )
 

--- a/geomesa-spark/geomesa-spark-sql/src/test/scala/org/locationtech/geomesa/spark/SparkSQLColumnsTest.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/test/scala/org/locationtech/geomesa/spark/SparkSQLColumnsTest.scala
@@ -33,27 +33,28 @@ class SparkSQLColumnsTest extends Specification with LazyLogging {
   var spark: SparkSession = _
   var sc: SQLContext = _
 
-  val spec =
-    """int:Integer,
-      |long:Long,
-      |float:Float,
-      |double:Double,
-      |uuid:UUID,
-      |string:String,
-      |boolean:Boolean,
-      |dtg:Date,
-      |time:Timestamp,
-      |bytes:Bytes,
-      |list:List[String],
-      |map:Map[String,Integer],
-      |line:LineString:srid=4326,
-      |poly:Polygon:srid=4326,
-      |points:MultiPoint:srid=4326,
-      |lines:MultiLineString:srid=4326,
-      |polys:MultiPolygon:srid=4326,
-      |geoms:GeometryCollection:srid=4326,
-      |*point:Point:srid=4326
-    """.stripMargin
+  val spec = Seq(
+    "int:Integer",
+    "long:Long",
+    "float:Float",
+    "double:Double",
+    "uuid:UUID",
+    "string:String",
+    "boolean:Boolean",
+    "dtg:Date",
+    "time:Timestamp",
+    "bytes:Bytes",
+    "list:List[String]",
+    "map:Map[String,Integer]",
+    "line:LineString:srid=4326",
+    "poly:Polygon:srid=4326",
+    "points:MultiPoint:srid=4326",
+    "lines:MultiLineString:srid=4326",
+    "polys:MultiPolygon:srid=4326",
+    "geoms:GeometryCollection:srid=4326",
+    "*point:Point:srid=4326"
+  ).mkString(",")
+
 
   lazy val sft = SimpleFeatureTypes.createType("complex", spec)
   lazy val sf = {
@@ -118,8 +119,8 @@ class SparkSQLColumnsTest extends Specification with LazyLogging {
     "map appropriate column types" in {
       val df = sc.sql(s"select * from ${sft.getTypeName}")
 
+      // note: bytes, list, map not supported
       val expected = Seq(
-        "__fid__" -> DataTypes.StringType,
         "int"     -> DataTypes.IntegerType,
         "long"    -> DataTypes.LongType,
         "float"   -> DataTypes.FloatType,
@@ -133,12 +134,12 @@ class SparkSQLColumnsTest extends Specification with LazyLogging {
         "points"  -> JTSTypes.MultiPointTypeInstance,
         "lines"   -> JTSTypes.MultiLineStringTypeInstance,
         "polys"   -> JTSTypes.MultipolygonTypeInstance,
-        "geoms"   -> JTSTypes.GeometryTypeInstance,
-        "point"   -> JTSTypes.PointTypeInstance
+        "geoms"   -> JTSTypes.GeometryCollectionTypeInstance,
+        "point"   -> JTSTypes.PointTypeInstance,
+        "__fid__" -> DataTypes.StringType
       )
 
       val schema = df.schema
-      schema must haveLength(16) // note: bytes, list, map not supported
       schema.map(_.name) mustEqual expected.map(_._1)
       schema.map(_.dataType) mustEqual expected.map(_._2)
 
@@ -148,8 +149,8 @@ class SparkSQLColumnsTest extends Specification with LazyLogging {
       val row = result.head
 
       // note: have to compare backwards so that java.util.Date == java.sql.Timestamp
-      Seq(sf.getID) ++ expected.drop(1).map { case (n, _) => sf.getAttribute(n) } mustEqual
-          Seq.tabulate(16)(i => row.get(i))
+      expected.dropRight(1).map { case (n, _) => sf.getAttribute(n) } ++ Seq(sf.getID) mustEqual
+          Seq.tabulate(row.length)(i => row.get(i))
     }
   }
 


### PR DESCRIPTION
* `__fid__` column is now last instead of first
* Geometry columns are structs of x/y doubles or lists of doubles

Co-authored-by: Jim Hughes <jnh5y@ccri.com>
Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>