### PR TITLE
GEOMESA-3162: Geomesa client configuration file properly loaded.

### DIFF
--- a/build/copyright/ccri-dstl-mitre.txt
+++ b/build/copyright/ccri-dstl-mitre.txt
@@ -1,0 +1,11 @@
+Copyright (c) ${project.inceptionYear}-2020 ${owner}
+Portions Crown Copyright (c) 2016-2020 Dstl
+Portions MITRE Copyright (c) 2021
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Apache License, Version 2.0
+which accompanies this distribution and is available at
+http://www.opensource.org/licenses/apache2.0.php.
+This software was produced for the U. S. Government under Basic
+Contract No. W56KGU-18-D-0004, and is subject to the Rights in
+Noncommercial Computer Software and Noncommercial Computer Software
+Documentation Clause 252.227-7014 (FEB 2012)

--- a/build/copyright/ccri-dstl-mitre.txt
+++ b/build/copyright/ccri-dstl-mitre.txt
@@ -1,6 +1,6 @@
 Copyright (c) ${project.inceptionYear}-2020 ${owner}
 Portions Crown Copyright (c) 2016-2020 Dstl
-Portions MITRE Copyright (c) 2021
+Portions Copyright (c) 2021 The MITRE Corporation
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Apache License, Version 2.0
 which accompanies this distribution and is available at

--- a/build/copyright/ccri-mitre.txt
+++ b/build/copyright/ccri-mitre.txt
@@ -1,5 +1,5 @@
-Copyright (c) ${project.inceptionYear}-${year} ${owner}
-Portions MITRE Copyright (c) 2021
+Copyright (c) ${project.inceptionYear}-2020 ${owner}
+Portions Copyright (c) 2021 The MITRE Corporation
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Apache License, Version 2.0
 which accompanies this distribution and is available at

--- a/build/copyright/ccri-mitre.txt
+++ b/build/copyright/ccri-mitre.txt
@@ -1,0 +1,10 @@
+Copyright (c) ${project.inceptionYear}-${year} ${owner}
+Portions MITRE Copyright (c) 2021
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Apache License, Version 2.0
+which accompanies this distribution and is available at
+http://www.opensource.org/licenses/apache2.0.php.
+This software was produced for the U. S. Government under Basic
+Contract No. W56KGU-18-D-0004, and is subject to the Rights in
+Noncommercial Computer Software and Noncommercial Computer Software
+Documentation Clause 252.227-7014 (FEB 2012)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloClientConfig.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloClientConfig.scala
@@ -27,7 +27,7 @@ import scala.util.Try
  * Client configuration options, loaded from a config file
  *
  * @param config Accumulo client configuration
- * @param hasInstances instance id or name set in config file
+ * @param hasInstance instance id or name set in config file
  * @param instance instance name (not actually used during configuration)
  * @param zookeepers zookeeper connect string (not actually used during configuration)
  * @param zkTimeout zookeeper timeout (not actually used during configuration)
