### PR TITLE
GEOMESA-3158 Seek ahead in Z scans

### DIFF
--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -267,6 +267,13 @@ This property works in conjunction with ``geomesa.scan.block-full-table``, above
 on the number of features that are returned (through the use of ``maxFeatures``), then it will not be blocked.
 The property is specified as an integer. By default, a limit of 1000 or less is allowed.
 
+geomesa.scan.ranges.recurse
++++++++++++++++++++++++++++
+
+This property controls the max level of recursion that will be used when generating scan ranges. Higher levels of
+recursion will generate more accurate ranges at the cost of longer query planning times, and vice-versa. Generally
+this does not need to be configured.
+
 geomesa.scan.ranges.target
 ++++++++++++++++++++++++++
 
@@ -274,6 +281,12 @@ This property provides a rough upper-limit for the number of row ranges that wil
 query. It is specified as a number. In general, more ranges will result in fewer false-positive rows being
 scanned, which will speed up most queries. However, too many ranges can take a long time to generate, and
 overwhelm clients, causing slowdowns. The optimal value depends on the environment.
+
+geomesa.scan.seek
++++++++++++++++++
+
+The property controls seeking in distributed scans. By default seeking is enabled, which should provide the best
+performance.
 
 geomesa.serializer.cache.expiry
 +++++++++++++++++++++++++++++++

--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -273,7 +273,7 @@ geomesa.scan.ranges.recurse
 This property controls the max level of recursion that will be used when generating scan ranges. Higher levels of
 recursion will generate more accurate ranges at the cost of longer query planning times, and lower levels will do
 the opposite. By default there is no limit. Generally this does not need to be configured, and setting it may
-limit the ranges generated to substantially less than ``geomesa.scan.ranges.target``.
+limit the ranges generated to substantially less than ``geomesa.scan.ranges.target``. It is specified as a integer.
 
 geomesa.scan.ranges.target
 ++++++++++++++++++++++++++
@@ -287,7 +287,7 @@ geomesa.scan.seek
 +++++++++++++++++
 
 The property controls seeking in distributed scans. By default seeking is enabled, which should provide the best
-performance.
+performance. It is specified as ``true`` or ``false``.
 
 geomesa.serializer.cache.expiry
 +++++++++++++++++++++++++++++++

--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -271,8 +271,8 @@ geomesa.scan.ranges.recurse
 +++++++++++++++++++++++++++
 
 This property controls the max level of recursion that will be used when generating scan ranges. Higher levels of
-recursion will generate more accurate ranges at the cost of longer query planning times, and vice-versa. Generally
-this does not need to be configured.
+recursion will generate more accurate ranges at the cost of longer query planning times, and vice-versa. By default
+there is no limit. Generally this does not need to be configured.
 
 geomesa.scan.ranges.target
 ++++++++++++++++++++++++++

--- a/docs/user/datastores/runtime_config.rst
+++ b/docs/user/datastores/runtime_config.rst
@@ -271,8 +271,9 @@ geomesa.scan.ranges.recurse
 +++++++++++++++++++++++++++
 
 This property controls the max level of recursion that will be used when generating scan ranges. Higher levels of
-recursion will generate more accurate ranges at the cost of longer query planning times, and vice-versa. By default
-there is no limit. Generally this does not need to be configured.
+recursion will generate more accurate ranges at the cost of longer query planning times, and lower levels will do
+the opposite. By default there is no limit. Generally this does not need to be configured, and setting it may
+limit the ranges generated to substantially less than ``geomesa.scan.ranges.target``.
 
 geomesa.scan.ranges.target
 ++++++++++++++++++++++++++

--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -90,6 +90,16 @@ Compatibility Matrix
 | Dependencies | N     | N     | Y     |
 +--------------+-------+-------+-------+
 
