### PR TITLE
GEOMESA-2983 Fix Kafka metadata migration from 1.x for reserved words

### DIFF
--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/MetadataMigration.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/MetadataMigration.scala
@@ -43,6 +43,7 @@ class MetadataMigration(ds: KafkaDataStore, zkPath: String, zookeepers: String) 
               val schema = new String(client.getData.forPath(s"/$name"), StandardCharsets.UTF_8)
               val sft = SimpleFeatureTypes.createType(name, schema)
               KafkaDataStore.setTopic(sft, new String(client.getData.forPath(s"/$name/Topic"), StandardCharsets.UTF_8))
+              sft.getUserData.put(SimpleFeatureTypes.Configs.OverrideReservedWords, "true")
               ds.createSchema(sft)
             }
             client.delete().deletingChildrenIfNeeded().forPath(s"/$name")

--- a/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreTest.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/test/scala/org/locationtech/geomesa/kafka/data/KafkaDataStoreTest.scala
@@ -656,7 +656,7 @@ class KafkaDataStoreTest extends Specification with Mockito with LazyLogging {
     }
 
     "migrate old kafka data store schemas" >> {
-      val spec = "test:String,dtg:Date,*geom:Point:srid=4326"
+      val spec = "test:String,dtg:Date,*location:Point:srid=4326"
 
       val path = s"geomesa/migrate/test/${paths.getAndIncrement()}"
       val client = CuratorFrameworkFactory.builder()


### PR DESCRIPTION
Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>