### PR TITLE
time partition filters

### DIFF
--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterHelper.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterHelper.scala
@@ -198,12 +198,14 @@ object FilterHelper {
   def extractAttributeBounds[T](filter: Filter, attribute: String, binding: Class[T]): FilterValues[Bounds[T]] = {
     filter match {
       case o: Or =>
+        val set = o.getChildren.foldLeft(Set.empty[Option[String]])((acc, f) => acc + getAttributeProperty(f))   
         val all = o.getChildren.flatMap { f =>
           val child = extractAttributeBounds(f, attribute, binding)
           if (child.isEmpty) { Seq.empty } else { Seq(child) }
         }
         val union = FilterValues.or[Bounds[T]](Bounds.union[T]) _
-        all.reduceLeftOption[FilterValues[Bounds[T]]](union).getOrElse(FilterValues.empty)
+        if (set.size != 1) FilterValues.empty  
+        else all.reduceLeftOption[FilterValues[Bounds[T]]](union).getOrElse(FilterValues.empty)
 
       case a: And =>
         val all = a.getChildren.flatMap { f =>

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBasePartitioningTest.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/scala/org/locationtech/geomesa/hbase/data/HBasePartitioningTest.scala
@@ -10,7 +10,6 @@ package org.locationtech.geomesa.hbase.data
 
 import java.time.{ZoneOffset, ZonedDateTime}
 import java.util.Date
-
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.data._
 import org.geotools.data.collection.ListFeatureCollection
@@ -20,6 +19,7 @@ import org.geotools.util.factory.Hints
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.hbase.data.HBaseDataStoreParams._
+import org.locationtech.geomesa.hbase.data.HBaseQueryPlan.EmptyPlan
 import org.locationtech.geomesa.index.conf.QueryProperties
 import org.locationtech.geomesa.index.conf.partition.{TablePartition, TimePartition}
 import org.locationtech.geomesa.index.index.attribute.AttributeIndex
@@ -117,6 +117,16 @@ class HBasePartitioningTest extends Specification with LazyLogging {
           testQuery(ds, typeName, "attr = 'name5' and bbox(geom,38,48,52,62) and dtg DURING 2018-01-01T00:00:00.000Z/2018-01-08T12:00:00.000Z", transforms, Seq(toAdd(5)))
           testQuery(ds, typeName, "name < 'name5'", transforms, toAdd.take(5))
           testQuery(ds, typeName, "name = 'name5'", transforms, Seq(toAdd(5)))
+        }
+
+        {
+          val filter = ECQL.toFilter("(bbox(geom,38,48,52,62) and " +
+            "dtg BETWEEN 2018-01-01T00:00:00+00:00 AND 2018-01-04T00:00:00+00:00) OR " +
+            "(bbox(geom,38,48,52,61) and dtg BETWEEN 2018-01-05T00:00:00+00:00 AND 2018-01-08T00:00:00+00:00)")
+          val plans = ds.getQueryPlan(new Query(sft.getTypeName, filter))
+          println(plans)
+          plans must not(beEmpty)
+          plans.head must not(beAnInstanceOf[EmptyPlan])
         }
 
         ds.getFeatureSource(typeName).removeFeatures(ECQL.toFilter("INCLUDE"))

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/geotools/GeoMesaDataStoreTest.scala
@@ -30,6 +30,9 @@ import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.Configs
+import org.locationtech.geomesa.index.conf.partition.TablePartition
+import org.locationtech.geomesa.index.conf.partition.TimePartition
 
 @RunWith(classOf[JUnitRunner])
 class GeoMesaDataStoreTest extends Specification {
@@ -111,6 +114,37 @@ class GeoMesaDataStoreTest extends Specification {
       // other queries should go through as normal
       results = SelfClosingIterator(ds.getFeatureReader(new Query(sft.getTypeName, ECQL.toFilter("bbox(geom,39,54,51,56)")), Transaction.AUTO_COMMIT)).toSeq
       results must haveLength(10)
+    }
+    "time-partitioned queries should return the same result" in {
+      val sftp = SimpleFeatureTypes.createType("test", s"name:String,age:Int,dtg:Date,*geom:Point:srid=4326;" +
+      s"${Configs.TablePartitioning}=${TimePartition.Name}")
+      
+      sftp.getUserData.put(SimpleFeatureTypes.Configs.QueryInterceptors, classOf[TestQueryInterceptor].getName)
+
+      val dsp = new TestGeoMesaDataStore(true)
+      dsp.createSchema(sftp)
+
+      dsp.getFeatureSource(sftp.getTypeName).addFeatures(new ListFeatureCollection(sftp, features.toArray[SimpleFeature]))
+
+      TablePartition.partitioned(sftp) must beTrue
+
+      val filter = "(bbox(geom,39,54,51,56) AND " +
+        "(dtg BETWEEN 2018-01-01T00:00:00+00:00 AND 2018-01-04T00:00:00+00:00)) OR " +
+        "(bbox(geom,39,54,51,57) AND " +
+        "(dtg BETWEEN 2018-01-05T00:00:00+00:00 AND 2018-01-08T00:00:00+00:00))"
+
+      val partitionOption = TablePartition(dsp, sftp)
+      partitionOption must beSome
+      val partition = partitionOption.get
+      val partitionsOption = partition.partitions(ECQL.toFilter(filter))
+      partitionsOption must beSome
+
+      var results = SelfClosingIterator(
+        dsp.getFeatureReader(
+          new Query(sftp.getTypeName, 
+          ECQL.toFilter(filter)), Transaction.AUTO_COMMIT)).toSeq
+      
+      results must not beEmpty
     }
     "block queries which would cause a full table scan" in {
       val sft = SimpleFeatureTypes.createType("61b44359ddb84822983587389d6a28a4",


### PR DESCRIPTION
ignore OR clauses with different attributes when extracting bounds