### PR TITLE
GEOMESA-2977 Option to query z-filters in 1.3 Accumulo installs

### DIFF
--- a/docs/user/datastores/query_config.rst
+++ b/docs/user/datastores/query_config.rst
@@ -106,6 +106,38 @@ QueryHints.EXACT_COUNT ``Boolean`` ``true`` or ``false``
 
         ...&viewparams=EXACT_COUNT:true
 
+Filter Compatibility
+--------------------
+
+GeoMesa provides a limited compatibility mode, which allows for using a newer client version with
+an older distributed-runtime version, for back-ends that have a distributed installation. Currently
+only GeoMesa 1.3.7 on Accumulo is supported, with the compatibility flag ``1.3``. Only basic
+spatio-temporal queries are supported, without transforms or advanced options.
+
+======================== ======================= ===========================
+Key                      Type                    GeoServer Conversion
+======================== ======================= ===========================
+QueryHints.FILTER_COMPAT String                  distributed install version
+======================== ======================= ===========================
+
+.. tabs::
+
+    .. code-tab:: java
+
+        import org.locationtech.geomesa.index.conf.QueryHints;
+
+        query.getHints().put(QueryHints.FILTER_COMPAT(), "1.3");
+
+    .. code-tab:: scala
+
+        import org.locationtech.geomesa.index.conf.QueryHints
+
+        query.getHints.put(QueryHints.FILTER_COMPAT, "1.3")
+
+    .. code-tab:: none GeoServer
+
+        ...&viewparams=FILTER_COMPAT:1.3
+
 .. _query_index_hint:
 
 Query Index

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloIndexAdapter.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloIndexAdapter.scala
@@ -228,7 +228,8 @@ class AccumuloIndexAdapter(ds: AccumuloDataStore) extends IndexAdapter[AccumuloD
           // TODO pull this out to be SPI loaded so that new indices can be added seamlessly
           val indexIter = if (index.name == Z3Index.name) {
             strategy.values.toSeq.map { case v: Z3IndexValues =>
-              Z3Iterator.configure(v, index.keySpace.sharding.length + index.keySpace.sharing.length, ZIterPriority)
+              val offset = index.keySpace.sharding.length + index.keySpace.sharing.length
+              Z3Iterator.configure(v, offset, hints.getFilterCompatibility, ZIterPriority)
             }
           } else if (index.name == Z2Index.name) {
             strategy.values.toSeq.map { case v: Z2IndexValues =>

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/FilterTransformIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/FilterTransformIterator.scala
@@ -14,11 +14,13 @@ import com.typesafe.scalalogging.LazyLogging
 import org.apache.accumulo.core.client.IteratorSetting
 import org.apache.accumulo.core.data.{ByteSequence, Key, Range, Value}
 import org.apache.accumulo.core.iterators.{IteratorEnvironment, SortedKeyValueIterator}
-import org.geotools.util.factory.Hints
 import org.geotools.filter.text.ecql.ECQL
+import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.features.SerializationOption.SerializationOptions
 import org.locationtech.geomesa.features.kryo.KryoBufferSimpleFeature
 import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
+import org.locationtech.geomesa.index.conf.FilterCompatibility
+import org.locationtech.geomesa.index.conf.FilterCompatibility.FilterCompatibility
 import org.locationtech.geomesa.index.iterators.{IteratorCache, SamplingIterator}
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -141,22 +143,24 @@ object FilterTransformIterator {
                 index: GeoMesaFeatureIndex[_, _],
                 filter: Option[Filter],
                 hints: Hints): Option[IteratorSetting] =
-    configure(sft, index, filter, hints.getTransform, hints.getSampling)
+    configure(sft, index, filter, hints.getTransform, hints.getSampling, hints.getFilterCompatibility)
 
   def configure(sft: SimpleFeatureType,
                 index: GeoMesaFeatureIndex[_, _],
                 filter: Option[Filter],
                 hints: Hints,
                 priority: Int): Option[IteratorSetting] =
-    configure(sft, index, filter, hints.getTransform, hints.getSampling, priority)
+    configure(sft, index, filter, hints.getTransform, hints.getSampling, hints.getFilterCompatibility, priority)
 
-  def configure(sft: SimpleFeatureType,
-                index: GeoMesaFeatureIndex[_, _],
-                filter: Option[Filter],
-                transform: Option[(String, SimpleFeatureType)],
-                sampling: Option[(Float, Option[String])],
-                priority: Int = DefaultPriority): Option[IteratorSetting] = {
-    if (filter.isDefined || transform.isDefined || sampling.isDefined) {
+  def configure(
+      sft: SimpleFeatureType,
+      index: GeoMesaFeatureIndex[_, _],
+      filter: Option[Filter],
+      transform: Option[(String, SimpleFeatureType)],
+      sampling: Option[(Float, Option[String])],
+      compatibility: Option[FilterCompatibility] = None,
+      priority: Int = DefaultPriority): Option[IteratorSetting] = {
+    if (filter.isEmpty && transform.isEmpty && sampling.isEmpty) { None } else {
       val is = new IteratorSetting(priority, "filter-transform-iter", classOf[FilterTransformIterator])
       is.addOption(SftOpt, SimpleFeatureTypes.encodeType(sft, includeUserData = true))
       if (sft != index.sft) {
@@ -169,9 +173,16 @@ object FilterTransformIterator {
         is.addOption(TransformSchemaOpt, SimpleFeatureTypes.encodeType(tsft))
       }
       sampling.foreach(SamplingIterator.configure(sft, _).foreach { case (k, v) => is.addOption(k, v) })
+
+      compatibility.foreach {
+        case FilterCompatibility.`1.3` =>
+          is.setIteratorClass("org.locationtech.geomesa.accumulo.iterators.KryoLazyFilterTransformIterator")
+          is.addOption(IndexOpt, s"${index.name}:${index.version}")
+
+        case c =>
+          throw new NotImplementedError(s"Unknown compatibility flag: '$c'")
+      }
       Some(is)
-    } else {
-      None
     }
   }
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3Iterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z3Iterator.scala
@@ -9,20 +9,59 @@
 package org.locationtech.geomesa.accumulo.iterators
 
 import org.apache.accumulo.core.client.IteratorSetting
+import org.locationtech.geomesa.index.conf.FilterCompatibility
+import org.locationtech.geomesa.index.conf.FilterCompatibility.FilterCompatibility
 import org.locationtech.geomesa.index.filters.Z3Filter
 import org.locationtech.geomesa.index.index.z3.Z3IndexValues
 
 class Z3Iterator extends RowFilterIterator[Z3Filter](Z3Filter)
 
 object Z3Iterator {
+
+  /**
+   * Configure the iterator
+   *
+   * @param values index values
+   * @param offset offset for z-value in each row
+   * @param compatibility compatibility mode
+   * @param priority iterator priority
+   * @return
+   */
   def configure(
       values: Z3IndexValues,
       offset: Int,
+      compatibility: Option[FilterCompatibility],
       priority: Int): IteratorSetting = {
+
+    val opts = compatibility match {
+      case None =>
+        Z3Filter.serializeToStrings(Z3Filter(values)) + (RowFilterIterator.RowOffsetKey -> offset.toString)
+
+      case Some(FilterCompatibility.`1.3`) =>
+        val Z3IndexValues(sfc, _, bounds, _, times, _) = values
+        val xyOpts = bounds.map { case (xmin, ymin, xmax, ymax) =>
+          s"${sfc.lon.normalize(xmin)}:${sfc.lat.normalize(ymin)}:" +
+              s"${sfc.lon.normalize(xmax)}:${sfc.lat.normalize(ymax)}"
+        }
+        val tOpts = times.toSeq.sortBy(_._1).map { case (bin, times) =>
+          val time = times.map { case (t1, t2) =>
+            s"${sfc.time.normalize(t1)}:${sfc.time.normalize(t2)}"
+          }
+          s"$bin;${time.mkString(";")}"
+        }
+        Map(
+          "zxy" -> xyOpts.mkString(";"),
+          "zt"  -> tOpts.mkString(","),
+          "zo"  -> offset.toString,
+          "zl"  -> "8"
+        )
+
+      case Some(c) =>
+        throw new NotImplementedError(s"Unknown compatibility flag: '$c'")
+    }
+
     val is = new IteratorSetting(priority, "z3", classOf[Z3Iterator])
-    is.addOption(RowFilterIterator.RowOffsetKey, offset.toString)
-    // index space values for comparing in the iterator
-    Z3Filter.serializeToStrings(Z3Filter(values)).foreach { case (k, v) => is.addOption(k, v) }
+    opts.foreach { case (k, v) => is.addOption(k, v) }
     is
   }
 }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/FilterTransformIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/FilterTransformIteratorTest.scala
@@ -1,0 +1,48 @@
+/***********************************************************************
+ * Copyright (c) 2013-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.accumulo.iterators
+
+import org.geotools.filter.text.ecql.ECQL
+import org.geotools.util.factory.Hints
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.index.conf.QueryHints
+import org.locationtech.geomesa.index.index.z3.legacy.XZ3IndexV1
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.index.IndexMode
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class FilterTransformIteratorTest extends Specification {
+
+  import scala.collection.JavaConverters._
+
+  val sft = SimpleFeatureTypes.createType("lines", "name:String,dtg:Date,*geom:LineString:srid=4326")
+
+  "FilterTransformIterator" should {
+    "configure 1.3 compatibility mode" >> {
+      // v1 index corresponds to gm 1.3
+      val index = new XZ3IndexV1(null, sft, "geom", "dtg", IndexMode.ReadWrite)
+      val filter = ECQL.toFilter("dtg DURING 2020-01-01T00:00:00.000Z/2020-01-01T01:00:00.000Z")
+      val hints = new Hints()
+      hints.put(QueryHints.FILTER_COMPAT, "1.3")
+      val configOpt = FilterTransformIterator.configure(sft, index, Option(filter), hints)
+      configOpt must beSome
+      val config = configOpt.get
+      config.getIteratorClass mustEqual "org.locationtech.geomesa.accumulo.iterators.KryoLazyFilterTransformIterator"
+      // expected values taken from a 1.3 install
+      config.getOptions.asScala mustEqual
+          Map(
+            "sft"   -> "name:String,dtg:Date,*geom:LineString:srid=4326;geomesa.index.dtg='dtg'",
+            "index" -> "xz3:1",
+            "cql"   -> "dtg DURING 2020-01-01T00:00:00+00:00/2020-01-01T01:00:00+00:00"
+          )
+    }
+  }
+}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/Z3IteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/Z3IteratorTest.scala
@@ -8,32 +8,34 @@
 
 package org.locationtech.geomesa.accumulo.iterators
 
-import java.util
-
-import com.google.common.primitives.{Bytes, Longs}
 import org.apache.accumulo.core.data.{ByteSequence, Key, Range, Value}
 import org.apache.accumulo.core.iterators.{IteratorEnvironment, SortedKeyValueIterator}
 import org.apache.hadoop.io.Text
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
-import org.locationtech.geomesa.curve.{TimePeriod, Z3SFC}
 import org.locationtech.geomesa.index.api.ShardStrategy.NoShardStrategy
+import org.locationtech.geomesa.index.conf.FilterCompatibility
 import org.locationtech.geomesa.index.index.z3.Z3IndexKeySpace
+import org.locationtech.geomesa.index.index.z3.legacy.Z3IndexV4.Z3IndexKeySpaceV4
 import org.locationtech.geomesa.index.utils.ExplainNull
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.index.ByteArrays
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class Z3IteratorTest extends Specification {
 
-  sequential
+  import scala.collection.JavaConverters._
 
-  "Z3Iterator" should {
+  val sft = SimpleFeatureTypes.createType("z3IteratorTest", "dtg:Date,*geom:Point:srid=4326")
+  val filter = ECQL.toFilter("bbox(geom, -78, 38, -75, 40) AND dtg DURING 1970-01-01T00:05:00.000Z/1970-01-01T00:15:00.000Z")
+  val indexValues = new Z3IndexKeySpace(sft, NoShardStrategy, "geom", "dtg").getIndexValues(filter, ExplainNull)
 
-    val srcIter = new SortedKeyValueIterator[Key, Value] {
-      var key: Key = _
-      var staged: Key = _
+  def iterator(k: Array[Byte]): Z3Iterator = {
+    val srcIter: SortedKeyValueIterator[Key, Value] = new SortedKeyValueIterator[Key, Value] {
+      private var key: Key = new Key(new Text(k))
+      private var staged: Key = _
       override def deepCopy(iteratorEnvironment: IteratorEnvironment): SortedKeyValueIterator[Key, Value] = this
       override def next(): Unit = {
         staged = key
@@ -41,41 +43,53 @@ class Z3IteratorTest extends Specification {
       }
       override def getTopValue: Value = null
       override def getTopKey: Key = staged
-      override def init(sortedKeyValueIterator: SortedKeyValueIterator[Key, Value],
-                        map: util.Map[String, String],
-                        iteratorEnvironment: IteratorEnvironment): Unit = {}
-      override def seek(range: Range, collection: util.Collection[ByteSequence], b: Boolean): Unit = {
+      override def init(
+          sortedKeyValueIterator: SortedKeyValueIterator[Key, Value],
+          map: java.util.Map[String, String],
+          iteratorEnvironment: IteratorEnvironment): Unit = {}
+      override def seek(range: Range, collection: java.util.Collection[ByteSequence], b: Boolean): Unit = {
         key = null
         staged = null
       }
       override def hasTop: Boolean = staged != null
     }
 
-    val sft = SimpleFeatureTypes.createType("z3IteratorTest", "dtg:Date,*geom:Point:srid=4326")
-    val filter = ECQL.toFilter("bbox(geom, -78, 38, -75, 40) AND dtg DURING 1970-01-01T00:05:00.000Z/1970-01-01T00:15:00.000Z")
-    val indexValues = new Z3IndexKeySpace(sft, NoShardStrategy, "geom", "dtg").getIndexValues(filter, ExplainNull)
-
     val iter = new Z3Iterator
-    iter.init(srcIter, Z3Iterator.configure(indexValues, 0, 25).getOptions, null)
+    iter.init(srcIter, Z3Iterator.configure(indexValues, 0, None, 25).getOptions, null)
+    iter
+  }
+
+  "Z3Iterator" should {
 
     "iterate on points" >> {
       "keep in bounds values" >> {
-        val test1 = Z3SFC(TimePeriod.Week).index(-76.0, 38.5, 500)
-        val prefix = Array[Byte](0, 0)
-        val row = Bytes.concat(prefix, Longs.toByteArray(test1))
-        srcIter.key = new Key(new Text(row))
+        val test1 = indexValues.sfc.index(-76.0, 38.5, 500)
+        val row = ByteArrays.toBytes(Array[Byte](0, 0), test1)
+        val iter = iterator(row)
         iter.next()
         iter.hasTop must beTrue
       }
 
       "drop out of bounds values" >> {
-        val test2 = Z3SFC(TimePeriod.Week).index(-70.0, 38.5, 500)
-        val prefix = Array[Byte](0, 0)
-        val row = Bytes.concat(prefix, Longs.toByteArray(test2))
-        srcIter.key = new Key(new Text(row))
+        val test2 = indexValues.sfc.index(-70.0, 38.5, 500)
+        val row = ByteArrays.toBytes(Array[Byte](0, 0), test2)
+        val iter = iterator(row)
         iter.next()
         iter.hasTop must beFalse
       }
+    }
+
+    "configure 1.3 compatibility mode" >> {
+      // v4 index corresponds to gm 1.3
+      val keySpace = new Z3IndexKeySpaceV4(sft, Array.empty, NoShardStrategy, "geom", "dtg")
+      val filter = "bbox(geom,0,-70,50,-50) and dtg during 2015-06-06T00:00:00.000Z/2015-06-08T00:00:00.000Z"
+      val values = keySpace.getIndexValues(ECQL.toFilter(filter), ExplainNull)
+      val config = Z3Iterator.configure(values, 2, Some(FilterCompatibility.`1.3`), 23)
+      config.getIteratorClass mustEqual classOf[Z3Iterator].getName
+      config.getPriority mustEqual 23
+      // expected values taken from a 1.3 install
+      config.getOptions.asScala mustEqual
+          Map("zl" -> "8", "zo" -> "2", "zxy" -> "1048576:233017:1339847:466034", "zt" -> "2370;299595:599184")
     }
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/package.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/package.scala
@@ -1,0 +1,17 @@
+/***********************************************************************
+ * Copyright (c) 2013-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.index
+
+package object conf {
+
+  object FilterCompatibility extends Enumeration {
+    type FilterCompatibility = Value
+    val `1.3`: Value = Value("1.3")
+  }
+}

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryPlanner.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryPlanner.scala
@@ -122,6 +122,7 @@ class QueryPlanner[DS <: GeoMesaDataStore[DS]](ds: DS) extends QueryRunner with 
           s"sampling[${hints.getSampling.map { case (s, f) => s"$s${f.map(":" + _).getOrElse("")}"}.getOrElse("none")}]")
       output(s"Sort: ${query.getHints.getSortFields.map(QueryHints.sortReadableString).getOrElse("none")}")
       output(s"Transforms: ${query.getHints.getTransformDefinition.map(t => if (t.isEmpty) { "empty" } else { t }).getOrElse("none")}")
+      hints.getFilterCompatibility.foreach(c => output(s"Filter compatibility: $c"))
 
       output.pushLevel("Strategy selection:")
       val requestedIndex = requested.orElse(hints.getRequestedIndex)


### PR DESCRIPTION
* Use QueryHints.FILTER_COMPAT = "1.3"
* Supports basic non-strict date time queries against z3 index
* Supports basic queries against xz3 index
* Does not support transforms or advanced queries

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>