+Version 3.4.0 Upgrade Guide
++++++++++++++++++++++++++++
+
+Scan Range Changes
+------------------
+
+GeoMesa will now generate a more accurate number of ranges based on ``geomesa.scan.ranges.target``. Users
+who have configured this property should verify their setting is still appropriate, especially if set to a
+large value. Setting ``geomesa.scan.ranges.recurse`` to ``7`` will restore the old behavior if needed.
+
 Version 3.3.0 Upgrade Guide
 +++++++++++++++++++++++++++
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloIndexAdapter.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloIndexAdapter.scala
@@ -239,11 +239,12 @@ class AccumuloIndexAdapter(ds: AccumuloDataStore) extends IndexAdapter[AccumuloD
           val indexIter = if (index.name == Z3Index.name) {
             strategy.values.toSeq.map { case v: Z3IndexValues =>
               val offset = index.keySpace.sharding.length + index.keySpace.sharing.length
-              Z3Iterator.configure(v, offset, hints.getFilterCompatibility, ZIterPriority)
+              Z3Iterator.configure(v, offset, hints, ZIterPriority)
             }
           } else if (index.name == Z2Index.name) {
             strategy.values.toSeq.map { case v: Z2IndexValues =>
-              Z2Iterator.configure(v, index.keySpace.sharding.length + index.keySpace.sharing.length, ZIterPriority)
+              val offset = index.keySpace.sharding.length + index.keySpace.sharing.length
+              Z2Iterator.configure(v, offset, hints, ZIterPriority)
             }
           } else if (index.name == S3Index.name) {
             strategy.values.toSeq.map { case v: S3IndexValues =>

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z2Iterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/Z2Iterator.scala
@@ -9,16 +9,22 @@
 package org.locationtech.geomesa.accumulo.iterators
 
 import org.apache.accumulo.core.client.IteratorSetting
+import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.index.filters.Z2Filter
 import org.locationtech.geomesa.index.index.z2.Z2IndexValues
 
 class Z2Iterator extends RowFilterIterator[Z2Filter](Z2Filter)
 
 object Z2Iterator {
-  def configure(values: Z2IndexValues, offset: Int, priority: Int): IteratorSetting = {
+
+  @deprecated
+  def configure(values: Z2IndexValues, offset: Int, priority: Int): IteratorSetting =
+    configure(values, offset, new Hints(), priority)
+
+  def configure(values: Z2IndexValues, offset: Int, hints: Hints, priority: Int): IteratorSetting = {
     val is = new IteratorSetting(priority, "z2", classOf[Z2Iterator])
     // index space values for comparing in the iterator
-    Z2Filter.serializeToStrings(Z2Filter(values)).foreach { case (k, v) => is.addOption(k, v) }
+    Z2Filter.serializeToStrings(Z2Filter(values, hints)).foreach { case (k, v) => is.addOption(k, v) }
     // account for shard and table sharing bytes
     is.addOption(RowFilterIterator.RowOffsetKey, offset.toString)
     is

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseIndexAdapter.scala
@@ -231,12 +231,12 @@ class HBaseIndexAdapter(ds: HBaseDataStore) extends IndexAdapter[HBaseDataStore]
       val indexFilter = strategy.index match {
         case _: Z3Index =>
           strategy.values.map { case v: Z3IndexValues =>
-            (Z3HBaseFilter.Priority, Z3HBaseFilter(Z3Filter(v), index.keySpace.sharding.length))
+            (Z3HBaseFilter.Priority, Z3HBaseFilter(Z3Filter(v, hints), index.keySpace.sharding.length))
           }
 
         case _: Z2Index =>
           strategy.values.map { case v: Z2IndexValues =>
-            (Z2HBaseFilter.Priority, Z2HBaseFilter(Z2Filter(v), index.keySpace.sharding.length))
+            (Z2HBaseFilter.Priority, Z2HBaseFilter(Z2Filter(v, hints), index.keySpace.sharding.length))
           }
 
         case _: S2Index =>

--- a/geomesa-hbase/geomesa-hbase-rpc/src/main/scala/org/locationtech/geomesa/hbase/rpc/filter/Z3HBaseFilter.scala
+++ b/geomesa-hbase/geomesa-hbase-rpc/src/main/scala/org/locationtech/geomesa/hbase/rpc/filter/Z3HBaseFilter.scala
@@ -8,23 +8,48 @@
 
 package org.locationtech.geomesa.hbase.rpc.filter
 
-import com.github.benmanes.caffeine.cache.{CacheLoader, Caffeine}
+import com.github.benmanes.caffeine.cache.{CacheLoader, Caffeine, LoadingCache}
 import com.typesafe.scalalogging.StrictLogging
-import org.apache.hadoop.hbase.Cell
 import org.apache.hadoop.hbase.exceptions.DeserializationException
 import org.apache.hadoop.hbase.filter.{Filter, FilterBase}
+import org.apache.hadoop.hbase.{Cell, KeyValue}
+import org.locationtech.geomesa.index.filters.RowFilter.FilterResult
 import org.locationtech.geomesa.index.filters.Z3Filter
 import org.locationtech.geomesa.utils.cache.ByteArrayCacheKey
 import org.locationtech.geomesa.utils.index.ByteArrays
 
 class Z3HBaseFilter(filter: Z3Filter, offset: Int, bytes: Array[Byte]) extends FilterBase {
 
+  private var nextBytes: Array[Byte] = _
+
   override def filterKeyValue(v: Cell): Filter.ReturnCode = {
-    if (filter.inBounds(v.getRowArray, v.getRowOffset + offset)) {
-      Filter.ReturnCode.INCLUDE
-    } else {
-      Filter.ReturnCode.SKIP
+    filter.filter(v.getRowArray, v.getRowOffset + offset) match {
+      case FilterResult.InBounds => Filter.ReturnCode.INCLUDE
+      case FilterResult.OutOfBounds => Filter.ReturnCode.SKIP
+      case FilterResult.SkipAhead(next) => nextBytes = next; Filter.ReturnCode.SEEK_NEXT_USING_HINT
     }
+  }
+
+  override def getNextCellHint(v: Cell): Cell = {
+    val row = Array.ofDim[Byte](nextBytes.length + offset)
+    System.arraycopy(v.getRowArray, v.getRowOffset, row, 0, offset)
+    System.arraycopy(nextBytes, 0, row, offset, nextBytes.length)
+    new KeyValue(
+      row,
+      0,
+      row.length,
+      v.getFamilyArray,
+      v.getFamilyOffset,
+      v.getFamilyLength,
+      v.getQualifierArray,
+      v.getQualifierOffset,
+      v.getQualifierLength,
+      v.getTimestamp,
+      KeyValue.Type.Maximum,
+      Array.empty,
+      0,
+      0
+    )
   }
 
   override def toByteArray: Array[Byte] = bytes
@@ -38,16 +63,17 @@ object Z3HBaseFilter extends StrictLogging {
 
   val Priority = 20
 
-  private val cache = Caffeine.newBuilder().maximumSize(ZFilterCacheSize.toInt.get).build(
-    new CacheLoader[ByteArrayCacheKey, (Z3Filter, Int)]() {
-      override def load(key: ByteArrayCacheKey): (Z3Filter, Int) = {
-        val filter = Z3Filter.deserializeFromBytes(key.bytes)
-        val offset = ByteArrays.readInt(key.bytes, key.bytes.length - 4)
-        logger.trace(s"Deserialized $offset:$filter")
-        (filter, offset)
+  private val cache: LoadingCache[ByteArrayCacheKey, (Z3Filter, Int)] =
+    Caffeine.newBuilder().maximumSize(ZFilterCacheSize.toInt.get).build(
+      new CacheLoader[ByteArrayCacheKey, (Z3Filter, Int)]() {
+        override def load(key: ByteArrayCacheKey): (Z3Filter, Int) = {
+          val filter = Z3Filter.deserializeFromBytes(key.bytes)
+          val offset = ByteArrays.readInt(key.bytes, key.bytes.length - 4)
+          logger.trace(s"Deserialized $offset:$filter")
+          (filter, offset)
+        }
       }
-    }
-  )
+    )
 
   /**
     * Create a new filter. Typically, filters created by this method will just be serialized to bytes and sent

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryHints.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryHints.scala
@@ -40,6 +40,7 @@ object QueryHints {
 
   val EXACT_COUNT      = new ClassKey(classOf[java.lang.Boolean])
   val LOOSE_BBOX       = new ClassKey(classOf[java.lang.Boolean])
+  val SCAN_SEEKING     = new ClassKey(classOf[java.lang.Boolean])
 
   val SAMPLING         = new ClassKey(classOf[java.lang.Float])
   val SAMPLE_BY        = new ClassKey(classOf[String])
@@ -186,6 +187,11 @@ object QueryHints {
       Option(hints.get(LAMBDA_QUERY_PERSISTENT).asInstanceOf[java.lang.Boolean]).forall(_.booleanValue)
     def isLambdaQueryTransient: Boolean =
       Option(hints.get(LAMBDA_QUERY_TRANSIENT).asInstanceOf[java.lang.Boolean]).forall(_.booleanValue)
+    def isScanSeeking: Boolean =
+      Option(hints.get(SCAN_SEEKING).asInstanceOf[java.lang.Boolean])
+          .map(_.booleanValue())
+          .orElse(QueryProperties.ScanSeek.toBoolean)
+          .getOrElse(true)
 
     def getFilterCompatibility: Option[FilterCompatibility] = {
       Option(hints.get(FILTER_COMPAT).asInstanceOf[String]).map { c =>

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryProperties.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryProperties.scala
@@ -22,6 +22,7 @@ object QueryProperties {
 
   // rough upper limit on the number of ranges we will generate per query
   val ScanRangesTarget: SystemProperty = SystemProperty("geomesa.scan.ranges.target", "2000")
+  val ScanSeek        : SystemProperty = SystemProperty("geomesa.scan.seek", "true")
 
   // decomposition is disabled by default
   val PolygonDecompMultiplier: SystemProperty = SystemProperty("geomesa.query.decomposition.multiplier", "0")

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/RowFilter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/RowFilter.scala
@@ -9,7 +9,17 @@
 package org.locationtech.geomesa.index.filters
 
 trait RowFilter {
+
+  import RowFilter.FilterResult
+
+  @deprecated("replaced with filter")
   def inBounds(buf: Array[Byte], offset: Int): Boolean
+
+  // TODO remove default impl in next major version
+  def filter(row: Array[Byte], offset: Int): FilterResult = {
+    // noinspection ScalaDeprecation
+    if (inBounds(row, offset)) { FilterResult.InBounds } else { FilterResult.OutOfBounds }
+  }
 }
 
 object RowFilter {
@@ -20,5 +30,13 @@ object RowFilter {
 
     def serializeToStrings(filter: T): Map[String, String]
     def deserializeFromStrings(serialized: scala.collection.Map[String, String]): T
+  }
+
+  sealed trait FilterResult
+
+  object FilterResult {
+    case object InBounds extends FilterResult
+    case object OutOfBounds extends FilterResult
+    case class SkipAhead(next: Array[Byte]) extends FilterResult
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z2Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z2Filter.scala
@@ -8,8 +8,9 @@
 
 package org.locationtech.geomesa.index.filters
 
-import java.nio.ByteBuffer
+import org.geotools.util.factory.Hints
 
+import java.nio.ByteBuffer
 import org.locationtech.geomesa.index.filters.RowFilter.RowFilterFactory
 import org.locationtech.geomesa.index.filters.Z3Filter._
 import org.locationtech.geomesa.index.index.z2.Z2IndexValues
@@ -38,10 +39,16 @@ class Z2Filter(val xy: Array[Array[Int]]) extends RowFilter {
 
 object Z2Filter extends RowFilterFactory[Z2Filter] {
 
+  import org.locationtech.geomesa.index.conf.QueryHints.RichHints
+
   private val RangeSeparator = ":"
   private val TermSeparator  = ";"
 
-  def apply(values: Z2IndexValues): Z2Filter = {
+  def apply(values: Z2IndexValues): Z2Filter = apply(values, seek = true)
+
+  def apply(values: Z2IndexValues, hints: Hints): Z2Filter = apply(values, hints.isScanSeeking)
+
+  private def apply(values: Z2IndexValues, seek: Boolean): Z2Filter = {
     val sfc = values.sfc
     val xy: Array[Array[Int]] = values.spatialBounds.map { case (xmin, ymin, xmax, ymax) =>
       Array(sfc.lon.normalize(xmin), sfc.lat.normalize(ymin), sfc.lon.normalize(xmax), sfc.lat.normalize(ymax))

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z2Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z2Filter.scala
@@ -8,30 +8,68 @@
 
 package org.locationtech.geomesa.index.filters
 
+import com.typesafe.scalalogging.StrictLogging
 import org.geotools.util.factory.Hints
-import org.locationtech.geomesa.index.filters.RowFilter.RowFilterFactory
-import org.locationtech.geomesa.index.filters.Z3Filter._
+import org.locationtech.geomesa.index.filters.RowFilter.{FilterResult, RowFilterFactory}
 import org.locationtech.geomesa.index.index.z2.Z2IndexValues
 import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.sfcurve.zorder.Z2
 
 import java.nio.ByteBuffer
 
-class Z2Filter(val xy: Array[Array[Int]]) extends RowFilter {
+class Z2Filter(val xy: Array[Array[Int]], val seek: Boolean) extends RowFilter with StrictLogging {
 
-  override def inBounds(buf: Array[Byte], offset: Int): Boolean = {
-    val z = ByteArrays.readLong(buf, offset)
+  private val zBounds: Array[Array[Long]] = Z2Filter.zBounds(xy)
+
+  override def filter(row: Array[Byte], offset: Int): FilterResult = {
+    val z = ByteArrays.readLong(row, offset)
     val x = Z2(z).d0
     val y = Z2(z).d1
     var i = 0
     while (i < xy.length) {
       val xyi = xy(i)
       if (x >= xyi(0) && x <= xyi(2) && y >= xyi(1) && y <= xyi(3)) {
-        return true
+        return FilterResult.InBounds
       }
       i += 1
     }
-    false
+
+    if (seek) {
+      nextJumpIn(z)
+    } else {
+      FilterResult.OutOfBounds
+    }
+  }
+
+  // noinspection ScalaDeprecation
+  override def inBounds(row: Array[Byte], offset: Int): Boolean = {
+    filter(row, offset) match {
+      case FilterResult.InBounds => true
+      case _ => false
+    }
+  }
+
+  private def nextJumpIn(z: Long): FilterResult = {
+    var nextZ = Long.MaxValue
+
+    var i = 0
+    while (i < zBounds.length) {
+      val Array(zmin, zmax) = zBounds(i)
+      if (z < zmin) {
+        if (zmin < nextZ) {
+          nextZ = zmin
+        }
+      } else if (z < zmax) {
+        val next = Z2.zdivide(z, zmin, zmax)._2
+        if (next < nextZ) {
+          nextZ = next
+        }
+      }
+      i += 1
+    }
+
+    logger.trace(s"Seeking ahead from $z to $nextZ")
+    FilterResult.SkipAhead(ByteArrays.toBytes(nextZ))
   }
 
   override def toString: String = Z2Filter.serializeToStrings(this).toSeq.sortBy(_._1).mkString(",")
@@ -40,6 +78,8 @@ class Z2Filter(val xy: Array[Array[Int]]) extends RowFilter {
 object Z2Filter extends RowFilterFactory[Z2Filter] {
 
   import org.locationtech.geomesa.index.conf.QueryHints.RichHints
+
+  private val ZBoundsOrdering = Ordering.by[Array[Long], Long](_.head)
 
   private val RangeSeparator = ":"
   private val TermSeparator  = ";"
@@ -54,16 +94,17 @@ object Z2Filter extends RowFilterFactory[Z2Filter] {
       Array(sfc.lon.normalize(xmin), sfc.lat.normalize(ymin), sfc.lon.normalize(xmax), sfc.lat.normalize(ymax))
     }.toArray
 
-    new Z2Filter(xy)
+    new Z2Filter(xy, seek)
   }
 
   override def serializeToBytes(filter: Z2Filter): Array[Byte] = {
-    // 4 bytes for length plus 16 bytes for each xy val (4 ints)
-    val xyLength = 4 + filter.xy.length * 16
+    // 4 bytes for length plus 1 byte for seek plus 16 bytes for each xy val (4 ints)
+    val xyLength = 5 + filter.xy.length * 16
     val buffer = ByteBuffer.allocate(xyLength)
 
     buffer.putInt(filter.xy.length)
     filter.xy.foreach(bounds => bounds.foreach(buffer.putInt))
+    buffer.put(if (filter.seek) { 1.toByte } else { 0.toByte })
 
     buffer.array()
   }
@@ -71,16 +112,26 @@ object Z2Filter extends RowFilterFactory[Z2Filter] {
   override def deserializeFromBytes(serialized: Array[Byte]): Z2Filter = {
     val buffer = ByteBuffer.wrap(serialized)
     val xy = Array.fill(buffer.getInt())(Array.fill(4)(buffer.getInt))
-    new Z2Filter(xy)
+    val seek = if (buffer.hasRemaining) { buffer.get() > 0 } else { true }
+    new Z2Filter(xy, seek)
   }
 
   override def serializeToStrings(filter: Z2Filter): Map[String, String] = {
     val xy = filter.xy.map(bounds => bounds.mkString(RangeSeparator)).mkString(TermSeparator)
-    Map(XYKey -> xy)
+    Map(Z3Filter.XYKey -> xy, Z3Filter.SeekKey -> java.lang.Boolean.toString(filter.seek))
   }
 
   override def deserializeFromStrings(serialized: scala.collection.Map[String, String]): Z2Filter = {
-    val xy = serialized(XYKey).split(TermSeparator).map(_.split(RangeSeparator).map(_.toInt))
-    new Z2Filter(xy)
+    val xy = serialized(Z3Filter.XYKey).split(TermSeparator).map(_.split(RangeSeparator).map(_.toInt))
+    new Z2Filter(xy, serialized.get(Z3Filter.SeekKey).forall(_.toBoolean))
+  }
+
+  /**
+   * Gets z-low and z-hi for a bounding box in normalized space
+   */
+  private def zBounds(xy: Array[Array[Int]]): Array[Array[Long]] = {
+    val bounds = xy.map { case Array(xmin, ymin, xmax, ymax) => Array(Z2(xmin, ymin).z, Z2(xmax, ymax).z) }
+    java.util.Arrays.sort(bounds, ZBoundsOrdering)
+    bounds
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z2Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z2Filter.scala
@@ -9,13 +9,13 @@
 package org.locationtech.geomesa.index.filters
 
 import org.geotools.util.factory.Hints
-
-import java.nio.ByteBuffer
 import org.locationtech.geomesa.index.filters.RowFilter.RowFilterFactory
 import org.locationtech.geomesa.index.filters.Z3Filter._
 import org.locationtech.geomesa.index.index.z2.Z2IndexValues
 import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.sfcurve.zorder.Z2
+
+import java.nio.ByteBuffer
 
 class Z2Filter(val xy: Array[Array[Int]]) extends RowFilter {
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
@@ -52,7 +52,8 @@ class Z3Filter(
     val bounds = xy.map { case Array(xmin, ymin, xmax, ymax) =>
       Z3Filter.zBound(xmin, ymin, 0, xmax, ymax, maxTime)
     }
-    ZBounds(bounds, bounds.map(_.head).min)
+    java.util.Arrays.sort(bounds, Z3Filter.ZBoundsOrdering)
+    ZBounds(bounds, bounds.head.head)
   }
 
   private val zBounds: Array[ZBounds] = if (!seek) { null } else {
@@ -64,7 +65,8 @@ class Z3Filter(
             Z3Filter.zBound(xmin, ymin, tmin, xmax, ymax, tmax)
           }
         }
-        ZBounds(bounds, bounds.map(_.head).min)
+        java.util.Arrays.sort(bounds, Z3Filter.ZBoundsOrdering)
+        ZBounds(bounds, bounds.head.head)
     }
   }
 
@@ -167,6 +169,8 @@ class Z3Filter(
 object Z3Filter extends RowFilterFactory[Z3Filter] {
 
   import org.locationtech.geomesa.index.conf.QueryHints.RichHints
+
+  private val ZBoundsOrdering = Ordering.by[Array[Long], Long](_.head)
 
   private val RangeSeparator = ":"
   private val TermSeparator  = ";"

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
@@ -8,23 +8,85 @@
 
 package org.locationtech.geomesa.index.filters
 
-import java.nio.ByteBuffer
-
-import org.locationtech.geomesa.index.filters.RowFilter.RowFilterFactory
+import com.typesafe.scalalogging.StrictLogging
+import org.geotools.util.factory.Hints
+import org.locationtech.geomesa.index.filters.RowFilter.{FilterResult, RowFilterFactory}
+import org.locationtech.geomesa.index.filters.Z3Filter.ZBounds
 import org.locationtech.geomesa.index.index.z3.Z3IndexValues
 import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.sfcurve.zorder.Z3
 
+import java.nio.ByteBuffer
+
+/**
+ * Z3 filter implementation
+ *
+ * @param xy spatial bounds
+ *           <ul><li>each element of the outer array is a bounding box</li>
+ *           <li>the inner arrays wil always have 4 elements, consisting of (xmin,ymin,xmax,ymax)</li></ul>
+ *           for example, `bbox(0,1,2,3) OR bbox(4,5,6,7)` would be `Array(Array(0,1,2,3), Array(4,5,6,7))`
+ *
+ * @param t temporal bounds
+ *          <ul><li>each element of the outer array is the times for a particular epoch, indexed by (epoch - epochOffset)
+ *            if the epoch is < epochOffset or > t.length + epochOffset, or the element corresponding to the epoch is null, then
+ *            the entire epoch is included in the time filter</li>
+ *          <li>each element of the second array is a time bound within the given epoch</li>
+ *          <li>the inner arrays will always have 2 elements, consisting of (min time, max time)</li>
+ *          <li>the outer array may be empty, which indicates all epochs are fully included in the time filter</li></ul>
+ *          for example, `during t1/t2 OR during t3/t4` would be `Array(Array(Array(tz1,tz2), Array(tz3,tz4)))`
+ *            (assuming a single epoch). tz refers to the time offset within the epoch
+ *
+ * @param epochOffset offset into the temporal bounds array
+ * @param maxTime max time for our space-filling curve
+ * @param seek whether to seek or not
+ */
 class Z3Filter(
     val xy: Array[Array[Int]],
     val t: Array[Array[Array[Int]]],
-    val minEpoch: Short,
-    val maxEpoch: Short
-  ) extends RowFilter {
+    val epochOffset: Short,
+    val maxTime: Int,
+    val seek: Boolean
+  ) extends RowFilter with StrictLogging {
 
+  private val zBoundsNoTime: ZBounds = if (!seek) { null } else {
+    val bounds = xy.map { case Array(xmin, ymin, xmax, ymax) =>
+      Z3Filter.zBound(xmin, ymin, 0, xmax, ymax, maxTime)
+    }
+    ZBounds(bounds, bounds.map(_.head).min)
+  }
+
+  private val zBounds: Array[ZBounds] = if (!seek) { null } else {
+    t.map {
+      case null => zBoundsNoTime
+      case ti =>
+        val bounds = ti.flatMap { case Array(tmin, tmax) =>
+          xy.map { case Array(xmin, ymin, xmax, ymax) =>
+            Z3Filter.zBound(xmin, ymin, tmin, xmax, ymax, tmax)
+          }
+        }
+        ZBounds(bounds, bounds.map(_.head).min)
+    }
+  }
+
+  override def filter(row: Array[Byte], offset: Int): FilterResult = {
+    // row consists of 2-byte epoch + 8 byte z value
+    val epoch = ByteArrays.readShort(row, offset)
+    val keyZ = ByteArrays.readLong(row, offset + 2)
+    if (pointInBounds(keyZ) && timeInBounds(epoch, keyZ)) {
+      FilterResult.InBounds
+    } else if (seek) {
+      nextJumpIn(epoch, keyZ)
+    } else {
+      FilterResult.OutOfBounds
+    }
+  }
+
+  // noinspection ScalaDeprecation
   override def inBounds(buf: Array[Byte], offset: Int): Boolean = {
-    val keyZ = ByteArrays.readLong(buf, offset + 2) // account for epoch - first 2 bytes
-    pointInBounds(keyZ) && timeInBounds(ByteArrays.readShort(buf, offset), keyZ)
+    filter(buf, offset) match {
+      case FilterResult.InBounds => true
+      case _ => false
+    }
   }
 
   private def pointInBounds(z: Long): Boolean = {
@@ -42,9 +104,10 @@ class Z3Filter(
   }
 
   private def timeInBounds(epoch: Short, z: Long): Boolean = {
+    val iEpoch = epoch - epochOffset
     // we know we're only going to scan appropriate epochs, so leave out whole epochs
-    if (epoch > maxEpoch || epoch < minEpoch) { true } else {
-      val tEpoch = t(epoch - minEpoch)
+    if (iEpoch < 0 || iEpoch >= t.length) { true } else {
+      val tEpoch = t(iEpoch)
       if (tEpoch == null) { true } else {
         val time = Z3(z).d2
         var i = 0
@@ -60,20 +123,87 @@ class Z3Filter(
     }
   }
 
+  private def nextJumpIn(epoch: Short, z: Long): FilterResult = {
+    val epochIndex = epoch - epochOffset
+    val zb = if (epochIndex < 0 || epochIndex >= zBounds.length) { zBoundsNoTime } else { zBounds(epochIndex) }
+
+    var nextZ = Long.MaxValue
+
+    var i = 0
+    while (i < zb.bounds.length) {
+      val Array(zmin, zmax) = zb.bounds(i)
+      if (z < zmin) {
+        if (zmin < nextZ) {
+          nextZ = zmin
+        }
+      } else if (z < zmax) {
+        val next = Z3.zdivide(z, zmin, zmax)._2
+        if (next < nextZ) {
+          nextZ = next
+        }
+      }
+      i += 1
+    }
+
+    var nextEpoch = epoch
+
+    if (nextZ == Long.MaxValue && epoch != Short.MaxValue) {
+      val nextEpochIndex = epochIndex + 1
+      if (nextEpochIndex < 0 || nextEpochIndex >= zBounds.length) {
+        nextZ = zBoundsNoTime.min
+      } else {
+        nextZ = zBounds(nextEpochIndex).min
+      }
+      nextEpoch = (epoch + 1).toShort
+    }
+
+    logger.trace(s"Seeking ahead from $epoch:$z to $nextEpoch:$nextZ")
+    FilterResult.SkipAhead(ByteArrays.toBytes(nextEpoch, nextZ))
+  }
+
   override def toString: String = Z3Filter.serializeToStrings(this).toSeq.sortBy(_._1).mkString(",")
 }
 
 object Z3Filter extends RowFilterFactory[Z3Filter] {
 
+  import org.locationtech.geomesa.index.conf.QueryHints.RichHints
+
   private val RangeSeparator = ":"
   private val TermSeparator  = ";"
   private val EpochSeparator = ","
 
-  val XYKey     = "zxy"
-  val TKey      = "zt"
-  val EpochKey  = "epoch"
+  val VersionKey = "v"
+  val XYKey      = "zxy"
+  val TKey       = "zt"
+  val EpochKey   = "epoch"
+  val MaxTimeKey = "mt"
+  val SeekKey    = "s"
 
-  def apply(values: Z3IndexValues): Z3Filter = {
+
+  // note: we use a negative version number to ensure that we error out with a negative length if an older version
+  // of the filter tries to deserialize a newer serialized buffer. This was verified with the code snippet below
+  val Version: Byte = -1
+
+  //  val buf = ByteBuffer.allocate(5)
+  //  val read = ByteBuffer.wrap(buf.array())
+  //  (-9 to -1).map(_.toByte).foreach { version =>
+  //    buf.clear()
+  //    buf.put(version).mark()
+  //    (0 to 10000).foreach { i =>
+  //      buf.reset()
+  //      buf.putInt(i)
+  //      read.clear()
+  //      read.getInt must beLessThan(0)
+  //      read.position(1)
+  //      read.get() must beGreaterThanOrEqualTo(0.toByte)
+  //    }
+  //  }
+
+  def apply(values: Z3IndexValues): Z3Filter = apply(values, seek = true)
+
+  def apply(values: Z3IndexValues, hints: Hints): Z3Filter = apply(values, hints.isScanSeeking)
+
+  private def apply(values: Z3IndexValues, seek: Boolean): Z3Filter = {
     val Z3IndexValues(sfc, _, spatialBounds, _, temporalBounds, _) = values
 
     val xy: Array[Array[Int]] = spatialBounds.map { case (xmin, ymin, xmax, ymax) =>
@@ -104,7 +234,8 @@ object Z3Filter extends RowFilterFactory[Z3Filter] {
 
     epochsAndTimes.foreach { case (w, times) => t(w - minEpoch) = times }
 
-    new Z3Filter(xy, t, minEpoch, maxEpoch)
+    // note: disable seek if we have no valid dimensions (degenerate scan case)
+    new Z3Filter(xy, t, minEpoch, sfc.time.normalize(wholePeriod.head._2), seek && xy.nonEmpty)
   }
 
   override def serializeToBytes(filter: Z3Filter): Array[Byte] = {
@@ -112,9 +243,10 @@ object Z3Filter extends RowFilterFactory[Z3Filter] {
     val xyLength = 4 + filter.xy.length * 16
     // 4 bytes for length, then per-epoch 4 bytes for length plus 8 bytes for each t val (2 ints)
     val tLength = 4 + filter.t.map(bounds => if (bounds == null) { 4 } else { 4 + bounds.length * 8 } ).sum
-    // additional 4 bytes for min/max epoch
-    val buffer = ByteBuffer.allocate(xyLength + tLength + 4)
+    // additional 1 byte fore version, 2 bytes for epoch offset, 4 bytes for max time, 1 byte for seek
+    val buffer = ByteBuffer.allocate(xyLength + tLength + 8)
 
+    buffer.put(Version)
     buffer.putInt(filter.xy.length)
     filter.xy.foreach(bounds => bounds.foreach(buffer.putInt))
 
@@ -128,14 +260,30 @@ object Z3Filter extends RowFilterFactory[Z3Filter] {
       }
     }
 
-    buffer.putShort(filter.minEpoch)
-    buffer.putShort(filter.maxEpoch)
+    buffer.putShort(filter.epochOffset)
+    buffer.putInt(filter.maxTime)
+    buffer.put(if (filter.seek) { 1.toByte } else { 0.toByte })
 
     buffer.array()
   }
 
   override def deserializeFromBytes(serialized: Array[Byte]): Z3Filter = {
     val buffer = ByteBuffer.wrap(serialized)
+
+    val version = buffer.get()
+    val maxTimeOpt = version match {
+      case -1 =>
+        None
+
+      case v if v > 0 =>
+        // back compatibility with older clients
+        // reset to start of buffer and set the max time, which isn't in the buffer
+        buffer.clear()
+        Some(0)
+
+      case _ =>
+        throw new IllegalArgumentException("Unexpected serialized filter")
+    }
 
     val xy = Array.fill(buffer.getInt())(Array.fill(4)(buffer.getInt))
     val t = Array.fill(buffer.getInt) {
@@ -144,10 +292,11 @@ object Z3Filter extends RowFilterFactory[Z3Filter] {
         Array.fill(length)(Array.fill(2)(buffer.getInt))
       }
     }
-    val minEpoch = buffer.getShort
-    val maxEpoch = buffer.getShort
+    val epochOffset = buffer.getShort
+    val maxTime = maxTimeOpt.getOrElse(buffer.getInt)
+    val seek = if (maxTimeOpt.isEmpty) { buffer.get > 0 } else { false }
 
-    new Z3Filter(xy, t, minEpoch, maxEpoch)
+    new Z3Filter(xy, t, epochOffset, maxTime, seek)
   }
 
   override def serializeToStrings(filter: Z3Filter): Map[String, String] = {
@@ -157,24 +306,38 @@ object Z3Filter extends RowFilterFactory[Z3Filter] {
         bounds.map(_.mkString(RangeSeparator)).mkString(TermSeparator)
       }
     }.mkString(EpochSeparator)
-    val epoch = s"${filter.minEpoch}$RangeSeparator${filter.maxEpoch}"
 
     Map(
-      XYKey    -> xy,
-      TKey     -> t,
-      EpochKey -> epoch
+      VersionKey -> java.lang.Byte.toString(Version),
+      XYKey      -> xy,
+      TKey       -> t,
+      EpochKey   -> java.lang.Short.toString(filter.epochOffset),
+      MaxTimeKey -> Integer.toString(filter.maxTime),
+      SeekKey    -> java.lang.Boolean.toString(filter.seek)
     )
   }
 
   override def deserializeFromStrings(serialized: scala.collection.Map[String, String]): Z3Filter = {
+    val (maxTime, epochOffset, seek) = serialized.get(VersionKey) match {
+      case Some("-1") => (serialized(MaxTimeKey).toInt, serialized(EpochKey).toShort, serialized(SeekKey).toBoolean)
+      case None       => (0, serialized(EpochKey).split(RangeSeparator).head.toShort, false)
+      case Some(v)    => throw new IllegalArgumentException(s"Unexpected serialized filter version $v")
+    }
     val xy = serialized(XYKey).split(TermSeparator).map(_.split(RangeSeparator).map(_.toInt))
     val t = serialized(TKey).split(EpochSeparator).map { bounds =>
       if (bounds.isEmpty) { null } else {
         bounds.split(TermSeparator).map(_.split(RangeSeparator).map(_.toInt))
       }
     }
-    val Array(minEpoch, maxEpoch) = serialized(EpochKey).split(RangeSeparator).map(_.toShort)
 
-    new Z3Filter(xy, t, minEpoch, maxEpoch)
+    new Z3Filter(xy, t, epochOffset, maxTime, seek)
   }
+
+  /**
+   * Gets z-low and z-hi for a bounding box in normalized space
+   */
+  private def zBound(xmin: Int, ymin: Int, tmin: Int, xmax: Int, ymax: Int, tmax: Int): Array[Long] =
+    Array(Z3(xmin, ymin, tmin).z, Z3(xmax, ymax, tmax).z)
+
+  private case class ZBounds(bounds: Array[Array[Long]], min: Long)
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
@@ -243,7 +243,7 @@ object Z3Filter extends RowFilterFactory[Z3Filter] {
     val xyLength = 4 + filter.xy.length * 16
     // 4 bytes for length, then per-epoch 4 bytes for length plus 8 bytes for each t val (2 ints)
     val tLength = 4 + filter.t.map(bounds => if (bounds == null) { 4 } else { 4 + bounds.length * 8 } ).sum
-    // additional 1 byte fore version, 2 bytes for epoch offset, 4 bytes for max time, 1 byte for seek
+    // additional 1 byte for version, 2 bytes for epoch offset, 4 bytes for max time, 1 byte for seek
     val buffer = ByteBuffer.allocate(xyLength + tLength + 8)
 
     buffer.put(Version)

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
@@ -339,5 +339,12 @@ object Z3Filter extends RowFilterFactory[Z3Filter] {
   private def zBound(xmin: Int, ymin: Int, tmin: Int, xmax: Int, ymax: Int, tmax: Int): Array[Long] =
     Array(Z3(xmin, ymin, tmin).z, Z3(xmax, ymax, tmax).z)
 
+  /**
+   * Holds z values for seeking in a given epoch
+   *
+   * @param bounds the inner array is tuples of min/max z values for valid scan ranges,
+   *               the outer array is to hold all the valid tuples
+   * @param min the absolute min z value in the bounds, used when seeking from a previous epoch
+   */
   private case class ZBounds(bounds: Array[Array[Long]], min: Long)
 }

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/filters/Z3FilterTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/filters/Z3FilterTest.scala
@@ -34,8 +34,8 @@ class Z3FilterTest extends Specification {
   val values = filters.map(keySpace.getIndexValues(_, ExplainNull))
 
   def compare(actual: Z3Filter, expected: Z3Filter): MatchResult[Boolean] = {
-    val left = Array[AnyRef](actual.xy, actual.t, Short.box(actual.minEpoch), Short.box(actual.maxEpoch))
-    val right = Array[AnyRef](expected.xy, expected.t, Short.box(expected.minEpoch), Short.box(expected.maxEpoch))
+    val left = Array[AnyRef](actual.xy, actual.t, Short.box(actual.epochOffset), Int.box(actual.maxTime))
+    val right = Array[AnyRef](expected.xy, expected.t, Short.box(expected.epochOffset), Int.box(expected.maxTime))
     java.util.Arrays.deepEquals(left, right) must beTrue
   }
 

--- a/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3SFC.scala
+++ b/geomesa-z3/src/main/scala/org/locationtech/geomesa/curve/Z3SFC.scala
@@ -55,10 +55,11 @@ class Z3SFC(period: TimePeriod, precision: Int = 21) extends SpaceTimeFillingCur
                       t: Seq[(Long, Long)],
                       precision: Int,
                       maxRanges: Option[Int]): Seq[IndexRange] = {
+    val maxRecursion = sys.props.get("geomesa.scan.ranges.recurse").map(_.toInt).orElse(Some(Int.MaxValue))
     val zbounds = for { (xmin, ymin, xmax, ymax) <- xy ; (tmin, tmax) <- t } yield {
       ZRange(index(xmin, ymin, tmin), index(xmax, ymax, tmax))
     }
-    Z3.zranges(zbounds.toArray, precision, maxRanges)
+    Z3.zranges(zbounds.toArray, precision, maxRanges, maxRecursion)
   }
 }
 


### PR DESCRIPTION
* Z3/Z2 scans will seek to the next valid z-value instead of iterating
* Z range calculations will not stop based on number of recursions
* New query hint `Z_SEEK` can be used to disable seeking
* New system property `geomesa.ranges.recurse` controls level of recursion

Co-authored-by: Jim Hughes <jhughes@ccri.com>