### PR TITLE
GEOMESA-3171 Postgis partitioning dialect for JDBCDataStore

### DIFF
--- a/docs/user/datastores/index.rst
+++ b/docs/user/datastores/index.rst
@@ -42,6 +42,7 @@ Specific back-end implementations are described in the following chapters:
  * :doc:`/user/redis/index`
  * :doc:`/user/filesystem/index`
  * :doc:`/user/kudu/index`
+ * :doc:`/user/postgis/index`
  * :doc:`/user/lambda/index`
 
 Additional information on using GeoTools can be found in the

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -27,6 +27,7 @@ User Manual
    redis/index
    filesystem/index
    kudu/index
+   postgis/index
    lambda/index
    ds_views
    geojson

--- a/docs/user/postgis/commandline.rst
+++ b/docs/user/postgis/commandline.rst
@@ -1,0 +1,5 @@
+Partitioned PostGIS Command-Line Tools
+======================================
+
+The partitioned PostGIS data store is bundled with the ``geomesa-gt`` command-line tools. See :ref:`gt_tools` for
+additional details.

--- a/docs/user/postgis/design.rst
+++ b/docs/user/postgis/design.rst
@@ -1,0 +1,72 @@
+Design Overview
+===============
+
+Motivation
+----------
+
+PostGIS is a widely used spatial database that is easily deployed, however it is limited in the total number of
+records it can handle in a single table. This module makes it possible to store much larger data sets using
+PostgreSQL's native partitioning, by automatically sorting data into time-based partitions.
+
+Overview
+--------
+
+The PostGIS partitioning module is an extension of the GeoTools
+`JDBC data store <https://docs.geotools.org/stable/userguide/library/jdbc/datastore.html>`__, implemented
+as a custom dialect. It is designed for sensor data, where each record has a timestamp and records are
+mostly ingested soon after they are generated.
+
+As data is written, it gets sorted into partitions based on record timestamps. Recent data gets sorted
+into smaller partitions, then into larger partitions once it has reached a certain age. The partitions are
+sorted spatio-temporally, to reduce page reads during typical queries. Since the data is sorted, it can be
+effectively indexed using a spatial ``BRIN`` index, which is much smaller than a standard ``GIST`` index. During
+queries, PostgreSQL will automatically skip over partitions that don't match the query, using standard partition
+pruning. This allows massive data sets to be efficiently queried with temporal predicates, although non-temporal
+queries may not perform well.
+
+.. _pg_partition_table_design:
+
+Table Design
+------------
+
+The data is split into one primary view and three tables, names of which are prefixed by the feature type:
+
+  * main view (named after the feature type) - a ``UNION ALL`` of the other tables, this is the view
+    that should generally be used for all external reads and writes.
+  * ``_wa`` - the write-ahead table. All writes to the main view are delegated to this table using a trigger.
+    The table is partitioned using table inheritance (as there may be overlap between the partitions), and
+    is rolled over every 10 minutes. Only the most recent partition is ever written to.
+  * ``_wa_partition`` - recent data, partitioned into 10 minute increments using declarative partitioning.
+    The most recent data is stored in this table in spatially-sorted order, copied out of the
+    write ahead table when it is rolled over (after which the write ahead table partition is dropped). This table
+    is designed to handle time-latent data, and to store enough data to fill an entire main partition,
+    while still providing partition pruning for queries.
+  * ``_partition`` - the main data, partitioned using declarative time partitioning. Data is copied into this table
+    from the ``_wa_partition`` table in spatially-sorted order, once enough time has elapsed (after which the
+    ``_wa_partition`` partitions are dropped). It uses a BRIN index, which is small but performs well on sorted data.
+    Keeping the data sorted also reduces the number of page hits required for most spatial queries.
+
+Helper Tables
+-------------
+
+In addition to the ones above, the following additional tables are used:
+
+  * ``_analyze_queue`` - tracks partitions which have been modified. Modified partitions will have ``ANALYZE``
+    invoked on them in a separate process.
+  * ``_sort_queue`` - tracks out-of-order inserts into the main partition table. This can be used to diagnose
+    slow queries, as unsorted data can negatively impact the effectiveness of the ``BRIN`` index.
+
+Maintenance Scripts
+-------------------
+
+Several PLPG/SQL procedures are used to move data around according to the design described above. The ``pg_cron``
+extension is used to schedule these tasks. The script names are prefixed by the feature type, and created based
+on the feature type configuration (i.e. field names, partition size, etc). The procedures consist of:
+
+  * ``_roll_wa`` - creates a new write-ahead table every 10 minutes
+  * ``_partition_maintenance`` umbrella function for invoking all the partition scripts at once
+  * ``_partition_wa`` - moves data from old write ahead tables into the ``_wa_partition`` table
+  * ``_merge_wa_partitions`` - moves data from the ``_wa_partition`` table into the main ``_partition`` table
+  * ``_age_off`` (if configured) - drops any partitions that have exceeded the maximum amount of data to keep
+  * ``_analyze_partitions`` - runs ``ANALYZE`` on any partitions that have been updated
+  * ``_partition_sort`` - manually called to re-sort a partition

--- a/docs/user/postgis/geoserver.rst
+++ b/docs/user/postgis/geoserver.rst
@@ -1,0 +1,19 @@
+Using the Partitioned PostGIS Data Store in GeoServer
+=====================================================
+
+.. note::
+
+    For general information on working with GeoMesa GeoServer plugins,
+    see :doc:`/user/geoserver`.
+
+From the main GeoServer page, create a new store by either clicking
+"Add stores" in the middle of the **Welcome** page, or anywhere in the
+interface by clicking "Data > Stores" in the left-hand menu and then
+clicking "Add new Store".
+
+On the "Add Store" page, select "PostGIS", and fill out the
+parameters. The parameters are described in :ref:`pg_partition_parameters`.
+
+Click "Save", and GeoServer will search PostGIS for any feature types.
+Select the primary view that is named after your particular schema, and not any of the
+partitioned sub-tables, which may also show up.

--- a/docs/user/postgis/index.rst
+++ b/docs/user/postgis/index.rst
@@ -1,0 +1,16 @@
+Partitioned PostGIS Data Store
+==============================
+
+GeoMesa provides an extension to the standard GeoTools PostGIS data store for better handling
+of time series data. The GeoMesa extension leverages PostgreSQL's native partitioning to support
+efficient spatio-temporal queries against large data sets.
+
+.. toctree::
+    :maxdepth: 1
+
+    design
+    install
+    usage
+    geoserver
+    commandline
+    index_config

--- a/docs/user/postgis/index_config.rst
+++ b/docs/user/postgis/index_config.rst
@@ -1,0 +1,89 @@
+Partitioned PostGIS Index Configuration
+=======================================
+
+GeoMesa exposes a variety of configuration options that can be used to customize and optimize a given installation.
+See :ref:`set_sft_options` for details on setting configuration parameters. Note that most of the general options
+for GeoMesa stores are not supported by the partitioned PostGIS store, except as specified below.
+
+Configuring the Default Date Attribute
+--------------------------------------
+
+The default date attribute is the attribute that will be used for sorting data into partitions. See
+:ref:`set_date_attribute` for details on how to specify it.
+
+Configuring Indices
+-------------------
+
+Attributes in the feature type may be marked for indexing, which will create a B-tree index on the associated
+table column. See :ref:`attribute_indices` for details on how to specify indices.
+
+Configuring Partition Size
+--------------------------
+
+Each feature type can be configured for a particular partition size. The partition size is specified as the number
+of hours that each partition will cover, and must be a divisor of 24, i.e. ``1``, ``2``, ``3``, ``4``, ``6``,
+``8``, ``12`` or ``24``.
+
+The number of hours should be based on the expected volume of data and type of queries. Due to partition
+pruning, PostGIS will not need to scan partitions that fall outside a given query window.
+
+Partition size is configured with the key ``pg.partitions.interval.hours``.
+
+.. code-block:: java
+
+    SimpleFeatureType sft = ....;
+    sft.getUserData().put("pg.partitions.interval.hours", "12");
+
+Configuring Data Age-Off
+------------------------
+
+Each feature type can be configured to automatically drop partitions older than a certain threshold. This
+is accomplished by setting the maximum number of partitions to keep. The age of the data will depend on
+the number of hours in each partition (see above). For example, keeping 14 partitions where each partition
+is 12 hours will keep the last week's worth of data.
+
+If not specified, data will not be dropped automatically.
+
+Age-off is configured with the key ``pg.partitions.max``.
+
+.. code-block:: java
+
+    SimpleFeatureType sft = ....;
+    sft.getUserData().put("pg.partitions.max", "14");
+
+Configuring Tablespaces
+-----------------------
+
+Each feature type can be configured to use different tablespaces for the different partition tables. Since
+all the writes initially go to the write-ahead table, having it on a fast disk may be beneficial. Conversely,
+since the main partitions are written once and not generally updated, having them on slower storage may be
+acceptable.
+
+Any configured tablespaces must already exist in the PostreSQL instance being used.
+
+Tablespaces are configured with the keys ``pg.partitions.tablespace.wa``, ``pg.partitions.tablespace.wa-partitions``
+and ``pg.partitions.tablespace.main``. See :ref:`pg_partition_table_design` for details on the different tables.
+
+.. code-block:: java
+
+    SimpleFeatureType sft = ....;
+    sft.getUserData().put("pg.partitions.tablespace.wa", "fasttablespace");
+
+Configuring the Maintenance Schedule
+------------------------------------
+
+Maintenance scripts are run every 10 minutes to move data between the write-ahead table and the partitioned tables.
+By default, the schedule is randomized to avoid all feature types running maintenance at the same time. To specify
+the exact minute that the scripts should run, use the key ``pg.partitions.cron.minute``.
+
+The scheduled minute must be between 0 and 8, inclusive. For example, setting the scheduled minute to 1 will
+cause the scripts to run at 00:01, 00:11, 00:21, 00:31, etc.
+
+The write-ahead table gets rolled over on the 9th minute of each ten minute block. Thus, running maintenance
+at minute 0 will move data out of the write-ahead table the fastest. Since the write-ahead table must be read
+for each query, moving data out of it faster may improve performance.
+
+.. code-block:: java
+
+    SimpleFeatureType sft = ....;
+    sft.getUserData().put("pg.partitions.cron.minute", "0");

--- a/docs/user/postgis/install.rst
+++ b/docs/user/postgis/install.rst
@@ -1,0 +1,18 @@
+Installing Partitioned PostGIS
+==============================
+
+The partitioned PostGIS data store is bundled with the ``geomesa-gt`` command-line tools. See :ref:`gt_tools` for
+installation instructions.
+
+Installing pg_cron in Postgres
+------------------------------
+
+The partitioning module requires the ``pg_cron`` PostgreSQL extension to be installed on the database being
+used. See `pg_cron <https://github.com/citusdata/pg_cron>`__ for details on installing the extension.
+
+.. _install_pg_partition_geoserver:
+
+Installing Partitioned PostGIS in GeoServer
+-------------------------------------------
+
+The regular PostGIS data store can be used in GeoServer, so no additional installation is required.

--- a/docs/user/postgis/usage.rst
+++ b/docs/user/postgis/usage.rst
@@ -1,0 +1,32 @@
+Using the Partitioned PostGIS Data Store Programmatically
+=========================================================
+
+Creating a Data Store
+---------------------
+
+An instance of a PostGIS data store can be obtained through the normal GeoTools discovery methods,
+assuming that the GeoMesa code is on the classpath.
+
+.. code-block:: java
+
+    Map<String, Serializable> parameters = new HashMap<>();
+    parameters.put("dbtype", "postgis-partitioned");
+    parameters.put("host", "localhost");
+    parameters.put("database", "geomesa");
+    parameters.put("user", "postgres");
+    parameters.put("passwd", "postgres");
+    org.geotools.data.DataStore dataStore =
+        org.geotools.data.DataStoreFinder.getDataStore(parameters);
+
+.. _pg_partition_parameters:
+
+Partitioned PostGIS Data Store Parameters
+-----------------------------------------
+
+The partitioned PostGIS data store uses the same parameters as the standard PostGIS data store, except
+that ``dbtype`` **must** be set to ``postgis-partitioned``. See the
+`JDBCDataStore <https://docs.geotools.org/stable/userguide/library/jdbc/datastore.html>`__ and
+`PostGIS Plugin <https://docs.geotools.org/stable/userguide/library/jdbc/postgis.html>`__ for other parameters.
+
+Note that once a schema has been created, the regular PostGIS data store may be used for query, insert, update
+and delete operations.

