### PR TITLE
GEOMESA-2991 Configuration to require visibilities on write

### DIFF
--- a/docs/user/datastores/index_config.rst
+++ b/docs/user/datastores/index_config.rst
@@ -638,6 +638,9 @@ Note that this configuration will prevent missing visibility labels in normal wr
 it is still possible to write unlabelled data through older clients, bulk loading, or direct access
 to the underlying database.
 
+In Accumulo data stores, setting this configuration will also set the Accumulo ``ReqVisFilter`` on all data
+tables, which will prevent any unlabelled data from being returned in queries.
+
 Mixed Geometry Types
 --------------------
 

--- a/docs/user/datastores/index_config.rst
+++ b/docs/user/datastores/index_config.rst
@@ -619,6 +619,25 @@ user-data key ``geomesa.temporal.priority``:
 
 This may be configured before calling ``createSchema``, or updated by calling ``updateSchema``.
 
+.. _required_vis_config:
+
+Configuring Required Visibilities
+---------------------------------
+
+GeoMesa supports :ref:`data_security` through the use of visibility labels to secure access to sensitive data.
+To help prevent data spills, a schema can be configured to reject any writes that don't contain valid visibilities.
+To enable this setting, use the user-data key ``geomesa.vis.required``:
+
+.. code-block:: java
+
+    sft.getUserData().put("geomesa.vis.required", "true");
+
+This may be configured before calling ``createSchema``, or updated by calling ``updateSchema``.
+
+Note that this configuration will prevent missing visibility labels in normal write paths, but that
+it is still possible to write unlabelled data through older clients, bulk loading, or direct access
+to the underlying database.
+
 Mixed Geometry Types
 --------------------
 

--- a/docs/user/datastores/security.rst
+++ b/docs/user/datastores/security.rst
@@ -19,6 +19,10 @@ two tags, ``admin`` and ``user``. An expression could be ``admin``, ``user``, ``
 depending on how you want to grant access to your data. For more complex expressions, parentheses can be used
 for operation order.
 
+.. note::
+
+  See :ref:`required_vis_config` to enforce visibility labels on all writes.
+
 Visibility labels can be written in two different ways, either at the level of each feature, or at the level
 of each attribute in a feature.
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStore.scala
@@ -23,7 +23,7 @@ import org.locationtech.geomesa.accumulo.data.AccumuloBackedMetadata.SingleRowAc
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStoreFactory.AccumuloDataStoreConfig
 import org.locationtech.geomesa.accumulo.data.stats._
 import org.locationtech.geomesa.accumulo.index._
-import org.locationtech.geomesa.accumulo.iterators.{AgeOffIterator, DtgAgeOffIterator, ProjectVersionIterator}
+import org.locationtech.geomesa.accumulo.iterators.{AgeOffIterator, DtgAgeOffIterator, ProjectVersionIterator, VisibilityIterator}
 import org.locationtech.geomesa.accumulo.util.TableUtils
 import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
@@ -250,6 +250,13 @@ class AccumuloDataStore(val connector: Connector, override val config: AccumuloD
     }
     if (sft.statsEnabled) {
       stats.configureStatCombiner(connector, sft)
+    }
+
+    if (previous.isVisibilityRequired != sft.isVisibilityRequired) {
+      VisibilityIterator.clear(this, previous)
+      if (sft.isVisibilityRequired) {
+        VisibilityIterator.set(this, sft)
+      }
     }
 
     AgeOffIterator.clear(this, previous)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/VisibilityIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/VisibilityIterator.scala