@@ -38,7 +38,7 @@ import scala.util.Try
 @SuppressWarnings(Array("deprecated"))
 case class AccumuloClientConfig(
     config: ClientConfiguration,
-    hasInstances: Boolean,
+    hasInstance: Boolean,
     instance: Option[String],
     zookeepers: Option[String],
     zkTimeout: Option[String],
@@ -48,7 +48,7 @@ case class AccumuloClientConfig(
   ) {
   override def toString: String = {
     val values =
-      Seq(s"hasInstances=$hasInstances") ++
+      Seq(s"hasInstance=$hasInstance") ++
       instance.map(s => s"instance=$s").toSeq ++ zookeepers.map(s => s"zookeepers=$s") ++
         zkTimeout.map(s => s"zookeepers.timeout=$s") ++ authType.map(s => s"auth.type=$s") ++
         principal.map(s => s"principal=$s") ++ token.map(_ => "token=***")

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloClientConfig.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloClientConfig.scala
@@ -1,6 +1,6 @@
 /***********************************************************************
  * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
- * Portions MITRE Copyright (c) 2021
+ * Portions Copyright (c) 2021 The MITRE Corporation
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloClientConfig.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloClientConfig.scala
@@ -1,9 +1,14 @@
 /***********************************************************************
  * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
+ * Portions MITRE Copyright (c) 2021
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at
  * http://www.opensource.org/licenses/apache2.0.php.
+ * This software was produced for the U. S. Government under Basic
+ * Contract No. W56KGU-18-D-0004, and is subject to the Rights in
+ * Noncommercial Computer Software and Noncommercial Computer Software
+ * Documentation Clause 252.227-7014 (FEB 2012)
  ***********************************************************************/
 
 package org.locationtech.geomesa.accumulo.data
@@ -12,6 +17,7 @@ import java.io.{File, FileInputStream}
 import java.util.Properties
 
 import com.typesafe.scalalogging.Logger
+import org.apache.accumulo.core.client.ClientConfiguration
 import org.locationtech.geomesa.utils.io.WithClose
 import org.slf4j.LoggerFactory
 
@@ -20,14 +26,19 @@ import scala.util.Try
 /**
  * Client configuration options, loaded from a config file
  *
- * @param instance instance name
- * @param zookeepers zookeeper connect string
- * @param zkTimeout zookeeper timeout
+ * @param config Accumulo client configuration
+ * @param hasInstances instance id or name set in config file
+ * @param instance instance name (not actually used during configuration)
+ * @param zookeepers zookeeper connect string (not actually used during configuration)
+ * @param zkTimeout zookeeper timeout (not actually used during configuration)
  * @param authType  authentication type ("password", "kerberos" or authentication token class)
  * @param principal authentication principal (username, keytab file, etc)
  * @param token authentication token (password, etc)
  */
+@SuppressWarnings(Array("deprecated"))
 case class AccumuloClientConfig(
+    config: ClientConfiguration,
+    hasInstances: Boolean,
     instance: Option[String],
     zookeepers: Option[String],
     zkTimeout: Option[String],
@@ -37,6 +48,7 @@ case class AccumuloClientConfig(
   ) {
   override def toString: String = {
     val values =
+      Seq(s"hasInstances=$hasInstances") ++
       instance.map(s => s"instance=$s").toSeq ++ zookeepers.map(s => s"zookeepers=$s") ++
         zkTimeout.map(s => s"zookeepers.timeout=$s") ++ authType.map(s => s"auth.type=$s") ++
         principal.map(s => s"principal=$s") ++ token.map(_ => "token=***")
@@ -49,8 +61,6 @@ object AccumuloClientConfig {
   val PasswordAuthType = "password"
   val KerberosAuthType = "kerberos"
 
-  private val Empty = AccumuloClientConfig(None, None, None, None, None, None)
-
   // get the logger directly so that the logger name (and config) doesn't have a $ on the end
   private lazy val logger: Logger = Logger(LoggerFactory.getLogger(classOf[AccumuloClientConfig]))
 
@@ -61,7 +71,8 @@ object AccumuloClientConfig {
    */
   def load(): AccumuloClientConfig = {
     val loader = Option(Thread.currentThread().getContextClassLoader).getOrElse(getClass.getClassLoader)
-    AccumuloClientProperties(loader).orElse(ClientConf(loader)).getOrElse(Empty)
+    AccumuloClientProperties(loader).orElse(ClientConf(loader))
+      .getOrElse(AccumuloClientConfig(ClientConfiguration.create(), false, None, None, None, None, None, None))
   }
 
   /**
@@ -69,7 +80,6 @@ object AccumuloClientConfig {
    */
   private object AccumuloClientProperties extends ConfigLoader {
     override protected val fileName: String = "accumulo-client.properties"
-    override protected val instanceKey: String = "instance.name"
     override protected val zookeeperKey: String = "instance.zookeepers"
     override protected val zookeeperTimeoutKey: String = "instance.zookeepers.timeout"
     override protected val authTypeKey: Option[String] = Some("auth.type")
@@ -82,7 +92,6 @@ object AccumuloClientConfig {
    */
   private object ClientConf extends ConfigLoader {
     override protected val fileName: String = "client.conf"
-    override protected val instanceKey: String = "instance.name"
     override protected val zookeeperKey: String = "instance.zookeeper.host"
     override protected val zookeeperTimeoutKey: String = "instance.zookeeper.timeout"
     override protected val authTypeKey: Option[String] = None
@@ -93,7 +102,6 @@ object AccumuloClientConfig {
   private trait ConfigLoader {
 
     protected def fileName: String
-    protected def instanceKey: String
     protected def zookeeperKey: String
     protected def zookeeperTimeoutKey: String
     protected def authTypeKey: Option[String]
@@ -105,13 +113,15 @@ object AccumuloClientConfig {
         val props = new Properties()
         WithClose(new FileInputStream(f))(props.load)
 
-        val instance = Option(props.getProperty(instanceKey))
+        val instance = Option(props.getProperty("instance.name"))
+        val hasInstance = (instance != None) || props.getProperty("instance.id") != null
         val zk = Option(props.getProperty(zookeeperKey))
         val zkTimeout = Option(props.getProperty(zookeeperTimeoutKey))//=30s
         val auth = authTypeKey.map(props.getProperty).filter(_ != null)
         val principal = principalKey.map(props.getProperty).filter(_ != null)
         val token = tokenKey.map(props.getProperty).filter(_ != null)
-        val config = AccumuloClientConfig(instance, zk, zkTimeout, auth, principal, token)
+        val conf = ClientConfiguration.fromFile(f)
+        val config = AccumuloClientConfig(conf, hasInstance, instance, zk, zkTimeout, auth, principal, token)
         logger.info(s"Loaded Accumulo config from '${f.getAbsolutePath}': $config")
         config
       }

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
@@ -21,7 +21,7 @@ import java.util.Locale
 
 import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty
 import org.apache.accumulo.core.client.security.tokens.{AuthenticationToken, KerberosToken, PasswordToken}
-import org.apache.accumulo.core.client.{ClientConfiguration, Connector, ZooKeeperInstance}
+import org.apache.accumulo.core.client.{Connector, ZooKeeperInstance}
 import org.apache.hadoop.security.UserGroupInformation
 import org.geotools.data.DataAccessFactory.Param
 import org.geotools.data.{DataStoreFactorySpi, Parameter}
@@ -132,7 +132,7 @@ object AccumuloDataStoreFactory extends GeoMesaDataStoreInfo {
       }
 
     lazy val config = AccumuloClientConfig.load()
-    val conf = config.config
+    val conf = config.getConfig()
 
     def doIfOverridden(param: GeoMesaParam[String], action: String => Any, inConf: Boolean) = {
       param.lookupOpt(params) match {
@@ -144,7 +144,7 @@ object AccumuloDataStoreFactory extends GeoMesaDataStoreInfo {
       }
     }
 
-    doIfOverridden(InstanceIdParam, { paramVal: String => conf.withInstance(paramVal) }, config.hasInstance)
+    doIfOverridden(InstanceIdParam, { paramVal: String => conf.withInstance(paramVal) }, config.getHasInstance())
     doIfOverridden(ZookeepersParam, { paramVal: String => conf.withZkHosts(paramVal) }, config.zookeepers != None)
     ZookeeperTimeoutParam.lookupOpt(params).foreach { timeout =>
       conf.`with`(ClientProperty.INSTANCE_ZK_TIMEOUT, timeout)

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
@@ -1,10 +1,15 @@
 /***********************************************************************
  * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
  * Portions Crown Copyright (c) 2016-2020 Dstl
+ * Portions MITRE Copyright (c) 2021
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at
  * http://www.opensource.org/licenses/apache2.0.php.
+ * This software was produced for the U. S. Government under Basic
+ * Contract No. W56KGU-18-D-0004, and is subject to the Rights in
+ * Noncommercial Computer Software and Noncommercial Computer Software
+ * Documentation Clause 252.227-7014 (FEB 2012)
  ***********************************************************************/
 
 package org.locationtech.geomesa.accumulo.data
@@ -127,11 +132,21 @@ object AccumuloDataStoreFactory extends GeoMesaDataStoreInfo {
       }
 
     lazy val config = AccumuloClientConfig.load()
-    val instance = lookup(InstanceIdParam, config.instance)
-    val zookeepers = lookup(ZookeepersParam, config.zookeepers)
+    val conf = config.config
 
-    val conf = ClientConfiguration.create().withInstance(instance).withZkHosts(zookeepers)
-    ZookeeperTimeoutParam.lookupOpt(params).orElse(config.zkTimeout).foreach { timeout =>
+    def doIfOverridden(param: GeoMesaParam[String], action: String => Any, inConf: Boolean) = {
+      param.lookupOpt(params) match {
+        case Some(paramVal) => action(paramVal)
+        case None =>
+          if (!inConf) {
+            throw new IOException(s"Parameter ${param.key} is required: ${param.description}")
+          }
+      }
+    }
+
+    doIfOverridden(InstanceIdParam, { paramVal: String => conf.withInstance(paramVal) }, config.hasInstances)
+    doIfOverridden(ZookeepersParam, { paramVal: String => conf.withZkHosts(paramVal) }, config.zookeepers != None)
+    ZookeeperTimeoutParam.lookupOpt(params).foreach { timeout =>
       conf.`with`(ClientProperty.INSTANCE_ZK_TIMEOUT, timeout)
     }
 
@@ -149,7 +164,7 @@ object AccumuloDataStoreFactory extends GeoMesaDataStoreInfo {
         AccumuloClientConfig.KerberosAuthType
       } else {
         config.authType.map(_.trim.toLowerCase(Locale.US)).getOrElse {
-          throw new IOException(s"Parameter ${PasswordParam.key} is required: ${PasswordParam.description}")
+          throw new IOException(s"Parameter ${PasswordParam.key} is required: ${PasswordParam.description} or parameter ${KeytabPathParam.key} is required: ${KeytabPathParam.description}")
         }
       }
 
@@ -157,9 +172,6 @@ object AccumuloDataStoreFactory extends GeoMesaDataStoreInfo {
     val auth: AuthenticationToken = if (authType == AccumuloClientConfig.PasswordAuthType) {
       new PasswordToken(lookup(PasswordParam, config.token).getBytes(StandardCharsets.UTF_8))
     } else if (authType == AccumuloClientConfig.KerberosAuthType) {
-      // explicitly enable SASL for kerberos connections
-      // this shouldn't be required if Accumulo client.conf is set appropriately, but it doesn't seem to work
-      conf.withSasl(true)
       val file = new java.io.File(lookup(KeytabPathParam, config.token))
       // mimic behavior from accumulo 1.9 and earlier:
       // `public KerberosToken(String principal, File keytab, boolean replaceCurrentUser)`

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
@@ -1,7 +1,7 @@
 /***********************************************************************
  * Copyright (c) 2013-2020 Commonwealth Computer Research, Inc.
  * Portions Crown Copyright (c) 2016-2020 Dstl
- * Portions MITRE Copyright (c) 2021
+ * Portions Copyright (c) 2021 The MITRE Corporation
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License, Version 2.0
  * which accompanies this distribution and is available at

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreFactory.scala
@@ -144,7 +144,7 @@ object AccumuloDataStoreFactory extends GeoMesaDataStoreInfo {
       }
     }
 
-    doIfOverridden(InstanceIdParam, { paramVal: String => conf.withInstance(paramVal) }, config.hasInstances)
+    doIfOverridden(InstanceIdParam, { paramVal: String => conf.withInstance(paramVal) }, config.hasInstance)
     doIfOverridden(ZookeepersParam, { paramVal: String => conf.withZkHosts(paramVal) }, config.zookeepers != None)
     ZookeeperTimeoutParam.lookupOpt(params).foreach { timeout =>
       conf.`with`(ClientProperty.INSTANCE_ZK_TIMEOUT, timeout)

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterTest.scala
@@ -17,7 +17,8 @@ import org.junit.runner.RunWith
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.io.WithClose
-import org.mortbay.jetty.{Handler, Request, Server}
+import org.mortbay.jetty.{Connector, Handler, Request, Server}
+import org.mortbay.jetty.bio.SocketConnector
 import org.mortbay.jetty.handler.{AbstractHandler, ContextHandler}
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -57,7 +58,11 @@ class AvroSchemaRegistryConverterTest extends Specification with AvroSchemaRegis
       }
     }
 
-    val jetty = new Server(8089)
+    val jetty = new Server()
+    val connector = new SocketConnector()
+    connector.setPort(0)
+    jetty.addConnector(connector)
+
     val context1 = new ContextHandler()
     context1.setContextPath("/schemas/ids/1")
     jetty.setHandler(context1)
@@ -71,26 +76,27 @@ class AvroSchemaRegistryConverterTest extends Specification with AvroSchemaRegis
 
     "properly convert a GenericRecord to a SimpleFeature with Schema Registry" >> {
 
-      val conf = ConfigFactory.parseString(
-        """
-          | {
-          |   type        = "avro-schema-registry"
-          |   schema-registry = "http://localhost:8089"
-          |   sft         = "testsft"
-          |   id-field    = "uuid()"
-          |   fields = [
-          |     { name = "tobj", transform = "avroPath($1, '/content$type=TObj')" },
-          |     { name = "dtg",  transform = "date('yyyy-MM-dd', avroPath($tobj, '/kvmap[$k=dtg]/v'))" },
-          |     { name = "lat",  transform = "avroPath($tobj, '/kvmap[$k=lat]/v')" },
-          |     { name = "lon",  transform = "avroPath($tobj, '/kvmap[$k=lon]/v')" },
-          |     { name = "geom", transform = "point($lon, $lat)" }
-          |     { name = "extra", transform = "avroPath($tobj, '/kvmap[$k=extra]/extra')" }
-          |   ]
-          | }
-        """.stripMargin)
-
       try {
         jetty.start()
+
+        val conf = ConfigFactory.parseString(
+          s"""
+            | {
+            |   type        = "avro-schema-registry"
+            |   schema-registry = "http://localhost:${connector.getLocalPort()}"
+          """.stripMargin + """
+            |   sft         = "testsft"
+            |   id-field    = "uuid()"
+            |   fields = [
+            |     { name = "tobj", transform = "avroPath($1, '/content$type=TObj')" },
+            |     { name = "dtg",  transform = "date('yyyy-MM-dd', avroPath($tobj, '/kvmap[$k=dtg]/v'))" },
+            |     { name = "lat",  transform = "avroPath($tobj, '/kvmap[$k=lat]/v')" },
+            |     { name = "lon",  transform = "avroPath($tobj, '/kvmap[$k=lon]/v')" },
+            |     { name = "geom", transform = "point($lon, $lat)" }
+            |     { name = "extra", transform = "avroPath($tobj, '/kvmap[$k=extra]/extra')" }
+            |   ]
+            | }
+        """.stripMargin)
 
         WithClose(SimpleFeatureConverter(sft, conf)) { converter =>
           val ec = converter.createEvaluationContext()

--- a/pom.xml
+++ b/pom.xml
@@ -2544,11 +2544,13 @@
                         <validHeaders>
                             <validHeader>build/copyright/ccri-dstl.txt</validHeader>
                             <validHeader>build/copyright/ccri-dstl-2016.txt</validHeader>
+                            <validHeader>build/copyright/ccri-dstl-mitre.txt</validHeader>
                             <validHeader>build/copyright/dstl.txt</validHeader>
                             <validHeader>build/copyright/ibm.txt</validHeader>
                             <validHeader>build/copyright/ibm-ccri.txt</validHeader>
                             <validHeader>build/copyright/mitre.txt</validHeader>
                             <validHeader>build/copyright/ccri-2021.txt</validHeader>
+                            <validHeader>build/copyright/ccri-mitre.txt</validHeader>
                         </validHeaders>
                         <properties>
                             <year>${copyright.year}</year>


### PR DESCRIPTION
Despite the best efforts of GEOMESA-2800 only a handful of Accumulo client settings were actually loaded at runtime. This meant that Accumulo client settings like TLS or instance.id were ignored. Worse, there was no way for a user to specify them because TLS settings are not available as command line options for tools like `geomesa-accumulo ingest`.

Other related changes (originally separate commits, but squashed together to meet coding standards):

* New license headers for MITRE 2021 contributions. This is fairly brittle, but AFAICT this is a limitation of the license-maven-plugin.
* AvroSchemaRegistryConverterTest now uses a random Jetty port, not 8089. (Necessary for the unit tests to complete successfully when port 8089 is in use by another process.)
* Error message in accumulo config parser is clearer when authentication options are missing.