### PR TITLE
GEOMESA-3027 Better handling of complex OR queries

### DIFF
--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -213,6 +213,17 @@ don't intersect the geometry. This behavior can be controlled through two proper
 decomposed into. If set below 2, no decomposition will be performed and instead the geometry envelope will be used.
 Also see ``geomesa.query.decomposition.bits``, above.
 
+geomesa.query.processing.or.threshold
++++++++++++++++++++++++++++++++++++++
+
+GeoMesa attempts to process input filters in order to determine the best query plan for a given predicate. However,
+since queries can be arbitrarily complex, this processing can potentially take a significant amount of time.
+``geomesa.query.processing.or.threshold`` sets a threshold for the complexity of an OR filter that
+will be considered, based on the permutations of the filter. For example, the filter ``A OR B OR C`` has three
+permutations, while ``(A OR B) AND (C OR D)`` has four permutations.
+
+By default complex OR predicates will not be considered, which is suitable for most queries.
+
 geomesa.query.timeout
 +++++++++++++++++++++
 

--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -105,6 +105,13 @@ Lambda Data Store Binary Distribution Change
 The Lambda data store binary distribution no longer contains the ``geomesa-accumulo-distributed-runtime`` JAR.
 This JAR is available in the Accumulo data store binary distribution.
 
+StrategyDecider API Update
+--------------------------
+
+The ``org.locationtech.geomesa.index.planning.StrategyDecider`` API has been extended with an optional
+``GeoMesaStats`` argument that enables stat-based strategy decisions. The old API method has been deprecated
+and will be removed in a future version.
+
 Deprecated Arrow Output Options
 -------------------------------
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreStatsTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreStatsTest.scala
@@ -11,6 +11,7 @@ package org.locationtech.geomesa.accumulo.data
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
 import java.util.Date
 
+import com.typesafe.scalalogging.LazyLogging
 import org.geotools.data._
 import org.geotools.data.simple.SimpleFeatureReader
 import org.geotools.feature.DefaultFeatureCollection