@@ -18,9 +18,10 @@ import org.opengis.feature.simple.SimpleFeatureType
 object VisibilityIterator {
 
   val Name = "ReqVisFilter"
+  val Priority = 15 // run before the accumulo versioning iterator at 20, and before any of our custom iterators
 
   def set(tableOps: TableOperations, table: String): Unit =
-    tableOps.attachIterator(table, new IteratorSetting(30, Name, classOf[ReqVisFilter]))
+    tableOps.attachIterator(table, new IteratorSetting(Priority, Name, classOf[ReqVisFilter]))
 
   def set(ds: AccumuloDataStore, sft: SimpleFeatureType): Unit = {
     val tableOps = ds.connector.tableOperations()

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/VisibilityIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/VisibilityIterator.scala
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (c) 2013-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ **********************************************************************/
+
+package org.locationtech.geomesa.accumulo.iterators
+
+import org.apache.accumulo.core.client.IteratorSetting
+import org.apache.accumulo.core.client.admin.TableOperations
+import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope
+import org.apache.accumulo.core.iterators.user.ReqVisFilter
+import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
+import org.opengis.feature.simple.SimpleFeatureType
+
+object VisibilityIterator {
+
+  val Name = "ReqVisFilter"
+
+  def set(tableOps: TableOperations, table: String): Unit =
+    tableOps.attachIterator(table, new IteratorSetting(30, Name, classOf[ReqVisFilter]))
+
+  def set(ds: AccumuloDataStore, sft: SimpleFeatureType): Unit = {
+    val tableOps = ds.connector.tableOperations()
+    ds.getAllIndexTableNames(sft.getTypeName).filter(tableOps.exists).foreach(set(tableOps, _))
+  }
+
+  def clear(ds: AccumuloDataStore, sft: SimpleFeatureType): Unit = {
+    val tableOps = ds.connector.tableOperations()
+    ds.getAllIndexTableNames(sft.getTypeName).filter(tableOps.exists).foreach { table =>
+      if (IteratorScope.values.exists(scope => tableOps.getIteratorSetting(table, Name, scope) != null)) {
+        tableOps.removeIterator(table, Name, java.util.EnumSet.allOf(classOf[IteratorScope]))
+      }
+    }
+  }
+}

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/VisibilityIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/VisibilityIterator.scala
@@ -1,10 +1,10 @@
-/**********************************************************************
+/***********************************************************************
  * Copyright (c) 2013-2021 Commonwealth Computer Research, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at
  * http://www.opensource.org/licenses/apache2.0.php.
- **********************************************************************/
+ ***********************************************************************/
 
 package org.locationtech.geomesa.accumulo.iterators
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureWriter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureWriter.scala
@@ -31,8 +31,6 @@ import scala.util.control.NonFatal
 
 trait GeoMesaFeatureWriter[DS <: GeoMesaDataStore[DS]] extends SimpleFeatureWriter with Flushable with LazyLogging {
 
-  import scala.collection.JavaConverters._
-
   def ds: DS
   def sft: SimpleFeatureType
   def indices: Seq[GeoMesaFeatureIndex[_, _]]

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureWriter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/GeoMesaFeatureWriter.scala
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.data.simple.SimpleFeatureWriter
-import org.geotools.data.{Query, Transaction}
+import org.geotools.data.{DataUtilities, Query, Transaction}
 import org.geotools.filter.identity.FeatureIdImpl
 import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.features.ScalaSimpleFeature
@@ -51,8 +51,13 @@ trait GeoMesaFeatureWriter[DS <: GeoMesaDataStore[DS]] extends SimpleFeatureWrit
     // `write` will calculate all mutations up front in case the feature is not valid, so we don't write partial entries
     try { getWriter(writable).write(writable, update) } catch {
       case NonFatal(e) =>
-        val attributes = s"${writable.getID}:${writable.getAttributes.asScala.mkString("|")}"
-        throw new IllegalArgumentException(s"Error indexing feature '$attributes'", e)
+        val msg = s"Error indexing feature '${writable.getID}:${DataUtilities.encodeFeature(writable, false)}'"
+        if (e.isInstanceOf[IllegalArgumentException]) {
+          throw new IllegalArgumentException(msg, e)
+        } else {
+          throw new RuntimeException(msg, e)
+        }
+
     }
     statUpdater.add(writable)
   }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
@@ -438,7 +438,7 @@ object MetadataBackedDataStore {
       TableSharingPrefix,
       IndexVisibilityLevel,
       IndexZ3Interval,
-      S3_INTERVAL_KEY,
+      IndexS3Interval,
       IndexXzPrecision,
       IndexZShards,
       IndexIdShards,

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaFeatureWriter.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaFeatureWriter.scala
@@ -20,8 +20,7 @@ import org.locationtech.geomesa.features.SerializationType.SerializationType
 import org.locationtech.geomesa.index.geotools.GeoMesaFeatureWriter
 import org.locationtech.geomesa.kafka.RecordVersions
 import org.locationtech.geomesa.kafka.utils.{GeoMessage, GeoMessageSerializer}
-import org.locationtech.geomesa.security.SecurityUtils
-import org.locationtech.geomesa.utils.text.TextTools
+import org.locationtech.geomesa.security.VisibilityChecker
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.{Filter, Id}
 
@@ -125,12 +124,10 @@ object KafkaFeatureWriter {
     }
   }
 
-  trait RequiredVisibilityWriter extends AppendKafkaFeatureWriter {
+  trait RequiredVisibilityWriter extends AppendKafkaFeatureWriter with VisibilityChecker {
     abstract override def write(): Unit = {
-      feature.getUserData.get(SecurityUtils.FEATURE_VISIBILITY) match {
-        case vis: String if !TextTools.isWhitespace(vis) => super.write()
-        case _ => throw new IllegalArgumentException("Visibility is required for writes")
-      }
+      requireVisibilities(feature)
+      super.write()
     }
   }
 }

--- a/geomesa-lambda/geomesa-lambda-datastore/src/main/scala/org/locationtech/geomesa/lambda/data/LambdaFeatureWriter.scala
+++ b/geomesa-lambda/geomesa-lambda-datastore/src/main/scala/org/locationtech/geomesa/lambda/data/LambdaFeatureWriter.scala
@@ -13,9 +13,8 @@ import java.util.concurrent.atomic.AtomicLong
 import org.geotools.data.simple.SimpleFeatureWriter
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.lambda.stream.TransientStore
-import org.locationtech.geomesa.security.SecurityUtils
+import org.locationtech.geomesa.security.VisibilityChecker
 import org.locationtech.geomesa.utils.collection.CloseableIterator
-import org.locationtech.geomesa.utils.text.TextTools
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 object LambdaFeatureWriter {
@@ -63,12 +62,10 @@ object LambdaFeatureWriter {
     override def close(): Unit = features.close()
   }
 
-  trait RequiredVisibilityWriter extends AppendLambdaFeatureWriter {
+  trait RequiredVisibilityWriter extends AppendLambdaFeatureWriter with VisibilityChecker {
     abstract override def write(): Unit = {
-      feature.getUserData.get(SecurityUtils.FEATURE_VISIBILITY) match {
-        case vis: String if !TextTools.isWhitespace(vis) => super.write()
-        case _ => throw new IllegalArgumentException("Visibility is required for writes")
-      }
+      requireVisibilities(feature)
+      super.write()
     }
   }
 }

--- a/geomesa-security/src/main/java/org/locationtech/geomesa/security/VisibilityChecker.scala
+++ b/geomesa-security/src/main/java/org/locationtech/geomesa/security/VisibilityChecker.scala
@@ -1,0 +1,29 @@
+/***********************************************************************
+ * Copyright (c) 2013-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.security
+
+import org.locationtech.geomesa.utils.text.TextTools
+import org.opengis.feature.simple.SimpleFeature
+
+/**
+ * Checks for visibilities set in a feature's user data
+ */
+trait VisibilityChecker {
+  @throws(classOf[IllegalArgumentException])
+  def requireVisibilities(feature: SimpleFeature): Unit = {
+    try {
+      val vis = feature.getUserData.get(SecurityUtils.FEATURE_VISIBILITY).asInstanceOf[String]
+      if (vis == null || TextTools.isWhitespace(vis)) {
+        throw new IllegalArgumentException("Feature does not have required visibility")
+      }
+    } catch {
+      case _: ClassCastException => throw new IllegalArgumentException("Feature does not have required visibility")
+    }
+  }
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -252,17 +252,21 @@ object RichSimpleFeatureType extends Conversions {
     }
     def setVisibilityLevel(vis: VisibilityLevel): Unit = sft.getUserData.put(IndexVisibilityLevel, vis.toString)
 
+    def isVisibilityRequired: Boolean = boolean(sft.getUserData.get(RequireVisibility), default = false)
+    def setVisibilityRequired(required: Boolean): Unit =
+      sft.getUserData.put(RequireVisibility, String.valueOf(required))
+
     def getZ3Interval: TimePeriod = userData[String](IndexZ3Interval) match {
       case None    => TimePeriod.Week
       case Some(i) => TimePeriod.withName(i.toLowerCase)
     }
     def setZ3Interval(i: TimePeriod): Unit = sft.getUserData.put(IndexZ3Interval, i.toString)
 
-    def getS3Interval: TimePeriod = userData[String](S3_INTERVAL_KEY) match {
+    def getS3Interval: TimePeriod = userData[String](IndexS3Interval) match {
       case None    => TimePeriod.Week
       case Some(i) => TimePeriod.withName(i.toLowerCase)
     }
-    def setS3Interval(i: TimePeriod): Unit = sft.getUserData.put(S3_INTERVAL_KEY, i.toString)
+    def setS3Interval(i: TimePeriod): Unit = sft.getUserData.put(IndexS3Interval, i.toString)
 
     def getXZPrecision: Short = userData(IndexXzPrecision).map(short).getOrElse(XZSFC.DefaultPrecision)
     def setXZPrecision(p: Short): Unit = sft.getUserData.put(IndexXzPrecision, p.toString)

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
@@ -45,13 +45,14 @@ object SimpleFeatureTypes {
     val IndexVisibilityLevel  = "geomesa.visibility.level"
     val IndexXzPrecision      = "geomesa.xz.precision"
     val IndexZ3Interval       = "geomesa.z3.interval"
-    val S3_INTERVAL_KEY       = "geomesa.s3.interval"
+    val IndexS3Interval       = "geomesa.s3.interval"
     val IndexZShards          = "geomesa.z.splits"
     val Keywords              = "geomesa.keywords"
     val MixedGeometries       = "geomesa.mixed.geometries"
     val OverrideDtgJoin       = "override.index.dtg.join"
     val OverrideReservedWords = "override.reserved.words"
     val QueryInterceptors     = "geomesa.query.interceptors"
+    val RequireVisibility     = "geomesa.vis.required"
     val StatsEnabled          = "geomesa.stats.enable"
     val TableCompressionType  = "geomesa.table.compression.type" // valid: gz(default), snappy, lzo, bzip2, lz4, zstd
     val TableLogicalTime      = "geomesa.logical.time"
@@ -62,6 +63,9 @@ object SimpleFeatureTypes {
     val TemporalPriority      = "geomesa.temporal.priority"
     val UpdateBackupMetadata  = "schema.update.backup.metadata"
     val UpdateRenameTables    = "schema.update.rename.tables"
+
+    @deprecated("replaced with IndexS3Interval")
+    val S3_INTERVAL_KEY: String = IndexS3Interval
 
     // keep around old values for back compatibility
     @deprecated("EnabledIndices")


### PR DESCRIPTION
* New index configuration `geomesa.vis.required`
* Writes are blocked in the API, so not 100% foolproof
* Accumulo will also apply the ReqVisFilter on all tables

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>