### PR TITLE
[GEOMESA-3199] String comparison should always comform to lexicographical order

### DIFF
--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/factory/FastFilterFactory.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/factory/FastFilterFactory.scala
@@ -112,7 +112,7 @@ class FastFilterFactory private extends org.geotools.filter.FilterFactoryImpl wi
                        exp2: Expression,
                        matchCase: Boolean,
                        matchAction: MatchAction): PropertyIsGreaterThan = {
-    if (matchCase || matchAction != MatchAction.ANY) {
+    if (matchAction != MatchAction.ANY) {
       super.greater(exp1, exp2, matchCase, matchAction)
     } else {
       org.locationtech.geomesa.filter.checkOrder(exp1, exp2) match {
@@ -150,7 +150,7 @@ class FastFilterFactory private extends org.geotools.filter.FilterFactoryImpl wi
                               exp2: Expression,
                               matchCase: Boolean,
                               matchAction: MatchAction): PropertyIsGreaterThanOrEqualTo = {
-    if (matchCase || matchAction != MatchAction.ANY) {
+    if (matchAction != MatchAction.ANY) {
       super.greaterOrEqual(exp1, exp2, matchCase, matchAction)
     } else {
       org.locationtech.geomesa.filter.checkOrder(exp1, exp2) match {
@@ -186,7 +186,7 @@ class FastFilterFactory private extends org.geotools.filter.FilterFactoryImpl wi
                     exp2: Expression,
                     matchCase: Boolean,
                     matchAction: MatchAction): PropertyIsLessThan = {
-    if (matchCase || matchAction != MatchAction.ANY) {
+    if (matchAction != MatchAction.ANY) {
       super.less(exp1, exp2, matchCase, matchAction)
     } else {
       org.locationtech.geomesa.filter.checkOrder(exp1, exp2) match {
@@ -224,7 +224,7 @@ class FastFilterFactory private extends org.geotools.filter.FilterFactoryImpl wi
                            exp2: Expression,
                            matchCase: Boolean,
                            matchAction: MatchAction): PropertyIsLessThanOrEqualTo = {
-    if (matchCase || matchAction != MatchAction.ANY) {
+    if (matchAction != MatchAction.ANY) {
       super.lessOrEqual(exp1, exp2, matchCase, matchAction)
     } else {
       org.locationtech.geomesa.filter.checkOrder(exp1, exp2) match {

--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/factory/FastFilterFactoryTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/factory/FastFilterFactoryTest.scala
@@ -113,5 +113,13 @@ class FastFilterFactoryTest extends Specification {
         }
       }
     }
+    "comparison operators should have consistent semantics" >> {
+      val sft = SimpleFeatureTypes.createType("test", "s:String")
+      val sf = ScalaSimpleFeature.create(sft, "id", "5")
+      FastFilterFactory.toFilter(sft, "s > '100'").evaluate(sf) must beTrue
+      FastFilterFactory.toFilter(sft, "s >= '100'").evaluate(sf) must beTrue
+      FastFilterFactory.toFilter(sft, "s < '100'").evaluate(sf) must beFalse
+      FastFilterFactory.toFilter(sft, "s <= '100'").evaluate(sf) must beFalse
+    }
   }
 }


### PR DESCRIPTION
The semantics of [GeoTools binary comparison operator](https://github.com/geotools/geotools/blob/main/modules/library/main/src/main/java/org/geotools/filter/CompareFilterImpl.java#L126) is quite strange: when both sides of the operator are string and can be parsed as a number, then it would compare them as if they were numbers. GeoMesa filter optimizer would often replace these filters with a fast version, which always compares strings by lexicographical order.

The default value of binary comparison operators' `matchCase` property is not consistent, the checks for the value of the `matchCase` property in `FastFilterFactory` sometimes prevent from GeoTools filters being replaced with fast filters. Removing these checks makes the behavior of binary comparison operators more consistent.

Indeed there will be some queries exhibiting inconsistent string comparison behavior when the GeoTools comparison operator was not replaced by the query optimizer. However, it is still useful to fix for the most common cases.