### PR TITLE
Address issues found during GeoMesa 3.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ geospatial analytics.
 
 ## Downloads
 
-**Current release: [3.2.0](https://github.com/locationtech/geomesa/releases/tag/geomesa_2.11-3.2.0)**
+**Current release: [3.2.0](https://github.com/locationtech/geomesa/releases/tag/geomesa-3.2.0)**
 
   &nbsp;&nbsp;&nbsp;&nbsp;
-  [**HBase**](https://github.com/locationtech/geomesa/releases/download/geomesa_2.11-3.2.0/geomesa-hbase_2.11-3.2.0-bin.tar.gz) |
-  [**Accumulo**](https://github.com/locationtech/geomesa/releases/download/geomesa_2.11-3.2.0/geomesa-accumulo_2.11-3.2.0-bin.tar.gz) |
-  [**Cassandra**](https://github.com/locationtech/geomesa/releases/download/geomesa_2.11-3.2.0/geomesa-cassandra_2.11-3.2.0-bin.tar.gz) |
-  [**Kafka**](https://github.com/locationtech/geomesa/releases/download/geomesa_2.11-3.2.0/geomesa-kafka_2.11-3.2.0-bin.tar.gz) |
-  [**Redis**](https://github.com/locationtech/geomesa/releases/download/geomesa_2.11-3.2.0/geomesa-redis_2.11-3.2.0-bin.tar.gz) |
-  [**FileSystem**](https://github.com/locationtech/geomesa/releases/download/geomesa_2.11-3.2.0/geomesa-fs_2.11-3.2.0-bin.tar.gz) |
-  [**Bigtable**](https://github.com/locationtech/geomesa/releases/download/geomesa_2.11-3.2.0/geomesa-bigtable_2.11-3.2.0-bin.tar.gz)
+  [**HBase**](https://github.com/locationtech/geomesa/releases/download/geomesa-3.2.0/geomesa-hbase_2.11-3.2.0-bin.tar.gz) |
+  [**Accumulo**](https://github.com/locationtech/geomesa/releases/download/geomesa-3.2.0/geomesa-accumulo_2.11-3.2.0-bin.tar.gz) |
+  [**Cassandra**](https://github.com/locationtech/geomesa/releases/download/geomesa-3.2.0/geomesa-cassandra_2.11-3.2.0-bin.tar.gz) |
+  [**Kafka**](https://github.com/locationtech/geomesa/releases/download/geomesa-3.2.0/geomesa-kafka_2.11-3.2.0-bin.tar.gz) |
+  [**Redis**](https://github.com/locationtech/geomesa/releases/download/geomesa-3.2.0/geomesa-redis_2.11-3.2.0-bin.tar.gz) |
+  [**FileSystem**](https://github.com/locationtech/geomesa/releases/download/geomesa-3.2.0/geomesa-fs_2.11-3.2.0-bin.tar.gz) |
+  [**Bigtable**](https://github.com/locationtech/geomesa/releases/download/geomesa-3.2.0/geomesa-bigtable_2.11-3.2.0-bin.tar.gz)
 
 ### Verifying Downloads
 

--- a/build/README.md
+++ b/build/README.md
@@ -37,16 +37,16 @@ geospatial analytics.
 
 ## Downloads
 
-**Current release: [${geomesa.release.version}](https://github.com/locationtech/geomesa/releases/tag/geomesa_${scala.binary.version}-${geomesa.release.version})**
+**Current release: [${geomesa.release.version}](https://github.com/locationtech/geomesa/releases/tag/geomesa-${geomesa.release.version})**
 
   &nbsp;&nbsp;&nbsp;&nbsp;
-  [**HBase**](https://github.com/locationtech/geomesa/releases/download/geomesa_${scala.binary.version}-${geomesa.release.version}/geomesa-hbase_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
-  [**Accumulo**](https://github.com/locationtech/geomesa/releases/download/geomesa_${scala.binary.version}-${geomesa.release.version}/geomesa-accumulo_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
-  [**Cassandra**](https://github.com/locationtech/geomesa/releases/download/geomesa_${scala.binary.version}-${geomesa.release.version}/geomesa-cassandra_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
-  [**Kafka**](https://github.com/locationtech/geomesa/releases/download/geomesa_${scala.binary.version}-${geomesa.release.version}/geomesa-kafka_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
-  [**Redis**](https://github.com/locationtech/geomesa/releases/download/geomesa_${scala.binary.version}-${geomesa.release.version}/geomesa-redis_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
-  [**FileSystem**](https://github.com/locationtech/geomesa/releases/download/geomesa_${scala.binary.version}-${geomesa.release.version}/geomesa-fs_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
-  [**Bigtable**](https://github.com/locationtech/geomesa/releases/download/geomesa_${scala.binary.version}-${geomesa.release.version}/geomesa-bigtable_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz)
+  [**HBase**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-hbase_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
+  [**Accumulo**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-accumulo_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
+  [**Cassandra**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-cassandra_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
+  [**Kafka**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-kafka_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
+  [**Redis**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-redis_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
+  [**FileSystem**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-fs_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
+  [**Bigtable**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-bigtable_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz)
 
 ### Verifying Downloads
 

--- a/geomesa-features/geomesa-feature-common/src/main/java/org/locationtech/geomesa/features/interop/SerializationOptions.java
+++ b/geomesa-features/geomesa-feature-common/src/main/java/org/locationtech/geomesa/features/interop/SerializationOptions.java
@@ -9,14 +9,14 @@
 package org.locationtech.geomesa.features.interop;
 
 import org.locationtech.geomesa.features.SerializationOption;
-import org.locationtech.geomesa.features.SerializationOption$;
+import scala.Enumeration;
 
 public class SerializationOptions {
-    public static scala.collection.immutable.Set<SerializationOption$.Value> withUserData() {
+    public static scala.collection.immutable.Set<Enumeration.Value> withUserData() {
         return SerializationOption.SerializationOptions$.MODULE$.withUserData();
     }
 
-    public static scala.collection.immutable.Set<SerializationOption$.Value> withoutId() {
+    public static scala.collection.immutable.Set<Enumeration.Value> withoutId() {
         return SerializationOption.SerializationOptions$.MODULE$.withoutId();
     }
 }

--- a/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/SerializationOption.scala
+++ b/geomesa-features/geomesa-feature-common/src/main/scala/org/locationtech/geomesa/features/SerializationOption.scala
@@ -8,8 +8,6 @@
 
 package org.locationtech.geomesa.features
 
-import org.locationtech.geomesa.features.SerializationOption.Value
-
 /**
  * Options to be applied when encoding.  The same options must be specified when decoding.
  */


### PR DESCRIPTION
* Java classes for SerializationOptions changed from SerializationOption$.Value to Enumeration.Value.
* Optimizes imports.
* Points to build artifacts with the tag structure.