### PR TITLE
GEOMESA-3140 Only load converter caches once

### DIFF
--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/EnrichmentCache.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert/EnrichmentCache.scala
@@ -28,10 +28,12 @@ trait EnrichmentCacheFactory {
 }
 
 object EnrichmentCache {
+
+  lazy private val factories = ServiceLoader.load[EnrichmentCacheFactory]()
+
   def apply(conf: Config): EnrichmentCache = {
-    ServiceLoader.load[EnrichmentCacheFactory]()
-        .find(_.canProcess(conf))
-        .getOrElse(throw new RuntimeException("Could not find applicable EnrichmentCache"))
+    factories.find(_.canProcess(conf))
+        .getOrElse(throw new RuntimeException(s"Could not find applicable EnrichmentCache for config: $conf"))
         .build(conf)
   }
 }

--- a/geomesa-tools/conf/sfts/adsbx/reference.conf
+++ b/geomesa-tools/conf/sfts/adsbx/reference.conf
@@ -1,84 +1,3 @@
-caches = {
-  spdtyp_codes = {
-    type = "simple"
-    data = {
-      "0" = { code = "Ground Speed" },
-      "1" = { code = "Ground Speed Reversing" },
-      "2" = { code = "Indicated Air Speed" },
-      "3" = { code = "True Air Speed" }
-    }
-  }
-  wtc_codes = {
-    type = "simple"
-    data = {
-      "0" = { code = "None" },
-      "1" = { code = "Light" },
-      "2" = { code = "Medium" },
-      "3" = { code = "Heavy" }
-    }
-  }
-  species_codes = {
-    type = "simple"
-    data = {
-      "0" = { code = "None" },
-      "1" = { code = "Land Plane" },
-      "2" = { code = "Sea Plane" },
-      "3" = { code = "Amphibian" },
-      "4" = { code = "Helicopter" },
-      "5" = { code = "Gyrocopter" },
-      "6" = { code = "Tiltwing" },
-      "7" = { code = "Ground Vehicle" },
-      "8" = { code = "Tower" }
-    }
-  }
-  engtype_codes = {
-    type = "simple"
-    data = {
-      "0" = { code = "None" },
-      "1" = { code = "Piston" },
-      "2" = { code = "Turboprop" },
-      "3" = { code = "Jet" },
-      "4" = { code = "Electric" }
-    }
-  }
-  engmount_codes = {
-    type = "simple"
-    data = {
-      "0" = { code = "Unknown" },
-      "1" = { code = "Aft Mounted" },
-      "2" = { code = "Wing Buried" },
-      "3" = { code = "Fuselage Buried" },
-      "4" = { code = "Nose Mounted" },
-      "5" = { code = "Wing Mounted" }
-    }
-  }
-  trt_codes = {
-    type = "simple"
-    data = {
-      "0" = { code = "Unknown" },
-      "1" = { code = "Mode-S" },
-      "2" = { code = "ADS-B (unknown version)" },
-      "3" = { code = "ADS-B 0 – DO-260" },
-      "4" = { code = "ADS-B 1 – DO-260 (A)" },
-      "5" = { code = "ADS-B 2 – DO-260 (B)" }
-    }
-  }
-  tt_codes = {
-    type = "simple"
-    data = {
-      "a" = { code = "Altitude" },
-      "s" = { code = "Speed" }
-    }
-  }
-  vsit_codes = {
-    type = "simple"
-    data = {
-      "0" = { code = "Barometric" },
-      "1" = { code = "Geometric" }
-    }
-  }
-}
-
 geomesa {
   sfts {
     adsbx = {
@@ -220,6 +139,86 @@ geomesa {
         { name = "dtg"                , transform = "withDefault($PosTime, now())"         }
         { name = "geom"               , transform = "point($Long::double, $Lat::double)"   }
       ]
+      caches = {
+        spdtyp_codes = {
+          type = "simple"
+          data = {
+            "0" = { code = "Ground Speed" },
+            "1" = { code = "Ground Speed Reversing" },
+            "2" = { code = "Indicated Air Speed" },
+            "3" = { code = "True Air Speed" }
+          }
+        }
+        wtc_codes = {
+          type = "simple"
+          data = {
+            "0" = { code = "None" },
+            "1" = { code = "Light" },
+            "2" = { code = "Medium" },
+            "3" = { code = "Heavy" }
+          }
+        }
+        species_codes = {
+          type = "simple"
+          data = {
+            "0" = { code = "None" },
+            "1" = { code = "Land Plane" },
+            "2" = { code = "Sea Plane" },
+            "3" = { code = "Amphibian" },
+            "4" = { code = "Helicopter" },
+            "5" = { code = "Gyrocopter" },
+            "6" = { code = "Tiltwing" },
+            "7" = { code = "Ground Vehicle" },
+            "8" = { code = "Tower" }
+          }
+        }
+        engtype_codes = {
+          type = "simple"
+          data = {
+            "0" = { code = "None" },
+            "1" = { code = "Piston" },
+            "2" = { code = "Turboprop" },
+            "3" = { code = "Jet" },
+            "4" = { code = "Electric" }
+          }
+        }
+        engmount_codes = {
+          type = "simple"
+          data = {
+            "0" = { code = "Unknown" },
+            "1" = { code = "Aft Mounted" },
+            "2" = { code = "Wing Buried" },
+            "3" = { code = "Fuselage Buried" },
+            "4" = { code = "Nose Mounted" },
+            "5" = { code = "Wing Mounted" }
+          }
+        }
+        trt_codes = {
+          type = "simple"
+          data = {
+            "0" = { code = "Unknown" },
+            "1" = { code = "Mode-S" },
+            "2" = { code = "ADS-B (unknown version)" },
+            "3" = { code = "ADS-B 0 – DO-260" },
+            "4" = { code = "ADS-B 1 – DO-260 (A)" },
+            "5" = { code = "ADS-B 2 – DO-260 (B)" }
+          }
+        }
+        tt_codes = {
+          type = "simple"
+          data = {
+            "a" = { code = "Altitude" },
+            "s" = { code = "Speed" }
+          }
+        }
+        vsit_codes = {
+          type = "simple"
+          data = {
+            "0" = { code = "Barometric" },
+            "1" = { code = "Geometric" }
+          }
+        }
+      }
     }
 
     adsbx-historical = ${geomesa.converters.adsbx-base} {


### PR DESCRIPTION
* Loading once stops log spam about loading caches from different classloaders
* Move adsbx caches into converter definition to avoid them being universally loaded