### PR TITLE
GEOMESA-3170 Allow for specifying different shard numbers for Z2 and …

### DIFF
--- a/docs/user/datastores/index_config.rst
+++ b/docs/user/datastores/index_config.rst
@@ -311,11 +311,12 @@ shards are more important as the tables might never split due to size. Setting t
 reduce performance, as it requires more calculations to be performed per query.
 
 The number of shards is set when calling ``createSchema``. It may be specified through the simple feature type
-user data using the key ``geomesa.z.splits``. See :ref:`set_sft_options` for details on setting user data.
+user data using the keys ``geomesa.z2.splits`` or ``geomesa.z3.splits`` for two and three dimensional indices
+respectively. See :ref:`set_sft_options` for details on setting user data.
 
 .. code-block:: java
 
-    sft.getUserData().put("geomesa.z.splits", "4");
+    sft.getUserData().put("geomesa.z3.splits", "4");
 
 .. _customizing_z_index:
 

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/ConfigureShardsTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/ConfigureShardsTest.scala
@@ -14,7 +14,7 @@ import org.locationtech.geomesa.accumulo.TestWithFeatureType
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.index.index.z3.Z3Index
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.Configs.IndexZShards
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.Configs.{IndexZ2Shards, IndexZ3Shards}
 import org.locationtech.geomesa.utils.index.GeoMesaSchemaValidator
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -28,7 +28,7 @@ class ConfigureShardsTest extends Specification with TestWithFeatureType {
 
   import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
-  val spec = "name:String,dtg:Date,*geom:Point:srid=4326;geomesa.z.splits='8'"
+  val spec = "name:String,dtg:Date,*geom:Point:srid=4326;geomesa.z3.splits='8'"
 
   val features: Seq[ScalaSimpleFeature] = {
     (0 until 100).map { i =>
@@ -65,9 +65,15 @@ class ConfigureShardsTest extends Specification with TestWithFeatureType {
       shardSet must haveSize(8)
     }
 
-    "throw exception" >> {
+    "throw exception on invalid z2 shards" >> {
       val sftPrivate = SimpleFeatureTypes.createType("private", spec)
-      sftPrivate.getUserData.put(IndexZShards, "128")
+      sftPrivate.getUserData.put(IndexZ2Shards, "128")
+      GeoMesaSchemaValidator.validate(sftPrivate) must throwAn[IllegalArgumentException]
+    }
+
+    "throw exception on invalid z3 shards" >> {
+      val sftPrivate = SimpleFeatureTypes.createType("private", spec)
+      sftPrivate.getUserData.put(IndexZ3Shards, "128")
       GeoMesaSchemaValidator.validate(sftPrivate) must throwAn[IllegalArgumentException]
     }
   }

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/index/CassandraColumnMapper.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/index/CassandraColumnMapper.scala
@@ -37,8 +37,8 @@ object CassandraColumnMapper {
   def apply(index: GeoMesaFeatureIndex[_, _]): CassandraColumnMapper = {
     index.name match {
       case IdIndex.name                             => IdColumnMapper(index.sft)
-      case Z3Index.name | XZ3Index.name             => Z3ColumnMapper(index.sft.getZShards)
-      case Z2Index.name | XZ2Index.name             => Z2ColumnMapper(index.sft.getZShards)
+      case Z3Index.name | XZ3Index.name             => Z3ColumnMapper(index.sft.getZ3Shards)
+      case Z2Index.name | XZ2Index.name             => Z2ColumnMapper(index.sft.getZ2Shards)
       case AttributeIndex.name if index.version > 7 => AttributeColumnMapper(index.sft.getAttributeShards)
       case AttributeIndex.name                      => SharedAttributeColumnMapper
       case _ => throw new IllegalArgumentException(s"Unexpected index: ${index.identifier}")

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/ShardStrategy.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/ShardStrategy.scala
@@ -60,8 +60,12 @@ object ShardStrategy {
     override val length: Int = 0
   }
 
-  object ZShardStrategy {
-    def apply(sft: SimpleFeatureType): ShardStrategy = ShardStrategy(sft.getZShards)
+  object Z2ShardStrategy {
+    def apply(sft: SimpleFeatureType): ShardStrategy = ShardStrategy(sft.getZ2Shards)
+  }
+
+  object Z3ShardStrategy {
+    def apply(sft: SimpleFeatureType): ShardStrategy = ShardStrategy(sft.getZ3Shards)
   }
 
   object AttributeShardStrategy {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
@@ -441,6 +441,8 @@ object MetadataBackedDataStore {
       IndexS3Interval,
       IndexXzPrecision,
       IndexZShards,
+      IndexZ2Shards,
+      IndexZ3Shards,
       IndexIdShards,
       IndexAttributeShards
     )

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/S2Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/S2Index.scala
@@ -9,10 +9,9 @@
 package org.locationtech.geomesa.index.index
 package s2
 
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z2ShardStrategy
 import org.locationtech.geomesa.index.api.{GeoMesaFeatureIndex, IndexKeySpace}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
-import org.locationtech.geomesa.index.index.ConfiguredIndex
 import org.locationtech.geomesa.index.strategies.SpatialFilterStrategy
 import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
 import org.opengis.feature.simple.SimpleFeatureType
@@ -32,7 +31,7 @@ class S2Index protected (ds: GeoMesaDataStore[_], sft: SimpleFeatureType, versio
   def this(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, mode: IndexMode) =
     this(ds, sft, S2Index.version, geom, mode)
 
-  override val keySpace: S2IndexKeySpace = new S2IndexKeySpace(sft, ZShardStrategy(sft), geom)
+  override val keySpace: S2IndexKeySpace = new S2IndexKeySpace(sft, Z2ShardStrategy(sft), geom)
 
   override val tieredKeySpace: Option[IndexKeySpace[_, _]] = None
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/S2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/S2IndexKeySpace.scala
@@ -13,7 +13,7 @@ import org.locationtech.geomesa.curve.S2SFC
 import org.locationtech.geomesa.filter.{FilterHelper, FilterValues}
 import org.locationtech.geomesa.index.api
 import org.locationtech.geomesa.index.api.IndexKeySpace.IndexKeySpaceFactory
-import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, ZShardStrategy}
+import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, Z2ShardStrategy}
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.conf.QueryHints.LOOSE_BBOX
 import org.locationtech.geomesa.index.conf.QueryProperties
@@ -215,7 +215,7 @@ object S2IndexKeySpace extends IndexKeySpaceFactory[S2IndexValues, Long] {
       classOf[Point].isAssignableFrom(sft.getDescriptor(attributes.head).getType.getBinding)
 
   override def apply(sft: SimpleFeatureType, attributes: Seq[String], tier: Boolean): S2IndexKeySpace = {
-    val shards = if (tier) { NoShardStrategy } else { ZShardStrategy(sft) }
+    val shards = if (tier) { NoShardStrategy } else { Z2ShardStrategy(sft) }
     new S2IndexKeySpace(sft, shards, attributes.head)
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/S3Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/S3Index.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.index.index
 package s3
 
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z3ShardStrategy
 import org.locationtech.geomesa.index.api.{GeoMesaFeatureIndex, IndexKeySpace}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.strategies.SpatioTemporalFilterStrategy
@@ -31,7 +31,7 @@ class S3Index protected (
     this(ds, sft, S3Index.version, geomField, dtgField, mode)
 
   override val keySpace: IndexKeySpace[S3IndexValues, S3IndexKey] =
-    new S3IndexKeySpace(sft, ZShardStrategy(sft), geom, dtg)
+    new S3IndexKeySpace(sft, Z3ShardStrategy(sft), geom, dtg)
 
   override def tieredKeySpace: Option[IndexKeySpace[_, _]] = None
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/S3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/S3IndexKeySpace.scala
@@ -8,15 +8,13 @@
 
 package org.locationtech.geomesa.index.index.s3
 
-import java.util.Date
-
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.curve.BinnedTime.TimeToBinnedTime
 import org.locationtech.geomesa.curve.{BinnedTime, S2SFC}
 import org.locationtech.geomesa.filter.FilterValues
 import org.locationtech.geomesa.index.api.IndexKeySpace.IndexKeySpaceFactory
-import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, ZShardStrategy}
+import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, Z3ShardStrategy}
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.conf.QueryProperties
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory
@@ -27,6 +25,7 @@ import org.locationtech.jts.geom.{Geometry, Point}
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
+import java.util.Date
 import scala.util.control.NonFatal
 
 /**
@@ -315,7 +314,7 @@ object S3IndexKeySpace extends IndexKeySpaceFactory[S3IndexValues, S3IndexKey]{
       classOf[Date].isAssignableFrom(sft.getDescriptor(attributes.last).getType.getBinding)
 
   override def apply(sft: SimpleFeatureType, attributes: Seq[String], tier: Boolean): S3IndexKeySpace = {
-    val shards = if (tier) { NoShardStrategy } else { ZShardStrategy(sft) }
+    val shards = if (tier) { NoShardStrategy } else { Z3ShardStrategy(sft) }
     new S3IndexKeySpace(sft, shards, attributes.head, attributes.last)
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/XZ2Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/XZ2Index.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.index.index
 package z2
 
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z2ShardStrategy
 import org.locationtech.geomesa.index.api.{GeoMesaFeatureIndex, IndexKeySpace}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.strategies.SpatialFilterStrategy
@@ -24,7 +24,7 @@ class XZ2Index protected (ds: GeoMesaDataStore[_], sft: SimpleFeatureType, versi
   def this(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, mode: IndexMode) =
     this(ds, sft, XZ2Index.version, geom, mode)
 
-  override val keySpace: XZ2IndexKeySpace = new XZ2IndexKeySpace(sft, ZShardStrategy(sft), geom)
+  override val keySpace: XZ2IndexKeySpace = new XZ2IndexKeySpace(sft, Z2ShardStrategy(sft), geom)
 
   override val tieredKeySpace: Option[IndexKeySpace[_, _]] = None
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/XZ2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/XZ2IndexKeySpace.scala
@@ -8,18 +8,18 @@
 
 package org.locationtech.geomesa.index.index.z2
 
-import org.locationtech.jts.geom.{Geometry, Point}
 import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.curve.XZ2SFC
 import org.locationtech.geomesa.filter.{FilterHelper, FilterValues}
 import org.locationtech.geomesa.index.api.IndexKeySpace.IndexKeySpaceFactory
-import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, ZShardStrategy}
+import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, Z2ShardStrategy}
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.conf.QueryProperties
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDataStoreConfig
 import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.utils.geotools.{GeometryUtils, WholeWorldPolygon}
 import org.locationtech.geomesa.utils.index.ByteArrays
+import org.locationtech.jts.geom.{Geometry, Point}
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
@@ -132,7 +132,7 @@ object XZ2IndexKeySpace extends IndexKeySpaceFactory[XZ2IndexValues, Long] {
         classOf[Geometry].isAssignableFrom(sft.getDescriptor(attributes.head).getType.getBinding)
 
   override def apply(sft: SimpleFeatureType, attributes: Seq[String], tier: Boolean): XZ2IndexKeySpace = {
-    val shards = if (tier) { NoShardStrategy } else { ZShardStrategy(sft) }
+    val shards = if (tier) { NoShardStrategy } else { Z2ShardStrategy(sft) }
     new XZ2IndexKeySpace(sft, shards, attributes.head)
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/Z2Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/Z2Index.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.index.index
 package z2
 
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z2ShardStrategy
 import org.locationtech.geomesa.index.api.{GeoMesaFeatureIndex, IndexKeySpace}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.strategies.SpatialFilterStrategy
@@ -24,7 +24,7 @@ class Z2Index protected (ds: GeoMesaDataStore[_], sft: SimpleFeatureType, versio
   def this(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, mode: IndexMode) =
     this(ds, sft, Z2Index.version, geom, mode)
 
-  override val keySpace: Z2IndexKeySpace = new Z2IndexKeySpace(sft, ZShardStrategy(sft), geom)
+  override val keySpace: Z2IndexKeySpace = new Z2IndexKeySpace(sft, Z2ShardStrategy(sft), geom)
 
   override val tieredKeySpace: Option[IndexKeySpace[_, _]] = None
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/Z2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/Z2IndexKeySpace.scala
@@ -8,12 +8,11 @@
 
 package org.locationtech.geomesa.index.index.z2
 
-import org.locationtech.jts.geom.{Geometry, Point}
 import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.curve.Z2SFC
 import org.locationtech.geomesa.filter.{FilterHelper, FilterValues}
 import org.locationtech.geomesa.index.api.IndexKeySpace.IndexKeySpaceFactory
-import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, ZShardStrategy}
+import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, Z2ShardStrategy}
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.conf.QueryHints.LOOSE_BBOX
 import org.locationtech.geomesa.index.conf.QueryProperties
@@ -21,6 +20,7 @@ import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDa
 import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.utils.geotools.{GeometryUtils, WholeWorldPolygon}
 import org.locationtech.geomesa.utils.index.ByteArrays
+import org.locationtech.jts.geom.{Geometry, Point}
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
@@ -145,7 +145,7 @@ object Z2IndexKeySpace extends IndexKeySpaceFactory[Z2IndexValues, Long] {
         classOf[Point].isAssignableFrom(sft.getDescriptor(attributes.head).getType.getBinding)
 
   override def apply(sft: SimpleFeatureType, attributes: Seq[String], tier: Boolean): Z2IndexKeySpace = {
-    val shards = if (tier) { NoShardStrategy } else { ZShardStrategy(sft) }
+    val shards = if (tier) { NoShardStrategy } else { Z2ShardStrategy(sft) }
     new Z2IndexKeySpace(sft, shards, attributes.head)
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/legacy/XZ2IndexV1.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/legacy/XZ2IndexV1.scala
@@ -8,7 +8,7 @@
 
 package org.locationtech.geomesa.index.index.z2.legacy
 
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z2ShardStrategy
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.LegacyTableNaming
@@ -27,7 +27,7 @@ class XZ2IndexV1(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, 
     extends XZ2Index(ds, sft, 1, geom, mode) with LegacyTableNaming[XZ2IndexValues, Long] {
 
   override val keySpace: XZ2IndexKeySpace =
-    new XZ2IndexKeySpaceV1(sft, sft.getTableSharingBytes, ZShardStrategy(sft), geom)
+    new XZ2IndexKeySpaceV1(sft, sft.getTableSharingBytes, Z2ShardStrategy(sft), geom)
 
   override protected val tableNameKey: String = "table.xz2.v1"
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/legacy/Z2IndexV1.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/legacy/Z2IndexV1.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.index.index.z2.legacy
 
 import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z2ShardStrategy
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.z2.Z2IndexKeySpace
@@ -27,7 +27,7 @@ class Z2IndexV1(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, m
   override val serializedWithId: Boolean = true
 
   override val keySpace: Z2IndexKeySpace =
-    new Z2IndexKeySpaceV1(sft, sft.getTableSharingBytes, ZShardStrategy(sft), geom)
+    new Z2IndexKeySpaceV1(sft, sft.getTableSharingBytes, Z2ShardStrategy(sft), geom)
 }
 
 object Z2IndexV1 {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/legacy/Z2IndexV2.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/legacy/Z2IndexV2.scala
@@ -8,9 +8,7 @@
 
 package org.locationtech.geomesa.index.index.z2.legacy
 
-import java.nio.charset.StandardCharsets
-
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z2ShardStrategy
 import org.locationtech.geomesa.index.api.{RowKeyValue, ShardStrategy, WritableFeature}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.z2.Z2IndexKeySpace
@@ -19,6 +17,8 @@ import org.locationtech.geomesa.index.index.z2.legacy.Z2IndexV3.Z2IndexKeySpaceV
 import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
 import org.opengis.feature.simple.SimpleFeatureType
 
+import java.nio.charset.StandardCharsets
+
 // deprecated non-point support in favor of xz, ids in row key, per-attribute vis
 class Z2IndexV2(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, mode: IndexMode)
     extends Z2IndexV3(ds, sft, 2, geom, mode) {
@@ -26,7 +26,7 @@ class Z2IndexV2(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, m
   import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
   override val keySpace: Z2IndexKeySpace =
-    new Z2IndexKeySpaceV2(sft, sft.getTableSharingBytes, ZShardStrategy(sft), geom)
+    new Z2IndexKeySpaceV2(sft, sft.getTableSharingBytes, Z2ShardStrategy(sft), geom)
 }
 
 object Z2IndexV2 {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/legacy/Z2IndexV3.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/legacy/Z2IndexV3.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.index.index.z2.legacy
 
 import org.locationtech.geomesa.curve.{LegacyZ2SFC, Z2SFC}
 import org.locationtech.geomesa.index.api.ShardStrategy
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z2ShardStrategy
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.LegacyTableNaming
 import org.locationtech.geomesa.index.index.z2.legacy.Z2IndexV3.Z2IndexKeySpaceV3
@@ -29,7 +29,7 @@ class Z2IndexV3 protected (ds: GeoMesaDataStore[_], sft: SimpleFeatureType, vers
     this(ds, sft, 3, geom, mode)
 
   override val keySpace: Z2IndexKeySpace =
-    new Z2IndexKeySpaceV3(sft, sft.getTableSharingBytes, ZShardStrategy(sft), geom)
+    new Z2IndexKeySpaceV3(sft, sft.getTableSharingBytes, Z2ShardStrategy(sft), geom)
 }
 
 object Z2IndexV3 {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/legacy/Z2IndexV4.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z2/legacy/Z2IndexV4.scala
@@ -8,7 +8,7 @@
 
 package org.locationtech.geomesa.index.index.z2.legacy
 
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z2ShardStrategy
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.z2.legacy.Z2IndexV4.Z2IndexKeySpaceV4
@@ -32,7 +32,7 @@ class Z2IndexV4 protected (ds: GeoMesaDataStore[_], sft: SimpleFeatureType, vers
   override protected val tableNameKey: String = s"table.z2.v$version"
 
   override val keySpace: Z2IndexKeySpace =
-    new Z2IndexKeySpaceV4(sft, sft.getTableSharingBytes, ZShardStrategy(sft), geom)
+    new Z2IndexKeySpaceV4(sft, sft.getTableSharingBytes, Z2ShardStrategy(sft), geom)
 }
 
 object Z2IndexV4 {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3Index.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.index.index
 package z3
 
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z3ShardStrategy
 import org.locationtech.geomesa.index.api.{GeoMesaFeatureIndex, IndexKeySpace}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.strategies.SpatioTemporalFilterStrategy
@@ -30,7 +30,7 @@ class XZ3Index protected (
   def this(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geomField: String, dtgField: String, mode: IndexMode) =
     this(ds, sft, XZ3Index.version, geomField, dtgField, mode)
 
-  override val keySpace: XZ3IndexKeySpace = new XZ3IndexKeySpace(sft, ZShardStrategy(sft), geom, dtg)
+  override val keySpace: XZ3IndexKeySpace = new XZ3IndexKeySpace(sft, Z3ShardStrategy(sft), geom, dtg)
 
   override val tieredKeySpace: Option[IndexKeySpace[_, _]] = None
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3IndexKeySpace.scala
@@ -16,7 +16,7 @@ import org.locationtech.geomesa.curve.BinnedTime.TimeToBinnedTime
 import org.locationtech.geomesa.curve.{BinnedTime, XZ3SFC}
 import org.locationtech.geomesa.filter.FilterValues
 import org.locationtech.geomesa.index.api.IndexKeySpace.IndexKeySpaceFactory
-import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, ZShardStrategy}
+import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, Z3ShardStrategy}
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.conf.QueryProperties
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDataStoreConfig
@@ -253,7 +253,7 @@ object XZ3IndexKeySpace extends IndexKeySpaceFactory[XZ3IndexValues, Z3IndexKey]
         classOf[Date].isAssignableFrom(sft.getDescriptor(attributes.last).getType.getBinding)
 
   override def apply(sft: SimpleFeatureType, attributes: Seq[String], tier: Boolean): XZ3IndexKeySpace = {
-    val shards = if (tier) { NoShardStrategy } else { ZShardStrategy(sft) }
+    val shards = if (tier) { NoShardStrategy } else { Z3ShardStrategy(sft) }
     new XZ3IndexKeySpace(sft, shards, attributes.head, attributes.last)
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3Index.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3Index.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.index.index
 package z3
 
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z3ShardStrategy
 import org.locationtech.geomesa.index.api.{GeoMesaFeatureIndex, IndexKeySpace}
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.strategies.SpatioTemporalFilterStrategy
@@ -30,7 +30,7 @@ class Z3Index protected (
   def this(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geomField: String, dtgField: String, mode: IndexMode) =
     this(ds, sft, Z3Index.version, geomField, dtgField, mode)
 
-  override val keySpace: Z3IndexKeySpace = new Z3IndexKeySpace(sft, ZShardStrategy(sft), geom, dtg)
+  override val keySpace: Z3IndexKeySpace = new Z3IndexKeySpace(sft, Z3ShardStrategy(sft), geom, dtg)
 
   override val tieredKeySpace: Option[IndexKeySpace[_, _]] = None
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/Z3IndexKeySpace.scala
@@ -16,7 +16,7 @@ import org.locationtech.geomesa.curve.BinnedTime.{DateToBinnedTime, TimeToBinned
 import org.locationtech.geomesa.curve.{BinnedTime, Z3SFC}
 import org.locationtech.geomesa.filter.FilterValues
 import org.locationtech.geomesa.index.api.IndexKeySpace.IndexKeySpaceFactory
-import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, ZShardStrategy}
+import org.locationtech.geomesa.index.api.ShardStrategy.{NoShardStrategy, Z3ShardStrategy}
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.conf.QueryHints.LOOSE_BBOX
 import org.locationtech.geomesa.index.conf.QueryProperties
@@ -257,7 +257,7 @@ object Z3IndexKeySpace extends IndexKeySpaceFactory[Z3IndexValues, Z3IndexKey] {
         classOf[Date].isAssignableFrom(sft.getDescriptor(attributes.last).getType.getBinding)
 
   override def apply(sft: SimpleFeatureType, attributes: Seq[String], tier: Boolean): Z3IndexKeySpace = {
-    val shards = if (tier) { NoShardStrategy } else { ZShardStrategy(sft) }
+    val shards = if (tier) { NoShardStrategy } else { Z3ShardStrategy(sft) }
     new Z3IndexKeySpace(sft, shards, attributes.head, attributes.last)
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/XZ3IndexV1.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/XZ3IndexV1.scala
@@ -11,7 +11,7 @@ package org.locationtech.geomesa.index.index.z3.legacy
 import java.util.Date
 
 import org.locationtech.geomesa.curve.BinnedTime
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z3ShardStrategy
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.LegacyTableNaming
@@ -35,7 +35,7 @@ class XZ3IndexV1(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, 
 
   // noinspection ScalaDeprecation
   override val keySpace: XZ3IndexKeySpace =
-    new XZ3IndexKeySpaceV1(sft, sft.getTableSharingBytes, ZShardStrategy(sft), geom, dtg)
+    new XZ3IndexKeySpaceV1(sft, sft.getTableSharingBytes, Z3ShardStrategy(sft), geom, dtg)
 }
 
 object XZ3IndexV1 {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/XZ3IndexV2.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/XZ3IndexV2.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.index.index.z3.legacy
 
 import org.locationtech.geomesa.curve.{TimePeriod, XZ3SFC}
 import org.locationtech.geomesa.index.api.ShardStrategy
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z3ShardStrategy
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.z3.legacy.XZ3IndexV2.XZ3IndexKeySpaceV2
 import org.locationtech.geomesa.index.index.z3.{XZ3Index, XZ3IndexKeySpace}
@@ -30,7 +30,7 @@ class XZ3IndexV2 protected (
   def this(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, dtg: String, mode: IndexMode) =
     this(ds, sft, 2, geom, dtg, mode)
 
-  override val keySpace: XZ3IndexKeySpace = new XZ3IndexKeySpaceV2(sft, ZShardStrategy(sft), geom, dtg)
+  override val keySpace: XZ3IndexKeySpace = new XZ3IndexKeySpaceV2(sft, Z3ShardStrategy(sft), geom, dtg)
 }
 
 object XZ3IndexV2 {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV2.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV2.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.index.index.z3.legacy
 
 import org.locationtech.geomesa.features.kryo.KryoFeatureSerializer
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z3ShardStrategy
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.z3.legacy.Z3IndexV2.Z3IndexKeySpaceV2
@@ -31,7 +31,7 @@ class Z3IndexV2 protected (ds: GeoMesaDataStore[_],
 
   override val serializedWithId: Boolean = true
 
-  override val keySpace: Z3IndexKeySpace = new Z3IndexKeySpaceV2(sft, ZShardStrategy(sft), geom, dtg)
+  override val keySpace: Z3IndexKeySpace = new Z3IndexKeySpaceV2(sft, Z3ShardStrategy(sft), geom, dtg)
 }
 
 object Z3IndexV2 {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV3.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV3.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.index.index.z3.legacy
 
 import java.nio.charset.StandardCharsets
 
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z3ShardStrategy
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.z3.legacy.Z3IndexV3.Z3IndexKeySpaceV3
@@ -31,7 +31,7 @@ class Z3IndexV3 protected (ds: GeoMesaDataStore[_],
     this(ds, sft, 3, geom, dtg, mode)
 
   // note: this index doesn't ever have table sharing
-  override val keySpace: Z3IndexKeySpace = new Z3IndexKeySpaceV3(sft, ZShardStrategy(sft), geom, dtg)
+  override val keySpace: Z3IndexKeySpace = new Z3IndexKeySpaceV3(sft, Z3ShardStrategy(sft), geom, dtg)
 }
 
 object Z3IndexV3 {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV4.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV4.scala
@@ -10,7 +10,7 @@ package org.locationtech.geomesa.index.index.z3.legacy
 
 import org.locationtech.geomesa.curve.{LegacyZ3SFC, Z3SFC}
 import org.locationtech.geomesa.index.api.ShardStrategy
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z3ShardStrategy
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.LegacyTableNaming
 import org.locationtech.geomesa.index.index.z3.legacy.Z3IndexV4.Z3IndexKeySpaceV4
@@ -34,7 +34,7 @@ class Z3IndexV4 protected (ds: GeoMesaDataStore[_],
     this(ds, sft, 4, geom, dtg, mode)
 
   override val keySpace: Z3IndexKeySpace =
-    new Z3IndexKeySpaceV4(sft, sft.getTableSharingBytes, ZShardStrategy(sft), geom, dtg)
+    new Z3IndexKeySpaceV4(sft, sft.getTableSharingBytes, Z3ShardStrategy(sft), geom, dtg)
 }
 
 object Z3IndexV4 {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV5.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV5.scala
@@ -11,7 +11,7 @@ package org.locationtech.geomesa.index.index.z3.legacy
 import java.util.Date
 
 import org.locationtech.geomesa.curve.BinnedTime
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z3ShardStrategy
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.index.z3.legacy.Z3IndexV5.Z3IndexKeySpaceV5
@@ -41,7 +41,7 @@ class Z3IndexV5 protected (ds: GeoMesaDataStore[_],
 
   // noinspection ScalaDeprecation
   override val keySpace: Z3IndexKeySpace =
-    new Z3IndexKeySpaceV5(sft, sft.getTableSharingBytes, ZShardStrategy(sft), geom, dtg)
+    new Z3IndexKeySpaceV5(sft, sft.getTableSharingBytes, Z3ShardStrategy(sft), geom, dtg)
 }
 
 object Z3IndexV5 {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV6.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/legacy/Z3IndexV6.scala
@@ -12,7 +12,7 @@ import java.time.ZonedDateTime
 
 import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.curve.{TimePeriod, Z3SFC}
-import org.locationtech.geomesa.index.api.ShardStrategy.ZShardStrategy
+import org.locationtech.geomesa.index.api.ShardStrategy.Z3ShardStrategy
 import org.locationtech.geomesa.index.api._
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStoreFactory.GeoMesaDataStoreConfig
@@ -34,7 +34,7 @@ class Z3IndexV6 protected (
   def this(ds: GeoMesaDataStore[_], sft: SimpleFeatureType, geom: String, dtg: String, mode: IndexMode) =
     this(ds, sft, 6, geom, dtg, mode)
 
-  override val keySpace: Z3IndexKeySpace = new Z3IndexKeySpaceV6(sft, ZShardStrategy(sft), geom, dtg)
+  override val keySpace: Z3IndexKeySpace = new Z3IndexKeySpaceV6(sft, Z3ShardStrategy(sft), geom, dtg)
 }
 
 object Z3IndexV6 {

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/api/ShardStrategyTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/api/ShardStrategyTest.scala
@@ -19,7 +19,7 @@ import org.specs2.runner.JUnitRunner
 class ShardStrategyTest extends Specification {
   "ShardStrategy" should {
     "handle negative hash values" in {
-      val sft = SimpleFeatureTypes.createType("hash", "geom:Point,dtg:Date;geomesa.z.splits=60")
+      val sft = SimpleFeatureTypes.createType("hash", "geom:Point,dtg:Date;geomesa.z3.splits=60")
       val wrapper = WritableFeature.wrapper(sft, new ColumnGroups)
       val sf = ScalaSimpleFeature.create(sft, "1371494157#3638946185",
         "POINT (88.3176015 22.5988557)", "2019-12-23T01:00:00.000Z")

--- a/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/index/Z2ColumnMapper.scala
+++ b/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/index/Z2ColumnMapper.scala
@@ -29,7 +29,7 @@ class Z2ColumnMapper(index: GeoMesaFeatureIndex[_, _]) extends KuduColumnMapper(
     val options = new CreateTableOptions()
 
     // add hash splits based on our shards, which we don't need to actually store as a separate column
-    val shards = index.sft.getZShards
+    val shards = index.sft.getZ2Shards
     if (shards > 1) {
       options.addHashPartitions(Collections.singletonList(FeatureIdAdapter.name), shards)
     }

--- a/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/index/Z3ColumnMapper.scala
+++ b/geomesa-kudu/geomesa-kudu-datastore/src/main/scala/org/locationtech/geomesa/kudu/index/Z3ColumnMapper.scala
@@ -34,7 +34,7 @@ class Z3ColumnMapper(index: GeoMesaFeatureIndex[_, _]) extends KuduColumnMapper(
     val options = new CreateTableOptions()
 
     // add hash splits based on our shards, which we don't need to actually store as a separate column
-    val shards = index.sft.getZShards
+    val shards = index.sft.getZ3Shards
     if (shards > 1) {
       options.addHashPartitions(Collections.singletonList(FeatureIdAdapter.name), shards)
     }

--- a/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/RedisDataStore.scala
+++ b/geomesa-redis/geomesa-redis-datastore/src/main/scala/org/locationtech/geomesa/redis/data/RedisDataStore.scala
@@ -57,7 +57,8 @@ class RedisDataStore(val connection: JedisPool, override val config: RedisDataSt
     }
 
     // disable shards
-    sft.setZShards(0)
+    sft.setZ2Shards(0)
+    sft.setZ3Shards(0)
     sft.setIdShards(0)
     sft.setAttributeShards(0)
 

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -303,8 +303,13 @@ object RichSimpleFeatureType extends Conversions {
     def getUserDataPrefixes: Seq[String] =
       Seq(GeomesaPrefix) ++ userData[String](UserDataPrefix).map(_.split(",")).getOrElse(Array.empty)
 
-    def setZShards(splits: Int): Unit = sft.getUserData.put(IndexZShards, splits.toString)
-    def getZShards: Int = userData(IndexZShards).map(int).getOrElse(4)
+    def setZ2Shards(splits: Int): Unit = sft.getUserData.put(IndexZ2Shards, splits.toString)
+    def getZ2Shards: Int =
+      userData(IndexZ2Shards).map(int).getOrElse(userData(IndexZShards).map(int).getOrElse(4))
+
+    def setZ3Shards(splits: Int): Unit = sft.getUserData.put(IndexZ3Shards, splits.toString)
+    def getZ3Shards: Int =
+      userData(IndexZ3Shards).map(int).getOrElse(userData(IndexZShards).map(int).getOrElse(4))
 
     def setAttributeShards(splits: Int): Unit = sft.getUserData.put(IndexAttributeShards, splits.toString)
     def getAttributeShards: Int = userData(IndexAttributeShards).map(int).getOrElse(4)

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -303,6 +303,9 @@ object RichSimpleFeatureType extends Conversions {
     def getUserDataPrefixes: Seq[String] =
       Seq(GeomesaPrefix) ++ userData[String](UserDataPrefix).map(_.split(",")).getOrElse(Array.empty)
 
+    def setZShards(splits: Int): Unit = sft.getUserData.put(IndexZShards, splits.toString)
+    @deprecated("use z2/z3 specific methods")
+    def getZShards: Int = userData(IndexZShards).map(int).getOrElse(4)
     def setZ2Shards(splits: Int): Unit = sft.getUserData.put(IndexZ2Shards, splits.toString)
     def getZ2Shards: Int =
       userData(IndexZ2Shards).map(int).getOrElse(userData(IndexZShards).map(int).getOrElse(4))

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SchemaBuilder.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SchemaBuilder.scala
@@ -457,6 +457,28 @@ object SchemaBuilder {
     def zShards(shards: Int): U = userData(Configs.IndexZShards, shards.toString)
 
     /**
+     * Specify the number of shards to use for the Z2 indices. Shards can provide distribution
+     * across nodes in a cluster, but also require more nodes to be scanned when querying.
+     *
+     * Default value is 4
+     *
+     * @param shards number of shards
+     * @return user data builder for chaining calls
+     */
+    def z2Shards(shards: Int): U = userData(Configs.IndexZ2Shards, shards.toString)
+
+    /**
+     * Specify the number of shards to use for the Z3 indices. Shards can provide distribution
+     * across nodes in a cluster, but also require more nodes to be scanned when querying.
+     *
+     * Default value is 4
+     *
+     * @param shards number of shards
+     * @return user data builder for chaining calls
+     */
+    def z3Shards(shards: Int): U = userData(Configs.IndexZ2Shards, shards.toString)
+
+    /**
       * Specify the number of shards to use for the attribute index. Shards can provide distribution
       * across nodes in a cluster, but also require more nodes to be scanned when querying.
       *

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SimpleFeatureTypes.scala
@@ -46,7 +46,6 @@ object SimpleFeatureTypes {
     val IndexXzPrecision      = "geomesa.xz.precision"
     val IndexZ3Interval       = "geomesa.z3.interval"
     val IndexS3Interval       = "geomesa.s3.interval"
-    val IndexZShards          = "geomesa.z.splits"
     val Keywords              = "geomesa.keywords"
     val MixedGeometries       = "geomesa.mixed.geometries"
     val OverrideDtgJoin       = "override.index.dtg.join"
@@ -63,6 +62,10 @@ object SimpleFeatureTypes {
     val TemporalPriority      = "geomesa.temporal.priority"
     val UpdateBackupMetadata  = "schema.update.backup.metadata"
     val UpdateRenameTables    = "schema.update.rename.tables"
+
+    val IndexZShards  = "geomesa.z.splits"
+    val IndexZ2Shards = "geomesa.z2.splits"
+    val IndexZ3Shards = "geomesa.z3.splits"
 
     @deprecated("replaced with IndexS3Interval")
     val S3_INTERVAL_KEY: String = IndexS3Interval

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/GeoMesaSchemaValidator.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/index/GeoMesaSchemaValidator.scala
@@ -117,7 +117,8 @@ object IndexConfigurationCheck {
 
   def validateIndices(sft: SimpleFeatureType): Unit = {
     import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
-    require(sft.getZShards > 0 && sft.getZShards < 128, "Z shards must be between 1 and 127")
+    require(sft.getZ2Shards > 0 && sft.getZ2Shards < 128, "Z shards must be between 1 and 127")
+    require(sft.getZ3Shards > 0 && sft.getZ3Shards < 128, "Z shards must be between 1 and 127")
     require(sft.getAttributeShards > 0 && sft.getAttributeShards < 128, "Attribute shards must be between 1 and 127")
   }
 }


### PR DESCRIPTION
…Z3 indices.

- Adds config keys geomesa.z2.splits and geomesa.z3.splits

Signed-off-by: Austin Heyne <aheyne@ccri.com>