--- a/geomesa-gt/geomesa-gt-dist/pom.xml
+++ b/geomesa-gt/geomesa-gt-dist/pom.xml
@@ -37,6 +37,10 @@
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-gt-tools_${scala.binary.version}</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-gt-partitioning_${scala.binary.version}</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/geomesa-gt/geomesa-gt-partitioning/pom.xml
+++ b/geomesa-gt/geomesa-gt-partitioning/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.locationtech.geomesa</groupId>
+        <artifactId>geomesa-gt_2.12</artifactId>
+        <version>3.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geomesa-gt-partitioning_2.12</artifactId>
+    <name>GeoMesa GeoTools Postgis Partitioning</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools.jdbc</groupId>
+            <artifactId>gt-jdbc-postgis</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging_${scala.binary.version}</artifactId>
+        </dependency>
+
+        <!-- provided dependencies -->
+
+        <!-- test deps -->
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/resources/META-INF/services/org.geotools.data.DataStoreFactorySpi
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/resources/META-INF/services/org.geotools.data.DataStoreFactorySpi
@@ -1,0 +1,1 @@
+org.locationtech.geomesa.gt.partition.postgis.PartitionedPostgisDataStoreFactory

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/PartitionedPostgisDataStoreFactory.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/PartitionedPostgisDataStoreFactory.scala
@@ -1,0 +1,63 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis
+
+import org.geotools.data.postgis.{PostGISDialect, PostGISPSDialect, PostgisNGDataStoreFactory}
+import org.geotools.jdbc.{JDBCDataStore, SQLDialect}
+import org.locationtech.geomesa.gt.partition.postgis.dialect.PartitionedPostgisDialect
+
+class PartitionedPostgisDataStoreFactory extends PostgisNGDataStoreFactory {
+
+  import PartitionedPostgisDataStoreParams.DbType
+
+  override def getDisplayName: String = "PostGIS (partitioned)"
+
+  override def getDescription: String = "PostGIS Database with time-partitioned tables"
+
+  override protected def getDatabaseID: String = DbType.sample.asInstanceOf[String]
+
+  override protected def setupParameters(parameters: java.util.Map[_, _]): Unit = {
+    super.setupParameters(parameters)
+    // override postgis dbkey
+    parameters.asInstanceOf[java.util.Map[AnyRef, AnyRef]].put(DbType.key, DbType)
+  }
+
+  override protected def createDataStoreInternal(store: JDBCDataStore, params: java.util.Map[_, _]): JDBCDataStore = {
+
+    val ds = super.createDataStoreInternal(store, params)
+    val dialect = new PartitionedPostgisDialect(ds)
+
+    // TODO copy any other configs?
+    ds.getSQLDialect match {
+      case d: PostGISDialect =>
+        dialect.setLooseBBOXEnabled(d.isLooseBBOXEnabled)
+        dialect.setEstimatedExtentsEnabled(d.isEstimatedExtentsEnabled)
+        dialect.setFunctionEncodingEnabled(d.isFunctionEncodingEnabled)
+        dialect.setSimplifyEnabled(d.isSimplifyEnabled)
+        dialect.setEncodeBBOXFilterAsEnvelope(d.isEncodeBBOXFilterAsEnvelope)
+        ds.setSQLDialect(dialect)
+
+      case d: PostGISPSDialect =>
+        dialect.setLooseBBOXEnabled(d.isLooseBBOXEnabled)
+        dialect.setFunctionEncodingEnabled(d.isFunctionEncodingEnabled)
+        // TODO dialect.setEstimatedExtentsEnabled(d.isEstimatedExtentsEnabled)
+        // TODO dialect.setSimplifyEnabled(d.isSimplifyEnabled)
+        dialect.setEncodeBBOXFilterAsEnvelope(d.isEncodeBBOXFilterAsEnvelope)
+        ds.setSQLDialect(new PostGISPSDialect(ds, dialect))
+
+      case d => throw new IllegalArgumentException(s"Expected PostGISDialect but got: ${d.getClass.getName}")
+    }
+    ds
+  }
+
+  // these will get replaced in createDataStoreInternal, above
+  override protected def createSQLDialect(dataStore: JDBCDataStore): SQLDialect = new PostGISDialect(dataStore)
+  override protected def createSQLDialect(dataStore: JDBCDataStore, params: java.util.Map[_, _]): SQLDialect =
+    new PostGISDialect(dataStore)
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/PartitionedPostgisDataStoreParams.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/PartitionedPostgisDataStoreParams.scala
@@ -1,0 +1,26 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis
+
+import org.geotools.data.{DataAccessFactory, Parameter}
+
+import java.util.Collections
+
+object PartitionedPostgisDataStoreParams {
+
+  val DbType =
+    new DataAccessFactory.Param(
+      "dbtype",
+      classOf[String],
+      "Type",
+      true,
+      "postgis-partitioned",
+      Collections.singletonMap(Parameter.LEVEL, "program")
+    )
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/PartitionedPostgisDialect.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/PartitionedPostgisDialect.scala
@@ -1,0 +1,188 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+
+import com.typesafe.scalalogging.StrictLogging
+import org.geotools.data.postgis.PostGISDialect
+import org.geotools.jdbc.JDBCDataStore
+import org.locationtech.geomesa.gt.partition.postgis.dialect.functions.{LogCleaner, TruncateToPartition, TruncateToTenMinutes}
+import org.locationtech.geomesa.gt.partition.postgis.dialect.procedures._
+import org.locationtech.geomesa.gt.partition.postgis.dialect.tables._
+import org.locationtech.geomesa.gt.partition.postgis.dialect.triggers.{DeleteTrigger, InsertTrigger, UpdateTrigger, WriteAheadTrigger}
+import org.locationtech.geomesa.utils.geotools.{Conversions, SimpleFeatureTypes}
+import org.opengis.feature.simple.SimpleFeatureType
+
+import java.sql.{Connection, DatabaseMetaData}
+import scala.collection.mutable.ArrayBuffer
+
+class PartitionedPostgisDialect(store: JDBCDataStore) extends PostGISDialect(store) with StrictLogging {
+
+  // order of calls from JDBCDataStore during create schema:
+  //  encodeCreateTable
+  //  encodeTableName
+  //  encodePrimaryKey
+  //  encodeColumnName
+  //  encodeColumnType
+  //  encodePostColumnCreateTable
+  //  encodePostCreateTable
+  //  postCreateTable
+
+  // order of calls during remove schema:
+  //  preDropTable
+  //  "DROP TABLE" + encodeTableName
+  //  postDropTable
+
+  // state for checking when we want to use the write_ahead table in place of the main view
+  private val replaceTableName = new ThreadLocal[Boolean]() {
+    override def initialValue(): Boolean = false
+  }
+
+  // filter out the partition tables from exposed feature types
+  override def getDesiredTablesType: Array[String] = Array("VIEW")
+
+  override def encodeTableName(raw: String, sql: StringBuffer): Unit = {
+    sql.append(s""""${if (replaceTableName.get) { raw + WriteAheadTableSuffix } else { raw }}"""")
+    replaceTableName.remove()
+  }
+
+  override def encodePrimaryKey(column: String, sql: StringBuffer): Unit = {
+    encodeColumnName(null, column, sql)
+    // make our primary key a string instead of the default integer
+    sql.append(" character varying NOT NULL")
+  }
+
+  override def postCreateTable(schemaName: String, sft: SimpleFeatureType, cx: Connection): Unit = {
+    val info = TypeInfo(schemaName, sft)
+
+    super.postCreateTable(schemaName, sft, cx)
+
+    implicit val ex: ExecutionContext = new ExecutionContext(cx)
+    try {
+      val commands = ArrayBuffer.empty[Sql]
+      commands += WriteAheadTable
+      commands += WriteAheadTrigger
+      commands += PartitionTables
+      commands += MainView
+      commands += InsertTrigger
+      commands += UpdateTrigger
+      commands += DeleteTrigger
+      commands += PrimaryKeyTable
+      commands += AnalyzeQueueTable
+      commands += SortQueueTable
+      commands += TruncateToTenMinutes
+      commands += TruncateToPartition
+      commands += RollWriteAheadLog
+      commands += PartitionWriteAheadLog
+      commands += MergeWriteAheadPartitions
+      if (info.partitions.maxPartitions.isDefined) {
+        commands += DropAgedOffPartitions
+      }
+      commands += PartitionMaintenance
+      commands += AnalyzePartitions
+      commands += PartitionSort
+      commands += LogCleaner
+
+      commands.foreach(_.create(info))
+    } finally {
+      ex.close()
+    }
+  }
+
+  /**
+   * Re-create the PLGP/SQL functions and procedures associated with a feature type. This can be used
+   * to 'upgrade in place' if the functions are changed.
+   *
+   * @param schemaName database schema, e.g. "public"
+   * @param sft feature type
+   * @param cx connection
+   */
+  def recreateFunctions(schemaName: String, sft: SimpleFeatureType, cx: Connection): Unit = {
+    val info = TypeInfo(schemaName, sft)
+    implicit val ex: ExecutionContext = new ExecutionContext(cx)
+    try {
+      val commands = ArrayBuffer.empty[Sql]
+      commands += TruncateToTenMinutes
+      commands += TruncateToPartition
+      commands += RollWriteAheadLog
+      commands += PartitionWriteAheadLog
+      commands += MergeWriteAheadPartitions
+      if (info.partitions.maxPartitions.isDefined) {
+        commands += DropAgedOffPartitions
+      }
+      commands += PartitionMaintenance
+      commands += AnalyzePartitions
+      commands += PartitionSort
+      commands += LogCleaner
+      commands.foreach(_.drop(info))
+      commands.foreach(_.create(info))
+    } finally {
+      ex.close()
+    }
+  }
+
+  override def postCreateFeatureType(
+      sft: SimpleFeatureType,
+      metadata: DatabaseMetaData,
+      schemaName: String,
+      cx: Connection): Unit = {
+    // normally views get set to read-only, override that here since we use triggers to delegate writes
+    sft.getUserData.remove(JDBCDataStore.JDBC_READ_ONLY)
+  }
+
+  override def preDropTable(schemaName: String, sft: SimpleFeatureType, cx: Connection): Unit = {
+    // due to the JDBCDataStore hard-coding "DROP TABLE" we have to redirect it away from the main view
+    replaceTableName.set(true)
+    val info = TypeInfo(schemaName, sft)
+
+    implicit val ex: ExecutionContext = new ExecutionContext(cx)
+    try {
+      Seq(
+        PartitionMaintenance,
+        PartitionSort,
+        LogCleaner,
+        PrimaryKeyTable,
+        MainView,
+        InsertTrigger,
+        UpdateTrigger,
+        DeleteTrigger,
+        PartitionTables
+      ).foreach(_.drop(info))
+    } finally {
+      ex.close()
+    }
+  }
+
+  override def postDropTable(schemaName: String, sft: SimpleFeatureType, cx: Connection): Unit = {
+    val tables = Tables(sft, schemaName)
+    // rename the sft so that configuration is applied to the write ahead table
+    super.postDropTable(schemaName, SimpleFeatureTypes.renameSft(sft, tables.writeAhead.name.raw), cx)
+  }
+}
+
+object PartitionedPostgisDialect {
+
+  object Config extends Conversions {
+
+    val IntervalHours                  = "pg.partitions.interval.hours"
+    val MaxPartitions                  = "pg.partitions.max"
+    val WriteAheadTableSpace           = "pg.partitions.tablespace.wa"
+    val WriteAheadPartitionsTableSpace = "pg.partitions.tablespace.wa-partitions"
+    val MainTableSpace                 = "pg.partitions.tablespace.main"
+    val CronMinute                     = "pg.partitions.cron.minute"
+
+    implicit class ConfigConversions(val sft: SimpleFeatureType) extends AnyVal {
+      def getIntervalHours: Int = Option(sft.getUserData.get(IntervalHours)).map(int).getOrElse(6)
+      def getMaxPartitions: Option[Int] = Option(sft.getUserData.get(MaxPartitions)).map(int)
+      def getWriteAheadTableSpace: Option[String] = Option(sft.getUserData.get(WriteAheadTableSpace).asInstanceOf[String])
+      def getWriteAheadPartitionsTableSpace: Option[String] = Option(sft.getUserData.get(WriteAheadPartitionsTableSpace).asInstanceOf[String])
+      def getMainTableSpace: Option[String] = Option(sft.getUserData.get(MainTableSpace).asInstanceOf[String])
+      def getCronMinute: Option[Int] = Option(sft.getUserData.get(CronMinute).asInstanceOf[String]).map(int)
+    }
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/functions/LogCleaner.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/functions/LogCleaner.scala
@@ -25,7 +25,7 @@ object LogCleaner extends SqlFunction with CronSchedule {
 
   override protected def dropStatements(info: TypeInfo): Seq[String] = Seq.empty // function is shared between types
 
-  override protected def schedule(info: TypeInfo): String = "0 0 * * *"
+  override protected def schedule(info: TypeInfo): String = "30 1 * * *" // 01:30 every day
 
   override protected def invocation(info: TypeInfo): String =
     s"SELECT cron_log_cleaner(''${info.tables.view.name.raw}'', INTERVAL ''7 DAYS'')"

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/functions/LogCleaner.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/functions/LogCleaner.scala
@@ -1,0 +1,61 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package functions
+
+import org.locationtech.geomesa.gt.partition.postgis.dialect.procedures.{AnalyzePartitions, PartitionMaintenance, RollWriteAheadLog}
+
+/**
+ * Deletes history older than 7 days
+ */
+object LogCleaner extends SqlFunction with CronSchedule {
+
+  override def name(info: TypeInfo): String = "cron_log_cleaner"
+
+  override def jobName(info: TypeInfo): String = s"${info.name}-cron-log-cleaner"
+
+  override protected def createStatements(info: TypeInfo): Seq[String] =
+    Seq(function()) ++ super.createStatements(info)
+
+  override protected def dropStatements(info: TypeInfo): Seq[String] = Seq.empty // function is shared between types
+
+  override protected def schedule(info: TypeInfo): String = "0 0 * * *"
+
+  override protected def invocation(info: TypeInfo): String =
+    s"SELECT cron_log_cleaner(''${info.tables.view.name.raw}'', INTERVAL ''7 DAYS'')"
+
+  private def function(): String = {
+    val info = TypeInfo("", "", null, null, null)
+    val maintenanceSuffix = PartitionMaintenance.jobName(info)
+    val rollSuffix = RollWriteAheadLog.jobName(info)
+    val analyzeSuffix = AnalyzePartitions.jobName(info)
+    val logsSuffix = jobName(info)
+
+    s"""CREATE OR REPLACE FUNCTION cron_log_cleaner(name text, tokeep interval) RETURNS void LANGUAGE plpgsql AS
+       |  $$BODY$$
+       |    DECLARE
+       |      maintenance_name text;
+       |      roll_name text;
+       |      analyze_name text;
+       |      logs_name text;
+       |    BEGIN
+       |      maintenance_name := name || '$maintenanceSuffix';
+       |      roll_name := name || '$rollSuffix';
+       |      analyze_name := name || '$analyzeSuffix';
+       |      logs_name := name || '$logsSuffix';
+       |      DELETE FROM cron.job_run_details
+       |        WHERE end_time < now() - tokeep
+       |        AND jobid IN (
+       |          SELECT jobid FROM cron.job
+       |            WHERE jobname IN (maintenance_name, roll_name, analyze_name, logs_name)
+       |        );
+       |    END;
+       |  $$BODY$$;""".stripMargin
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/functions/TruncateToPartition.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/functions/TruncateToPartition.scala
@@ -1,0 +1,30 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package functions
+
+/**
+ * Truncates a timestamp to the closest partition boundary, based on the number of hours in each partition
+ */
+object TruncateToPartition extends SqlStatements {
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = {
+    Seq(
+      """CREATE OR REPLACE FUNCTION truncate_to_partition(dtg timestamp without time zone, hours int)
+        |RETURNS timestamp without time zone AS
+        |  $BODY$
+        |    SELECT date_trunc('day', dtg) +
+        |      (hours * INTERVAL '1 HOUR' * floor(date_part('hour', dtg) / hours));
+        |  $BODY$
+        |LANGUAGE sql;""".stripMargin
+    )
+  }
+
+  override protected def dropStatements(info: TypeInfo): Seq[String] = Seq.empty // function is shared between types
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/functions/TruncateToTenMinutes.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/functions/TruncateToTenMinutes.scala
@@ -1,0 +1,29 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package functions
+
+/**
+ * Truncates a timestamp to the nearest ten-minute boundary. For example, 05:45:23 -> 05:40:00
+ */
+object TruncateToTenMinutes extends SqlStatements {
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = {
+    Seq(
+      """CREATE OR REPLACE FUNCTION truncate_to_ten_minutes(dtg timestamp without time zone)
+        |RETURNS timestamp without time zone AS
+        |  $BODY$
+        |    SELECT date_trunc('hour', dtg) + INTERVAL '10 MINUTES' * floor(date_part('minute', dtg) / 10);
+        |  $BODY$
+        |LANGUAGE sql;""".stripMargin
+    )
+  }
+
+  override protected def dropStatements(info: TypeInfo): Seq[String] = Seq.empty // function is shared between types
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/package.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/package.scala
@@ -1,0 +1,426 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis
+
+import com.typesafe.scalalogging.StrictLogging
+import org.locationtech.geomesa.gt.partition.postgis.dialect.PartitionedPostgisDialect.Config
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.AttributeOptions
+import org.locationtech.geomesa.utils.index.TemporalIndexCheck
+import org.locationtech.geomesa.utils.stats.IndexCoverage
+import org.opengis.feature.`type`.{AttributeDescriptor, GeometryDescriptor}
+import org.opengis.feature.simple.SimpleFeatureType
+
+import java.io.Closeable
+import java.sql.{Connection, PreparedStatement}
+import scala.util.Try
+import scala.util.control.NonFatal
+
+package object dialect {
+
+  private[dialect] val WriteAheadTableSuffix            = "_wa"
+  private[dialect] val PartitionedWriteAheadTableSuffix = "_wa_partition"
+  private[dialect] val PartitionedTableSuffix           = "_partition"
+  private[dialect] val AnalyzeTableSuffix               = "_analyze_queue"
+  private[dialect] val SortTableSuffix                  = "_sort_queue"
+
+  /**
+   * Wrapper to facilitate jdbc calls.
+   *
+   * Note: does not do any validation, inputs must be sanitized by the caller.
+   *
+   * @param cx connection
+   */
+  class ExecutionContext(val cx: Connection) extends Closeable with StrictLogging {
+
+    private val statement = cx.createStatement()
+    private var rollback = false
+
+    /**
+     * Execute a sql command
+     *
+     * @param sql sql string
+     */
+    def execute(sql: String): Unit = {
+      try {
+        logger.debug(sql)
+        statement.execute(sql)
+      } catch {
+        case NonFatal(e) => rollback = true; throw e
+      }
+    }
+
+    /**
+     * Execute an update statements
+     *
+     * @param sql sql string, with arguments denoted by '?'
+     * @param args arguments to the update statement, must match the argument placeholders in the sql string
+     */
+    def executeUpdate(sql: String, args: Seq[Any]): Unit = {
+      val ps: PreparedStatement = cx.prepareStatement(sql)
+      try {
+        var i = 1
+        args.foreach { arg =>
+          ps.setObject(i, arg)
+          i += 1
+        }
+        logger.debug(s"$sql, ${args.mkString(", ")}")
+        ps.executeUpdate()
+      } catch {
+        case NonFatal(e) => rollback = true; throw e
+      } finally {
+        ps.close()
+      }
+    }
+
+    override def close(): Unit = {
+      if (!cx.getAutoCommit) {
+        if (rollback) {
+          Try(cx.rollback())
+        } else {
+          cx.commit()
+        }
+      }
+      statement.close()
+    }
+  }
+
+  /**
+   * All the info for a feature type used by the partitioning scheme
+   *
+   * @param schema database schema (e.g. "public")
+   * @param name feature type name
+   * @param tables table names
+   * @param cols columns
+   * @param partitions partition config
+   */
+  case class TypeInfo(schema: String, name: String, tables: Tables, cols: Columns, partitions: PartitionInfo)
+
+  object TypeInfo {
+    def apply(schema: String, sft: SimpleFeatureType): TypeInfo = {
+      val tables = Tables(sft, schema)
+      val columns = Columns(sft)
+      val partitions = PartitionInfo(sft)
+      TypeInfo(schema, sft.getTypeName, tables, columns, partitions)
+    }
+  }
+
+  /**
+   * Tables used by the partitioning system
+   *
+   * @param schema database schema name (e.g. "public")
+   * @param view primary view of all partitions
+   * @param writeAhead write ahead table
+   * @param writeAheadPartitions recent partitions table
+   * @param mainPartitions main partitions table
+   * @param analyzeQueue analyze queue table
+   * @param sortQueue sort queue table
+   */
+  case class Tables(
+      schema: String,
+      view: TableConfig,
+      writeAhead: TableConfig,
+      writeAheadPartitions: TableConfig,
+      mainPartitions: TableConfig,
+      analyzeQueue: TableConfig,
+      sortQueue: TableConfig)
+
+  object Tables {
+
+    import Config.ConfigConversions
+
+    def apply(sft: SimpleFeatureType, schema: String): Tables = {
+      val view = TableConfig(schema, sft.getTypeName, None)
+      // we disable autovacuum for write ahead tables, as they are transient and get dropped fairly quickly
+      val writeAhead = TableConfig(schema, view.name.raw + WriteAheadTableSuffix, sft.getWriteAheadTableSpace, vacuum = false)
+      val writeAheadPartitions = TableConfig(schema, view.name.raw + PartitionedWriteAheadTableSuffix, sft.getWriteAheadPartitionsTableSpace, vacuum = false)
+      val mainPartitions = TableConfig(schema, view.name.raw + PartitionedTableSuffix, sft.getMainTableSpace)
+      val analyzeQueue = TableConfig(schema, view.name.raw + AnalyzeTableSuffix, sft.getMainTableSpace)
+      val sortQueue = TableConfig(schema, view.name.raw + SortTableSuffix, sft.getMainTableSpace)
+      Tables(schema, view, writeAhead, writeAheadPartitions, mainPartitions, analyzeQueue, sortQueue)
+    }
+  }
+
+  /**
+   * Table configuration
+   *
+   * @param name table name
+   * @param tablespace table space
+   * @param storage storage opts (auto vacuum)
+   */
+  case class TableConfig(name: TableName, tablespace: TableSpace, storage: String)
+
+  object TableConfig {
+    def apply(schema: String, name: String, tablespace: Option[String], vacuum: Boolean = true): TableConfig = {
+      val storage = if (vacuum) { "" } else { " WITH (autovacuum_enabled = false)" }
+      TableConfig(TableName(schema, name), TableSpace(tablespace), storage)
+    }
+  }
+
+  /**
+   * Table name
+   *
+   * @param full fully qualified and escaped name
+   * @param unqualified escaped name without the schema
+   * @param raw unqualified name without escaping
+   */
+  case class TableName(full: String, unqualified: String, raw: String)
+
+  object TableName {
+    def apply(schema: String, raw: String): TableName = TableName(s""""$schema"."$raw"""", s""""$raw"""", raw)
+  }
+
+  sealed trait TableSpace {
+
+    /**
+     * Name of the table space
+     *
+     * @return
+     */
+    def name: String
+
+    /**
+     * Sql to specify the tablespace when creating a table
+     *
+     * @return
+     */
+    def table: String
+
+    /**
+     * Sql to specify the table space when creating an index
+     *
+     * @return
+     */
+    def index: String
+  }
+
+  object TableSpace {
+
+    def apply(tablespace: Option[String]): TableSpace = {
+      tablespace match {
+        case None => DefaultTableSpace
+        case Some(t) => NamedTableSpace(t)
+      }
+    }
+
+    case object DefaultTableSpace extends TableSpace {
+      override val name: String = ""
+      override val table: String = ""
+      override val index: String = ""
+    }
+
+    case class NamedTableSpace(name: String) extends TableSpace {
+      override val table: String = s" TABLESPACE $name"
+      override val index: String = s" USING INDEX TABLESPACE $name"
+    }
+  }
+
+  /**
+   * Columns names for the feature type
+   *
+   * @param dtg primary dtg column
+   * @param geom primary geometry column
+   * @param geoms all geometry cols (including primary)
+   * @param indexed any indexed columns
+   * @param all all columns
+   */
+  case class Columns(
+      dtg: ColumnName,
+      geom: ColumnName,
+      geoms: Seq[ColumnName],
+      indexed: Seq[ColumnName],
+      all: Seq[ColumnName]
+    )
+
+  object Columns {
+
+    import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
+    import scala.collection.JavaConverters._
+
+    def apply(original: SimpleFeatureType): Columns = {
+      val sft = SimpleFeatureTypes.copy(original)
+      TemporalIndexCheck.validateDtgField(sft)
+      val dtg = sft.getDtgField.map(ColumnName.apply).getOrElse {
+        throw new IllegalArgumentException("Must include a date-type attribute when using a partitioned store")
+      }
+      val geom = Option(sft.getGeomField).map(ColumnName.apply).getOrElse {
+        throw new IllegalArgumentException("Must include a geometry-type attribute when using a partitioned store")
+      }
+      val geoms = sft.getAttributeDescriptors.asScala.collect { case d: GeometryDescriptor => ColumnName(d) }
+      // TODO we could use covering indices, but BRIN indices don't support them
+      //  val includes =
+      //    Seq(dtg) ++ sft.getAttributeDescriptors.asScala.collect { case d if d.isIndexValue() => ColumnName(d) }
+      //    .distinct
+      def indexed(d: AttributeDescriptor): Boolean = d.getLocalName != geom.raw && d.getLocalName != dtg.raw &&
+          Option(d.getUserData.get(AttributeOptions.OptIndex).asInstanceOf[String]).exists { i =>
+            Seq("true", IndexCoverage.FULL, IndexCoverage.JOIN).map(_.toString).exists(_.equalsIgnoreCase(i))
+          }
+
+      val indices = sft.getAttributeDescriptors.asScala.collect { case d if indexed(d) => ColumnName(d) }
+      val all = sft.getAttributeDescriptors.asScala.map(ColumnName.apply)
+      Columns(dtg, geom, geoms, indices, all)
+    }
+  }
+
+  /**
+   * Column name
+   *
+   * @param name escaped name
+   * @param raw unescaped name
+   */
+  case class ColumnName(name: String, raw: String)
+
+  object ColumnName {
+    def apply(d: AttributeDescriptor): ColumnName = apply(d.getLocalName)
+    def apply(raw: String): ColumnName = ColumnName(s""""$raw"""", raw)
+  }
+
+  /**
+   * Partition config
+   *
+   * @param hoursPerPartition number of hours to keep in each partition, must be a divisor of 24
+   * @param maxPartitions max number of partitions to keep
+   * @param cronMinute minute of each 10 minute chunk that partition maintenance will run
+   */
+  case class PartitionInfo(hoursPerPartition: Int, maxPartitions: Option[Int], cronMinute: Option[Int])
+
+  object PartitionInfo {
+
+    import Config.ConfigConversions
+
+    def apply(sft: SimpleFeatureType): PartitionInfo = {
+      val hours = sft.getIntervalHours
+      require(hours > 0 && hours <= 24, s"Partition interval must be between 1 and 24 hours: $hours hours")
+      require(24 % hours == 0, s"Partition interval must be a divisor of 24 hours: $hours hours")
+      val cronMinute = sft.getCronMinute
+      require(cronMinute.forall(m => m >= 0 && m < 9), s"Cron minute must be between 0 and 8: ${cronMinute.orNull}")
+      PartitionInfo(hours, sft.getMaxPartitions, cronMinute)
+    }
+  }
+
+  /**
+   * Trait for modelling sql objects
+   */
+  trait Sql {
+
+    /**
+     * Execute sql defined by this class
+     *
+     * @param info type info
+     */
+    def create(info: TypeInfo)(implicit ex: ExecutionContext): Unit
+
+    /**
+     * Drop things created by this class
+     *
+     * @param info type info
+     */
+    def drop(info: TypeInfo)(implicit ex: ExecutionContext): Unit
+  }
+
+  /**
+   * Trait for modeling a list of sql statements
+   */
+  trait SqlStatements extends Sql {
+
+    override def create(info: TypeInfo)(implicit ex: ExecutionContext): Unit =
+      createStatements(info).foreach(ex.execute)
+
+    override def drop(info: TypeInfo)(implicit ex: ExecutionContext): Unit =
+      dropStatements(info).foreach(ex.execute)
+
+    /**
+     * The sql defined by this class
+     *
+     * @param info type info
+     * @return
+     */
+    protected def createStatements(info: TypeInfo): Seq[String]
+
+    /**
+     * The sql to drop things created by this class
+     *
+     * @param info type info
+     * @return
+     */
+    protected def dropStatements(info: TypeInfo): Seq[String]
+  }
+
+  /**
+   * A function definition
+   */
+  trait SqlFunction extends SqlStatements {
+
+    /**
+     * The name of the function
+     *
+     * @param info type info
+     * @return
+     */
+    def name(info: TypeInfo): String
+
+    override protected def dropStatements(info: TypeInfo): Seq[String] =
+      Seq(s"""DROP FUNCTION IF EXISTS "${name(info)}";""")
+  }
+
+  /**
+   * A procedure definition
+   */
+  trait SqlProcedure extends SqlStatements {
+
+    /**
+     * The name of the procedure
+     *
+     * @param info type info
+     * @return
+     */
+    def name(info: TypeInfo): String
+
+    override protected def dropStatements(info: TypeInfo): Seq[String] =
+      Seq(s"""DROP PROCEDURE IF EXISTS "${name(info)}";""")
+  }
+
+  /**
+   * A cron'd function or procedure
+   */
+  trait CronSchedule extends SqlStatements {
+
+    /**
+     * The name of the cron job in the cron.job tables
+     *
+     * @param info type info
+     * @return
+     */
+    def jobName(info: TypeInfo): String
+
+    /**
+     * The cron schedule, e.g. "* * * * *"
+     *
+     * @param info type info
+     * @return
+     */
+    protected def schedule(info: TypeInfo): String
+
+    /**
+     * The statement to execute for each cron run
+     *
+     * @param info type info
+     * @return
+     */
+    protected def invocation(info: TypeInfo): String
+
+    override protected def createStatements(info: TypeInfo): Seq[String] =
+      Seq(s"SELECT cron.schedule('${jobName(info)}', '${schedule(info)}', '${invocation(info)}');")
+
+    abstract override protected def dropStatements(info: TypeInfo): Seq[String] =
+      Seq(s"SELECT cron.unschedule('${jobName(info)}');") ++ super.dropStatements(info)
+  }
+
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/package.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/package.scala
@@ -33,7 +33,7 @@ package object dialect {
   /**
    * Wrapper to facilitate jdbc calls.
    *
-   * Note: does not do any validation, inputs must be sanitized by the caller.
+   * Note: does not do any validation, sql must be sanitized by the caller.
    *
    * @param cx connection
    */

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/AnalyzePartitions.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/AnalyzePartitions.scala
@@ -1,0 +1,51 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package procedures
+
+/**
+ * Runs 'analyze' on partitions that have been modified
+ */
+object AnalyzePartitions extends SqlProcedure with CronSchedule {
+
+  override def name(info: TypeInfo): String = s"${info.name}_analyze_partitions"
+
+  override def jobName(info: TypeInfo): String = s"${info.name}-analyze"
+
+  override protected def createStatements(info: TypeInfo): Seq[String] =
+    Seq(proc(info)) ++ super.createStatements(info)
+
+  override protected def schedule(info: TypeInfo): String = "* * * * *" // run every minute
+
+  override protected def invocation(info: TypeInfo): String = s"""CALL "${name(info)}"()"""
+
+  private def proc(info: TypeInfo): String = {
+    s"""CREATE OR REPLACE PROCEDURE "${name(info)}"() LANGUAGE plpgsql AS
+       |  $$BODY$$
+       |    DECLARE
+       |      cur_time timestamp without time zone;        -- current time
+       |      to_analyze record;                           -- result
+       |    BEGIN
+       |      LOOP
+       |        cur_time := now();
+       |        SELECT * INTO to_analyze FROM ${info.tables.analyzeQueue.name.full}
+       |          WHERE enqueued < cur_time
+       |          ORDER BY enqueued ASC;
+       |        EXIT WHEN to_analyze IS NULL;
+       |        RAISE INFO '% Running analyze on partition table %', timeofday()::timestamp, to_analyze.partition_name;
+       |        EXECUTE 'ANALYZE "${info.schema}".' || quote_ident(to_analyze.partition_name);
+       |        DELETE FROM ${info.tables.analyzeQueue.name.full}
+       |          WHERE partition_name = to_analyze.partition_name AND enqueued < cur_time;
+       |        COMMIT;
+       |      END LOOP;
+       |    END;
+       |  $$BODY$$;
+       |""".stripMargin
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/DropAgedOffPartitions.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/DropAgedOffPartitions.scala
@@ -1,0 +1,53 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package procedures
+
+/**
+ * Drops any partitions older than the configured maximum
+ */
+object DropAgedOffPartitions extends SqlProcedure {
+
+  override def name(info: TypeInfo): String = s"${info.name}_age_off"
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = Seq(proc(info))
+
+  private def proc(info: TypeInfo): String = {
+    val hours = info.partitions.hoursPerPartition
+    val mainPartitions = info.tables.mainPartitions
+    val max = info.partitions.maxPartitions.getOrElse(throw new IllegalStateException("No configured max partitions"))
+
+    s"""CREATE OR REPLACE PROCEDURE "${name(info)}"(cur_time timestamp without time zone) LANGUAGE plpgsql AS
+       |  $$BODY$$
+       |    DECLARE
+       |      main_cutoff timestamp without time zone;     -- max age of the records for main tables
+       |      partition_start timestamp without time zone; -- start bounds for the partition we're writing
+       |      partition_name text;                         -- partition table name
+       |    BEGIN
+       |      -- constants
+       |      main_cutoff := truncate_to_partition(cur_time, $hours) - INTERVAL '$hours HOURS';
+       |
+       |      -- remove any partitions that have aged out
+       |      partition_start := main_cutoff - INTERVAL '${hours * max} HOURS'
+       |      FOR partition_name IN
+       |        SELECT relid
+       |          FROM pg_partition_tree('${info.schema}.${mainPartitions.name.raw}'::regclass)
+       |          WHERE parentrelid IS NOT NULL
+       |          AND child <= '${mainPartitions.name.raw}_' || to_char(partition_start, 'YYYY_MM_DD_HH24')
+       |      LOOP
+       |        IF EXISTS(SELECT FROM pg_tables WHERE schemaname = '${info.schema}' AND tablename = partition_name) THEN
+       |          EXECUTE 'DROP TABLE IF EXISTS "${info.schema}".' || quote_ident(partition_name);
+       |          RAISE NOTICE 'A partition has been deleted %', partition_name;
+       |        END IF;
+       |      END LOOP;
+       |    END;
+       |  $$BODY$$;
+       |""".stripMargin
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/MergeWriteAheadPartitions.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/MergeWriteAheadPartitions.scala
@@ -1,0 +1,141 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package procedures
+
+/**
+ * Merge recent write-ahead partitions and move them into the main partition table
+ */
+object MergeWriteAheadPartitions extends SqlProcedure {
+
+  override def name(info: TypeInfo): String = s"${info.name}_merge_wa_partitions"
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = Seq(proc(info))
+
+  private def proc(info: TypeInfo): String = {
+    val hours = info.partitions.hoursPerPartition
+    val writeAheadPartitions = info.tables.writeAheadPartitions
+    val mainPartitions = info.tables.mainPartitions
+    val dtgCol = info.cols.dtg.name
+    val geomCol = info.cols.geom.name
+
+    s"""CREATE OR REPLACE PROCEDURE "${name(info)}"(cur_time timestamp without time zone) LANGUAGE plpgsql AS
+       |  $$BODY$$
+       |    DECLARE
+       |      min_dtg timestamp without time zone;         -- min date in our partitioned tables
+       |      main_cutoff timestamp without time zone;     -- max age of the records for main tables
+       |      partition_start timestamp without time zone; -- start bounds for the partition we're writing
+       |      partition_end timestamp without time zone;   -- end bounds for the partition we're writing
+       |      partition_name text;                         -- partition table name
+       |      partition_parent text;                       -- partition parent table name
+       |      partition_tablespace text;                   -- partition tablespace
+       |      write_ahead_partitions text[];               -- names of the partitions we're migrating
+       |      write_ahead_partition text;                  -- name of current partition
+       |      pexists boolean;                             -- table exists check
+       |      unsorted_count bigint;
+       |    BEGIN
+       |      -- constants
+       |      main_cutoff := truncate_to_partition(cur_time, $hours) - INTERVAL '$hours HOURS';
+       |
+       |      -- move data from the write ahead partitions to the main partitions
+       |      LOOP
+       |        -- find the range of dates in the write ahead partition tables
+       |        SELECT min($dtgCol) INTO min_dtg FROM ${writeAheadPartitions.name.full}
+       |          WHERE $dtgCol < main_cutoff;
+       |        EXIT WHEN min_dtg IS NULL;
+       |
+       |        partition_start := truncate_to_partition(min_dtg, $hours);
+       |        partition_end := partition_start + INTERVAL '$hours HOURS';
+       |        partition_name := '${mainPartitions.name.raw}' || '_' || to_char(partition_start, 'YYYY_MM_DD_HH24');
+       |
+       |        SELECT EXISTS(SELECT FROM pg_tables WHERE schemaname = '${info.schema}' AND tablename = partition_name)
+       |          INTO pexists;
+       |
+       |        -- create the partition table if it doesn't exist
+       |        IF NOT pexists THEN
+       |          -- upper bounds are exclusive
+       |          -- this won't have any indices until we attach it to the parent partition table
+       |          EXECUTE 'CREATE TABLE "${info.schema}".' || quote_ident(partition_name) ||
+       |            ' (LIKE ${mainPartitions.name.full} INCLUDING DEFAULTS INCLUDING CONSTRAINTS)${mainPartitions.tablespace.table}';
+       |          -- creating a constraint allows it to be attached to the parent without any additional checks
+       |          EXECUTE 'ALTER TABLE  "${info.schema}".' || quote_ident(partition_name) ||
+       |            ' ADD CONSTRAINT ' || quote_ident(partition_name || '_constraint') ||
+       |            ' CHECK ( $dtgCol >= ' || quote_literal(partition_start) ||
+       |            ' AND $dtgCol < ' || quote_literal(partition_end) || ' );';
+       |        END IF;
+       |
+       |        -- find the write ahead partitions we're copying from
+       |        -- order the results to ensure we get locks in a consistent order to avoid deadlocks
+       |        write_ahead_partitions := Array(
+       |          SELECT '"${info.schema}".' || quote_ident(pg_class.relname)
+       |            FROM pg_catalog.pg_inherits
+       |            INNER JOIN pg_catalog.pg_class ON (pg_inherits.inhrelid = pg_class.oid)
+       |            INNER JOIN pg_catalog.pg_namespace ON (pg_class.relnamespace = pg_namespace.oid)
+       |            WHERE inhparent = '${writeAheadPartitions.name.raw}'::regclass
+       |              AND pg_class.relname >= '${writeAheadPartitions.name.raw}' || '_' || to_char(partition_start, 'YYYY_MM_DD_HH24_MI')
+       |              AND pg_class.relname < '${writeAheadPartitions.name.raw}' || '_' || to_char(partition_end, 'YYYY_MM_DD_HH24_MI')
+       |            ORDER BY 1
+       |          );
+       |
+       |        -- get a lock on the tables - this mode won't prevent reads but will prevent writes
+       |        -- (there shouldn't be any writes though) and will synchronize this method
+       |        -- TODO we really just need to sync this method for safety in manual invocations
+       |        -- FOREACH write_ahead_partition IN ARRAY write_ahead_partitions LOOP
+       |        --   EXECUTE 'LOCK TABLE ' || write_ahead_partition || ' IN SHARE ROW EXCLUSIVE MODE';
+       |        --   RAISE INFO '% Locked write ahead partition % for migration', timeofday()::timestamp, write_ahead_partition;
+       |        -- END LOOP;
+       |
+       |        -- create a view from the tables so that we can sort the result by an expression (geohash)
+       |        EXECUTE 'CREATE TEMP VIEW ' || quote_ident(partition_name || '_tmp_migrate') ||
+       |          ' AS SELECT * FROM ' || array_to_string(write_ahead_partitions, ' UNION ALL SELECT * FROM ');
+       |
+       |        -- copy rows from write ahead partitions to main partition table
+       |        EXECUTE 'INSERT INTO "${info.schema}".' || quote_ident(partition_name) ||
+       |          ' SELECT * FROM ' || quote_ident(partition_name || '_tmp_migrate') ||
+       |          '   ORDER BY st_geohash($geomCol), $dtgCol' ||
+       |          '   ON CONFLICT DO NOTHING';
+       |
+       |        IF NOT pexists THEN
+       |          EXECUTE 'ALTER TABLE ${mainPartitions.name.full}' ||
+       |            ' ATTACH PARTITION "${info.schema}".' || quote_ident(partition_name) ||
+       |            ' FOR VALUES FROM (' || quote_literal(partition_start) ||
+       |            ') TO (' || quote_literal(partition_end) || ' );';
+       |          -- now that we've attached the table we can drop the redundant constraint
+       |          EXECUTE 'ALTER TABLE "${info.schema}".' || quote_ident(partition_name) ||
+       |            ' DROP CONSTRAINT ' || quote_ident(partition_name || '_constraint');
+       |          RAISE NOTICE 'A partition has been created %', partition_name;
+       |        ELSE
+       |          -- store record of unsorted row counts which could negatively impact BRIN index scans
+       |          GET DIAGNOSTICS unsorted_count := ROW_COUNT;
+       |          INSERT INTO ${info.tables.sortQueue.name.full}(partition_name, unsorted_count, enqueued)
+       |            VALUES (partition_name, unsorted_count, now());
+       |          RAISE NOTICE 'Inserting % rows into existing partition %, queries may be impacted',
+       |                unsorted_count, partition_name;
+       |        END IF;
+       |
+       |        -- drop the tables that we've copied out
+       |        EXECUTE 'DROP VIEW ' || quote_ident(partition_name || '_tmp_migrate');
+       |        FOREACH write_ahead_partition IN ARRAY write_ahead_partitions LOOP
+       |          EXECUTE 'DROP TABLE ' || write_ahead_partition;
+       |          RAISE NOTICE 'A partition has been deleted %', write_ahead_partition;
+       |        END LOOP;
+       |
+       |        -- mark the partition to be analyzed in a separate thread
+       |        INSERT INTO ${info.tables.analyzeQueue.name.full}(partition_name, enqueued)
+       |          VALUES (partition_name, now());
+       |
+       |        -- commit after each move, also releases the table locks
+       |        COMMIT;
+       |
+       |      END LOOP;
+       |    END;
+       |  $$BODY$$;
+       |""".stripMargin
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/PartitionMaintenance.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/PartitionMaintenance.scala
@@ -27,8 +27,6 @@ object PartitionMaintenance extends SqlProcedure with CronSchedule {
     val minute = info.partitions.cronMinute.getOrElse {
       // spread out the cron schedule so that all the feature types don't run at the exact same time
       // also don't run at same minute as roll-write-ahead (i.e. use 0-8)
-      // TODO this will mean data left in the write ahead table longer -
-      //   revisit if this impacts performance, since write ahead isn't partition pruned during queries
       math.abs(MurmurHash3.stringHash(info.name) % 9)
     }
     val minutes = Seq(0, 10, 20, 30, 40, 50).map(_ + minute).mkString(",")

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/PartitionMaintenance.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/PartitionMaintenance.scala
@@ -1,0 +1,58 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package procedures
+
+import scala.util.hashing.MurmurHash3
+
+/**
+ * High level procedure to manage data shuffling between write-ahead table and partitioned tables
+ */
+object PartitionMaintenance extends SqlProcedure with CronSchedule {
+
+  override def name(info: TypeInfo): String = s"${info.name}_partition_maintenance"
+
+  override def jobName(info: TypeInfo): String = s"${info.name}-part-maintenance"
+
+  override protected def createStatements(info: TypeInfo): Seq[String] =
+    Seq(proc(info)) ++ super.createStatements(info)
+
+  override protected def schedule(info: TypeInfo): String = {
+    val minute = info.partitions.cronMinute.getOrElse {
+      // spread out the cron schedule so that all the feature types don't run at the exact same time
+      // also don't run at same minute as roll-write-ahead (i.e. use 0-8)
+      // TODO this will mean data left in the write ahead table longer -
+      //   revisit if this impacts performance, since write ahead isn't partition pruned during queries
+      math.abs(MurmurHash3.stringHash(info.name) % 9)
+    }
+    val minutes = Seq(0, 10, 20, 30, 40, 50).map(_ + minute).mkString(",")
+    s"$minutes * * * *"
+  }
+
+  override protected def invocation(info: TypeInfo): String = s"""CALL "${name(info)}"()"""
+
+  private def proc(info: TypeInfo): String = {
+    val callPrune = if (info.partitions.maxPartitions.isEmpty) { "" }  else {
+      s"""CALL "${DropAgedOffPartitions.name(info)}"(cur_time);"""
+    }
+    s"""CREATE OR REPLACE PROCEDURE "${name(info)}"() LANGUAGE plpgsql AS
+       |  $$BODY$$
+       |    DECLARE
+       |      cur_time timestamp without time zone;        -- current time
+       |    BEGIN
+       |      -- constants
+       |      cur_time := now();
+       |      CALL "${PartitionWriteAheadLog.name(info)}"(cur_time);
+       |      CALL "${MergeWriteAheadPartitions.name(info)}"(cur_time);
+       |      $callPrune
+       |    END;
+       |  $$BODY$$;
+       |""".stripMargin
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/PartitionSort.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/PartitionSort.scala
@@ -1,0 +1,67 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package procedures
+
+/**
+ * Re-sorts a partition table. Can be used for maintenance if time-latent data comes in and degrades performance
+ * of the BRIN index
+ */
+object PartitionSort extends SqlProcedure {
+
+  override def name(info: TypeInfo): String = s"${info.name}_partition_sort"
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = Seq(proc(info))
+
+  private def proc(info: TypeInfo): String = {
+    val hours = info.partitions.hoursPerPartition
+    s"""CREATE OR REPLACE PROCEDURE "${name(info)}"(for_date timestamp without time zone) LANGUAGE plpgsql AS
+       |  $$BODY$$
+       |    DECLARE
+       |      partition_names text[];
+       |      partition_name text;
+       |    BEGIN
+       |      IF for_date IS NOT NULL THEN
+       |        partition_names := ARRAY[
+       |          '${info.tables.mainPartitions.name.raw}' || '_' || to_char(truncate_to_partition(for_date, $hours), 'YYYY_MM_DD_HH24')
+       |        ];
+       |      ELSE
+       |        partition_names := Array(
+       |          SELECT relid
+       |            FROM pg_partition_tree('${info.tables.schema}.${info.tables.mainPartitions.name.raw}'::regclass)
+       |            WHERE parentrelid IS NOT NULL
+       |            ORDER BY relid
+       |        );
+       |        -- start a new transaction to ensure our lock is correct
+       |        COMMIT;
+       |      END IF;
+       |
+       |      FOREACH partition_name IN ARRAY partition_names LOOP
+       |        RAISE INFO '% Sorting partition table %', timeofday()::timestamp, partition_name;
+       |        LOCK TABLE ONLY ${info.tables.mainPartitions.name.full} IN SHARE UPDATE EXCLUSIVE MODE;
+       |        EXECUTE 'LOCK TABLE "${info.schema}".' || quote_ident(partition_name) ||
+       |          ' IN SHARE UPDATE EXCLUSIVE MODE';
+       |        EXECUTE 'CREATE TEMP TABLE ' || quote_ident(partition_name || '_tmp_sort') || ' ON COMMIT DROP' ||
+       |          ' AS SELECT * FROM "${info.schema}".' || quote_ident(partition_name);
+       |        EXECUTE 'ANALYZE ' || quote_ident(partition_name || '_tmp_sort');
+       |        EXECUTE 'TRUNCATE "${info.schema}".' || quote_ident(partition_name);
+       |        EXECUTE 'INSERT INTO "${info.schema}".' || quote_ident(partition_name) ||
+       |          ' (SELECT * FROM ' || quote_ident(partition_name || '_tmp_sort') ||
+       |          ' ORDER BY st_geohash(${info.cols.geom.name}), ${info.cols.dtg.name})';
+       |        -- mark the partition to be analyzed in a separate thread
+       |        INSERT INTO ${info.tables.analyzeQueue.name.full}(partition_name, enqueued)
+       |          VALUES (partition_name, now());
+       |        COMMIT;
+       |      END LOOP;
+       |
+       |    END;
+       |  $$BODY$$;
+       |""".stripMargin
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/PartitionWriteAheadLog.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/PartitionWriteAheadLog.scala
@@ -1,0 +1,171 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package procedures
+
+import org.locationtech.geomesa.gt.partition.postgis.dialect.tables.WriteAheadTable
+
+/**
+ * Partitions the write ahead table into the recent and/or main partition tables
+ */
+object PartitionWriteAheadLog extends SqlProcedure {
+
+  override def name(info: TypeInfo): String = s"${info.name}_partition_wa"
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = Seq(proc(info))
+
+  private def proc(info: TypeInfo): String = {
+    val hours = info.partitions.hoursPerPartition
+    val writeAhead = info.tables.writeAhead
+    val writeAheadPartitions = info.tables.writeAheadPartitions
+    val mainPartitions = info.tables.mainPartitions
+    val dtgCol = info.cols.dtg.name
+    val geomCol = info.cols.geom.name
+
+    s"""CREATE OR REPLACE PROCEDURE "${name(info)}"(cur_time timestamp without time zone) LANGUAGE plpgsql AS
+       |  $$BODY$$
+       |    DECLARE
+       |      min_dtg timestamp without time zone;         -- min date in our partitioned tables
+       |      main_cutoff timestamp without time zone;     -- max age of the records for main tables
+       |      write_ahead record;
+       |      partition_start timestamp without time zone; -- start bounds for the partition we're writing
+       |      partition_end timestamp without time zone;   -- end bounds for the partition we're writing
+       |      partition_name text;                         -- partition table name
+       |      partition_parent text;                       -- partition parent table name
+       |      partition_name_format text;                  -- date format for partition names
+       |      partition_tablespace text;                   -- partition tablespace
+       |      pexists boolean;                             -- table exists check
+       |      unsorted_count bigint;
+       |    BEGIN
+       |      -- constants
+       |      main_cutoff := truncate_to_partition(cur_time, $hours) - INTERVAL '$hours HOURS';
+       |
+       |      -- check for write ahead partitions and move the data into the time partitioned tables
+       |      FOR write_ahead IN
+       |        SELECT pg_class.relname AS name
+       |          FROM pg_catalog.pg_inherits
+       |          INNER JOIN pg_catalog.pg_class ON (pg_inherits.inhrelid = pg_class.oid)
+       |          INNER JOIN pg_catalog.pg_namespace ON (pg_class.relnamespace = pg_namespace.oid)
+       |          WHERE inhparent = '${writeAhead.name.raw}'::regclass
+       |          AND relname != '${WriteAheadTable.writesPartitionRaw(info)}'
+       |          ORDER BY name
+       |      LOOP
+       |
+       |        RAISE INFO '% Checking write ahead table %', timeofday()::timestamp, write_ahead.name;
+       |        -- get a lock on the table - this mode won't prevent reads but will prevent writes
+       |        -- (there shouldn't be any writes though) and will synchronize this method
+       |        LOCK TABLE ONLY ${mainPartitions.name.full} IN SHARE UPDATE EXCLUSIVE MODE;
+       |        EXECUTE 'LOCK TABLE "${info.schema}".' || quote_ident(write_ahead.name) ||
+       |          ' IN SHARE UPDATE EXCLUSIVE MODE';
+       |        RAISE INFO '% Locked write ahead table % for migration', timeofday()::timestamp, write_ahead.name;
+       |
+       |        -- wait until the table doesn't contain any recent records
+       |        EXECUTE 'SELECT EXISTS(SELECT 1 FROM "${info.schema}".' || quote_ident(write_ahead.name) ||
+       |          ' WHERE $dtgCol >= ' || quote_literal(truncate_to_ten_minutes(cur_time)) || ')'
+       |          INTO pexists;
+       |
+       |        IF pexists THEN
+       |          -- should only happen if data is inserted with timestamps from the future
+       |          RAISE NOTICE '% Skipping write ahead table % due to min date', timeofday()::timestamp, write_ahead.name;
+       |        ELSE
+       |          partition_end := '-infinity'::timestamp without time zone;
+       |          LOOP
+       |            -- find the range of dates in the write ahead partition
+       |            EXECUTE 'SELECT min($dtgCol) FROM "${info.schema}".' || quote_ident(write_ahead.name) ||
+       |              ' WHERE $dtgCol >= ' || quote_literal(partition_end) INTO min_dtg;
+       |            EXIT WHEN min_dtg IS NULL;
+       |
+       |            -- calculate the partition bounds for the min date
+       |            IF min_dtg < main_cutoff THEN
+       |              partition_start := truncate_to_partition(min_dtg, $hours);
+       |              partition_end := partition_start + INTERVAL '$hours HOURS';
+       |              partition_parent := '${mainPartitions.name.raw}';
+       |              partition_tablespace := '${mainPartitions.storage}${mainPartitions.tablespace.table}';
+       |              partition_name_format := 'YYYY_MM_DD_HH24';
+       |            ELSE
+       |              partition_start := truncate_to_ten_minutes(min_dtg);
+       |              partition_end := partition_start + INTERVAL '10 MINUTES';
+       |              partition_parent := '${writeAheadPartitions.name.raw}';
+       |              partition_tablespace := '${writeAheadPartitions.storage}${writeAheadPartitions.tablespace.table}';
+       |              partition_name_format := 'YYYY_MM_DD_HH24_MI';
+       |            END IF;
+       |
+       |            partition_name := partition_parent || '_' || to_char(partition_start, partition_name_format);
+       |
+       |            RAISE INFO '% Writing to partition %', timeofday()::timestamp, partition_name;
+       |
+       |            SELECT EXISTS(SELECT FROM pg_tables WHERE schemaname = '${info.schema}' AND tablename = partition_name)
+       |              INTO pexists;
+       |
+       |            -- create the partition table if it doesn't exist
+       |            -- note: normally the partition will not exist unless time-latent data was inserted
+       |            -- we create it unattached so that it doesn't lock the _recent table on insert
+       |            -- then we attach it after inserting the rows
+       |            -- since this is all within a transaction it should all happen "at once"
+       |            -- see https://www.postgresql.org/docs/13/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE-MAINTENANCE
+       |            IF NOT pexists THEN
+       |              RAISE INFO '% Creating partition % (unattached)', timeofday()::timestamp, partition_name;
+       |              -- upper bounds are exclusive
+       |              EXECUTE 'CREATE TABLE "${info.schema}".' || quote_ident(partition_name) ||
+       |                ' (LIKE "${info.schema}".' || quote_ident(partition_parent) ||
+       |                ' INCLUDING DEFAULTS INCLUDING CONSTRAINTS)' || partition_tablespace;
+       |              -- creating a constraint allows it to be attached to the parent without any additional checks
+       |              EXECUTE 'ALTER TABLE  "${info.schema}".' || quote_ident(partition_name) ||
+       |                ' ADD CONSTRAINT ' || quote_ident(partition_name || '_constraint') ||
+       |                ' CHECK ( $dtgCol >= ' || quote_literal(partition_start) ||
+       |                ' AND $dtgCol < ' || quote_literal(partition_end) || ' );';
+       |            END IF;
+       |
+       |            -- copy rows from write ahead table to partition table
+       |            RAISE INFO '% Copying rows to partition %', timeofday()::timestamp, partition_name;
+       |            EXECUTE 'INSERT INTO "${info.schema}".' || quote_ident(partition_name) ||
+       |              ' SELECT * FROM ' || quote_ident(write_ahead.name) ||
+       |              '   WHERE $dtgCol >= ' || quote_literal(partition_start) ||
+       |              '     AND $dtgCol < ' || quote_literal(partition_end) ||
+       |              '   ORDER BY st_geohash($geomCol), $dtgCol' ||
+       |              '   ON CONFLICT DO NOTHING';
+       |            RAISE INFO '% Done copying rows to partition %', timeofday()::timestamp, partition_name;
+       |
+       |            -- attach the partition table to the parent
+       |            IF NOT pexists THEN
+       |              RAISE INFO '% Attaching partition % to parent', timeofday()::timestamp, partition_name;
+       |              EXECUTE 'ALTER TABLE "${info.schema}".' || quote_ident(partition_parent) ||
+       |                ' ATTACH PARTITION "${info.schema}".' || quote_ident(partition_name) ||
+       |                ' FOR VALUES FROM (' || quote_literal(partition_start) ||
+       |                ') TO (' || quote_literal(partition_end) || ' );';
+       |              -- once the table is attached we can drop the redundant constraint
+       |              EXECUTE 'ALTER TABLE "${info.schema}".' || quote_ident(partition_name) ||
+       |                ' DROP CONSTRAINT ' || quote_ident(partition_name || '_constraint');
+       |              RAISE NOTICE 'A partition has been created %', partition_name;
+       |            ELSIF partition_parent = '${mainPartitions.name.raw}' THEN
+       |              -- store record of unsorted row counts which could negatively impact BRIN index scans
+       |              GET DIAGNOSTICS unsorted_count := ROW_COUNT;
+       |              INSERT INTO ${info.tables.sortQueue.name.full}(partition_name, unsorted_count, enqueued)
+       |                VALUES (partition_name, unsorted_count, now());
+       |              RAISE NOTICE 'Inserting % rows into existing partition %, queries may be impacted',
+       |                unsorted_count, partition_name;
+       |            END IF;
+       |
+       |            -- mark the partition to be analyzed in a separate thread
+       |            INSERT INTO ${info.tables.analyzeQueue.name.full}(partition_name, enqueued)
+       |              VALUES (partition_name, now());
+       |          END LOOP;
+       |
+       |          RAISE INFO '% Dropping write ahead table %', timeofday()::timestamp, write_ahead.name;
+       |          EXECUTE 'DROP TABLE ' || quote_ident(write_ahead.name);
+       |
+       |        END IF;
+       |
+       |        COMMIT; -- releases the lock
+       |      END LOOP;
+       |    END;
+       |  $$BODY$$;
+       |""".stripMargin
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/RollWriteAheadLog.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/RollWriteAheadLog.scala
@@ -1,0 +1,83 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package procedures
+
+import org.locationtech.geomesa.gt.partition.postgis.dialect.tables.WriteAheadTable
+
+import java.util.Locale
+
+/**
+ * Moves the current write ahead table to a sequential name, and creates a new write ahead table
+ * to accept writes going forward
+ */
+object RollWriteAheadLog extends SqlProcedure with CronSchedule {
+
+  override def name(info: TypeInfo): String = s"${info.name}_roll_wa"
+
+  override def jobName(info: TypeInfo): String = s"${info.name}-roll-wa"
+
+  override protected def schedule(info: TypeInfo): String = "9,19,29,39,49,59 * * * *"
+
+  override protected def invocation(info: TypeInfo): String = s"""CALL "${name(info)}"()"""
+
+  override protected def createStatements(info: TypeInfo): Seq[String] =
+    Seq(proc(info)) ++ super.createStatements(info)
+
+  private def proc(info: TypeInfo): String = {
+    val table = info.tables.writeAhead
+    val writePartition = WriteAheadTable.writesPartition(info)
+    s"""CREATE OR REPLACE PROCEDURE "${name(info)}"() LANGUAGE plpgsql AS
+       |  $$BODY$$
+       |    DECLARE
+       |      seq_val smallint;
+       |      cur_partition text;  -- rename of the _writes table
+       |      next_partition text; -- next partition that will be created from the _writes table
+       |    BEGIN
+       |
+       |      -- get the required locks up front to avoid deadlocks with inserts
+       |      LOCK TABLE ONLY ${table.name.full} IN SHARE UPDATE EXCLUSIVE MODE;
+       |      LOCK TABLE $writePartition IN ACCESS EXCLUSIVE MODE;
+       |
+       |      -- don't re-create the table if there hasn't been any data inserted
+       |      IF EXISTS(SELECT 1 FROM $writePartition) THEN
+       |        SELECT nextval('${table.name.raw + "_seq"}') INTO seq_val;
+       |
+       |        -- format the table name to be 3 digits, with leading zeros as needed
+       |        cur_partition := lpad((seq_val - 1)::text, 3, '0');
+       |        next_partition := lpad(seq_val::text, 3, '0');
+       |
+       |        -- requires ACCESS EXCLUSIVE
+       |        EXECUTE 'ALTER TABLE $writePartition RENAME TO ' || quote_ident('${table.name.raw}_' || cur_partition);
+       |        -- requires SHARE UPDATE EXCLUSIVE
+       |        EXECUTE 'CREATE TABLE IF NOT EXISTS $writePartition (' ||
+       |          ' CONSTRAINT ' || quote_ident('${table.name.raw}_pkey_' || next_partition) ||
+       |          ' PRIMARY KEY (fid, ${info.cols.dtg.name})${table.tablespace.index})' ||
+       |          ' INHERITS (${table.name.full})${table.storage}${table.tablespace.table}';
+       |        EXECUTE 'CREATE INDEX IF NOT EXISTS ' ||
+       |          quote_ident('${table.name.raw}_${info.cols.dtg.raw}_' || next_partition) ||
+       |          ' ON $writePartition (${info.cols.dtg.name})${table.tablespace.table}';
+       |${info.cols.geoms.map { col =>
+    s"""        EXECUTE 'CREATE INDEX IF NOT EXISTS ' ||
+       |          quote_ident('spatial_${table.name.raw}_${col.raw.toLowerCase(Locale.US)}_' || next_partition) ||
+       |          ' ON $writePartition USING gist(${col.name})${table.tablespace.table}';""".stripMargin }.mkString("\n") }
+       |${info.cols.indexed.map { col =>
+    s"""        EXECUTE 'CREATE INDEX IF NOT EXISTS ' ||
+       |          quote_ident('${table.name.raw}_${col.raw}_' || next_partition) ||
+       |          ' ON $writePartition (${col.name})${table.tablespace.table}';""".stripMargin }.mkString("\n") }
+       |
+       |        COMMIT; -- releases our locks
+       |
+       |        EXECUTE 'ANALYZE ' || quote_ident('${table.name.raw}_' || cur_partition);
+       |
+       |      END IF;
+       |    END;
+       |  $$BODY$$;""".stripMargin
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/AnalyzeQueueTable.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/AnalyzeQueueTable.scala
@@ -1,0 +1,28 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package tables
+
+/**
+ * Stores tables that need to be analyzed
+ */
+object AnalyzeQueueTable extends SqlStatements {
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = {
+    val create =
+      s"""CREATE TABLE IF NOT EXISTS ${info.tables.analyzeQueue.name.full} (
+         |  partition_name text,
+         |  enqueued timestamp without time zone
+         |);""".stripMargin
+    Seq(create)
+  }
+
+  override protected def dropStatements(info: TypeInfo): Seq[String] =
+    Seq(s"DROP TABLE IF EXISTS ${info.tables.analyzeQueue.name.full};")
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/MainView.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/MainView.scala
@@ -1,0 +1,28 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package tables
+
+/**
+ * Main view of all the partitions and write ahead table. This should accept and reads and writes.
+ */
+object MainView extends SqlStatements {
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = {
+    Seq(
+      s"""CREATE OR REPLACE VIEW ${info.tables.view.name.full} AS
+         |  SELECT * FROM ${info.tables.writeAhead.name.full} UNION ALL
+         |  SELECT * FROM ${info.tables.writeAheadPartitions.name.full} UNION ALL
+         |  SELECT * FROM ${info.tables.mainPartitions.name.full};""".stripMargin
+    )
+  }
+
+  override protected def dropStatements(info: TypeInfo): Seq[String] =
+    Seq(s"DROP VIEW IF EXISTS ${info.tables.view.name.full};")
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/PartitionTables.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/PartitionTables.scala
@@ -1,0 +1,46 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package tables
+
+/**
+ * The main and write ahead partitioned tables
+ */
+object PartitionTables extends SqlStatements {
+
+  override protected def createStatements(info: TypeInfo): Seq[String] =
+    statements(info, info.tables.writeAheadPartitions, "gist") ++
+        statements(info, info.tables.mainPartitions, "brin")
+
+  private def statements(info: TypeInfo, table: TableConfig, indexType: String): Seq[String] = {
+    // note: don't include storage opts since these are parent partition tables
+    val create =
+      s"""CREATE TABLE IF NOT EXISTS ${table.name.full} (
+         |  LIKE ${info.tables.writeAhead.name.full} INCLUDING DEFAULTS INCLUDING CONSTRAINTS,
+         |  CONSTRAINT "${s"${table.name.raw}_pkey"}" PRIMARY KEY (fid, ${info.cols.dtg.name})${table.tablespace.index}
+         |) PARTITION BY RANGE(${info.cols.dtg.name})${table.tablespace.table};""".stripMargin
+    // note: brin doesn't support 'include' cols
+    val geomIndex =
+      s"""CREATE INDEX IF NOT EXISTS "${table.name.raw}_${info.cols.geom.raw}"
+         |  ON ${table.name.full}
+         |  USING $indexType(${info.cols.geom.name})${table.tablespace.table};""".stripMargin
+    val dtgIndex =
+      s"""CREATE INDEX IF NOT EXISTS "${table.name.raw}_${info.cols.dtg.raw}"
+         |  ON ${table.name.full} (${info.cols.dtg.name})${table.tablespace.table};""".stripMargin
+    val indices = info.cols.indexed.map { col =>
+      s"""CREATE INDEX IF NOT EXISTS s"${table.name.raw}_${col.raw}"
+         |  ON ${table.name.full} (${col.name})${table.tablespace.table};""".stripMargin
+    }
+    Seq(create, geomIndex, dtgIndex) ++ indices
+  }
+
+  override protected def dropStatements(info: TypeInfo): Seq[String] =
+    Seq(info.tables.writeAheadPartitions, info.tables.mainPartitions)
+        .map(table => s"DROP TABLE IF EXISTS ${table.name.full};")
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/PrimaryKeyTable.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/PrimaryKeyTable.scala
@@ -1,0 +1,49 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package tables
+
+import org.geotools.jdbc.MetadataTablePrimaryKeyFinder
+
+import java.util.Locale
+
+/**
+ * Primary key table used by the JDBC data store to specify primary key columns
+ */
+object PrimaryKeyTable extends Sql {
+
+  override def create(info: TypeInfo)(implicit ex: ExecutionContext): Unit = {
+    // we need to define the primary key separately since the main view can't have any primary key columns
+    val table = s""""${info.schema}"."${MetadataTablePrimaryKeyFinder.DEFAULT_TABLE.toLowerCase(Locale.US)}""""
+    val create =
+      s"""CREATE TABLE IF NOT EXISTS $table (
+         |  table_schema character varying,
+         |  table_name character varying,
+         |  pk_column_idx integer,
+         |  pk_column character varying,
+         |  pk_policy character varying,
+         |  pk_sequence character varying
+         |);""".stripMargin
+    val cleanup = s"""DELETE FROM $table WHERE table_schema = ? AND table_name = ?;"""
+    val entry = s"""INSERT INTO $table(table_schema, table_name, pk_column_idx, pk_column) VALUES (?, ?, ?, ?);"""
+    ex.execute(create)
+    ex.executeUpdate(cleanup, Seq(info.schema, info.tables.view.name.raw))
+    ex.executeUpdate(entry, Seq(info.schema, info.tables.view.name.raw, 0, "fid"))
+  }
+
+  override def drop(info: TypeInfo)(implicit ex: ExecutionContext): Unit = {
+    val table = MetadataTablePrimaryKeyFinder.DEFAULT_TABLE.toLowerCase(Locale.US)
+    val rs = ex.cx.getMetaData.getTables(null, info.schema, table, null)
+    val exists = try { rs.next() } finally { rs.close() }
+    if (exists) {
+      val entry = s"""DELETE FROM "${info.schema}"."$table" WHERE table_schema = ? AND table_name = ?;"""
+      ex.executeUpdate(entry, Seq(info.tables.schema, info.tables.view.name.raw))
+    }
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/SortQueueTable.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/SortQueueTable.scala
@@ -1,0 +1,29 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package tables
+
+/**
+ * Stores main partitions that have data inserted out-of-order, which may end up impacting scan performance
+ */
+object SortQueueTable extends SqlStatements {
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = {
+    val create =
+      s"""CREATE TABLE IF NOT EXISTS ${info.tables.sortQueue.name.full} (
+         |  partition_name text,
+         |  unsorted_count bigint,
+         |  enqueued timestamp without time zone
+         |);""".stripMargin
+    Seq(create)
+  }
+
+  override protected def dropStatements(info: TypeInfo): Seq[String] =
+    Seq(s"DROP TABLE IF EXISTS ${info.tables.sortQueue.name.full};")
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/WriteAheadTable.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/WriteAheadTable.scala
@@ -1,0 +1,60 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package tables
+
+import java.util.Locale
+
+/**
+ * Write ahead log, partitioned using inheritance to avoid any restraints on data overlap between partitions.
+ * All writes get directed to the main partition, which is identified with the suffix `_writes`. Every 10 minutes,
+ * the current writes partition is renamed based on a sequence number, and a new writes partition is created
+ */
+object WriteAheadTable extends SqlStatements {
+
+  def writesPartition(info: TypeInfo): String =
+    TableName(info.schema, info.tables.writeAhead.name.raw + "_writes").full
+
+  def writesPartitionRaw(info: TypeInfo): String =
+    TableName(info.schema, info.tables.writeAhead.name.raw + "_writes").raw
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = {
+    val table = info.tables.writeAhead
+    val partition = writesPartition(info)
+    val seq = s"""CREATE SEQUENCE IF NOT EXISTS "${table.name.raw}_seq" AS smallint MINVALUE 1 MAXVALUE 999 CYCLE;"""
+    // rename the table created by the JdbcDataStore to be the write ahead table
+    val rename = s"ALTER TABLE ${info.tables.view.name.full} RENAME TO ${table.name.unqualified};"
+    // drop the index created by the JDBC data store on the parent table, as all the data is in the inherited table
+    val dropIndices = info.cols.geoms.map { col =>
+      s"""DROP INDEX IF EXISTS "spatial_${info.tables.view.name.raw}_${col.raw.toLowerCase(Locale.US)}";"""
+    }
+    val move = if (table.tablespace.table.isEmpty) { Seq.empty } else {
+      Seq(s"ALTER TABLE ${table.name.full} SET${table.tablespace.table};")
+    }
+    val child =
+      s"""CREATE TABLE IF NOT EXISTS $partition (
+         |  CONSTRAINT "${table.name.raw}_000_pkey" PRIMARY KEY (fid, ${info.cols.dtg.name})${table.tablespace.index}
+         |) INHERITS (${table.name.full})${table.storage}${table.tablespace.table};""".stripMargin
+    val dtgIndex =
+      s"""CREATE INDEX IF NOT EXISTS "${table.name.raw}_${info.cols.dtg.raw}_000"
+         |  ON $partition (${info.cols.dtg.name})${table.tablespace.table};""".stripMargin
+    val geomIndices = info.cols.geoms.map { col =>
+      s"""CREATE INDEX IF NOT EXISTS "spatial_${table.name.raw}_${col.raw.toLowerCase(Locale.US)}_000"
+         |  ON $partition USING gist(${col.name})${table.tablespace.table};""".stripMargin
+    }
+    val indices = info.cols.indexed.map { col =>
+      s"""CREATE INDEX IF NOT EXISTS "${table.name.raw}_${col.raw}_000"
+         |  ON $partition (${col.name})${table.tablespace.table};""".stripMargin
+    }
+    Seq(seq, rename) ++ dropIndices ++ move ++ Seq(child, dtgIndex) ++ geomIndices ++ indices
+  }
+
+  override protected def dropStatements(info: TypeInfo): Seq[String] =
+    Seq(s"DROP TABLE IF EXISTS ${info.tables.writeAhead.name.full};") // note: actually gets dropped by jdbc store
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/DeleteTrigger.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/DeleteTrigger.scala
@@ -1,0 +1,60 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package triggers
+
+/**
+ * Trigger to delegate deletes from the main view to the sub tables
+ */
+object DeleteTrigger extends SqlFunction {
+
+  override def name(info: TypeInfo): String = s"delete_from_${info.name}"
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = Seq(function(info)) ++ trigger(info)
+
+  private def function(info: TypeInfo): String = {
+    def delete(table: TableConfig): String =
+      s"DELETE FROM ${table.name.full} WHERE fid = OLD.fid AND ${info.cols.dtg.name} = OLD.${info.cols.dtg.name}"
+
+    s"""CREATE OR REPLACE FUNCTION "${name(info)}"() RETURNS trigger AS
+       |  $$BODY$$
+       |    DECLARE
+       |      del_count integer;
+       |    BEGIN
+       |      ${delete(info.tables.writeAhead)};
+       |      GET DIAGNOSTICS del_count := ROW_COUNT;
+       |      IF del_count = 0 THEN
+       |        ${delete(info.tables.writeAheadPartitions)};
+       |        GET DIAGNOSTICS del_count := ROW_COUNT;
+       |        IF del_count = 0 THEN
+       |          ${delete(info.tables.mainPartitions)};
+       |          GET DIAGNOSTICS del_count := ROW_COUNT;
+       |          IF del_count = 0 THEN
+       |            RETURN NULL;
+       |          END IF;
+       |        END IF;
+       |      END IF;
+       |      RETURN OLD;
+       |    END;
+       |  $$BODY$$
+       |LANGUAGE plpgsql VOLATILE
+       |COST 100;""".stripMargin
+  }
+
+  // note: trigger gets automatically dropped when main view is dropped
+  private def trigger(info: TypeInfo): Seq[String] = {
+    val trigger = s"${name(info)}_trigger"
+    val drop = s"""DROP TRIGGER IF EXISTS "$trigger" ON ${info.tables.view.name.full};"""
+    val create =
+      s"""CREATE TRIGGER "$trigger"
+         |  INSTEAD OF DELETE ON ${info.tables.view.name.full}
+         |  FOR EACH ROW EXECUTE PROCEDURE "${name(info)}"();""".stripMargin
+    Seq(drop, create)
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/InsertTrigger.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/InsertTrigger.scala
@@ -1,0 +1,42 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package triggers
+
+/**
+ * Trigger to delegate inserts from the main view to the sub tables
+ */
+object InsertTrigger extends SqlFunction {
+
+  override def name(info: TypeInfo): String = s"insert_to_${info.name}"
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = Seq(function(info)) ++ trigger(info)
+
+  private def function(info: TypeInfo): String =
+    s"""CREATE OR REPLACE FUNCTION "${name(info)}"() RETURNS trigger AS
+       |  $$BODY$$
+       |    BEGIN
+       |      INSERT INTO ${info.tables.writeAhead.name.full} VALUES(NEW.*);
+       |      RETURN NEW;
+       |    END;
+       |  $$BODY$$
+       |LANGUAGE plpgsql VOLATILE
+       |COST 100;""".stripMargin
+
+  // note: trigger gets automatically dropped when main view is dropped
+  private def trigger(info: TypeInfo): Seq[String] = {
+    val trigger = s"${name(info)}_trigger"
+    val drop = s"""DROP TRIGGER IF EXISTS "$trigger" ON ${info.tables.view.name.full};"""
+    val create =
+      s"""CREATE TRIGGER "$trigger"
+         |  INSTEAD OF INSERT ON ${info.tables.view.name.full}
+         |  FOR EACH ROW EXECUTE PROCEDURE "${name(info)}"();""".stripMargin
+    Seq(drop, create)
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/UpdateTrigger.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/UpdateTrigger.scala
@@ -9,6 +9,9 @@
 package org.locationtech.geomesa.gt.partition.postgis.dialect
 package triggers
 
+/**
+ * Trigger to delegate updates from the main view to the sub tables
+ */
 object UpdateTrigger extends SqlFunction {
 
   override def name(info: TypeInfo): String = s"update_to_${info.name}"

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/UpdateTrigger.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/UpdateTrigger.scala
@@ -1,0 +1,60 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package triggers
+
+object UpdateTrigger extends SqlFunction {
+
+  override def name(info: TypeInfo): String = s"update_to_${info.name}"
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = Seq(function(info)) ++ trigger(info)
+
+  private def function(info: TypeInfo): String = {
+    val updateFields = info.cols.all.map(c => s"${c.name} = NEW.${c.name}").mkString(",")
+    val where = s"fid = OLD.fid AND ${info.cols.dtg.name} = OLD.${info.cols.dtg.name}"
+
+    s"""CREATE OR REPLACE FUNCTION "${name(info)}"() RETURNS trigger AS
+       |  $$BODY$$
+       |    DECLARE
+       |      del_count integer;
+       |    BEGIN
+       |      UPDATE ${info.tables.writeAhead.name.full} SET $updateFields WHERE $where;
+       |      IF NOT FOUND THEN
+       |        DELETE FROM ${info.tables.writeAheadPartitions.name.full} WHERE $where;
+       |        GET DIAGNOSTICS del_count := ROW_COUNT;
+       |        IF del_count > 0 THEN
+       |          INSERT INTO ${info.tables.writeAhead.name.full} VALUES(NEW.*);
+       |        ELSE
+       |          DELETE FROM ${info.tables.mainPartitions.name.full} WHERE $where;
+       |          GET DIAGNOSTICS del_count := ROW_COUNT;
+       |          IF del_count > 0 THEN
+       |            INSERT INTO ${info.tables.writeAhead.name.full} VALUES(NEW.*);
+       |          ELSE
+       |            RETURN NULL;
+       |          END IF;
+       |        END IF;
+       |      END IF;
+       |      RETURN NEW;
+       |    END;
+       |  $$BODY$$
+       |LANGUAGE plpgsql VOLATILE
+       |COST 100;""".stripMargin
+  }
+
+  // note: trigger gets automatically dropped when main view is dropped
+  private def trigger(info: TypeInfo): Seq[String] = {
+    val trigger = s"${name(info)}_trigger"
+    val drop = s"""DROP TRIGGER IF EXISTS "$trigger" ON ${info.tables.view.name.full};"""
+    val create =
+      s"""CREATE TRIGGER "$trigger"
+         |  INSTEAD OF UPDATE ON ${info.tables.view.name.full}
+         |  FOR EACH ROW EXECUTE PROCEDURE "${name(info)}"();""".stripMargin
+    Seq(drop, create)
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/WriteAheadTrigger.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/WriteAheadTrigger.scala
@@ -1,0 +1,43 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package triggers
+
+import org.locationtech.geomesa.gt.partition.postgis.dialect.tables.WriteAheadTable
+
+/**
+ * Trigger to delegate writes from the write ahead table to the _writes partition
+ */
+object WriteAheadTrigger extends SqlFunction {
+
+  override def name(info: TypeInfo): String = s"insert_to_wa_writes_${info.name}"
+
+  override protected def createStatements(info: TypeInfo): Seq[String] = Seq(function(info)) ++ trigger(info)
+
+  private def function(info: TypeInfo): String =
+    s"""CREATE OR REPLACE FUNCTION "${name(info)}"() RETURNS trigger AS
+       |  $$BODY$$
+       |    BEGIN
+       |      INSERT INTO ${WriteAheadTable.writesPartition(info)} VALUES (NEW.*);
+       |      RETURN NULL;
+       |    END;
+       |  $$BODY$$
+       |LANGUAGE plpgsql;""".stripMargin
+
+  // note: trigger gets automatically dropped when associated table is dropped
+  private def trigger(info: TypeInfo): Seq[String] = {
+    val trigger = s"${name(info)}_trigger"
+    val drop = s"""DROP TRIGGER IF EXISTS "$trigger" ON ${info.tables.writeAhead.name.full};"""
+    val create =
+      s"""CREATE TRIGGER "$trigger"
+         |  BEFORE INSERT ON ${info.tables.writeAhead.name.full}
+         |  FOR EACH ROW EXECUTE FUNCTION "${name(info)}"();""".stripMargin
+    Seq(drop, create)
+  }
+}

--- a/geomesa-gt/geomesa-gt-partitioning/src/test/scala/org/locationtech/geomesa/gt/partition/postgis/PartitionedPostgisDataStoreTest.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/test/scala/org/locationtech/geomesa/gt/partition/postgis/PartitionedPostgisDataStoreTest.scala
@@ -1,0 +1,158 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis
+
+import com.typesafe.scalalogging.LazyLogging
+import org.geotools.data.postgis.PostGISPSDialect
+import org.geotools.data.{DataStoreFinder, DefaultTransaction, Transaction}
+import org.geotools.filter.identity.FeatureIdImpl
+import org.geotools.filter.text.ecql.ECQL
+import org.geotools.jdbc.JDBCDataStore
+import org.geotools.util.factory.Hints
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.gt.partition.postgis.dialect.PartitionedPostgisDialect
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
+import org.locationtech.geomesa.utils.io.WithClose
+import org.locationtech.geomesa.utils.text.WKTUtils
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.util.control.NonFatal
+
+@RunWith(classOf[JUnitRunner])
+class PartitionedPostgisDataStoreTest extends Specification with LazyLogging {
+
+  import scala.collection.JavaConverters._
+
+  val hours = 1
+  val spec =
+    "name:String,age:Int,dtg:Date,*geom:Point:srid=4326;" +
+        Seq(
+          s"pg.partitions.interval.hours=$hours",
+          "pg.partitions.cron.minute=0"/*,
+          "pg.partitions.max=2",
+          "pg.partitions.tablespace.wa=wa",
+          "pg.partitions.tablespace.wa-partitions=wapa",
+          "pg.partitions.tablespace.main=main"*/
+        ).mkString(",")
+
+  val methods =
+    Methods(
+      create = true,
+      write = true,
+      update = false,
+      delete = false,
+      remove = false
+    )
+
+  lazy val sft = SimpleFeatureTypes.createType(s"test", spec)
+
+  "PartitionedPostgisDataStore" should {
+    "work" in {
+      skipped("requires postgis instance")
+      val params =
+        Map(
+          "dbtype"   -> PartitionedPostgisDataStoreParams.DbType.sample,
+          "host"     -> "localhost",
+          "port"     -> "5432",
+          "schema"   -> "public",
+          "database" -> "geodata",
+          "user"     -> "postgres",
+          "passwd"   -> "gimmee",
+          "Batch insert size"  -> "10",
+          "Commit size"        -> "20",
+          "preparedStatements" -> "true"
+        )
+
+      val ds = DataStoreFinder.getDataStore(params.asJava)
+
+      try {
+        ds must not(beNull)
+        ds must beAnInstanceOf[JDBCDataStore]
+
+        logger.info(s"Existing type names: ${ds.getTypeNames.mkString(", ")}")
+
+        if (methods.create) {
+          ds.createSchema(sft)
+        } else {
+          WithClose(ds.asInstanceOf[JDBCDataStore].getConnection(Transaction.AUTO_COMMIT)) { cx =>
+            val dialect = ds.asInstanceOf[JDBCDataStore].dialect match {
+              case p: PartitionedPostgisDialect => p
+              case p: PostGISPSDialect =>
+                val m = p.getClass.getDeclaredMethod("getDelegate")
+                m.setAccessible(true)
+                m.invoke(p).asInstanceOf[PartitionedPostgisDialect]
+            }
+            dialect.recreateFunctions("public", sft, cx)
+          }
+        }
+
+        val now = System.currentTimeMillis()
+
+        if (methods.write) {
+          WithClose(new DefaultTransaction()) { tx =>
+            WithClose(ds.getFeatureWriterAppend(sft.getTypeName, tx)) { writer =>
+              (1 to 10).foreach { i =>
+                val next = writer.next()
+                next.setAttribute("name", s"name$i")
+                next.setAttribute("age", i)
+                next.setAttribute("dtg", new java.util.Date(now - (i * 20 * 60 * 1000))) // 20 minutes
+                next.setAttribute("geom", WKTUtils.read(s"POINT(0 $i)"))
+                next.getUserData.put(Hints.USE_PROVIDED_FID, java.lang.Boolean.TRUE)
+                next.getIdentifier.asInstanceOf[FeatureIdImpl].setID(s"fid$i")
+                writer.write()
+              }
+            }
+            tx.commit()
+          }
+        }
+
+        if (methods.update) {
+          (1 to 10).foreach { i =>
+            WithClose(ds.getFeatureWriter(sft.getTypeName, ECQL.toFilter(s"IN('fid$i')"), Transaction.AUTO_COMMIT)) { writer =>
+              if (writer.hasNext) {
+                val next = writer.next()
+                next.setAttribute("dtg", new java.util.Date(now - (i * 5 * 60 * 1000)))
+                writer.write()
+              } else {
+                logger.warn(s"No entry found for update fid$i")
+              }
+            }
+          }
+        }
+
+        if (methods.delete) {
+          (1 to 10).foreach { i =>
+            WithClose(ds.getFeatureWriter(sft.getTypeName, ECQL.toFilter(s"IN('fid$i')"), Transaction.AUTO_COMMIT)) { writer =>
+              if (writer.hasNext) {
+                writer.next()
+                writer.remove()
+              } else {
+                logger.warn(s"No entry found for delete fid$i")
+              }
+            }
+          }
+        }
+
+        if (methods.remove) {
+          ds.removeSchema(sft.getTypeName)
+        }
+      } catch {
+        case NonFatal(e) => e.printStackTrace(); ko(e.toString)
+      } finally {
+        if (ds != null) {
+          ds.dispose()
+        }
+      }
+      ok
+    }
+  }
+
+  case class Methods(create: Boolean, write: Boolean, update: Boolean, delete: Boolean, remove: Boolean)
+}

--- a/geomesa-gt/pom.xml
+++ b/geomesa-gt/pom.xml
@@ -14,6 +14,7 @@
 
     <modules>
         <module>geomesa-gt-dist</module>
+        <module>geomesa-gt-partitioning</module>
         <module>geomesa-gt-spark</module>
         <module>geomesa-gt-spark-runtime</module>
         <module>geomesa-gt-tools</module>

--- a/pom.xml
+++ b/pom.xml
@@ -514,6 +514,11 @@
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
+                <artifactId>geomesa-gt-partitioning_${scala.binary.version}</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.locationtech.geomesa</groupId>
                 <artifactId>geomesa-gt-tools_${scala.binary.version}</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
* Designed for real-time data flows
* Data is partitioned into tables based on the feature time
  * Allows effecient querying through Postgres partition pruning
* Partitioning can be enabled through data store param `dbtype=postgis-partitioned`
* Requires `pg_cron` extension to be installed