@@ -33,7 +34,7 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class AccumuloDataStoreStatsTest extends Specification with TestWithMultipleSfts {
+class AccumuloDataStoreStatsTest extends Specification with TestWithMultipleSfts with LazyLogging {
 
   sequential
 
@@ -421,7 +422,7 @@ class AccumuloDataStoreStatsTest extends Specification with TestWithMultipleSfts
           exact must beGreaterThan(0L)
           val calculated = ds.stats.getCount(sft, filter, exact = true, hints)
           calculated must beSome(exact)
-          println(s"FS Count: $count reader count: $exact stats count: $calculated")
+          logger.debug(s"FS Count: $count reader count: $exact stats count: $calculated")
           count mustEqual exact
         }
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/ArrowDeltaIteratorTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/iterators/ArrowDeltaIteratorTest.scala
@@ -10,6 +10,7 @@ package org.locationtech.geomesa.accumulo.iterators
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.DirtyRootAllocator
 import org.geotools.data.{Query, Transaction}
@@ -26,7 +27,7 @@ import org.specs2.mock.Mockito
 import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class ArrowDeltaIteratorTest extends TestWithFeatureType with Mockito {
+class ArrowDeltaIteratorTest extends TestWithFeatureType with Mockito with LazyLogging {
 
   import scala.collection.JavaConverters._
 
@@ -60,7 +61,7 @@ class ArrowDeltaIteratorTest extends TestWithFeatureType with Mockito {
       val result = WithClose(SimpleFeatureArrowFileReader.streaming(in)) { reader =>
         WithClose(reader.features())(_.map(ScalaSimpleFeature.copy).toList)
       }
-      println(result.map(_.getAttributes.asScala))
+      logger.debug(result.map(_.getAttributes.asScala).toString)
       result.map(_.getID) mustEqual features.map(_.getID)
       result.map(_.getAttributes.asScala) mustEqual features.map { f =>
         val geom = f.getAttribute("geom").asInstanceOf[Point]

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/accumulo/AccumuloJobUtils.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/jobs/accumulo/AccumuloJobUtils.scala
@@ -76,7 +76,7 @@ object AccumuloJobUtils extends LazyLogging {
       val queryPlans = ds.getQueryPlan(query)
 
       if (queryPlans.isEmpty) {
-        EmptyPlan(FilterStrategy(fallbackIndex, None, Some(Filter.EXCLUDE), temporal = false, 0L))
+        EmptyPlan(FilterStrategy(fallbackIndex, None, Some(Filter.EXCLUDE), temporal = false, Float.PositiveInfinity))
       } else if (queryPlans.lengthCompare(1) > 0) {
         // this query requires multiple scans, which we can't execute from some input formats
         // instead, fall back to a full table scan
@@ -122,7 +122,7 @@ object AccumuloJobUtils extends LazyLogging {
 
       val queryPlans = ds.getQueryPlan(query)
       if (queryPlans.isEmpty) {
-        Seq(EmptyPlan(FilterStrategy(fallbackIndex, None, Some(Filter.EXCLUDE), temporal = false, 0L)))
+        Seq(EmptyPlan(FilterStrategy(fallbackIndex, None, Some(Filter.EXCLUDE), temporal = false, Float.PositiveInfinity)))
       } else {
         queryPlans
       }

--- a/geomesa-hbase/geomesa-hbase-rpc/src/main/scala/org/locationtech/geomesa/hbase/rpc/filter/CqlTransformFilter.scala
+++ b/geomesa-hbase/geomesa-hbase-rpc/src/main/scala/org/locationtech/geomesa/hbase/rpc/filter/CqlTransformFilter.scala
@@ -549,10 +549,8 @@ object CqlTransformFilter extends StrictLogging {
 
     override def tieredKeySpace: Option[IndexKeySpace[_, _]] = throw new NotImplementedError()
 
-    override def getFilterStrategy(
-        filter: Filter,
-        transform: Option[SimpleFeatureType],
-        stats: Option[GeoMesaStats]): Option[FilterStrategy] = throw new NotImplementedError()
+    override def getFilterStrategy(filter: Filter, transform: Option[SimpleFeatureType]): Option[FilterStrategy] =
+      throw new NotImplementedError()
 
     override def getIdFromRow(row: Array[Byte], offset: Int, length: Int, feature: SimpleFeature): String = ""
   }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
@@ -222,20 +222,27 @@ abstract class GeoMesaFeatureIndex[T, U](val ds: GeoMesaDataStore[_],
   /**
     * Gets options for a 'simple' filter, where each OR is on a single attribute, e.g.
     *   (bbox1 OR bbox2) AND dtg
-    *   bbox AND dtg AND (attr1 = foo OR attr = bar)
+    *   bbox AND dtg AND (attr = foo OR attr = bar)
     * not:
     *   bbox OR dtg
     *
-    * Because the inputs are simple, each one can be satisfied with a single query filter.
-    * The returned values will each satisfy the query.
+    * Because the input is simple, it can be satisfied with a single query filter.
     *
     * @param filter input filter
     * @param transform attribute transforms
     * @return a filter strategy which can satisfy the query, if available
     */
-  def getFilterStrategy(filter: Filter,
-                        transform: Option[SimpleFeatureType],
-                        stats: Option[GeoMesaStats]): Option[FilterStrategy]
+  def getFilterStrategy(filter: Filter, transform: Option[SimpleFeatureType]): Option[FilterStrategy] = {
+    // TODO remove default impl in next major release
+    // noinspection ScalaDeprecation
+    getFilterStrategy(filter, transform, None)
+  }
+
+  @deprecated("replaced with getFilterStrategy(Filter,Option[SimpleFeatureType])")
+  def getFilterStrategy(
+      filter: Filter,
+      transform: Option[SimpleFeatureType],
+      stats: Option[GeoMesaStats]): Option[FilterStrategy] = throw new NotImplementedError()
 
   /**
     * Plans the query
@@ -372,7 +379,8 @@ abstract class GeoMesaFeatureIndex[T, U](val ds: GeoMesaDataStore[_],
     case _ => false
   }
 
-  override def hashCode(): Int = Seq(identifier, ds, sft, mode).map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  override def hashCode(): Int =
+    Seq(identifier, ds, sft, mode).collect { case o if o != null => o.hashCode() }.foldLeft(0)((a, b) => 31 * a + b)
 }
 
 object GeoMesaFeatureIndex {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/id/IdIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/id/IdIndex.scala
@@ -25,6 +25,8 @@ class IdIndex protected (ds: GeoMesaDataStore[_], sft: SimpleFeatureType, versio
   override val keySpace: IdIndexKeySpace = new IdIndexKeySpace(sft)
 
   override val tieredKeySpace: Option[IndexKeySpace[_, _]] = None
+
+  override def toString: String = getClass.getSimpleName
 }
 
 object IdIndex extends ConfiguredIndex {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/StrategyDecider.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/StrategyDecider.scala
@@ -14,6 +14,7 @@ import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.attribute.AttributeIndex
 import org.locationtech.geomesa.index.planning.QueryPlanner.CostEvaluation
 import org.locationtech.geomesa.index.planning.QueryPlanner.CostEvaluation.CostEvaluation
+import org.locationtech.geomesa.index.stats.GeoMesaStats
 import org.locationtech.geomesa.index.utils.{ExplainNull, Explainer}
 import org.locationtech.geomesa.utils.conf.GeoMesaSystemProperties.SystemProperty
 import org.locationtech.geomesa.utils.index.IndexMode
@@ -26,17 +27,28 @@ import org.opengis.filter.Filter
   */
 trait StrategyDecider {
 
-  /**
-    * Select from available filter plans
-    *
-    * @param sft simple feature type being queried
-    * @param options filter plans that can satisfy the query
-    * @param explain explain logging
-    * @return filter plan to execute
-    */
+  @deprecated("replaced with selectFilterPlan(SimpleFeatureType,Seq[FilterPlan],Option[GeoMesaStats],Explainer)")
   def selectFilterPlan(sft: SimpleFeatureType, options: Seq[FilterPlan], explain: Explainer): FilterPlan
-}
 
+  /**
+   * Select from available filter plans
+   *
+   * @param sft simple feature type being queried
+   * @param options filter plans that can satisfy the query
+   * @param stats stats (if available)
+   * @param explain explain logging
+   * @return filter plan to execute
+   */
+  def selectFilterPlan(
+      sft: SimpleFeatureType,
+      options: Seq[FilterPlan],
+      stats: Option[GeoMesaStats],
+      explain: Explainer): FilterPlan = {
+    // TODO remove default impl in next major release
+    // noinspection ScalaDeprecation
+    selectFilterPlan(sft, options, explain)
+  }
+}
 
 object StrategyDecider extends MethodProfiling with LazyLogging {
 
@@ -74,17 +86,11 @@ object StrategyDecider extends MethodProfiling with LazyLogging {
 
     def complete(op: String, time: Long, count: Int): Unit = explain(s"$op took ${time}ms for $count options")
 
-    // choose the best option based on cost
-    val stats = evaluation match {
-      case CostEvaluation.Stats => Some(ds.stats)
-      case CostEvaluation.Index => None
-    }
-
     val indices = ds.manager.indices(sft, mode = IndexMode.Read)
 
     // get the various options that we could potentially use
     val options = profile((o: Seq[FilterPlan], t: Long) => complete("Query processing", t, o.length)) {
-      new FilterSplitter(sft, indices, stats).getQueryOptions(filter, transform)
+      new FilterSplitter(sft, indices).getQueryOptions(filter, transform)
     }
 
     val selected = profile(t => complete("Strategy selection", t, options.length)) {
@@ -101,10 +107,12 @@ object StrategyDecider extends MethodProfiling with LazyLogging {
         explain(s"Filter plan: ${options.head}")
         options.head
       } else {
-        val plan = decider.selectFilterPlan(sft, options, explain)
-        explain(s"Filter plan selected: $plan")
-        explain(s"Filter plans not selected: ${options.filterNot(_.eq(plan)).mkString(", ")}")
-        plan
+        // choose the best option based on cost
+        val stats = evaluation match {
+          case CostEvaluation.Stats => Some(ds.stats)
+          case CostEvaluation.Index => None
+        }
+        decider.selectFilterPlan(sft, options, stats, explain)
       }
     }
 
@@ -131,7 +139,7 @@ object StrategyDecider extends MethodProfiling with LazyLogging {
                 indices.map(i => s"${i.name}, ${i.identifier}").mkString(", "))
           }
       val secondary = if (filter == Filter.INCLUDE) { None } else { Some(filter) }
-      FilterPlan(Seq(FilterStrategy(index, None, secondary, temporal = false, 0L)))
+      FilterPlan(Seq(FilterStrategy(index, None, secondary, temporal = false, Float.PositiveInfinity)))
     }
 
     byId.orElse(byName).orElse(byJoin).getOrElse(fallback)
@@ -141,24 +149,39 @@ object StrategyDecider extends MethodProfiling with LazyLogging {
 
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
+    // noinspection ScalaDeprecation
     override def selectFilterPlan(
         sft: SimpleFeatureType,
         options: Seq[FilterPlan],
+        explain: Explainer): FilterPlan = selectFilterPlan(sft, options, None, explain)
+
+    override def selectFilterPlan(
+        sft: SimpleFeatureType,
+        options: Seq[FilterPlan],
+        stats: Option[GeoMesaStats],
         explain: Explainer): FilterPlan = {
 
+      def cost(option: FilterPlan): FilterPlanCost = {
+        profile((fpc: FilterPlanCost, time: Long) => fpc.copy(time = time)) {
+          var cost = BigInt(0)
+          option.strategies.foreach { strategy =>
+            val filter = strategy.primary.getOrElse(Filter.INCLUDE)
+            val count = stats.flatMap(_.getCount(sft, filter, exact = false)).getOrElse(100L)
+            cost = cost + BigInt((count * strategy.costMultiplier).toLong)
+          }
+          FilterPlanCost(option, if (cost.isValidLong) { cost.longValue() } else { Long.MaxValue }, 0L)
+        }
+      }
+
       val costs = options.map(cost).sorted
-      explain(s"Costs: ${costs.mkString("; ")}")
 
       val temporal = if (!sft.isTemporalPriority) { None } else {
         costs.find(c => c.plan.strategies.nonEmpty && c.plan.strategies.forall(_.temporal))
       }
-      temporal.getOrElse(costs.head).plan
-    }
-
-    private def cost(option: FilterPlan): FilterPlanCost = {
-      profile((fpc: FilterPlanCost, time: Long) => fpc.copy(time = time)) {
-        FilterPlanCost(option, option.strategies.map(_.cost).sum, 0L)
-      }
+      val selected = temporal.getOrElse(costs.head)
+      explain(s"Filter plan selected: $selected")
+      explain(s"Filter plans not selected: ${costs.filterNot(_.eq(selected)).mkString(", ")}")
+      selected.plan
     }
 
     private case class FilterPlanCost(plan: FilterPlan, cost: Long, time: Long) extends Comparable[FilterPlanCost] {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/strategies/IdFilterStrategy.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/strategies/IdFilterStrategy.scala
@@ -11,36 +11,28 @@ package org.locationtech.geomesa.index.strategies
 import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.filter.visitor.IdExtractingVisitor
 import org.locationtech.geomesa.index.api.{FilterStrategy, GeoMesaFeatureIndex}
-import org.locationtech.geomesa.index.stats.GeoMesaStats
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.{And, Filter, Id, Or}
 
 trait IdFilterStrategy[T, U] extends GeoMesaFeatureIndex[T, U] {
 
-  override def getFilterStrategy(
-      filter: Filter,
-      transform: Option[SimpleFeatureType],
-      stats: Option[GeoMesaStats]): Option[FilterStrategy] = {
+  override def getFilterStrategy(filter: Filter, transform: Option[SimpleFeatureType]): Option[FilterStrategy] = {
     if (filter == Filter.INCLUDE) {
-      Some(FilterStrategy(this, None, None, temporal = false, Long.MaxValue))
-    } else if (filter == Filter.EXCLUDE) {
-      None
+      Some(FilterStrategy(this, None, None, temporal = false, Float.PositiveInfinity))
     } else {
       val (ids, notIds) = IdExtractingVisitor(filter)
       if (ids.isDefined) {
-        // top-priority index - always 1 if there are actually ID filters
+        // top-priority index if there are actually ID filters
         // note: although there's no temporal predicate, there's an implied exact date for the given feature
-        Some(FilterStrategy(this, ids, notIds, temporal = true, IdFilterStrategy.StaticCost))
+        Some(FilterStrategy(this, ids, notIds, temporal = true, .001f))
       } else {
-        Some(FilterStrategy(this, None, Some(filter), temporal = false, Long.MaxValue))
+        Some(FilterStrategy(this, None, Some(filter), temporal = false, Float.PositiveInfinity))
       }
     }
   }
 }
 
 object IdFilterStrategy {
-
-  val StaticCost = 1L
 
   def intersectIdFilters(filter: Filter): Set[String] = {
     import scala.collection.JavaConversions._

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/strategies/SpatialFilterStrategy.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/strategies/SpatialFilterStrategy.scala
@@ -11,40 +11,31 @@ package org.locationtech.geomesa.index.strategies
 import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.filter.visitor.FilterExtractingVisitor
 import org.locationtech.geomesa.index.api.{FilterStrategy, GeoMesaFeatureIndex}
-import org.locationtech.geomesa.index.stats.GeoMesaStats
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.{And, Filter, Or}
 
 trait SpatialFilterStrategy[T, U] extends GeoMesaFeatureIndex[T, U] {
 
-  import SpatialFilterStrategy.{StaticCost, spatialCheck}
+  import SpatialFilterStrategy.spatialCheck
 
   // attributes are assumed to be a single geometry field
   lazy private val Seq(geom) = attributes
 
-  override def getFilterStrategy(filter: Filter,
-                                 transform: Option[SimpleFeatureType],
-                                 stats: Option[GeoMesaStats]): Option[FilterStrategy] = {
+  override def getFilterStrategy(filter: Filter, transform: Option[SimpleFeatureType]): Option[FilterStrategy] = {
     if (filter == Filter.INCLUDE) {
-      Some(FilterStrategy(this, None, None, temporal = false, Long.MaxValue))
-    } else if (filter == Filter.EXCLUDE) {
-      None
+      Some(FilterStrategy(this, None, None, temporal = false, Float.PositiveInfinity))
     } else {
       val (spatial, nonSpatial) = FilterExtractingVisitor(filter, geom, sft, spatialCheck)
       if (spatial.nonEmpty) {
-        // add one so that we prefer the z3 index even if geometry is the limiting factor, resulting in the same count
-        lazy val cost = stats.flatMap(_.getCount(sft, spatial.get, exact = false).map(c => if (c == 0L) 0L else c + 1L))
-        Some(FilterStrategy(this, spatial, nonSpatial, temporal = false, cost.getOrElse(StaticCost)))
+        Some(FilterStrategy(this, spatial, nonSpatial, temporal = false, 1.2f))
       } else {
-        Some(FilterStrategy(this, None, Some(filter), temporal = false, Long.MaxValue))
+        Some(FilterStrategy(this, None, Some(filter), temporal = false, Float.PositiveInfinity))
       }
     }
   }
 }
 
 object SpatialFilterStrategy {
-
-  val StaticCost = 400L
 
   /**
     * Evaluates filters that we can handle with the z-index strategies

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/strategies/SpatioTemporalFilterStrategy.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/strategies/SpatioTemporalFilterStrategy.scala
@@ -11,61 +11,38 @@ package org.locationtech.geomesa.index.strategies
 import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.filter.visitor.FilterExtractingVisitor
 import org.locationtech.geomesa.index.api.{FilterStrategy, GeoMesaFeatureIndex}
-import org.locationtech.geomesa.index.index.attribute.AttributeIndex
-import org.locationtech.geomesa.index.stats.GeoMesaStats
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
 trait SpatioTemporalFilterStrategy[T, U] extends GeoMesaFeatureIndex[T, U] {
 
-  import SpatioTemporalFilterStrategy.StaticCost
-
   // attributes are assumed to be a geometry field and a date field
   lazy private val Seq(geom, dtg) = attributes
 
-  override def getFilterStrategy(filter: Filter,
-                                 transform: Option[SimpleFeatureType],
-                                 stats: Option[GeoMesaStats]): Option[FilterStrategy] = {
-
+  override def getFilterStrategy(filter: Filter, transform: Option[SimpleFeatureType]): Option[FilterStrategy] = {
     if (filter == Filter.INCLUDE) {
-      Some(FilterStrategy(this, None, None, temporal = false, Long.MaxValue))
-    } else if (filter == Filter.EXCLUDE) {
-      None
+      Some(FilterStrategy(this, None, None, temporal = false, Float.PositiveInfinity))
     } else {
       val (temporal, nonTemporal) = FilterExtractingVisitor(filter, dtg, sft)
       val intervals = temporal.map(FilterHelper.extractIntervals(_, dtg)).getOrElse(FilterValues.empty)
 
       if (!intervals.disjoint && !intervals.exists(_.isBounded)) {
         // if there aren't any intervals then we would have to do a full table scan
-        Some(FilterStrategy(this, None, Some(filter), temporal = false, Long.MaxValue))
+        Some(FilterStrategy(this, None, Some(filter), temporal = false, Float.PositiveInfinity))
       } else {
         val (spatial, others) = nonTemporal match {
           case Some(f) => FilterExtractingVisitor(f, geom, sft, SpatialFilterStrategy.spatialCheck)
           case None    => (None, None)
         }
         val primary = andFilters(spatial.toSeq ++ temporal)
+        // TODO check date range and use z2 instead if too big
+        // TODO also if very small bbox, z2 has ~10 more bits of lat/lon info
+        // https://geomesa.atlassian.net/browse/GEOMESA-1166
 
-        lazy val cost = {
-          // we can still use this index with a geom, but if there is a date attribute index that will work better
-          if (spatial.isEmpty && AttributeIndex.indexed(sft, dtg)) {
-            Long.MaxValue
-          } else {
-            // TODO check date range and use z2 instead if too big
-            // TODO also if very small bbox, z2 has ~10 more bits of lat/lon info
-            // https://geomesa.atlassian.net/browse/GEOMESA-1166
-
-            val base = stats.flatMap(_.getCount(sft, primary, exact = false)).getOrElse(StaticCost)
-            // de-prioritize non-spatial and one-sided date filters
-            if (spatial.isDefined && intervals.forall(_.isBoundedBothSides)) { base } else { base * 2 + 1 }
-          }
-        }
-
-        Some(FilterStrategy(this, Some(primary), others, temporal = true, cost))
+        // de-prioritize non-spatial and one-sided date filters
+        val priority = if (spatial.isDefined && intervals.forall(_.isBoundedBothSides)) { 1.1f } else { 3f }
+        Some(FilterStrategy(this, Some(primary), others, temporal = true, priority))
       }
     }
   }
-}
-
-object SpatioTemporalFilterStrategy {
-  val StaticCost = 200L
 }


### PR DESCRIPTION
* Separate filter plan cost into a base cost and a multiplier
** Multiplier reflects the priority/ranking of the filter plan
* Check cross-attribute OR filters for simple filter plans
* Only return best "tier" of filter plans from FilterSplitter
* Add `geomesa.query.processing.or.threshold` to enable expensive
  OR processing

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>