### PR TITLE
GEOMESA-2971 Support configurable file sizes in FSDS

### DIFF
--- a/docs/user/filesystem/commandline.rst
+++ b/docs/user/filesystem/commandline.rst
@@ -26,7 +26,7 @@ Commands
 ``compact``
 ^^^^^^^^^^^
 
-Compact one or more filesystem partitions. This will merge multiple files into a single file, which may
+Compact one or more filesystem partitions. This will merge multiple files into fewer, larger files, which may
 provide better query performance.
 
 ======================== =========================================================
@@ -35,6 +35,7 @@ Argument                 Description
 ``-p, --path *``         The filesystem root path used to store data
 ``-f, --feature-name *`` The name of the schema
 ``--partitions``         Partitions to compact (omit to compact all partitions)
+``--target-file-size``   Target size for data files (e.g. 500MB or 1GB)
 ``--mode``               One of ``local`` or ``distributed`` (to use map/reduce)
 ``--temp-path``          Path to a temp directory used for working files
 ======================== =========================================================
@@ -117,6 +118,7 @@ Argument                 Description
 ``--partition-scheme``   Common partition scheme name (e.g. daily, z2) or path to a file containing a scheme config
 ``--num-reducers``       Number of reducers to use (required for distributed ingest)
 ``--leaf-storage``       Use leaf storage
+``--target-file-size``   Target size for data files (e.g. 500MB or 1GB)
 ``--temp-path``          Path to a temp directory used for working files
 ``--storage-opt``        Additional storage options, as ``key=value``
 ======================== =============================================================

--- a/docs/user/filesystem/configuration.rst
+++ b/docs/user/filesystem/configuration.rst
@@ -11,6 +11,20 @@ File Writers
 
 The following properties control the writing of data files.
 
+.. _fsds_size_threshold_prop:
+
+geomesa.fs.size.threshold
++++++++++++++++++++++++++
+
+When specifying a target size for data files, this property controls the error margin that is considered acceptable.
+Files which are outside of the margin may be merged or split during compactions. See :ref:`fsds_file_size_config`
+for more information.
+
+The threshold is specified as a float greater than ``0`` and less than ``1``, with a default value of ``0.05``.
+For example, if the target file size is 100 bytes, then an error threshold of ``0.05`` means that files will not
+be compacted if they are between 95 and 105 bytes.
+
+
 geomesa.fs.writer.partition.timeout
 +++++++++++++++++++++++++++++++++++
 

--- a/docs/user/filesystem/index_config.rst
+++ b/docs/user/filesystem/index_config.rst
@@ -108,6 +108,35 @@ Leaf storage can be specified through the user data key ``geomesa.fs.leaf-storag
         // or set directly in the user data as a string
         sft.getUserData.put("geomesa.fs.leaf-storage", "false")
 
+Configuring Target File Size
+----------------------------
+
+By default data files can grow to unlimited size as more data is written and files are compacted. This may lead
+to poor performance, if a file becomes too large. To manage this, a target file size can be configured through
+the user data key ``geomesa.fs.file-size``:
+
+.. tabs::
+
+    .. code-tab:: java
+
+        import org.locationtech.geomesa.fs.storage.common.interop.ConfigurationUtils;
+
+        SimpleFeatureType sft = ...
+        // use the utility method
+        ConfigurationUtils.setTargetFileSize(sft, false);
+        // or set directly in the user data as a string
+        sft.getUserData().put("geomesa.fs.file-size", "1GB");
+
+    .. code-tab:: scala
+
+        import org.locationtech.geomesa.fs.storage.common.RichSimpleFeatureType
+
+        val sft: SimpleFeatureType = ???
+        // use the implicit method from RichSimpleFeatureType
+        sft.setTargetFileSize("1GB")
+        // or set directly in the user data as a string
+        sft.getUserData.put("geomesa.fs.file-size", "1GB")
+
 .. _fsds_metadata_config:
 
 Configuring Metadata Persistence

--- a/docs/user/filesystem/index_config.rst
+++ b/docs/user/filesystem/index_config.rst
@@ -108,6 +108,8 @@ Leaf storage can be specified through the user data key ``geomesa.fs.leaf-storag
         // or set directly in the user data as a string
         sft.getUserData.put("geomesa.fs.leaf-storage", "false")
 
+.. _fsds_file_size_config:
+
 Configuring Target File Size
 ----------------------------
 
@@ -138,7 +140,9 @@ the user data key ``geomesa.fs.file-size``:
         sft.getUserData.put("geomesa.fs.file-size", "1GB")
 
 Note that target file size can also be specified in some operations, which will override any default configured
-in the feature type. See :ref:`fsds_compact_command` and :ref:`fsds_ingest_command` for details.
+in the feature type. See :ref:`fsds_compact_command` and :ref:`fsds_ingest_command` for details. See
+:ref:`fsds_size_threshold_prop` for controlling the file size error margin.
+
 .. _fsds_metadata_config:
 
 Configuring Metadata Persistence

--- a/docs/user/filesystem/index_config.rst
+++ b/docs/user/filesystem/index_config.rst
@@ -137,6 +137,8 @@ the user data key ``geomesa.fs.file-size``:
         // or set directly in the user data as a string
         sft.getUserData.put("geomesa.fs.file-size", "1GB")
 
+Note that target file size can also be specified in some operations, which will override any default configured
+in the feature type. See :ref:`fsds_compact_command` and :ref:`fsds_ingest_command` for details.
 .. _fsds_metadata_config:
 
 Configuring Metadata Persistence
@@ -239,4 +241,3 @@ Observers can be specified through the user data key ``geomesa.fs.observers``:
         sft.setObservers(factories)
         // or set directly in the user data as a comma-delimited string
         sft.getUserData.put("geomesa.fs.observers", factories.mkString(","))
-

--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -90,6 +90,15 @@ Compatibility Matrix
 | Dependencies | N     | N     | Y     |
 +--------------+-------+-------+-------+
 
+Version 3.2.0 Upgrade Guide
++++++++++++++++++++++++++++
+
+FileSystem Data Store Metadata Format Change
+--------------------------------------------
+
+The metadata format for the FileSystem data store has been changed to support storing arbitrary key-value pairs.
+Any data written with version 3.2.0 or later will not be readable by earlier GeoMesa versions.
+
 Version 3.1.0 Upgrade Guide
 +++++++++++++++++++++++++++
 

--- a/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/data/FileSystemDataStore.scala
+++ b/geomesa-fs/geomesa-fs-datastore/src/main/scala/org/locationtech/geomesa/fs/data/FileSystemDataStore.scala
@@ -76,11 +76,13 @@ class FileSystemDataStore(
           }
           deprecated.getOrElse(true)
         }
+        val fileSize = sft.removeTargetFileSize()
 
         val path = manager.defaultPath(sft.getTypeName)
         val context = FileSystemContext(fc, conf, path, namespace)
 
-        val metadata = StorageMetadataFactory.create(context, meta, Metadata(sft, encoding, scheme, leafStorage))
+        val metadata =
+          StorageMetadataFactory.create(context, meta, Metadata(sft, encoding, scheme, leafStorage, fileSize))
         try { manager.register(path, FileSystemStorageFactory(context, metadata)) } catch {
           case NonFatal(e) => CloseQuietly(metadata).foreach(e.addSuppressed); throw e
         }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/src/main/scala/org/locationtech/geomesa/fs/storage/api/StorageMetadata.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/src/main/scala/org/locationtech/geomesa/fs/storage/api/StorageMetadata.scala
@@ -12,7 +12,6 @@ import java.io.Closeable
 
 import org.apache.hadoop.fs.Path
 import org.locationtech.geomesa.fs.storage.api.StorageMetadata.PartitionMetadata
-import org.locationtech.geomesa.fs.storage.api.StorageMetadata.StorageFileAction.StorageFileAction
 import org.locationtech.jts.geom.Envelope
 import org.opengis.feature.simple.SimpleFeatureType
 
@@ -53,6 +52,22 @@ trait StorageMetadata extends Compactable with Closeable {
     * @return leaf
     */
   def leafStorage: Boolean
+
+  /**
+   * Get a previously set key-value pair
+   *
+   * @param key key
+   * @return
+   */
+  def get(key: String): Option[String] = None
+
+  /**
+   * Set a key-value pair
+   *
+   * @param key key
+   * @param value value
+   */
+  def set(key: String, value: String): Unit = throw new NotImplementedError()
 
   /**
     * Get a partition by name. Ensure that `reload` has been invoked at least once before calling this method
@@ -136,7 +151,11 @@ object StorageMetadata {
     * @param timestamp timestamp for the file
     * @param action type of file (append, modify, delete)
     */
-  case class StorageFile(name: String, timestamp: Long, action: StorageFileAction = StorageFileAction.Append)
+  case class StorageFile(
+      name: String,
+      timestamp: Long,
+      action: StorageFileAction.StorageFileAction = StorageFileAction.Append
+    )
 
   /**
     * Holds a storage file path
@@ -160,11 +179,11 @@ object StorageMetadata {
     * Note that conversions to/from 'null' envelopes should be handled carefully, as envelopes are considered
     * null if xmin > xmax, however, when instantiating an envelope it will re-order the coordinates:
     *
-    * ```
+    * {{{
     *   val env = new Envelope()
     *   val copy = new Envelope(env.getMinX, env.getMinY, env.getMaxX, env.getMaxY)
     *   copy == env // false
-    * ```
+    * }}}
     *
     * Thus, ensure that 'null' envelopes are converted to `None` and not directly to a bounds object. See
     * `PartitionBounds.apply`

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/src/main/scala/org/locationtech/geomesa/fs/storage/api/package.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-api/src/main/scala/org/locationtech/geomesa/fs/storage/api/package.scala
@@ -40,11 +40,33 @@ package object api {
     * Holder for the metadata defining a storage instance
     *
     * @param sft simple feature type
-    * @param encoding file encoding
     * @param scheme partition scheme configuration
-    * @param leafStorage leaf storage configuration
+    * @param config key-value configurations
     */
-  case class Metadata(sft: SimpleFeatureType, encoding: String, scheme: NamedOptions, leafStorage: Boolean)
+  case class Metadata(sft: SimpleFeatureType, scheme: NamedOptions, config: Map[String, String]) {
+    def encoding: String = config(Metadata.Encoding)
+    def leafStorage: Boolean = config(Metadata.LeafStorage).toBoolean
+    def targetFileSize: Option[Long] = config.get(Metadata.TargetFileSize).map(_.toLong)
+  }
+
+  object Metadata {
+
+    val Encoding       = "encoding"
+    val LeafStorage    = "leaf-storage"
+    val TargetFileSize = "target-file-size"
+
+    def apply(
+        sft: SimpleFeatureType,
+        encoding: String,
+        scheme: NamedOptions,
+        leafStorage: Boolean,
+        fileSize: Option[Long] = None): Metadata = {
+      val config: Map[String, String] =
+        Map(Encoding -> encoding, LeafStorage -> java.lang.Boolean.toString(leafStorage)) ++
+            fileSize.map(f => TargetFileSize -> java.lang.Long.toString(f)).toMap
+      Metadata(sft, scheme, config)
+    }
+  }
 
   /**
     * Case class holding a filter and partitions
@@ -65,6 +87,23 @@ package object api {
       * @param partition partition to compact, or all partitions
       * @param threads suggested threads to use for file system operations
       */
-    def compact(partition: Option[String], threads: Int = 1)
+    @deprecated("replaced with compact(Option[String], Option[Long], Int)")
+    def compact(partition: Option[String], threads: Int): Unit
+
+    /**
+     * Compact a partition - merge multiple data files into a single file.
+     *
+     * Care should be taken with this method. Currently, there is no guarantee for correct behavior if
+     * multiple threads or storage instances attempt to compact the same partition simultaneously.
+     *
+     * @param partition partition to compact, or all partitions
+     * @param fileSize approximate target size of files, in bytes
+     * @param threads suggested threads to use for file system operations
+     */
+    // noinspection ScalaDeprecation
+    def compact(partition: Option[String], fileSize: Option[Long] = None, threads: Int = 1): Unit = {
+      // default impl to prevent API breakage
+      compact(partition, threads)
+    }
   }
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/java/org/locationtech/geomesa/fs/storage/common/interop/ConfigurationUtils.java
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/java/org/locationtech/geomesa/fs/storage/common/interop/ConfigurationUtils.java
@@ -11,6 +11,7 @@ package org.locationtech.geomesa.fs.storage.common.interop;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
 import com.typesafe.config.ConfigValueFactory;
