### PR TITLE
GEOMESA-3200 Make filter bounds union and intersection produce non overlapping bounds

### DIFF
--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterValues.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterValues.scala
@@ -54,7 +54,7 @@ object FilterValues {
       if (intersections.isEmpty) {
         FilterValues.disjoint
       } else {
-        FilterValues(intersections, left.precise && right.precise)
+        FilterValues(intersections.distinct, left.precise && right.precise)
       }
     }
   }

--- a/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterHelperTest.scala
+++ b/geomesa-filter/src/test/scala/org/locationtech/geomesa/filter/FilterHelperTest.scala
@@ -314,6 +314,56 @@ class FilterHelperTest extends Specification {
       intervals1 mustEqual intervals2
     }
 
+    "remove interleaving bounds for AND filter" >> {
+      var cql = "S < 3 AND S < 2 AND S < 4"
+      var bounds = FilterHelper.extractAttributeBounds(ECQL.toFilter(cql), "S", classOf[Integer])
+      bounds.values must haveSize(1)
+      bounds.values.exists(_ == Bounds(Bound(None, false), Bound(Some(2), false))) must beTrue
+      cql = "S >= 3 AND S >= 2 AND S >= 1"
+      bounds = FilterHelper.extractAttributeBounds(ECQL.toFilter(cql), "S", classOf[Integer])
+      bounds.values must haveSize(1)
+      bounds.values.exists(_ == Bounds(Bound(Some(3), true), Bound(None, false))) must beTrue
+    }
+
+    "remove interleaving bounds for OR filter" >> {
+      var cql = "S < 3 OR S < 2 OR S < 1"
+      var bounds = FilterHelper.extractAttributeBounds(ECQL.toFilter(cql), "S", classOf[Integer])
+      bounds.values must haveSize(1)
+      bounds.values.exists(_ == Bounds(Bound(None, false), Bound(Some(3), false))) must beTrue
+      cql = "S >= 3 OR S >= 2 OR S >= 1"
+      bounds = FilterHelper.extractAttributeBounds(ECQL.toFilter(cql), "S", classOf[Integer])
+      bounds.values must haveSize(1)
+      bounds.values.exists(_ == Bounds(Bound(Some(1), true), Bound(None, false))) must beTrue
+    }
+
+    "concatenate bounds for OR filter" >> {
+      var cql = "(S > 2 AND S <= 5) OR (S > 1 AND S < 3)"
+      var bounds = FilterHelper.extractAttributeBounds(ECQL.toFilter(cql), "S", classOf[Integer])
+      bounds.values must haveSize(1)
+      bounds.values.exists(_ == Bounds(Bound(Some(1), false), Bound(Some(5), true))) must beTrue
+      cql = "(S >= 3 AND S <= 5) OR (S > 1 AND S < 3)"
+      bounds = FilterHelper.extractAttributeBounds(ECQL.toFilter(cql), "S", classOf[Integer])
+      bounds.values must haveSize(1)
+      bounds.values.exists(_ == Bounds(Bound(Some(1), false), Bound(Some(5), true))) must beTrue
+    }
+
+    "don't concatenate open bounds for OR filter" >> {
+      val cql = "(S > 3 AND S <= 5) OR (S > 1 AND S < 3)"
+      val bounds = FilterHelper.extractAttributeBounds(ECQL.toFilter(cql), "S", classOf[Integer])
+      bounds.values must haveSize(2)
+      bounds.values.exists(_ == Bounds(Bound(Some(1), false), Bound(Some(3), false))) must beTrue
+      bounds.values.exists(_ == Bounds(Bound(Some(3), false), Bound(Some(5), true))) must beTrue
+    }
+
+    "remove duplicated bounds" >> {
+      val cql1 = "(S > 3 AND S < 5) OR (S > 8)"
+      val cql2 = "(S > 3 OR S > 8) AND (S < 5 OR S > 8)"
+      val bounds1 = FilterHelper.extractAttributeBounds(ECQL.toFilter(cql1), "S", classOf[Integer])
+      val bounds2 = FilterHelper.extractAttributeBounds(ECQL.toFilter(cql2), "S", classOf[Integer])
+      bounds1 mustEqual bounds2
+      bounds1.values must haveSize(2)
+    }
+
     "deduplicate OR filters" >> {
       val filters = Seq(
         ("(a > 1 AND b < 2 AND c = 3) OR (c = 3 AND a > 2 AND b < 2) OR (b < 2 AND a > 3 AND c = 3)",

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/test/scala/org/locationtech/geomesa/fs/storage/common/partitions/PartitionSchemeTest.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/test/scala/org/locationtech/geomesa/fs/storage/common/partitions/PartitionSchemeTest.scala
@@ -41,8 +41,9 @@ class PartitionSchemeTest extends Specification with AllExpectations {
     "partition based on attribute" >> {
       val ps = PartitionSchemeFactory.load(sft, NamedOptions("attribute", Map("partitioned-attribute" -> "name")))
       ps.getPartitionName(sf) mustEqual "test"
-      ps.getSimplifiedFilters(ECQL.toFilter("name IN ('foo', 'bar')")) must
-          beSome(Seq(SimplifiedFilter(Filter.INCLUDE, Seq("foo", "bar"), partial = false)))
+      ps.getSimplifiedFilters(ECQL.toFilter("name IN ('foo', 'bar')")) must beOneOf(
+        Some(Seq(SimplifiedFilter(Filter.INCLUDE, Seq("foo", "bar"), partial = false))),
+        Some(Seq(SimplifiedFilter(Filter.INCLUDE, Seq("bar", "foo"), partial = false))))
       ps.getSimplifiedFilters(ECQL.toFilter("name IN ('foo', 'bar')"), Some("foo")) must
           beSome(Seq(SimplifiedFilter(Filter.INCLUDE, Seq("foo"), partial = false)))
       ps.getSimplifiedFilters(ECQL.toFilter("name < 'foo' and name > 'bar'")) must beNone


### PR DESCRIPTION
GeoTools filters were transformed to ranges of values when running queries on indexed attributes. When value ranges overlap with each other, running the query would yield duplicated results.

For example, the CQL query `a < 1 OR a < 2` will be transformed to attribute value ranges `[(-inf, 1), (-inf, 2)]`. These value ranges would be transformed into index key ranges, thus leading to a redundant range scan on the index table.

This patch prevents overlapping attribute value ranges from being populated, thus preventing queries from generating duplicated results.