### PR TITLE
GEOMESA-2973 Fix indexing for yearly z3 epoch

### DIFF
--- a/docs/user/datastores/index_basics.rst
+++ b/docs/user/datastores/index_basics.rst
@@ -136,6 +136,7 @@ The following versions are available:
         4             1.3.1           Support for table sharing
         5             2.0.0           Uses fixed Z-curve implementation
         6             2.3.0           Configurable attributes
+        7             3.2.0           Fixes yearly epoch indexing
         ============= =============== =================================================================
 
     .. tab:: Z2
@@ -161,6 +162,7 @@ The following versions are available:
         ============= =============== =================================================================
         1             1.2.5           Initial implementation
         2             2.3.0           Configurable attributes
+        3             3.2.0           Fixes yearly epoch indexing
         ============= =============== =================================================================
 
     .. tab:: XZ2

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/DefaultFeatureIndexFactory.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/DefaultFeatureIndexFactory.scala
@@ -58,14 +58,16 @@ object DefaultFeatureIndexFactory extends GeoMesaFeatureIndexFactory {
       case (IdIndex.name, 2)  => Some(new IdIndexV2(ds, sft, index.mode))
       case (IdIndex.name, 1)  => Some(new IdIndexV1(ds, sft, index.mode))
 
-      case (Z3Index.name, 6)  => Some(new Z3Index(ds, sft, geom3, dtg, index.mode))
+      case (Z3Index.name, 7)  => Some(new Z3Index(ds, sft, geom3, dtg, index.mode))
+      case (Z3Index.name, 6)  => Some(new Z3IndexV6(ds, sft, geom3, dtg, index.mode))
       case (Z3Index.name, 5)  => Some(new Z3IndexV5(ds, sft, geom3, dtg, index.mode))
       case (Z3Index.name, 4)  => Some(new Z3IndexV4(ds, sft, geom3, dtg, index.mode))
       case (Z3Index.name, 3)  => Some(new Z3IndexV3(ds, sft, geom3, dtg, index.mode))
       case (Z3Index.name, 2)  => Some(new Z3IndexV2(ds, sft, geom3, dtg, index.mode))
       case (Z3Index.name, 1)  => Some(new Z3IndexV1(ds, sft, geom3, dtg, index.mode))
 
-      case (XZ3Index.name, 2) => Some(new XZ3Index(ds, sft, geom3, dtg, index.mode))
+      case (XZ3Index.name, 3) => Some(new XZ3Index(ds, sft, geom3, dtg, index.mode))
+      case (XZ3Index.name, 2) => Some(new XZ3IndexV2(ds, sft, geom3, dtg, index.mode))
       case (XZ3Index.name, 1) => Some(new XZ3IndexV1(ds, sft, geom3, dtg, index.mode))
 
       case (Z2Index.name, 5)  => Some(new Z2Index(ds, sft, geom2, index.mode))

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3Index.scala
@@ -40,7 +40,7 @@ object XZ3Index extends ConfiguredIndex {
   import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
   override val name = "xz3"
-  override val version = 2
+  override val version = 3
 
   override def supports(sft: SimpleFeatureType, attributes: Seq[String]): Boolean =
     XZ3IndexKeySpace.supports(sft, attributes)

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3IndexKeySpace.scala
@@ -45,7 +45,7 @@ class XZ3IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, 
   protected val geomIndex: Int = sft.indexOf(geomField)
   protected val dtgIndex: Int = sft.indexOf(dtgField)
 
-  protected val sfc = XZ3SFC(sft.getXZPrecision, sft.getZ3Interval)
+  protected val sfc: XZ3SFC = XZ3SFC(sft.getXZPrecision, sft.getZ3Interval)
   protected val timeToIndex: TimeToBinnedTime = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
 
   private val dateToIndex = BinnedTime.dateToBinnedTime(sft.getZ3Interval)

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3Index.scala
@@ -40,7 +40,7 @@ object Z3Index extends ConfiguredIndex {
   import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
   override val name = "z3"
-  override val version = 6
+  override val version = 7
 
   override def supports(sft: SimpleFeatureType, attributes: Seq[String]): Boolean =
     Z3IndexKeySpace.supports(sft, attributes)

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3IndexKeySpace.scala
@@ -45,7 +45,7 @@ class Z3IndexKeySpace(val sft: SimpleFeatureType,
     s"Expected field $dtgField to have a date binding, but instead it has: " +
         sft.getDescriptor(dtgField).getType.getBinding.getSimpleName)
 
-  protected val sfc = Z3SFC(sft.getZ3Interval)
+  protected val sfc: Z3SFC = Z3SFC(sft.getZ3Interval)
 
   protected val geomIndex: Int = sft.indexOf(geomField)
   protected val dtgIndex: Int = sft.indexOf(dtgField)

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3IndexKeySpace.scala
@@ -12,7 +12,7 @@ import java.util.Date
 
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.util.factory.Hints
-import org.locationtech.geomesa.curve.BinnedTime.TimeToBinnedTime
+import org.locationtech.geomesa.curve.BinnedTime.{DateToBinnedTime, TimeToBinnedTime}
 import org.locationtech.geomesa.curve.{BinnedTime, Z3SFC}
 import org.locationtech.geomesa.filter.FilterValues
 import org.locationtech.geomesa.index.api.IndexKeySpace.IndexKeySpaceFactory
@@ -51,8 +51,8 @@ class Z3IndexKeySpace(val sft: SimpleFeatureType,
   protected val dtgIndex: Int = sft.indexOf(dtgField)
 
   protected val timeToIndex: TimeToBinnedTime = BinnedTime.timeToBinnedTime(sft.getZ3Interval)
+  protected val dateToIndex: DateToBinnedTime = BinnedTime.dateToBinnedTime(sft.getZ3Interval)
 
-  private val dateToIndex = BinnedTime.dateToBinnedTime(sft.getZ3Interval)
   private val boundsToDates = BinnedTime.boundsToIndexableDates(sft.getZ3Interval)
 
   override val attributes: Seq[String] = Seq(geomField, dtgField)

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/XZ3IndexV1.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/XZ3IndexV1.scala
@@ -16,7 +16,8 @@ import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.LegacyTableNaming
 import org.locationtech.geomesa.index.index.z3.legacy.XZ3IndexV1.XZ3IndexKeySpaceV1
-import org.locationtech.geomesa.index.index.z3.{XZ3Index, XZ3IndexKeySpace, XZ3IndexValues, Z3IndexKey}
+import org.locationtech.geomesa.index.index.z3.legacy.XZ3IndexV2.XZ3IndexKeySpaceV2
+import org.locationtech.geomesa.index.index.z3.{XZ3IndexKeySpace, XZ3IndexValues, Z3IndexKey}
 import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
 import org.locationtech.jts.geom.Geometry
@@ -26,12 +27,13 @@ import scala.util.control.NonFatal
 
 // supports table sharing
 class XZ3IndexV1(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, dtg: String, mode: IndexMode)
-    extends XZ3Index(ds, sft, 1, geom, dtg, mode) with LegacyTableNaming[XZ3IndexValues, Z3IndexKey] {
+    extends XZ3IndexV2(ds, sft, 1, geom, dtg, mode) with LegacyTableNaming[XZ3IndexValues, Z3IndexKey] {
 
   import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
   override protected val tableNameKey: String = "table.xz3.v1"
 
+  // noinspection ScalaDeprecation
   override val keySpace: XZ3IndexKeySpace =
     new XZ3IndexKeySpaceV1(sft, sft.getTableSharingBytes, ZShardStrategy(sft), geom, dtg)
 }
@@ -43,7 +45,7 @@ object XZ3IndexV1 {
                            sharding: ShardStrategy,
                            geomField: String,
                            dtgField: String)
-      extends XZ3IndexKeySpace(sft, sharding, geomField, dtgField) {
+      extends XZ3IndexKeySpaceV2(sft, sharding, geomField, dtgField) {
 
     private val rangePrefixes = {
       if (sharing.isEmpty && sharding.length == 0) {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/XZ3IndexV2.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/XZ3IndexV2.scala
@@ -1,0 +1,53 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.index.z3.legacy
+
+import org.locationtech.geomesa.curve.{TimePeriod, XZ3SFC}
+import org.locationtech.geomesa.index.api.ShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
+import org.locationtech.geomesa.index.index.z3.legacy.XZ3IndexV2.XZ3IndexKeySpaceV2
+import org.locationtech.geomesa.index.index.z3.{XZ3Index, XZ3IndexKeySpace}
+import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
+import org.opengis.feature.simple.SimpleFeatureType
+
+// legacy yearly epoch z curve
+class XZ3IndexV2 protected (
+    ds: GeoMesaDataStore[_],
+    sft: SimpleFeatureType,
+    version: Int,
+    geom: String,
+    dtg: String,
+    mode: IndexMode
+  ) extends XZ3Index(ds, sft, version, geom, dtg, mode) {
+
+  def this(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, dtg: String, mode: IndexMode) =
+    this(ds, sft, 2, geom, dtg, mode)
+
+  override val keySpace: XZ3IndexKeySpace = new XZ3IndexKeySpaceV2(sft, ZShardStrategy(sft), geom, dtg)
+}
+
+object XZ3IndexV2 {
+
+  class XZ3IndexKeySpaceV2(
+      sft: SimpleFeatureType,
+      sharding: ShardStrategy,
+      geomField: String,
+      dtgField: String
+    ) extends XZ3IndexKeySpace(sft, sharding, geomField, dtgField) {
+
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
+    // noinspection ScalaDeprecation
+    override protected val sfc: XZ3SFC = sft.getZ3Interval match {
+      case TimePeriod.Year => new org.locationtech.geomesa.curve.LegacyYearXZ3SFC(sft.getXZPrecision)
+      case p => XZ3SFC(sft.getXZPrecision, p)
+    }
+  }
+}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV5.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV5.scala
@@ -15,7 +15,8 @@ import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.z3.legacy.Z3IndexV5.Z3IndexKeySpaceV5
-import org.locationtech.geomesa.index.index.z3.{Z3Index, Z3IndexKey, Z3IndexKeySpace}
+import org.locationtech.geomesa.index.index.z3.legacy.Z3IndexV6.Z3IndexKeySpaceV6
+import org.locationtech.geomesa.index.index.z3.{Z3IndexKey, Z3IndexKeySpace}
 import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
 import org.locationtech.jts.geom.Point
@@ -29,7 +30,7 @@ class Z3IndexV5 protected (ds: GeoMesaDataStore[_],
                            version: Int,
                            geom: String,
                            dtg: String,
-                           mode: IndexMode) extends Z3Index(ds, sft, version: Int, geom, dtg, mode) {
+                           mode: IndexMode) extends Z3IndexV6(ds, sft, version: Int, geom, dtg, mode) {
 
   import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
@@ -38,6 +39,7 @@ class Z3IndexV5 protected (ds: GeoMesaDataStore[_],
 
   override protected val tableNameKey: String = s"table.z3.v$version"
 
+  // noinspection ScalaDeprecation
   override val keySpace: Z3IndexKeySpace =
     new Z3IndexKeySpaceV5(sft, sft.getTableSharingBytes, ZShardStrategy(sft), geom, dtg)
 }
@@ -48,7 +50,7 @@ object Z3IndexV5 {
                           override val sharing: Array[Byte],
                           sharding: ShardStrategy,
                           geomField: String,
-                          dtgField: String) extends Z3IndexKeySpace(sft, sharding, geomField, dtgField) {
+                          dtgField: String) extends Z3IndexKeySpaceV6(sft, sharding, geomField, dtgField) {
 
     private val rangePrefixes = {
       if (sharding.length == 0 && sharing.isEmpty) {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV6.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV6.scala
@@ -8,6 +8,8 @@
 
 package org.locationtech.geomesa.index.index.z3.legacy
 
+import java.time.ZonedDateTime
+
 import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.curve.{TimePeriod, Z3SFC}
 import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
@@ -59,11 +61,11 @@ object Z3IndexV6 {
       super.useFullFilter(values, config, hints) || values.exists { v =>
         // fix to handle incorrect yearly z values - use full filter if querying the collapsed days
         sft.getZ3Interval == TimePeriod.Year && v.intervals.exists { bounds =>
-          (bounds.lower.value.toSeq ++ bounds.upper.value).exists { date =>
-            dateToIndex(date).offset.toDouble >= sfc.time.max
-          }
+          bounds.lower.value.exists(collapsed) || bounds.upper.value.exists(collapsed)
         }
       }
     }
+
+    private def collapsed(d: ZonedDateTime): Boolean = dateToIndex(d).offset.toDouble >= sfc.time.max
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV6.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV6.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.index.index.z3.legacy
 
 import org.geotools.util.factory.Hints
-import org.locationtech.geomesa.curve.{BinnedTime, TimePeriod, Z3SFC}
+import org.locationtech.geomesa.curve.{TimePeriod, Z3SFC}
 import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
@@ -46,8 +46,6 @@ object Z3IndexV6 {
 
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
-    private lazy val dateToTime = BinnedTime.dateToBinnedTime(sft.getZ3Interval)
-
     // noinspection ScalaDeprecation
     override protected val sfc: Z3SFC = sft.getZ3Interval match {
       case TimePeriod.Year => new org.locationtech.geomesa.curve.LegacyYearZ3SFC()
@@ -62,7 +60,7 @@ object Z3IndexV6 {
         // fix to handle incorrect yearly z values - use full filter if querying the collapsed days
         sft.getZ3Interval == TimePeriod.Year && v.intervals.exists { bounds =>
           (bounds.lower.value.toSeq ++ bounds.upper.value).exists { date =>
-            dateToTime(date).offset.toDouble >= sfc.time.max
+            dateToIndex(date).offset.toDouble >= sfc.time.max
           }
         }
       }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV6.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV6.scala
@@ -1,0 +1,53 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.index.z3.legacy
+
+import org.locationtech.geomesa.curve.{TimePeriod, Z3SFC}
+import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api._
+import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
+import org.locationtech.geomesa.index.index.z3.legacy.Z3IndexV6.Z3IndexKeySpaceV6
+import org.locationtech.geomesa.index.index.z3.{Z3Index, Z3IndexKeySpace}
+import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
+import org.opengis.feature.simple.SimpleFeatureType
+
+// legacy yearly epoch z curve
+class Z3IndexV6 protected (
+    ds: GeoMesaDataStore[_],
+    sft: SimpleFeatureType,
+    version: Int,
+    geom: String,
+    dtg: String,
+    mode: IndexMode
+  ) extends Z3Index(ds, sft, version, geom, dtg, mode) {
+
+  def this(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, dtg: String, mode: IndexMode) =
+    this(ds, sft, 6, geom, dtg, mode)
+
+  override val keySpace: Z3IndexKeySpace = new Z3IndexKeySpaceV6(sft, ZShardStrategy(sft), geom, dtg)
+}
+
+object Z3IndexV6 {
+
+  class Z3IndexKeySpaceV6(
+      sft: SimpleFeatureType,
+      sharding: ShardStrategy,
+      geomField: String,
+      dtgField: String
+    ) extends Z3IndexKeySpace(sft, sharding, geomField, dtgField) {
+
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
+    // noinspection ScalaDeprecation
+    override protected val sfc: Z3SFC = sft.getZ3Interval match {
+      case TimePeriod.Year => new org.locationtech.geomesa.curve.LegacyYearZ3SFC()
+      case p => Z3SFC(p)
+    }
+  }
+}

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/XZ3IndexTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/XZ3IndexTest.scala
@@ -55,6 +55,13 @@ class XZ3IndexTest extends Specification with LazyLogging {
 
         SelfClosingIterator(ds.getFeatureReader(new Query("test", filter), Transaction.AUTO_COMMIT)).toList must
             containTheSameElementsAs(features)
+
+        val lastDayFilter = ECQL.toFilter("bbox(geom,9,59,12,61) AND dtg during 2020-12-31T00:00:00.000Z/2020-12-31T23:59:59.999Z")
+
+        val lastDayResults =
+          SelfClosingIterator(ds.getFeatureReader(new Query("test", lastDayFilter), Transaction.AUTO_COMMIT)).toList
+
+        lastDayResults mustEqual Seq(features.last)
       }
     }
   }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/XZ3IndexTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/XZ3IndexTest.scala
@@ -1,0 +1,61 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.index
+
+import com.typesafe.scalalogging.LazyLogging
+import org.geotools.data.{Query, Transaction}
+import org.geotools.filter.text.ecql.ECQL
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.index.TestGeoMesaDataStore
+import org.locationtech.geomesa.utils.collection.SelfClosingIterator
+import org.locationtech.geomesa.utils.geotools.{FeatureUtils, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.io.WithClose
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class XZ3IndexTest extends Specification with LazyLogging {
+
+  "XZ3Index" should {
+    "index and query yearly epochs correctly" in {
+      foreach(Seq("xz3:geom:dtg", "xz3:2:geom:dtg")) { indices =>
+        val spec =
+          "name:String,track:String,dtg:Date,*geom:LineString:srid=4326;" +
+              s"geomesa.z3.interval=year,geomesa.indices.enabled=$indices"
+
+        val sft = SimpleFeatureTypes.createType("test", spec)
+
+        val ds = new TestGeoMesaDataStore(false) // requires strict bbox...
+
+        // note: 2020 was a leap year
+        val features =
+          (0 until 10).map { i =>
+            ScalaSimpleFeature.create(sft, s"$i", s"name$i", "track1", s"2020-12-07T0$i:00:00.000Z", s"LINESTRING(4$i 60, 4$i 61)")
+          } ++ (10 until 20).map { i =>
+            ScalaSimpleFeature.create(sft, s"$i", s"name$i", "track2", s"2020-12-${i}T$i:00:00.000Z", s"LINESTRING(4${i - 10} 60, 4${i - 10} 61)")
+          } ++ (20 until 30).map { i =>
+            ScalaSimpleFeature.create(sft, s"$i", s"name$i", "track3", s"2020-12-${i}T${i-10}:00:00.000Z", s"LINESTRING(6${i - 20} 60, 6${i - 20} 61)")
+          } ++ (30 until 32).map { i =>
+            ScalaSimpleFeature.create(sft, s"$i", s"name$i", "track4", s"2020-12-${i}T${i-10}:00:00.000Z", s"LINESTRING(${i - 20} 60, ${i - 20} 61)")
+          }
+
+        ds.createSchema(sft)
+        WithClose(ds.getFeatureWriterAppend(sft.getTypeName, Transaction.AUTO_COMMIT)) { writer =>
+          features.foreach(FeatureUtils.write(writer, _, useProvidedFid = true))
+        }
+
+        val filter = ECQL.toFilter("bbox(geom,0,55,70,65) AND dtg during 2020-12-01T00:00:00.000Z/2020-12-31T23:59:59.999Z")
+
+        SelfClosingIterator(ds.getFeatureReader(new Query("test", filter), Transaction.AUTO_COMMIT)).toList must
+            containTheSameElementsAs(features)
+      }
+    }
+  }
+}

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/Z3IndexTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/Z3IndexTest.scala
@@ -1,0 +1,61 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index.index
+
+import com.typesafe.scalalogging.LazyLogging
+import org.geotools.data.{Query, Transaction}
+import org.geotools.filter.text.ecql.ECQL
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.index.TestGeoMesaDataStore
+import org.locationtech.geomesa.utils.collection.SelfClosingIterator
+import org.locationtech.geomesa.utils.geotools.{FeatureUtils, SimpleFeatureTypes}
+import org.locationtech.geomesa.utils.io.WithClose
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class Z3IndexTest extends Specification with LazyLogging {
+
+  "Z3Index" should {
+    "index and query yearly epochs correctly" in {
+      foreach(Seq("z3:geom:dtg", "z3:6:geom:dtg")) { indices =>
+        val spec =
+          "name:String,track:String,dtg:Date,*geom:Point:srid=4326;" +
+              s"geomesa.z3.interval=year,geomesa.indices.enabled=$indices"
+
+        val sft = SimpleFeatureTypes.createType("test", spec)
+
+        val ds = new TestGeoMesaDataStore(false) // requires strict bbox...
+
+        // note: 2020 was a leap year
+        val features =
+          (0 until 10).map { i =>
+            ScalaSimpleFeature.create(sft, s"$i", s"name$i", "track1", s"2020-12-07T0$i:00:00.000Z", s"POINT(4$i 60)")
+          } ++ (10 until 20).map { i =>
+            ScalaSimpleFeature.create(sft, s"$i", s"name$i", "track2", s"2020-12-${i}T$i:00:00.000Z", s"POINT(4${i - 10} 60)")
+          } ++ (20 until 30).map { i =>
+            ScalaSimpleFeature.create(sft, s"$i", s"name$i", "track3", s"2020-12-${i}T${i-10}:00:00.000Z", s"POINT(6${i - 20} 60)")
+          } ++ (30 until 32).map { i =>
+            ScalaSimpleFeature.create(sft, s"$i", s"name$i", "track4", s"2020-12-${i}T${i-10}:00:00.000Z", s"POINT(${i - 20} 60)")
+          }
+
+        ds.createSchema(sft)
+        WithClose(ds.getFeatureWriterAppend(sft.getTypeName, Transaction.AUTO_COMMIT)) { writer =>
+          features.foreach(FeatureUtils.write(writer, _, useProvidedFid = true))
+        }
+
+        val filter = ECQL.toFilter("bbox(geom,0,55,70,65) AND dtg during 2020-12-01T00:00:00.000Z/2020-12-31T23:59:59.999Z")
+
+        SelfClosingIterator(ds.getFeatureReader(new Query("test", filter), Transaction.AUTO_COMMIT)).toList must
+            containTheSameElementsAs(features)
+      }
+    }
+  }
+}

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/Z3IndexTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/Z3IndexTest.scala
@@ -32,7 +32,7 @@ class Z3IndexTest extends Specification with LazyLogging {
 
         val sft = SimpleFeatureTypes.createType("test", spec)
 
-        val ds = new TestGeoMesaDataStore(false) // requires strict bbox...
+        val ds = new TestGeoMesaDataStore(true) // loose bbox
 
         // note: 2020 was a leap year
         val features =
@@ -55,6 +55,18 @@ class Z3IndexTest extends Specification with LazyLogging {
 
         SelfClosingIterator(ds.getFeatureReader(new Query("test", filter), Transaction.AUTO_COMMIT)).toList must
             containTheSameElementsAs(features)
+
+        val lastDayFilter = ECQL.toFilter("bbox(geom,9,59,12,61) AND dtg during 2020-12-31T00:00:00.000Z/2020-12-31T23:59:59.999Z")
+
+        val lastDayResults =
+          SelfClosingIterator(ds.getFeatureReader(new Query("test", lastDayFilter), Transaction.AUTO_COMMIT)).toList
+
+        if (indices.indexOf("6") == -1) {
+          lastDayResults mustEqual Seq(features.last)
+        } else {
+          (lastDayResults mustEqual Seq(features.last)).pendingUntilFixed("requires strict bbox")
+        }
+        ok
       }
     }
   }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/Z3IndexTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/Z3IndexTest.scala
@@ -61,12 +61,7 @@ class Z3IndexTest extends Specification with LazyLogging {
         val lastDayResults =
           SelfClosingIterator(ds.getFeatureReader(new Query("test", lastDayFilter), Transaction.AUTO_COMMIT)).toList
 
-        if (indices.indexOf("6") == -1) {
-          lastDayResults mustEqual Seq(features.last)
-        } else {
-          (lastDayResults mustEqual Seq(features.last)).pendingUntilFixed("requires strict bbox")
-        }
-        ok
+        lastDayResults mustEqual Seq(features.last)
       }
     }
   }

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/BinnedTime.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/BinnedTime.scala
@@ -150,7 +150,8 @@ object BinnedTime {
       case TimePeriod.Day   => ChronoUnit.DAYS.getDuration.toMillis
       case TimePeriod.Week  => ChronoUnit.WEEKS.getDuration.toMillis / 1000L
       case TimePeriod.Month => (ChronoUnit.DAYS.getDuration.toMillis / 1000L) * 31L
-      case TimePeriod.Year  => ChronoUnit.WEEKS.getDuration.toMinutes * 52L
+      // based on 365 days + 1 leap day, with a fudge factor of 10 minutes to account for leap seconds added each year
+      case TimePeriod.Year  => (ChronoUnit.DAYS.getDuration.toMinutes * 366L) + 10L
     }
   }
 

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearXZ3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearXZ3SFC.scala
@@ -15,7 +15,7 @@ import java.time.temporal.ChronoUnit
  * index keys and query ranges are consistent. Any dates that exceed the original max time will be dropped into
  * the last time bin, potentially degrading results for the last day or two of the year.
  *
- * @param g resolution level of the curve - i.e. how many times the space will be recursively quartered
+ * @param g resolution level of the curve - i.e. how many times the space will be recursively split into eighths
  */
 @deprecated("XZ3SFC", "3.2.0")
 class LegacyYearXZ3SFC(g: Short)

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearXZ3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearXZ3SFC.scala
@@ -10,6 +10,8 @@ package org.locationtech.geomesa.curve
 
 import java.time.temporal.ChronoUnit
 
+import com.typesafe.scalalogging.StrictLogging
+
 /**
  * XZ3SFC with a legacy, incorrect max time value of 52 weeks. The max value is kept the same to ensure that
  * index keys and query ranges are consistent. Any dates that exceed the original max time will be dropped into
@@ -19,12 +21,17 @@ import java.time.temporal.ChronoUnit
  */
 @deprecated("XZ3SFC", "3.2.0")
 class LegacyYearXZ3SFC(g: Short)
-    extends XZ3SFC(g, (-180.0, 180.0), (-90.0, 90.0), (0.0, ChronoUnit.WEEKS.getDuration.toMinutes * 52d)) {
+    extends XZ3SFC(g, (-180.0, 180.0), (-90.0, 90.0), (0.0, ChronoUnit.WEEKS.getDuration.toMinutes * 52d))
+        with StrictLogging {
 
   // the correct max time duration
   private val maxTime = BinnedTime.maxOffset(TimePeriod.Year).toDouble
   // the incorrect max time duration
   private val zHi = zBounds._2
+
+  logger.warn(
+    "Yearly Z3 interval is broken in this index version. See " +
+        "https://geomesa.atlassian.net/browse/GEOMESA-2973 for details")
 
   override protected def normalize(
       xmin: Double,

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearXZ3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearXZ3SFC.scala
@@ -1,0 +1,43 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.curve
+
+import java.time.temporal.ChronoUnit
+
+/**
+ * XZ3SFC with a legacy, incorrect max time value of 52 weeks. The max value is kept the same to ensure that
+ * index keys and query ranges are consistent. Any dates that exceed the original max time will be dropped into
+ * the last time bin, potentially degrading results for the last day or two of the year.
+ *
+ * @param g resolution level of the curve - i.e. how many times the space will be recursively quartered
+ */
+@deprecated("XZ3SFC", "3.2.0")
+class LegacyYearXZ3SFC(g: Short)
+    extends XZ3SFC(g, (-180.0, 180.0), (-90.0, 90.0), (0.0, ChronoUnit.WEEKS.getDuration.toMinutes * 52d)) {
+
+  // the correct max time duration
+  private val maxTime = BinnedTime.maxOffset(TimePeriod.Year).toDouble
+  // the incorrect max time duration
+  private val zHi = zBounds._2
+
+  override protected def normalize(
+      xmin: Double,
+      ymin: Double,
+      zmin: Double,
+      xmax: Double,
+      ymax: Double,
+      zmax: Double,
+      lenient: Boolean): (Double, Double, Double, Double, Double, Double) = {
+    if (zmax > zHi && zmax <= maxTime) {
+      super.normalize(xmin, ymin, math.min(zmin, zHi), xmax, ymax, zHi, lenient)
+    } else {
+      super.normalize(xmin, ymin, zmin, xmax, ymax, zmax, lenient)
+    }
+  }
+}

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearXZ3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearXZ3SFC.scala
@@ -10,8 +10,6 @@ package org.locationtech.geomesa.curve
 
 import java.time.temporal.ChronoUnit
 
-import com.typesafe.scalalogging.StrictLogging
-
 /**
  * XZ3SFC with a legacy, incorrect max time value of 52 weeks. The max value is kept the same to ensure that
  * index keys and query ranges are consistent. Any dates that exceed the original max time will be dropped into
@@ -21,17 +19,12 @@ import com.typesafe.scalalogging.StrictLogging
  */
 @deprecated("XZ3SFC", "3.2.0")
 class LegacyYearXZ3SFC(g: Short)
-    extends XZ3SFC(g, (-180.0, 180.0), (-90.0, 90.0), (0.0, ChronoUnit.WEEKS.getDuration.toMinutes * 52d))
-        with StrictLogging {
+    extends XZ3SFC(g, (-180.0, 180.0), (-90.0, 90.0), (0.0, ChronoUnit.WEEKS.getDuration.toMinutes * 52d)) {
 
   // the correct max time duration
   private val maxTime = BinnedTime.maxOffset(TimePeriod.Year).toDouble
   // the incorrect max time duration
   private val zHi = zBounds._2
-
-  logger.warn(
-    "Yearly Z3 interval is broken in this index version. See " +
-        "https://geomesa.atlassian.net/browse/GEOMESA-2973 for details")
 
   override protected def normalize(
       xmin: Double,

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearZ3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearZ3SFC.scala
@@ -10,6 +10,7 @@ package org.locationtech.geomesa.curve
 
 import java.time.temporal.ChronoUnit
 
+import com.typesafe.scalalogging.StrictLogging
 import org.locationtech.geomesa.curve.NormalizedDimension.NormalizedTime
 
 /**
@@ -25,10 +26,14 @@ class LegacyYearZ3SFC(precision: Int = 21) extends {
   // legacy incorrect time max duration
   override val time: NormalizedDimension =
     NormalizedTime(precision, ChronoUnit.WEEKS.getDuration.toMinutes * 52d)
-  } with Z3SFC(TimePeriod.Year, precision) {
+  } with Z3SFC(TimePeriod.Year, precision) with StrictLogging {
 
   // the correct max time duration
   private val maxTime = BinnedTime.maxOffset(TimePeriod.Year)
+
+  logger.warn(
+    "Yearly Z3 interval is broken in this index version. See " +
+        "https://geomesa.atlassian.net/browse/GEOMESA-2973 for details")
 
   override def index(x: Double, y: Double, t: Long, lenient: Boolean = false): Long = {
     if (t > time.max && t <= maxTime) {

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearZ3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearZ3SFC.scala
@@ -10,7 +10,6 @@ package org.locationtech.geomesa.curve
 
 import java.time.temporal.ChronoUnit
 
-import com.typesafe.scalalogging.StrictLogging
 import org.locationtech.geomesa.curve.NormalizedDimension.NormalizedTime
 
 /**
@@ -26,14 +25,10 @@ class LegacyYearZ3SFC(precision: Int = 21) extends {
   // legacy incorrect time max duration
   override val time: NormalizedDimension =
     NormalizedTime(precision, ChronoUnit.WEEKS.getDuration.toMinutes * 52d)
-  } with Z3SFC(TimePeriod.Year, precision) with StrictLogging {
+  } with Z3SFC(TimePeriod.Year, precision) {
 
   // the correct max time duration
   private val maxTime = BinnedTime.maxOffset(TimePeriod.Year)
-
-  logger.warn(
-    "Yearly Z3 interval is broken in this index version. See " +
-        "https://geomesa.atlassian.net/browse/GEOMESA-2973 for details")
 
   override def index(x: Double, y: Double, t: Long, lenient: Boolean = false): Long = {
     if (t > time.max && t <= maxTime) {

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearZ3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/LegacyYearZ3SFC.scala
@@ -1,0 +1,40 @@
+/***********************************************************************
+ * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.curve
+
+import java.time.temporal.ChronoUnit
+
+import org.locationtech.geomesa.curve.NormalizedDimension.NormalizedTime
+
+/**
+ * Z3SFC with a legacy, incorrect max time value of 52 weeks. The max value is kept the same to ensure that
+ * index keys and query ranges are consistent. Any dates that exceed the original max time will be dropped into
+ * the last time bin, potentially degrading results for the last day or two of the year.
+ *
+ * @param precision bits used per dimension - note all precisions must sum to less than 64
+ */
+@deprecated("Z3SFC", "3.2.0")
+class LegacyYearZ3SFC(precision: Int = 21) extends {
+  // need to use early instantiation here to prevent errors in creating parent class
+  // legacy incorrect time max duration
+  override val time: NormalizedDimension =
+    NormalizedTime(precision, ChronoUnit.WEEKS.getDuration.toMinutes * 52d)
+  } with Z3SFC(TimePeriod.Year, precision) {
+
+  // the correct max time duration
+  private val maxTime = BinnedTime.maxOffset(TimePeriod.Year)
+
+  override def index(x: Double, y: Double, t: Long, lenient: Boolean = false): Long = {
+    if (t > time.max && t <= maxTime) {
+      super.index(x, y, time.max.toLong, lenient)
+    } else {
+      super.index(x, y, t, lenient)
+    }
+  }
+}

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/XZ3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/XZ3SFC.scala
@@ -335,13 +335,14 @@ class XZ3SFC(val g: Short, val xBounds: (Double, Double), val yBounds: (Double, 
     * @param lenient standardize boundaries to valid values, or raise an exception
     * @return
     */
-  private def normalize(xmin: Double,
-                        ymin: Double,
-                        zmin: Double,
-                        xmax: Double,
-                        ymax: Double,
-                        zmax: Double,
-                        lenient: Boolean): (Double, Double, Double, Double, Double, Double) = {
+  protected def normalize(
+      xmin: Double,
+      ymin: Double,
+      zmin: Double,
+      xmax: Double,
+      ymax: Double,
+      zmax: Double,
+      lenient: Boolean): (Double, Double, Double, Double, Double, Double) = {
     require(xmin <= xmax && ymin <= ymax && zmin <= zmax,
       s"Bounds must be ordered: [$xmin $xmax] [$ymin $ymax] [$zmin $zmax]")
 

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/XZ3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/XZ3SFC.scala
@@ -20,7 +20,7 @@ import scala.collection.mutable.ArrayBuffer
   * Based on 'XZ-Ordering: A Space-Filling Curve for Objects with Spatial Extension'
   * by Christian Böhm, Gerald Klump  and Hans-Peter Kriegel, expanded to 3 dimensions
   *
-  * @param g resolution level of the curve - i.e. how many times the space will be recursively quartered
+  * @param g resolution level of the curve - i.e. how many times the space will be recursively split into eighths
 
   */
 class XZ3SFC(val g: Short, val xBounds: (Double, Double), val yBounds: (Double, Double), val zBounds: (Double, Double)) {


### PR DESCRIPTION
* Does not fix z3 index versions < 5 (created with GeoMesa versions < 2.0.0)

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>