+import org.locationtech.geomesa.utils.text.Suffixes.Memory$;
 import org.opengis.feature.simple.SimpleFeatureType;
 
 import java.util.List;
@@ -33,6 +34,11 @@ public class ConfigurationUtils {
 
     public static void setLeafStorage(SimpleFeatureType sft, boolean leafStorage) {
         sft.getUserData().put("geomesa.fs.leaf-storage", String.valueOf(leafStorage));
+    }
+
+    public static void setTargetFileSize(SimpleFeatureType sft, String size) {
+        Memory$.MODULE$.bytes(size).get(); // validate input
+        sft.getUserData().put("geomesa.fs.file-size", size);
     }
 
     public static void setScheme(SimpleFeatureType sft, String scheme, Map<String, String> options) {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/AbstractFileSystemStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/AbstractFileSystemStorage.scala
@@ -17,14 +17,15 @@ import org.locationtech.geomesa.fs.storage.api.FileSystemStorage.{FileSystemUpda
 import org.locationtech.geomesa.fs.storage.api.StorageMetadata.StorageFileAction.StorageFileAction
 import org.locationtech.geomesa.fs.storage.api.StorageMetadata._
 import org.locationtech.geomesa.fs.storage.api._
-import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage.{FileSystemPathReader, MetadataObserver}
+import org.locationtech.geomesa.fs.storage.common.AbstractFileSystemStorage.{FileSystemPathReader, MetadataObserver, WriterConfig}
 import org.locationtech.geomesa.fs.storage.common.observer.FileSystemObserverFactory.CompositeObserver
 import org.locationtech.geomesa.fs.storage.common.observer.{FileSystemObserver, FileSystemObserverFactory}
 import org.locationtech.geomesa.fs.storage.common.utils.StorageUtils.FileType
+import org.locationtech.geomesa.fs.storage.common.utils.StorageUtils.FileType.FileType
 import org.locationtech.geomesa.fs.storage.common.utils.{PathCache, StorageUtils}
 import org.locationtech.geomesa.index.planning.QueryRunner
 import org.locationtech.geomesa.utils.collection.CloseableIterator
-import org.locationtech.geomesa.utils.io.{CloseQuietly, FlushQuietly, WithClose}
+import org.locationtech.geomesa.utils.io.{CloseQuietly, FileSizeEstimator, FlushQuietly, WithClose}
 import org.locationtech.geomesa.utils.stats.MethodProfiling
 import org.locationtech.jts.geom.{Envelope, Geometry}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -44,7 +45,7 @@ abstract class AbstractFileSystemStorage(
     val context: FileSystemContext,
     val metadata: StorageMetadata,
     extension: String
-  ) extends FileSystemStorage with MethodProfiling with LazyLogging {
+  ) extends FileSystemStorage with SizeableFileSystemStorage with MethodProfiling with LazyLogging {
 
   // don't require observers if we never write any data
   lazy private val observers = {
@@ -137,43 +138,66 @@ abstract class AbstractFileSystemStorage(
     }
   }
 
-  override def getWriter(partition: String): FileSystemWriter = createWriter(partition, StorageFileAction.Append)
+  override def getWriter(partition: String): FileSystemWriter =
+    createWriter(partition, StorageFileAction.Append, FileType.Written)
 
   override def getWriter(filter: Filter, partition: Option[String], threads: Int): FileSystemUpdateWriter = {
     val query = new Query(metadata.sft.getTypeName, filter)
     new FileSystemUpdateWriterImpl(getReader(query, partition, threads), partition)
   }
 
-  override def compact(partition: Option[String], threads: Int): Unit = {
+  // noinspection ScalaDeprecation
+  override def compact(partition: Option[String], threads: Int): Unit = compact(partition, None, threads)
+
+  override def compact(partition: Option[String], fileSize: Option[Long], threads: Int): Unit = {
+    val target = targetSize(fileSize)
     partition.map(Seq(_)).getOrElse(metadata.getPartitions().map(_.name)).foreach { partition =>
-      val toCompact = getFilePaths(partition)
+      val paths = getFilePaths(partition)
+      val toCompact = target match {
+        case None => paths
+        case Some(t) =>
+          paths.filter { p =>
+            if (fileIsSized(p.path, t)) {
+              logger.debug(s"Skipping compaction for file [${p.path}] (already target size)")
+              false
+            } else {
+              true
+            }
+          }
+      }
 
-      if (toCompact.lengthCompare(2) < 0) {
-        logger.debug(s"Skipping compaction for single data file: ${toCompact.mkString(", ")}")
+      if (toCompact.isEmpty) {
+        logger.debug("Skipping compaction - no files to compact")
+      } else if (toCompact.lengthCompare(1) == 0 && target.forall(fileIsSized(toCompact.head.path, _))) {
+        logger.debug(s"Skipping compaction for single data file [${toCompact.mkString}]")
       } else {
-        val path = StorageUtils.nextFile(context.root, partition, metadata.leafStorage, extension, FileType.Compacted)
-
-        logger.debug(s"Compacting data files: [${toCompact.mkString(", ")}] to into file $path")
+        logger.debug(s"Compacting data files: [${toCompact.mkString(", ")}]")
 
         var written = 0L
+        val bounds = new Envelope()
 
         val reader = createReader(None, None)
-        def threaded = FileSystemThreadedReader(Iterator.single(reader -> toCompact), threads)
-        val compactObserver = new CompactObserver(partition, path, toCompact)
-        val observer = if (observers.isEmpty) { compactObserver } else {
-          new CompositeObserver(observers.map(_.apply(path)).+:(compactObserver))
-        }
 
-        WithClose(createWriter(path, observer), threaded) { case (writer, features) =>
+        def writer: FileSystemWriter =
+          createWriter(partition, StorageFileAction.Append, FileType.Compacted, target)
+        def threaded: CloseableIterator[SimpleFeature] =
+          FileSystemThreadedReader(Iterator.single(reader -> toCompact), threads)
+
+        WithClose(writer, threaded) { case (writer, features) =>
           while (features.hasNext) {
-            writer.write(features.next())
+            val feature = features.next()
+            writer.write(feature)
             written += 1
+            val geom = feature.getDefaultGeometry.asInstanceOf[Geometry]
+            if (geom != null) {
+              bounds.expandToInclude(geom.getEnvelopeInternal)
+            }
           }
         }
-        PathCache.register(context.fc, path)
 
-        logger.debug(s"Wrote compacted file $path")
         logger.debug(s"Deleting old files [${toCompact.mkString(", ")}]")
+        metadata.removePartition(
+          PartitionMetadata(partition, toCompact.map(_.file), PartitionBounds(bounds), written))
 
         val failures = ListBuffer.empty[Path]
         toCompact.foreach { file =>
@@ -187,32 +211,87 @@ abstract class AbstractFileSystemStorage(
           logger.error(s"Failed to delete some files: [${failures.mkString(", ")}]")
         }
 
-        logger.debug(s"Compacted $written records into file $path")
+        logger.debug(s"Compacted $written records")
       }
     }
   }
 
   /**
-    * Create a new writer
-    *
-    * @param partition partition being written to
-    * @param action write type
-    * @return
-    */
-  private def createWriter(partition: String, action: StorageFileAction): FileSystemWriter = {
-    val fileType = action match {
-      case StorageFileAction.Append => FileType.Written
-      case StorageFileAction.Modify => FileType.Modified
-      case StorageFileAction.Delete => FileType.Deleted
-      case _ => throw new NotImplementedError(s"Unexpected storage action type: $action")
+   * Create a new writer
+   *
+   * @param partition partition being written to
+   * @param action write type
+   * @param fileType file type
+   * @param targetFileSize target file size
+   * @return
+   */
+  private def createWriter(
+      partition: String,
+      action: StorageFileAction,
+      fileType: FileType,
+      targetFileSize: Option[Long] = None): FileSystemWriter = {
+
+    def pathAndObserver: WriterConfig = {
+      val path = StorageUtils.nextFile(context.root, partition, metadata.leafStorage, extension, fileType)
+      PathCache.register(context.fc, path)
+      val updateObserver = new UpdateObserver(partition, path, action)
+      val observer = if (observers.isEmpty) { updateObserver } else {
+        new CompositeObserver(observers.map(_.apply(path)).+:(updateObserver))
+      }
+      WriterConfig(path, observer)
     }
-    val path = StorageUtils.nextFile(context.root, partition, metadata.leafStorage, extension, fileType)
-    PathCache.register(context.fc, path)
-    val updateObserver = new UpdateObserver(partition, path, action)
-    val observer = if (observers.isEmpty) { updateObserver } else {
-      new CompositeObserver(observers.map(_.apply(path)).+:(updateObserver))
+
+    targetSize(targetFileSize) match {
+      case None => createWriter(pathAndObserver)
+      case Some(s) => new ChunkedFileSystemWriter(Iterator.continually(pathAndObserver), estimator(s))
     }
-    createWriter(path, observer)
+  }
+
+  private def createWriter(config: WriterConfig): FileSystemWriter = createWriter(config.path, config.observer)
+
+  /**
+   * Writes files up to a given size, then starts a new file
+   *
+   * @param paths iterator of files to write
+   * @param estimator target file size estimator
+   */
+  class ChunkedFileSystemWriter(paths: Iterator[WriterConfig], estimator: FileSizeEstimator)
+      extends FileSystemWriter {
+
+    private var count = 0L // number of features written
+    private var total = 0L // sum size of all finished chunks
+    private var remaining = estimator.estimate(0L)
+
+    private var path: Path = _
+    private var writer: FileSystemWriter = _
+
+    override def write(feature: SimpleFeature): Unit = {
+      if (writer == null) {
+        val config = paths.next
+        path = config.path
+        writer = createWriter(config)
+      }
+      writer.write(feature)
+      count += 1
+      remaining -= 1
+      if (remaining == 0) {
+        writer.close()
+        writer = null
+        // adjust our estimate to account for the actual bytes written
+        total += context.fc.getFileStatus(path).getLen
+        estimator.update(total, count)
+        remaining = estimator.estimate(0L)
+      }
+    }
+
+    override def flush(): Unit = if (writer != null) { writer.flush() }
+
+    override def close(): Unit = {
+      if (writer != null) {
+        writer.close()
+      }
+      updateFileSize(estimator)
+    }
   }
 
   /**
@@ -237,9 +316,9 @@ abstract class AbstractFileSystemStorage(
       val update = metadata.scheme.getPartitionName(feature)
       if (update != partition) {
         // add a delete marker in the old partition, since we only track updates per-partition
-        deleters.getOrElseUpdate(partition, createWriter(partition, StorageFileAction.Delete)).write(feature)
+        deleters.getOrElseUpdate(partition, createWriter(partition, StorageFileAction.Delete, FileType.Deleted)).write(feature)
       }
-      modifiers.getOrElseUpdate(update, createWriter(update, StorageFileAction.Modify)).write(feature)
+      modifiers.getOrElseUpdate(update, createWriter(update, StorageFileAction.Modify, FileType.Modified)).write(feature)
       feature = null
     }
 
@@ -247,7 +326,7 @@ abstract class AbstractFileSystemStorage(
       if (feature == null) {
         throw new IllegalArgumentException("Must call 'next' before calling 'remove'")
       }
-      deleters.getOrElseUpdate(partition, createWriter(partition, StorageFileAction.Delete)).write(feature)
+      deleters.getOrElseUpdate(partition, createWriter(partition, StorageFileAction.Delete, FileType.Deleted)).write(feature)
       feature = null
     }
 
@@ -275,22 +354,6 @@ abstract class AbstractFileSystemStorage(
     override protected def onClose(bounds: Envelope, count: Long): Unit = {
       val files = Seq(StorageFile(file.getName, System.currentTimeMillis(), action))
       metadata.addPartition(PartitionMetadata(partition, files, PartitionBounds(bounds), count))
-    }
-  }
-
-  /**
-    * Writes compacted partition data to the metadata
-    *
-    * @param partition partition being compacted
-    * @param file compacted file being written
-    * @param replaced files being replaced
-    */
-  class CompactObserver(partition: String, file: Path, replaced: Seq[StorageFilePath]) extends MetadataObserver {
-    override protected def onClose(bounds: Envelope, count: Long): Unit = {
-      val partitionBounds = PartitionBounds(bounds)
-      metadata.removePartition(PartitionMetadata(partition, replaced.map(_.file), partitionBounds, count))
-      val added = Seq(StorageFile(file.getName, System.currentTimeMillis(), StorageFileAction.Append))
-      metadata.addPartition(PartitionMetadata(partition, added, partitionBounds, count))
     }
   }
 }
@@ -327,4 +390,6 @@ object AbstractFileSystemStorage {
 
     protected def onClose(bounds: Envelope, count: Long): Unit
   }
+
+  private case class WriterConfig(path: Path, observer: FileSystemObserver)
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/SizeableFileSystemStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/SizeableFileSystemStorage.scala
@@ -1,0 +1,76 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.fs.storage.common
+
+import org.apache.hadoop.fs.Path
+import org.locationtech.geomesa.fs.storage.api.{FileSystemStorage, Metadata}
+import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
+import org.locationtech.geomesa.utils.io.FileSizeEstimator
+
+trait SizeableFileSystemStorage extends FileSystemStorage {
+
+  private val fileSizeError = SizeableFileSystemStorage.FileSizeErrorThreshold.toFloat.get
+
+  private var averageBytesPerFeature = metadata.get(SizeableFileSystemStorage.BytesPerFeature) match {
+    case Some(b) => b.toFloat
+    case None    => (metadata.sft.getAttributeCount + 1) * 1.6f // 1.6 taken from some sample data estimates...
+  }
+
+  /**
+   * Gets the target file size
+   *
+   * @param size override default target size
+   * @return
+   */
+  def targetSize(size: Option[Long]): Option[Long] =
+    size.orElse(metadata.get(Metadata.TargetFileSize).map(_.toLong))
+
+  /**
+   * Check if a file is already the desired size
+   *
+   * @param path file path
+   * @param target target file size
+   * @return true if the file is appropriately sized
+   */
+  def fileIsSized(path: Path, target: Long): Boolean = {
+    val size = context.fc.getFileStatus(path).getLen
+    math.abs((size.toDouble / target) - 1d) <= fileSizeError
+  }
+
+  /**
+   * Gets a file size estimator for this storage instance
+   *
+   * @param size target file size
+   * @return
+   */
+  def estimator(size: Long): FileSizeEstimator = synchronized {
+    new FileSizeEstimator(size, fileSizeError, averageBytesPerFeature)
+  }
+
+  def updateFileSize(estimator: FileSizeEstimator): Unit = {
+    estimator.getBytesPerFeature.foreach { b =>
+      if (metadata.get(SizeableFileSystemStorage.UseDynamicSizing).forall(_.toBoolean)) {
+        synchronized {
+          if (math.abs((b / averageBytesPerFeature) - 1f) > fileSizeError) {
+            metadata.set(SizeableFileSystemStorage.BytesPerFeature, java.lang.Float.toString(b))
+            averageBytesPerFeature = b
+          }
+        }
+      }
+    }
+  }
+}
+
+object SizeableFileSystemStorage {
+
+  val BytesPerFeature  = "bytes-per-feature"
+  val UseDynamicSizing = "use-dynamic-sizing"
+
+  val FileSizeErrorThreshold: SystemProperty = SystemProperty("geomesa.fs.size.threshold", "0.05")
+}

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/jobs/PartitionOutputFormat.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/jobs/PartitionOutputFormat.scala
@@ -116,7 +116,8 @@ class PartitionOutputFormat(delegate: SingleFileOutputFormat) extends OutputForm
       }
 
       def meta: PartitionMetadata = {
-        val f = files.map(StorageFile(_, System.currentTimeMillis()))
+        val millis = System.currentTimeMillis()
+        val f = files.map(StorageFile(_, millis))
         PartitionMetadata(partition, f, PartitionBounds(bounds), count)
       }
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/jobs/PartitionOutputFormat.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/jobs/PartitionOutputFormat.scala
@@ -15,12 +15,15 @@ import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.output.{FileOutputCommitter, FileOutputFormat}
 import org.apache.hadoop.mapreduce.security.TokenCache
 import org.locationtech.geomesa.fs.storage.api.StorageMetadata.{PartitionBounds, PartitionMetadata, StorageFile}
-import org.locationtech.geomesa.fs.storage.api.{FileSystemContext, StorageMetadataFactory}
-import org.locationtech.geomesa.fs.storage.common.jobs.PartitionOutputFormat.{PartitionState, SingleFileOutputFormat}
+import org.locationtech.geomesa.fs.storage.api.{FileSystemContext, FileSystemStorageFactory, StorageMetadataFactory}
+import org.locationtech.geomesa.fs.storage.common.SizeableFileSystemStorage
+import org.locationtech.geomesa.fs.storage.common.jobs.PartitionOutputFormat.SingleFileOutputFormat
 import org.locationtech.geomesa.fs.storage.common.utils.StorageUtils
-import org.locationtech.geomesa.utils.io.CloseWithLogging
+import org.locationtech.geomesa.utils.io.{CloseWithLogging, FileSizeEstimator}
 import org.locationtech.jts.geom.{Envelope, Geometry}
 import org.opengis.feature.simple.SimpleFeature
+
+import scala.collection.mutable.ArrayBuffer
 
 /**
   * Output format that writes to multiple partition files
@@ -51,49 +54,135 @@ class PartitionOutputFormat(delegate: SingleFileOutputFormat) extends OutputForm
 
     import StorageConfiguration.Counters.{Features, Group}
 
-    // note: don't invoke 'reload' - the metadata may not have any partition data, but we only use it for writing
-    private val metadata = {
+    private val storage = {
       val conf = context.getConfiguration
       val root = StorageConfiguration.getRootPath(conf)
       val fsc = FileSystemContext(FileContext.getFileContext(root.toUri, conf), conf, root)
-      StorageMetadataFactory.load(fsc).getOrElse {
+      val metadata = StorageMetadataFactory.load(fsc).getOrElse {
         throw new IllegalArgumentException(s"No storage defined under path '$root'")
       }
+      FileSystemStorageFactory(fsc, metadata)
     }
+    private val encoding = storage.metadata.encoding
+    private val leaf = storage.metadata.leafStorage
+
     private val fileType = StorageConfiguration.getFileType(context.getConfiguration)
+    private val fileSize = StorageConfiguration.getTargetFileSize(context.getConfiguration)
 
     private val counter = context.getCounter(Group, Features)
     private val cache = scala.collection.mutable.Map.empty[String, PartitionState]
 
-    override def write(key: Void, value: SimpleFeature): Unit = {
-      val partition = metadata.scheme.getPartitionName(value)
-      val state = cache.getOrElseUpdate(partition, createWriter(partition))
-      state.writer.write(key, value)
-      val geom = value.getDefaultGeometry.asInstanceOf[Geometry]
-      if (geom != null) {
-        state.bounds.expandToInclude(geom.getEnvelopeInternal)
+    private val workPath = delegate.getOutputCommitter(context).asInstanceOf[FileOutputCommitter].getWorkPath
+
+    private def newState(partition: String): PartitionState = {
+      val estimator = storage match {
+        case s: SizeableFileSystemStorage => s.targetSize(fileSize).map(s.estimator)
+        case _ => None
       }
-      state.count += 1L
+      estimator match {
+        case None => new SinglePartitionState(partition)
+        case Some(e) => new ChunkedPartitionState(partition, e, context)
+      }
+    }
+
+    override def write(key: Void, value: SimpleFeature): Unit = {
+      val partition = storage.metadata.scheme.getPartitionName(value)
+      val state = cache.getOrElseUpdate(partition, newState(partition))
+      state.write(key, value)
       counter.increment(1)
     }
 
     override def close(context: TaskAttemptContext): Unit = {
       cache.foreach { case (partition, state) =>
         logger.debug(s"Closing writer for $partition")
-        state.writer.close(context)
-        val files = Seq(StorageFile(state.file, System.currentTimeMillis()))
-        metadata.addPartition(PartitionMetadata(partition, files, PartitionBounds(state.bounds), state.count))
+        state.close(context)
+        storage.metadata.addPartition(state.meta)
       }
-      CloseWithLogging(metadata)
+      CloseWithLogging(storage)
     }
 
-    private def createWriter(partition: String): PartitionState = {
-      val root = delegate.getOutputCommitter(context).asInstanceOf[FileOutputCommitter].getWorkPath
-      // TODO combine this with the same code in ParquetFileSystemStorage
-      val file = StorageUtils.nextFile(root, partition, metadata.leafStorage, metadata.encoding, fileType)
-      logger.debug(s"Creating record writer at path $file")
-      // noinspection LanguageFeature
-      PartitionState(root, file.getName, delegate.getRecordWriter(context, file))
+    sealed abstract class PartitionState(partition: String) {
+
+      private var count = 0L
+      private val bounds = new Envelope()
+      private val files = ArrayBuffer.empty[String]
+
+      def write(key: Void, value: SimpleFeature): Unit = {
+        val geom = value.getDefaultGeometry.asInstanceOf[Geometry]
+        if (geom != null) {
+          bounds.expandToInclude(geom.getEnvelopeInternal)
+        }
+        count += 1L
+      }
+
+      def meta: PartitionMetadata = {
+        val f = files.map(StorageFile(_, System.currentTimeMillis()))
+        PartitionMetadata(partition, f, PartitionBounds(bounds), count)
+      }
+
+      def close(context: TaskAttemptContext): Unit =
+        context.getCounter(Group, StorageConfiguration.Counters.partition(partition)).increment(count)
+
+      protected def newWriter(): (Path, RecordWriter[Void, SimpleFeature]) = {
+        val file = StorageUtils.nextFile(workPath, partition, leaf, encoding, fileType)
+        logger.debug(s"Creating record writer at path $file")
+        files += file.getName
+        // noinspection LanguageFeature
+        (file, delegate.getRecordWriter(context, file))
+      }
+    }
+
+    private class SinglePartitionState(partition: String) extends PartitionState(partition) {
+
+      private val writer = newWriter()._2
+
+      override def write(key: Void, value: SimpleFeature): Unit = {
+        writer.write(key, value)
+        super.write(key, value)
+      }
+
+      override def close(context: TaskAttemptContext): Unit = {
+        writer.close(context)
+        super.close(context)
+      }
+    }
+
+    private class ChunkedPartitionState(partition: String, estimator: FileSizeEstimator, context: TaskAttemptContext)
+        extends PartitionState(partition) {
+
+      private var count = 0L // number of features written
+      private var total = 0L // sum size of all finished chunks
+      private var remaining = estimator.estimate(0L)
+
+      private var path: Path = _
+      private var writer: RecordWriter[Void, SimpleFeature] = _
+
+      override def write(key: Void, value: SimpleFeature): Unit = {
+        if (writer == null) {
+          val (p, w) = newWriter()
+          path = p
+          writer = w
+        }
+        writer.write(key, value)
+        count += 1
+        remaining -= 1
+        if (remaining == 0) {
+          writer.close(context)
+          writer = null
+          // adjust our estimate to account for the actual bytes written
+          total += storage.context.fc.getFileStatus(path).getLen
+          estimator.update(total, count)
+          remaining = estimator.estimate(0L)
+        }
+        super.write(key, value)
+      }
+
+      override def close(context: TaskAttemptContext): Unit = {
+        if (writer != null) {
+          writer.close(context)
+        }
+        super.close(context)
+      }
     }
   }
 }
@@ -102,10 +191,5 @@ object PartitionOutputFormat {
 
   type SingleFileOutputFormat = FileOutputFormat[Void, SimpleFeature] {
     def getRecordWriter(context: TaskAttemptContext, file: Path): RecordWriter[Void, SimpleFeature]
-  }
-
-  private case class PartitionState(root: Path, file: String, writer: RecordWriter[Void, SimpleFeature]) {
-    var count = 0L
-    val bounds = new Envelope()
   }
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/jobs/StorageConfiguration.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/jobs/StorageConfiguration.scala
@@ -29,15 +29,22 @@ import org.opengis.filter.Filter
 object StorageConfiguration {
 
   object Counters {
+
     val Group    = "org.locationtech.geomesa.jobs.fs"
+
     val Features = "features"
     val Written  = "written"
     val Failed   = "failed"
+
+    val PartitionPrefix = "p-"
+
+    def partition(name: String): String = PartitionPrefix + name
   }
 
   val PathKey                = "geomesa.fs.path"
   val PartitionsKey          = "geomesa.fs.partitions"
   val FileTypeKey            = "geomesa.fs.output.file-type"
+  val FileSizeKey            = "geomesa.fs.output.file-size"
   val SftNameKey             = "geomesa.fs.sft.name"
   val SftSpecKey             = "geomesa.fs.sft.spec"
   val FilterKey              = "geomesa.fs.filter"
@@ -65,6 +72,9 @@ object StorageConfiguration {
 
   def setFileType(conf: Configuration, fileType: FileType): Unit = conf.set(FileTypeKey, fileType.toString)
   def getFileType(conf: Configuration): FileType = FileType.withName(conf.get(FileTypeKey))
+
+  def setTargetFileSize(conf: Configuration, fileSize: Long): Unit = conf.set(FileSizeKey, fileSize.toString)
+  def getTargetFileSize(conf: Configuration): Option[Long] = Option(conf.get(FileSizeKey)).map(_.toLong)
 
   def setFilter(conf: Configuration, filter: Filter): Unit = conf.set(FilterKey, ECQL.toCQL(filter))
   def getFilter(conf: Configuration, sft: SimpleFeatureType): Option[Filter] =

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/metadata/FileBasedMetadata.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/metadata/FileBasedMetadata.scala
@@ -20,7 +20,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.fs.Options.CreateOpts
 import org.apache.hadoop.fs._
 import org.locationtech.geomesa.fs.storage.api.StorageMetadata.PartitionMetadata
-import org.locationtech.geomesa.fs.storage.api.{NamedOptions, PartitionScheme, StorageMetadata}
+import org.locationtech.geomesa.fs.storage.api._
 import org.locationtech.geomesa.fs.storage.common.utils.PathCache
 import org.locationtech.geomesa.utils.concurrent.CachedThreadPool
 import org.locationtech.geomesa.utils.io.WithClose
@@ -53,17 +53,13 @@ import scala.util.control.NonFatal
   * @param fc file context
   * @param directory metadata root path
   * @param sft simple feature type
-  * @param encoding file encoding
-  * @param scheme partition scheme
-  * @param leafStorage leaf storage
+  * @param meta basic metadata config
   */
 class FileBasedMetadata(
     private val fc: FileContext,
     val directory: Path,
     val sft: SimpleFeatureType,
-    val encoding: String,
-    val scheme: PartitionScheme,
-    val leafStorage: Boolean
+    private val meta: Metadata
   ) extends StorageMetadata with MethodProfiling with LazyLogging {
 
   import FileBasedMetadata._
@@ -89,6 +85,19 @@ class FileBasedMetadata(
           Option(partitions.get(BoxedUnit.UNIT).get(key)).flatMap(readPartition(_, 8)).map(_.toMetadata).orNull
       }
     )
+
+  override val scheme: PartitionScheme = PartitionSchemeFactory.load(sft, meta.scheme)
+  override val encoding: String = meta.config(Metadata.Encoding)
+  override val leafStorage: Boolean = meta.config(Metadata.LeafStorage).toBoolean
+
+  private val kvs = new ConcurrentHashMap[String, String](meta.config.asJava)
+
+  override def get(key: String): Option[String] = Option(kvs.get(key))
+
+  override def set(key: String, value: String): Unit = {
+    kvs.put(key, value)
+    FileBasedMetadataFactory.write(fc, directory.getParent, meta.copy(config = kvs.asScala.toMap))
+  }
 
   override def getPartitions(prefix: Option[String]): Seq[PartitionMetadata] = {
     partitions.get(BoxedUnit.UNIT).asScala.toStream.flatMap { case (p, _) =>
@@ -132,7 +141,10 @@ class FileBasedMetadata(
     }
   }
 
-  override def compact(partition: Option[String], threads: Int): Unit = {
+  // noinspection ScalaDeprecation
+  override def compact(partition: Option[String], threads: Int): Unit = compact(partition, None, threads)
+
+  override def compact(partition: Option[String], fileSize: Option[Long], threads: Int): Unit = {
     require(threads > 0, "Threads must be a positive number")
 
     // in normal usage, we never pass in a partition to this method
@@ -426,8 +438,7 @@ object FileBasedMetadata {
    * @param m metadata
    * @return
    */
-  def copy(m: FileBasedMetadata): FileBasedMetadata =
-    new FileBasedMetadata(m.fc, m.directory, m.sft, m.encoding, m.scheme, m.leafStorage)
+  def copy(m: FileBasedMetadata): FileBasedMetadata = new FileBasedMetadata(m.fc, m.directory, m.sft, m.meta)
 
   /**
    * Holder for metadata files for a partition

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/metadata/FileBasedMetadataFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/metadata/FileBasedMetadataFactory.scala
@@ -52,14 +52,13 @@ class FileBasedMetadataFactory extends StorageMetadataFactory {
   }
 
   override def create(context: FileSystemContext, config: Map[String, String], meta: Metadata): FileBasedMetadata = {
-    val Metadata(_, encoding, _, leaf) = meta
     val sft = namespaced(meta.sft, context.namespace)
     // load the partition scheme first in case it fails
     val scheme = PartitionSchemeFactory.load(sft, meta.scheme)
     MetadataJson.writeMetadata(context, NamedOptions(name, config))
     FileBasedMetadataFactory.write(context.fc, context.root, meta)
     val directory = new Path(context.root, FileBasedMetadataFactory.MetadataDirectory)
-    val metadata = new FileBasedMetadata(context.fc, directory, sft, encoding, scheme, leaf)
+    val metadata = new FileBasedMetadata(context.fc, directory, sft, meta)
     FileBasedMetadataFactory.cache.put(FileBasedMetadataFactory.key(context), metadata)
     metadata
   }
@@ -82,10 +81,8 @@ object FileBasedMetadataFactory extends MethodProfiling with LazyLogging {
         if (!PathCache.exists(context.fc, file)) { null } else {
           val directory = new Path(context.root, MetadataDirectory)
           val meta = WithClose(context.fc.open(file))(MetadataSerialization.deserialize)
-          val leaf = meta.leafStorage
           val sft = namespaced(meta.sft, context.namespace)
-          val scheme = PartitionSchemeFactory.load(sft, meta.scheme)
-          new FileBasedMetadata(context.fc, directory, sft, meta.encoding, scheme, leaf)
+          new FileBasedMetadata(context.fc, directory, sft, meta)
         }
       }
     }
@@ -99,12 +96,10 @@ object FileBasedMetadataFactory extends MethodProfiling with LazyLogging {
     * @param root root path
     * @param metadata simple feature type, file encoding, partition scheme, etc
     */
-  private def write(fc: FileContext, root: Path, metadata: Metadata): Unit = {
+  private [metadata] def write(fc: FileContext, root: Path, metadata: Metadata): Unit = {
     val file = new Path(root, StoragePath)
-    if (PathCache.exists(fc, file, reload = true)) {
-      throw new IllegalArgumentException(s"Metadata file already exists at path '$file'")
-    }
-    WithClose(fc.create(file, java.util.EnumSet.of(CreateFlag.CREATE), CreateOpts.createParent)) { out =>
+    val flags = java.util.EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE)
+    WithClose(fc.create(file, flags, CreateOpts.createParent)) { out =>
       MetadataSerialization.serialize(out, metadata)
       out.hflush()
       out.hsync()

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/metadata/JdbcMetadataFactory.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/metadata/JdbcMetadataFactory.scala
@@ -44,8 +44,7 @@ class JdbcMetadataFactory extends StorageMetadataFactory {
             throw new IllegalArgumentException(s"Could not load metadata at root '$root'")
           }
           val sft = namespaced(metadata.sft, context.namespace)
-          val scheme = PartitionSchemeFactory.load(sft, metadata.scheme)
-          new JdbcMetadata(source, root, sft, metadata.encoding, scheme, metadata.leafStorage)
+          new JdbcMetadata(source, root, sft, metadata)
         } catch {
           case NonFatal(e) => CloseQuietly(source).foreach(e.addSuppressed); throw e
         }
@@ -61,7 +60,7 @@ class JdbcMetadataFactory extends StorageMetadataFactory {
     val source = JdbcMetadataFactory.createDataSource(config)
     try {
       JdbcMetadata.create(source, root, meta)
-      new JdbcMetadata(source, root, sft, meta.encoding, scheme, meta.leafStorage)
+      new JdbcMetadata(source, root, sft, meta)
     } catch {
       case NonFatal(e) => CloseQuietly(source).foreach(e.addSuppressed); throw e
     }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/metadata/MetadataSerialization.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/metadata/MetadataSerialization.scala
@@ -13,7 +13,7 @@ import java.nio.charset.StandardCharsets
 
 import com.typesafe.config.{Config, ConfigFactory}
 import org.locationtech.geomesa.fs.storage.api.{Metadata, NamedOptions}
-import org.locationtech.geomesa.fs.storage.common.metadata.MetadataSerialization.Persistence.{PartitionSchemeConfig, StoragePersistence, StoragePersistenceV1}
+import org.locationtech.geomesa.fs.storage.common.metadata.MetadataSerialization.Persistence.{PartitionSchemeConfig, StoragePersistence, StoragePersistenceV1, StoragePersistenceV2}
 import org.locationtech.geomesa.fs.storage.common.{ParseOptions, RenderOptions}
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.stats.MethodProfiling
@@ -36,7 +36,7 @@ object MetadataSerialization extends MethodProfiling {
   def serialize(out: OutputStream, metadata: Metadata): Unit = {
     val sftConfig = SimpleFeatureTypes.toConfig(metadata.sft, includePrefix = false, includeUserData = true)
     val schemeConfig = PartitionSchemeConfig(metadata.scheme.name, metadata.scheme.options)
-    val persistence = StoragePersistence(sftConfig, schemeConfig, metadata.encoding, metadata.leafStorage)
+    val persistence = StoragePersistence(sftConfig, schemeConfig, metadata.config)
 
     val data = profile("Serialized storage configuration") {
       ConfigWriter[StoragePersistence].to(persistence).render(RenderOptions)
@@ -57,16 +57,26 @@ object MetadataSerialization extends MethodProfiling {
       val config = ConfigFactory.parseReader(new InputStreamReader(in, StandardCharsets.UTF_8), ParseOptions)
       try { pureconfig.loadConfigOrThrow[StoragePersistence](config) } catch {
         case NonFatal(e) =>
-          val v1 = Try(pureconfig.loadConfigOrThrow[StoragePersistenceV1](config)).getOrElse(throw e)
-          val leaf = v1.partitionScheme.options.get("leaf-storage").forall(_.equalsIgnoreCase("true"))
-          StoragePersistence(v1.featureType, v1.partitionScheme, v1.encoding, leaf)
+          def v1: Try[StoragePersistence] =
+            Try(pureconfig.loadConfigOrThrow[StoragePersistenceV1](config)).map { p =>
+              val leaf = p.partitionScheme.options.get("leaf-storage").forall(_.equalsIgnoreCase("true"))
+              val config = Map(Metadata.Encoding -> p.encoding, Metadata.LeafStorage -> s"$leaf")
+              StoragePersistence(p.featureType, p.partitionScheme, config)
+            }
+          def v2: Try[StoragePersistence] =
+            Try(pureconfig.loadConfigOrThrow[StoragePersistenceV2](config)).map { p =>
+              val leaf = java.lang.Boolean.toString(p.leafStorage)
+              val config = Map(Metadata.Encoding -> p.encoding, Metadata.LeafStorage -> leaf)
+              StoragePersistence(p.featureType, p.partitionScheme, config)
+            }
+          v2.orElse(v1).getOrElse(throw e)
       }
     }
     val sft = profile("Parsed simple feature type") {
       SimpleFeatureTypes.createType(persistence.featureType, path = None)
     }
     val scheme = NamedOptions(persistence.partitionScheme.scheme, persistence.partitionScheme.options)
-    Metadata(sft, persistence.encoding, scheme, persistence.leafStorage)
+    Metadata(sft, scheme, persistence.config)
   }
 
   // case classes used for serialization to/from typesafe config
@@ -77,9 +87,10 @@ object MetadataSerialization extends MethodProfiling {
     case class StoragePersistence(
         featureType: Config,
         partitionScheme: PartitionSchemeConfig,
-        encoding: String,
-        leafStorage: Boolean
+        config: Map[String, String]
       )
+    case class StoragePersistenceV2(
+        featureType: Config, partitionScheme: PartitionSchemeConfig, encoding: String, leafStorage: Boolean)
     case class StoragePersistenceV1(featureType: Config, partitionScheme: PartitionSchemeConfig, encoding: String)
     case class PartitionSchemeConfig(scheme: String, options: Map[String, String])
 
@@ -87,6 +98,8 @@ object MetadataSerialization extends MethodProfiling {
       deriveConvert[PartitionSchemeConfig]
     implicit val StoragePersistenceV1Convert: ConfigConvert[StoragePersistenceV1] =
       deriveConvert[StoragePersistenceV1]
+    implicit val StoragePersistenceV2Convert: ConfigConvert[StoragePersistenceV2] =
+      deriveConvert[StoragePersistenceV2]
     implicit val StoragePersistenceConvert: ConfigConvert[StoragePersistence] = deriveConvert[StoragePersistence]
   }
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/package.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/package.scala
@@ -11,11 +11,12 @@ package org.locationtech.geomesa.fs.storage
 import com.typesafe.config._
 import org.locationtech.geomesa.fs.storage.api.NamedOptions
 import org.locationtech.geomesa.fs.storage.common.metadata.MetadataSerialization.Persistence.PartitionSchemeConfig
+import org.locationtech.geomesa.utils.text.Suffixes.Memory
 import org.opengis.feature.simple.SimpleFeatureType
 import pureconfig.ConfigConvert
 import pureconfig.generic.semiauto.deriveConvert
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 package object common {
@@ -59,6 +60,7 @@ package object common {
     val LeafStorageKey = "geomesa.fs.leaf-storage"
     val MetadataKey    = "geomesa.fs.metadata"
     val SchemeKey      = "geomesa.fs.scheme"
+    val FileSizeKey    = "geomesa.fs.file-size"
     val ObserversKey   = "geomesa.fs.observers"
   }
 
@@ -87,6 +89,20 @@ package object common {
     def setMetadata(name: String, options: Map[String, String] = Map.empty): Unit =
       sft.getUserData.put(MetadataKey, serialize(NamedOptions(name, options)))
     def removeMetadata(): Option[NamedOptions] = remove(MetadataKey).map(deserialize)
+
+    def setTargetFileSize(size: String): Unit = {
+      // validate input
+      Memory.bytes(size).failed.foreach(e => throw new IllegalArgumentException("Invalid file size", e))
+      sft.getUserData.put(FileSizeKey, size)
+    }
+    def removeTargetFileSize(): Option[Long] = {
+      remove(FileSizeKey).map { s =>
+        Memory.bytes(s) match {
+          case Success(b) => b
+          case Failure(e) => throw new IllegalArgumentException("Invalid file size", e)
+        }
+      }
+    }
 
     def setObservers(names: Seq[String]): Unit = sft.getUserData.put(ObserversKey, names.mkString(","))
     def getObservers: Seq[String] = {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterMetadata.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterMetadata.scala
@@ -61,7 +61,10 @@ class ConverterMetadata(
   override def removePartition(partition: PartitionMetadata): Unit =
     throw new UnsupportedOperationException("Converter storage does not support updating metadata")
 
-  override def compact(partition: Option[String], threads: Int): Unit =
+  // noinspection ScalaDeprecation
+  override def compact(partition: Option[String], threads: Int): Unit = compact(partition, None, threads)
+
+  override def compact(partition: Option[String], fileSize: Option[Long], threads: Int): Unit =
     throw new UnsupportedOperationException("Converter storage does not support updating metadata")
 
   override def close(): Unit = es.shutdown()

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
@@ -49,7 +49,10 @@ class ConverterStorage(context: FileSystemContext, metadata: StorageMetadata, co
   override def getWriter(partition: String): FileSystemWriter =
     throw new UnsupportedOperationException("Converter storage does not support feature writing")
 
-  override def compact(partition: Option[String], threads: Int): Unit =
+  // noinspection ScalaDeprecation
+  override def compact(partition: Option[String], threads: Int): Unit = compact(partition, None, threads)
+
+  override def compact(partition: Option[String], fileSize: Option[Long], threads: Int): Unit =
     throw new UnsupportedOperationException("Converter storage does not support compactions")
 }
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/jobs/ParquetStorageConfiguration.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/parquet/jobs/ParquetStorageConfiguration.scala
@@ -25,14 +25,18 @@ trait ParquetStorageConfiguration extends StorageConfiguration with LazyLogging 
     ParquetOutputFormat.setWriteSupportClass(job, classOf[SimpleFeatureWriteSupport])
 
     // Parquet Options
-    val summaryLevel = Option(sft.getUserData.get(ParquetOutputFormat.JOB_SUMMARY_LEVEL).asInstanceOf[String])
-        .getOrElse(ParquetOutputFormat.JobSummaryLevel.NONE.toString)
+    val summaryLevel =
+      Option(job.getConfiguration.get(ParquetOutputFormat.JOB_SUMMARY_LEVEL))
+          .orElse(Option(sft.getUserData.get(ParquetOutputFormat.JOB_SUMMARY_LEVEL).asInstanceOf[String]))
+          .getOrElse(ParquetOutputFormat.JobSummaryLevel.NONE.toString)
     job.getConfiguration.set(ParquetOutputFormat.JOB_SUMMARY_LEVEL, summaryLevel)
     logger.debug(s"Parquet metadata summary level is $summaryLevel")
 
-    val compression = Option(sft.getUserData.get(ParquetOutputFormat.COMPRESSION).asInstanceOf[String])
-        .map(CompressionCodecName.valueOf)
-        .getOrElse(CompressionCodecName.SNAPPY)
+    val compression =
+      Option(job.getConfiguration.get(ParquetOutputFormat.COMPRESSION))
+          .orElse(Option(sft.getUserData.get(ParquetOutputFormat.COMPRESSION).asInstanceOf[String]))
+          .map(CompressionCodecName.valueOf)
+          .getOrElse(CompressionCodecName.SNAPPY)
     ParquetOutputFormat.setCompression(job, compression)
     logger.debug(s"Parquet compression is $compression")
   }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/CompactionTest.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/CompactionTest.scala
@@ -15,6 +15,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileContext, Path}
 import org.geotools.data.Query
 import org.geotools.filter.text.ecql.ECQL
+import org.geotools.util.factory.Hints
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.fs.storage.api.StorageMetadata.StorageFile
@@ -23,7 +24,6 @@ import org.locationtech.geomesa.fs.storage.common.metadata.FileBasedMetadataFact
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.io.WithClose
-import org.opengis.feature.simple.SimpleFeature
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.AllExpectations
@@ -56,33 +56,41 @@ class CompactionTest extends Specification with AllExpectations {
 
       partition mustEqual "2017/01/01"
 
-      def write(sf: SimpleFeature): Unit = {
+      def write(sf: ScalaSimpleFeature): Unit = {
+        sf.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
         val writer = fsStorage.getWriter(partition)
+        val id = sf.getID
         writer.write(sf)
+        var i = 1
+        while (i < 100) {
+          sf.setId(id + f"$i%02d")
+          writer.write(sf)
+          i += 1
+        }
         writer.close()
       }
 
       // First simple feature goes in its own file
       write(sf1)
       fsStorage.metadata.getPartition(partition).map(_.files) must beSome(haveSize[Seq[StorageFile]](1))
-      SelfClosingIterator(fsStorage.getReader(Query.ALL, Some(partition))).toList must haveSize(1)
+      SelfClosingIterator(fsStorage.getReader(Query.ALL, Some(partition))).toList must haveSize(100)
 
       // Second simple feature should be in a separate file
       val sf2 = ScalaSimpleFeature.create(sft, "2", "second", 200, dtg, "POINT (10 10)")
       write(sf2)
       fsStorage.metadata.getPartition(partition).map(_.files) must beSome(haveSize[Seq[StorageFile]](2))
-      SelfClosingIterator(fsStorage.getReader(Query.ALL, Some(partition))).toList must haveSize(2)
+      SelfClosingIterator(fsStorage.getReader(Query.ALL, Some(partition))).toList must haveSize(200)
 
       // Third feature in a third file
       val sf3 = ScalaSimpleFeature.create(sft, "3", "third", 300, dtg, "POINT (10 10)")
       write(sf3)
       fsStorage.metadata.getPartition(partition).map(_.files) must beSome(haveSize[Seq[StorageFile]](3))
-      SelfClosingIterator(fsStorage.getReader(Query.ALL, Some(partition))).toList must haveSize(3)
+      SelfClosingIterator(fsStorage.getReader(Query.ALL, Some(partition))).toList must haveSize(300)
 
       // Compact to create a single file
       fsStorage.compact(Some(partition))
       fsStorage.metadata.getPartition(partition).map(_.files) must beSome(haveSize[Seq[StorageFile]](1))
-      SelfClosingIterator(fsStorage.getReader(Query.ALL, Some(partition))).toList must haveSize(3)
+      SelfClosingIterator(fsStorage.getReader(Query.ALL, Some(partition))).toList must haveSize(300)
 
       // delete a feature and compact again
       WithClose(fsStorage.getWriter(ECQL.toFilter("IN ('2')"))) { writer =>
@@ -93,7 +101,18 @@ class CompactionTest extends Specification with AllExpectations {
       fsStorage.metadata.getPartition(partition).map(_.files) must beSome(haveSize[Seq[StorageFile]](2))
       fsStorage.compact(Some(partition))
       fsStorage.metadata.getPartition(partition).map(_.files) must beSome(haveSize[Seq[StorageFile]](1))
-      SelfClosingIterator(fsStorage.getReader(Query.ALL, Some(partition))).toList must haveSize(2)
+      SelfClosingIterator(fsStorage.getReader(Query.ALL, Some(partition))).toList must haveSize(299)
+
+      // compact to a given file size
+      // verify if file is appropriately sized, it won't be modified
+      val paths = fsStorage.getFilePaths(partition).map(_.path)
+      val size = paths.map(f => fc.getFileStatus(f).getLen).sum
+      fsStorage.compact(Some(partition), Some(size))
+      fsStorage.getFilePaths(partition).map(_.path) mustEqual paths
+      // verify files are split into smaller ones
+      fsStorage.compact(Some(partition), Some(size / 2))
+      fsStorage.metadata.getPartition(partition).map(_.files.length).getOrElse(0) must beGreaterThan(1)
+      SelfClosingIterator(fsStorage.getReader(Query.ALL, Some(partition))).toList must haveSize(299)
     }
   }
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/ParquetStorageTest.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/ParquetStorageTest.scala
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.fs.storage.api.FileSystemStorage.FileSystemWriter
 import org.locationtech.geomesa.fs.storage.api._
-import org.locationtech.geomesa.fs.storage.common.StorageKeys
+import org.locationtech.geomesa.fs.storage.common.{SizeableFileSystemStorage, StorageKeys}
 import org.locationtech.geomesa.fs.storage.common.metadata.FileBasedMetadataFactory
 import org.locationtech.geomesa.utils.collection.SelfClosingIterator
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
@@ -310,6 +310,53 @@ class ParquetStorageTest extends Specification with AllExpectations with LazyLog
 
         forall(TestObserverFactory.observers)(_.closed must beTrue)
         TestObserverFactory.observers.flatMap(_.features) must haveLength(2)
+      }
+    }
+
+    "write files with a target size" in {
+      val sft = SimpleFeatureTypes.createType("parquet-test", "name:String,age:Int,dtg:Date,*geom:Point:srid=4326")
+
+      val features = (0 until 10000).map { i =>
+        val sf = new ScalaSimpleFeature(sft, i.toString)
+        sf.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+        sf.setAttribute(0, s"name${i % 10}")
+        sf.setAttribute(1, s"${i % 10}")
+        sf.setAttribute(2, f"2014-01-${i % 10 + 1}%02dT00:00:01.000Z")
+        sf.setAttribute(3, s"POINT(4${i % 10} 5${i % 10})")
+        sf
+      }
+
+      // note: this is somewhat of a magic number, in that it works the first time through with no remainder
+      val targetSize = 1700L
+
+      withTestDir { dir =>
+        val context = FileSystemContext(FileContext.getFileContext(dir.toUri), config, dir)
+        val metadata =
+          new FileBasedMetadataFactory()
+              .create(context, Map.empty, Metadata(sft, "parquet", scheme, leafStorage = true, Some(targetSize)))
+        val storage = new ParquetFileSystemStorageFactory().apply(context, metadata)
+
+        storage must not(beNull)
+
+        val writers = scala.collection.mutable.Map.empty[String, FileSystemWriter]
+
+        features.foreach { f =>
+          val partition = storage.metadata.scheme.getPartitionName(f)
+          val writer = writers.getOrElseUpdate(partition, storage.getWriter(partition))
+          writer.write(f)
+        }
+
+        writers.foreach(_._2.close())
+
+        logger.debug(s"wrote to ${writers.size} partitions for ${features.length} features")
+
+        val partitions = storage.getPartitions.map(_.name)
+        partitions must haveLength(writers.size)
+        foreach(partitions) { partition =>
+          val paths = storage.getFilePaths(partition)
+          paths.size must beGreaterThan(1)
+          foreach(paths)(p => context.fc.getFileStatus(p.path).getLen must beCloseTo(targetSize, targetSize / 10))
+        }
       }
     }
 

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/FsDataStoreCommand.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/FsDataStoreCommand.scala
@@ -17,7 +17,7 @@ import org.locationtech.geomesa.fs.data.FileSystemDataStore
 import org.locationtech.geomesa.fs.data.FileSystemDataStoreFactory.FileSystemDataStoreParams
 import org.locationtech.geomesa.fs.storage.api.FileSystemStorageFactory
 import org.locationtech.geomesa.fs.tools.FsDataStoreCommand.FsParams
-import org.locationtech.geomesa.tools.utils.ParameterConverters.KeyValueConverter
+import org.locationtech.geomesa.tools.utils.ParameterConverters.{BytesConverter, BytesValidator, KeyValueConverter}
 import org.locationtech.geomesa.tools.{DataStoreCommand, DistributedCommand}
 import org.locationtech.geomesa.utils.classpath.ClassPathUtils
 import org.locationtech.geomesa.utils.io.PathUtils
@@ -85,6 +85,12 @@ object FsDataStoreCommand {
 
     @Parameter(names = Array("--storage-opt"), variableArity = true, description = "Additional storage opts (k=v)", converter = classOf[KeyValueConverter])
     var storageOpts: java.util.List[(String, String)] = new java.util.ArrayList[(String, String)]()
+
+    @Parameter(
+      names = Array("--target-file-size"),
+      description = "Target size for data files",
+      validateValueWith = classOf[BytesValidator])
+    var targetFileSize: String = _
   }
 
   class EncodingValidator extends IValueValidator[String] {

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/compact/PartitionInputFormat.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/compact/PartitionInputFormat.scala
@@ -10,12 +10,13 @@ package org.locationtech.geomesa.fs.tools.compact
 
 import java.io.{DataInput, DataOutput}
 
-import org.apache.hadoop.fs.FileContext
+import org.apache.hadoop.fs.{FileContext, Path}
 import org.apache.hadoop.io.Writable
 import org.apache.hadoop.mapreduce._
 import org.geotools.data.Query
 import org.locationtech.geomesa.fs.storage.api.StorageMetadata.{PartitionMetadata, StorageFile, StorageFileAction}
 import org.locationtech.geomesa.fs.storage.api._
+import org.locationtech.geomesa.fs.storage.common.SizeableFileSystemStorage
 import org.locationtech.geomesa.fs.storage.common.jobs.StorageConfiguration
 import org.locationtech.geomesa.fs.storage.common.utils.PathCache
 import org.locationtech.geomesa.fs.tools.compact.PartitionInputFormat.{PartitionInputSplit, PartitionRecordReader}
@@ -35,16 +36,24 @@ class PartitionInputFormat extends InputFormat[Void, SimpleFeature] {
 
     val root = StorageConfiguration.getRootPath(conf)
     val fsc = FileSystemContext(FileContext.getFileContext(root.toUri, conf), conf, root)
+    val fileSize = StorageConfiguration.getTargetFileSize(conf)
 
     val metadata = StorageMetadataFactory.load(fsc).getOrElse {
       throw new IllegalArgumentException(s"No storage defined under path '$root'")
     }
     WithClose(metadata) { meta =>
-      WithClose(FileSystemStorageFactory(fsc, metadata)) { storage =>
+      WithClose(FileSystemStorageFactory(fsc, meta)) { storage =>
+        val sizeable = Option(storage).collect { case s: SizeableFileSystemStorage => s }
+        val sizeCheck = sizeable.flatMap(s => s.targetSize(fileSize).map(t => (p: Path) => s.fileIsSized(p, t)))
         val splits = StorageConfiguration.getPartitions(conf).map { partition =>
-          val files = storage.metadata.getPartition(partition).map(_.files).getOrElse(Seq.empty)
-          val size = storage.getFilePaths(partition).map(f => PathCache.status(fsc.fc, f.path).getLen).sum
-          new PartitionInputSplit(partition, files, size)
+          var size = 0L
+          val files = storage.getFilePaths(partition).filter { f =>
+            if (sizeCheck.exists(_.apply(f.path))) { false } else {
+              size += PathCache.status(fsc.fc, f.path).getLen
+              true
+            }
+          }
+          new PartitionInputSplit(partition, files.map(_.file), size)
         }
         java.util.Arrays.asList(splits: _*)
       }
@@ -162,7 +171,10 @@ object PartitionInputFormat {
       if (prefix.forall(partition.name.startsWith)) { Seq(partition) } else { Seq.empty }
     override def addPartition(partition: PartitionMetadata): Unit = throw new NotImplementedError()
     override def removePartition(partition: PartitionMetadata): Unit = throw new NotImplementedError()
+    // noinspection ScalaDeprecation
     override def compact(partition: Option[String], threads: Int): Unit = throw new NotImplementedError()
+    override def compact(partition: Option[String], fileSize: Option[Long], threads: Int): Unit =
+      throw new NotImplementedError()
     override def close(): Unit = {}
   }
 }

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/data/FsCreateSchemaCommand.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/data/FsCreateSchemaCommand.scala
@@ -74,6 +74,10 @@ object FsCreateSchemaCommand {
       throw new ParameterException(s"The following options are required: ${errors.mkString(" ")}")
     }
 
+    if (params.targetFileSize != null) {
+      sft.setTargetFileSize(params.targetFileSize)
+    }
+
     // Can use this to set things like compression and summary levels for parquet in the sft user data
     // to be picked up by the ingest job
     params.storageOpts.asScala.foreach { case (k, v) => sft.getUserData.put(k,v) }

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/FileSystemConverterJob.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/FileSystemConverterJob.scala
@@ -42,7 +42,8 @@ abstract class FileSystemConverterJob(
     libjarsPaths: Iterator[() => Seq[File]],
     reducers: Int,
     root: Path,
-    tmpPath: Option[Path]
+    tmpPath: Option[Path],
+    targetFileSize: Option[Long]
   ) extends ConverterIngestJob(dsParams, sft, converterConfig, paths, libjarsFiles, libjarsPaths)
     with StorageConfiguration with LazyLogging {
 
@@ -65,6 +66,7 @@ abstract class FileSystemConverterJob(
 
     StorageConfiguration.setRootPath(job.getConfiguration, root)
     StorageConfiguration.setFileType(job.getConfiguration, FileType.Written)
+    targetFileSize.foreach(StorageConfiguration.setTargetFileSize(job.getConfiguration, _))
 
     FileOutputFormat.setOutputPath(job, tmpPath.getOrElse(root))
 
@@ -98,8 +100,10 @@ object FileSystemConverterJob {
       libjarsPaths: Iterator[() => Seq[File]],
       reducers: Int,
       root: Path,
-      tmpPath: Option[Path]
-    ) extends FileSystemConverterJob(dsParams, sft, converterConfig, paths, libjarsFiles, libjarsPaths, reducers, root, tmpPath)
+      tmpPath: Option[Path],
+      targetFileSize: Option[Long]
+    ) extends FileSystemConverterJob(
+        dsParams, sft, converterConfig, paths, libjarsFiles, libjarsPaths, reducers, root, tmpPath, targetFileSize)
           with ParquetStorageConfiguration
 
   class OrcConverterJob(
@@ -111,8 +115,10 @@ object FileSystemConverterJob {
       libjarsPaths: Iterator[() => Seq[File]],
       reducers: Int,
       root: Path,
-      tmpPath: Option[Path]
-    ) extends FileSystemConverterJob(dsParams, sft, converterConfig, paths, libjarsFiles, libjarsPaths, reducers, root, tmpPath)
+      tmpPath: Option[Path],
+      targetFileSize: Option[Long]
+    ) extends FileSystemConverterJob(
+        dsParams, sft, converterConfig, paths, libjarsFiles, libjarsPaths, reducers, root, tmpPath, targetFileSize)
           with OrcStorageConfiguration
 
   class FsIngestMapper extends Mapper[LongWritable, SimpleFeature, Text, BytesWritable] with LazyLogging {

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/FsIngestCommand.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/FsIngestCommand.scala
@@ -10,15 +10,18 @@ package org.locationtech.geomesa.fs.tools.ingest
 
 import com.beust.jcommander.{Parameter, ParameterException, Parameters}
 import com.typesafe.config.Config
-import org.apache.hadoop.fs.{FileContext, Path}
-import org.locationtech.geomesa.fs.data.{FileSystemDataStore, FileSystemStorageManager}
-import org.locationtech.geomesa.fs.data.FileSystemDataStoreFactory.FileSystemDataStoreParams
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.Job
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
+import org.locationtech.geomesa.fs.data.FileSystemDataStore
+import org.locationtech.geomesa.fs.storage.api.Metadata
 import org.locationtech.geomesa.fs.storage.orc.OrcFileSystemStorage
 import org.locationtech.geomesa.fs.tools.FsDataStoreCommand.{FsDistributedCommand, FsParams, OptionalEncodingParam, OptionalSchemeParams}
 import org.locationtech.geomesa.fs.tools.data.FsCreateSchemaCommand
 import org.locationtech.geomesa.fs.tools.ingest.FileSystemConverterJob.{OrcConverterJob, ParquetConverterJob}
 import org.locationtech.geomesa.fs.tools.ingest.FsIngestCommand.FsIngestParams
 import org.locationtech.geomesa.jobs.Awaitable
+import org.locationtech.geomesa.jobs.mapreduce.ConverterCombineInputFormat
 import org.locationtech.geomesa.parquet.ParquetFileSystemStorage
 import org.locationtech.geomesa.tools.Command
 import org.locationtech.geomesa.tools.DistributedRunParam.RunModes
@@ -40,20 +43,18 @@ class FsIngestCommand extends IngestCommand[FileSystemDataStore] with FsDistribu
       sft: SimpleFeatureType,
       converter: Config,
       inputs: Seq[String]): Awaitable = {
-    if (params.combineInputs) {
-      throw new NotImplementedError("--combine-inputs is not supported for the FileSystem data store")
-    }
     mode match {
       case RunModes.Local =>
         super.startIngest(mode, ds, sft, converter, inputs)
 
       case RunModes.Distributed =>
-        Command.user.info("Running ingestion in distributed mode")
+        Command.user.info(s"Running ingestion in distributed ${if (params.combineInputs) "combine " else "" }mode")
         val reducers = Option(params.reducers).filter(_ > 0).getOrElse {
           throw new ParameterException("Please specify --num-reducers for distributed ingest")
         }
         val storage = ds.storage(sft.getTypeName)
         val tmpPath = Option(params.tempDir).map(d => storage.context.fc.makeQualified(new Path(d)))
+        val targetFileSize = storage.metadata.get(Metadata.TargetFileSize).map(_.toLong)
 
         tmpPath.foreach { tp =>
           if (storage.context.fc.util.exists(tp)) {
@@ -65,11 +66,29 @@ class FsIngestCommand extends IngestCommand[FileSystemDataStore] with FsDistribu
         storage.metadata.encoding match {
           case OrcFileSystemStorage.Encoding =>
             new OrcConverterJob(
-              connection, sft, converter, inputs, libjarsFiles, libjarsPaths, reducers, storage.context.root, tmpPath)
+              connection, sft, converter, inputs, libjarsFiles, libjarsPaths, reducers,
+              storage.context.root, tmpPath, targetFileSize) {
+              override def configureJob(job: Job): Unit = {
+                super.configureJob(job)
+                if (params.combineInputs) {
+                  job.setInputFormatClass(classOf[ConverterCombineInputFormat])
+                  Option(params.maxSplitSize).foreach(s => FileInputFormat.setMaxInputSplitSize(job, s.toLong))
+                }
+              }
+            }
 
           case ParquetFileSystemStorage.Encoding =>
             new ParquetConverterJob(
-              connection, sft, converter, inputs, libjarsFiles, libjarsPaths, reducers, storage.context.root, tmpPath)
+              connection, sft, converter, inputs, libjarsFiles, libjarsPaths, reducers,
+              storage.context.root, tmpPath, targetFileSize) {
+              override def configureJob(job: Job): Unit = {
+                super.configureJob(job)
+                if (params.combineInputs) {
+                  job.setInputFormatClass(classOf[ConverterCombineInputFormat])
+                  Option(params.maxSplitSize).foreach(s => FileInputFormat.setMaxInputSplitSize(job, s.toLong))
+                }
+              }
+            }
 
           case _ =>
             throw new ParameterException(s"Ingestion is not supported for encoding '${params.encoding}'")

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ExportCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ExportCommand.scala
@@ -467,12 +467,13 @@ object ExportCommand extends LazyLogging {
       }
       exporter = new Exporter(options.copy(file = names.next), hints, queriedDictionaries)
       exporter.start(sft)
-      count = 0
+      count = 0L
     }
 
     @tailrec
     private def export(features: Iterator[SimpleFeature], result: Option[Long]): Option[Long] = {
-      val counter = features.take(estimator.estimate(exporter.bytes)).map { f => count += 1; f }
+      var estimate = estimator.estimate(exporter.bytes)
+      val counter = features.takeWhile { _ => count += 1; estimate -= 1; estimate >= 0 }
       val exported = exporter.export(counter) match {
         case None    => result
         case Some(c) => result.map(_ + c).orElse(Some(c))

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ExportJob.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ExportJob.scala
@@ -385,7 +385,7 @@ object ExportJob extends JobWithLibJars {
     private var exporter: FeatureExporter = _
     private var estimator: FileSizeEstimator = _
     private var estimate = 0L // estimated number of features to write to hit our chunk size
-    private var count = 0 // current number of features written since the last estimate
+    private var count = 0L // current number of features written since the last estimate
 
     override def write(key: Text, value: SimpleFeature): Unit = {
       if (exporter == null) {

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ExportJob.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ExportJob.scala
@@ -30,10 +30,10 @@ import org.locationtech.geomesa.index.geoserver.ViewParams
 import org.locationtech.geomesa.index.index.attribute.AttributeIndexKey
 import org.locationtech.geomesa.jobs.GeoMesaConfigurator
 import org.locationtech.geomesa.jobs.mapreduce.JobWithLibJars
-import org.locationtech.geomesa.tools.export.ExportCommand.{ExportOptions, Exporter, FileSizeEstimator}
+import org.locationtech.geomesa.tools.export.ExportCommand.{ExportOptions, Exporter}
 import org.locationtech.geomesa.tools.export.formats.{ExportFormat, FeatureExporter}
 import org.locationtech.geomesa.utils.index.ByteArrays
-import org.locationtech.geomesa.utils.io.{IncrementingFileName, PathUtils}
+import org.locationtech.geomesa.utils.io.{FileSizeEstimator, IncrementingFileName, PathUtils}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 /**

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/utils/ParameterConverters.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/utils/ParameterConverters.scala
@@ -10,8 +10,8 @@ package org.locationtech.geomesa.tools.utils
 
 import java.util.Date
 
-import com.beust.jcommander.ParameterException
 import com.beust.jcommander.converters.BaseConverter
+import com.beust.jcommander.{IValueValidator, ParameterException}
 import org.geotools.filter.text.ecql.ECQL
 import org.locationtech.geomesa.convert.Modes.ErrorMode
 import org.locationtech.geomesa.tools.export.formats.ExportFormat
@@ -121,5 +121,10 @@ object ParameterConverters {
         case Failure(e) => throw new ParameterException(s"Invalid byte string '$value'", e)
       }
     }
+  }
+
+  class BytesValidator extends IValueValidator[String] {
+    override def validate(name: String, value: String): Unit =
+      Memory.bytes(value).failed.foreach(e => throw new ParameterException(s"Invalid byte string '$value'", e))
   }
 }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/FileSizeEstimator.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/FileSizeEstimator.scala
@@ -31,10 +31,7 @@ class FileSizeEstimator(target: Long, error: Float, estimatedBytesPerFeature: Fl
    * @param written number of bytes written so far
    * @return
    */
-  def estimate(written: Long): Int = {
-    val e = math.round((target - written) / estimate)
-    if (e < 1) { 1 } else if (e.isValidInt) { e.intValue() } else { Int.MaxValue }
-  }
+  def estimate(written: Long): Long = math.max(1L, math.round((target - written) / estimate))
 
   /**
    * Re-evaluate the bytes per feature, based on having written out a certain number of features

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/FileSizeEstimator.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/FileSizeEstimator.scala
@@ -33,7 +33,7 @@ class FileSizeEstimator(target: Long, error: Float, estimatedBytesPerFeature: Fl
    */
   def estimate(written: Long): Int = {
     val e = math.round((target - written) / estimate)
-    if (e < 1) { 1 } else if (e.isValidInt) { e.intValue() } else { Int.MaxValue}
+    if (e < 1) { 1 } else if (e.isValidInt) { e.intValue() } else { Int.MaxValue }
   }
 
   /**

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/FileSizeEstimator.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/FileSizeEstimator.scala
@@ -1,0 +1,70 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.io
+
+import com.typesafe.scalalogging.LazyLogging
+
+/**
+ * Estimates how many features to write to create a file of a target size
+ *
+ * @param target target file size, in bytes
+ * @param error acceptable percent error for file size, in bytes
+ * @param estimatedBytesPerFeature initial estimate for bytes per feature
+ */
+class FileSizeEstimator(target: Long, error: Float, estimatedBytesPerFeature: Float) extends LazyLogging {
+
+  require(error >= 0 && error < 1f, "Error must be a percentage between [0,1)")
+
+  private val threshold = math.round(target * error.toDouble)
+  private var estimate = estimatedBytesPerFeature.toDouble
+  private var updatedEstimate: Option[Float] = None
+
+  /**
+   * Estimate how many features to write to hit our target size
+   *
+   * @param written number of bytes written so far
+   * @return
+   */
+  def estimate(written: Long): Int = {
+    val e = math.round((target - written) / estimate)
+    if (e < 1) { 1 } else if (e.isValidInt) { e.intValue() } else { Int.MaxValue}
+  }
+
+  /**
+   * Re-evaluate the bytes per feature, based on having written out a certain number of features
+   *
+   * @param size size of the file created
+   * @param count number of features written to the file
+   */
+  def update(size: Long, count: Long): Unit = {
+    if (size > 0 && count > 0 && math.abs(size - target) > threshold) {
+      val update = size.toDouble / count
+      logger.debug(s"Updating bytesPerFeature from $estimate to $update based on writing $count features in $size bytes")
+      estimate = update
+      updatedEstimate = Some(estimate.toFloat)
+    } else {
+      logger.debug(s"Not updating bytesPerFeature from $estimate based on writing $count features in $size bytes")
+    }
+  }
+
+  /**
+   * Returns the bytes per feature, based on data written so far
+   *
+   * @return
+   */
+  def getBytesPerFeature: Option[Float] = updatedEstimate
+
+  /**
+   * Checks if the bytes written is (at least) within the error threshold of the desired size
+   *
+   * @param size size of the file created
+   * @return
+   */
+  def done(size: Long): Boolean = size > target || math.abs(size - target) < threshold
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/text/Suffixes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/text/Suffixes.scala
@@ -56,11 +56,11 @@ object Suffixes {
       if (m.matches() && m.groupCount() == 2) {
         Try(m.group(1).toLong).flatMap { num =>
           val mult: Long = m.group(2) match {
-            case "k" => 1024l
-            case "m" => 1024l * 1024l
-            case "g" => 1024l * 1024l * 1024l
-            case "t" => 1024l * 1024l * 1024l * 1024l
-            case _   => 1l
+            case "k" => 1024L
+            case "m" => 1024L * 1024L
+            case "g" => 1024L * 1024L * 1024L
+            case "t" => 1024L * 1024L * 1024L * 1024L
+            case _   => 1L
           }
           val res = num * mult
           if (res > 0) {

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/io/FileSizeEstimatorTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/io/FileSizeEstimatorTest.scala
@@ -6,10 +6,9 @@
  * http://www.opensource.org/licenses/apache2.0.php.
  ***********************************************************************/
 
-package org.locationtech.geomesa.tools.export
+package org.locationtech.geomesa.utils.io
 
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.tools.export.ExportCommand.FileSizeEstimator
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/io/FileSizeEstimatorTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/io/FileSizeEstimatorTest.scala
@@ -42,7 +42,7 @@ class FileSizeEstimatorTest extends Specification {
     }
     "always estimate at least 1" in {
       val estimator = new FileSizeEstimator(1000, 0.1f, 100)
-      forall(Range(0, 2000, 100))(i => estimator.estimate(i) must beGreaterThanOrEqualTo(1))
+      forall(Range(0, 2000, 100))(i => estimator.estimate(i) must beGreaterThanOrEqualTo(1L))
     }
   }
 }


### PR DESCRIPTION
* Add set/get kvs to FS metadata
* Add target file size to sft/create schema
* Update metadata serialization
* Deprecated and updated file system compaction api to allow for size
* Move FileSizeEstimator to geomesa-utils

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>