### PR TITLE
GEOMESA-3203 Short-circuit disjoint filters in index scans

### DIFF
--- a/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterHelper.scala
+++ b/geomesa-filter/src/main/scala/org/locationtech/geomesa/filter/FilterHelper.scala
@@ -150,6 +150,7 @@ object FilterHelper {
                        handleExclusiveBounds: Boolean = false): FilterValues[Bounds[ZonedDateTime]] = {
     extractAttributeBounds(filter, attribute, classOf[Date]).map { bounds =>
       var lower, upper: Bound[ZonedDateTime] = null
+      // this if check determines if rounding will be used and if we need to account for narrow ranges
       if (!handleExclusiveBounds || bounds.lower.value.isEmpty || bounds.upper.value.isEmpty ||
           (bounds.lower.inclusive && bounds.upper.inclusive)) {
         lower = createDateTime(bounds.lower, roundSecondsUp, handleExclusiveBounds)

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/GeoMesaFeatureIndex.scala
@@ -10,7 +10,6 @@ package org.locationtech.geomesa.index.api
 
 import java.nio.charset.StandardCharsets
 import java.util.UUID
-
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex.IdFromRow
@@ -31,7 +30,7 @@ import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.geomesa.utils.index.IndexMode.IndexMode
 import org.locationtech.geomesa.utils.text.StringSerialization
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
-import org.opengis.filter.Filter
+import org.opengis.filter.{ExcludeFilter, Filter}
 
 /**
   * Represents a particular indexing strategy
@@ -264,79 +263,82 @@ abstract class GeoMesaFeatureIndex[T, U](val ds: GeoMesaDataStore[_],
 
     indexValues match {
       case None =>
-        // check that full table scans are allowed
-        if (hints.getMaxFeatures.forall(_ > QueryProperties.BlockMaxThreshold.toInt.get)) {
+        if (filter.filter.exists(_.isInstanceOf[ExcludeFilter])) {
+          QueryStrategy(filter, Seq.empty, Seq.empty, Seq.empty, ecql, hints, indexValues)
+        } else {
           // check that full table scans are allowed
-          QueryProperties.BlockFullTableScans.onFullTableScan(sft.getTypeName, filter.filter.getOrElse(Filter.INCLUDE))
-        }
-        val keyRanges = Seq(UnboundedRange(null))
-        val byteRanges = Seq(BoundedByteRange(sharing, ByteArrays.rowFollowingPrefix(sharing)))
+          if (hints.getMaxFeatures.forall(_ > QueryProperties.BlockMaxThreshold.toInt.get)) {
+            // check that full table scans are allowed
+            QueryProperties.BlockFullTableScans.onFullTableScan(sft.getTypeName, filter.filter.getOrElse(Filter.INCLUDE))
+          }
+          val keyRanges = Seq(UnboundedRange(null))
+          val byteRanges = Seq(BoundedByteRange(sharing, ByteArrays.rowFollowingPrefix(sharing)))
 
-        QueryStrategy(filter, byteRanges, keyRanges, Seq.empty, ecql, hints, indexValues)
+          QueryStrategy(filter, byteRanges, keyRanges, Seq.empty, ecql, hints, indexValues)
+        }
 
       case Some(values) =>
         val keyRanges = keySpace.getRanges(values).toSeq
+        val bytes = keySpace.getRangeBytes(keyRanges.iterator, tieredKeySpace.isDefined).toSeq
         val tier = tieredKeySpace.orNull.asInstanceOf[IndexKeySpace[Any, Any]]
+        val secondary = filter.secondary.orNull
+        lazy val tiers = {
+          val multiplier = math.max(1, bytes.count(_.isInstanceOf[SingleRowByteRange]))
+          tier.getRangeBytes(tier.getRanges(tier.getIndexValues(secondary, explain), multiplier)).toSeq
+        }
 
         if (tier == null) {
-          val byteRanges = keySpace.getRangeBytes(keyRanges.iterator).toSeq
+          QueryStrategy(filter, bytes, keyRanges, Seq.empty, ecql, hints, indexValues)
+        } else if (secondary == null) {
+          val byteRanges = keySpace.getRangeBytes(keyRanges.iterator, tier = true).map {
+            case BoundedByteRange(lo, hi)      => BoundedByteRange(lo, ByteArrays.concat(hi, ByteRange.UnboundedUpperRange))
+            case SingleRowByteRange(row)       => BoundedByteRange(row, ByteArrays.concat(row, ByteRange.UnboundedUpperRange))
+            case UpperBoundedByteRange(lo, hi) => BoundedByteRange(lo, ByteArrays.concat(hi, ByteRange.UnboundedUpperRange))
+            case LowerBoundedByteRange(lo, hi) => BoundedByteRange(lo, hi)
+            case UnboundedByteRange(lo, hi)    => BoundedByteRange(lo, hi)
+            case r => throw new IllegalArgumentException(s"Unexpected range type $r")
+          }.toSeq
           QueryStrategy(filter, byteRanges, keyRanges, Seq.empty, ecql, hints, indexValues)
+        } else if (tiers.isEmpty) {
+          // disjoint secondary filter
+          QueryStrategy(filter, Seq.empty, Seq.empty, Seq.empty, ecql, hints, indexValues)
         } else {
-          val secondary = filter.secondary.orNull
-          if (secondary == null) {
-            val byteRanges = keySpace.getRangeBytes(keyRanges.iterator, tier = true).map {
-              case BoundedByteRange(lo, hi)      => BoundedByteRange(lo, ByteArrays.concat(hi, ByteRange.UnboundedUpperRange))
-              case SingleRowByteRange(row)       => BoundedByteRange(row, ByteArrays.concat(row, ByteRange.UnboundedUpperRange))
-              case UpperBoundedByteRange(lo, hi) => BoundedByteRange(lo, ByteArrays.concat(hi, ByteRange.UnboundedUpperRange))
-              case LowerBoundedByteRange(lo, hi) => BoundedByteRange(lo, hi)
-              case UnboundedByteRange(lo, hi)    => BoundedByteRange(lo, hi)
-              case r => throw new IllegalArgumentException(s"Unexpected range type $r")
-            }.toSeq
-            QueryStrategy(filter, byteRanges, keyRanges, Seq.empty, ecql, hints, indexValues)
-          } else {
-            val bytes = keySpace.getRangeBytes(keyRanges.iterator, tier = true).toSeq
+          lazy val minTier = ByteRange.min(tiers)
+          lazy val maxTier = ByteRange.max(tiers)
 
-            val tiers = {
-              val multiplier = math.max(1, bytes.count(_.isInstanceOf[SingleRowByteRange]))
-              tier.getRangeBytes(tier.getRanges(tier.getIndexValues(secondary, explain), multiplier)).toSeq
-            }
-            lazy val minTier = ByteRange.min(tiers)
-            lazy val maxTier = ByteRange.max(tiers)
-
-            val byteRanges = bytes.flatMap {
-              case SingleRowByteRange(row) =>
-                // single row - we can use all the tiered ranges appended to the end
-                if (tiers.isEmpty) {
-                  Iterator.single(BoundedByteRange(row, ByteArrays.concat(row, ByteRange.UnboundedUpperRange)))
-                } else {
-                  tiers.map {
-                    case BoundedByteRange(lo, hi) => BoundedByteRange(ByteArrays.concat(row, lo), ByteArrays.concat(row, hi))
-                    case SingleRowByteRange(trow) => SingleRowByteRange(ByteArrays.concat(row, trow))
-                  }
+          val byteRanges = bytes.flatMap {
+            case SingleRowByteRange(row) =>
+              // single row - we can use all the tiered ranges appended to the end
+              if (tiers.isEmpty) {
+                Iterator.single(BoundedByteRange(row, ByteArrays.concat(row, ByteRange.UnboundedUpperRange)))
+              } else {
+                tiers.map {
+                  case BoundedByteRange(lo, hi) => BoundedByteRange(ByteArrays.concat(row, lo), ByteArrays.concat(row, hi))
+                  case SingleRowByteRange(trow) => SingleRowByteRange(ByteArrays.concat(row, trow))
                 }
+              }
 
-              case BoundedByteRange(lo, hi) =>
-                // bounded ranges - we can use the min/max tier on the endpoints
-                Iterator.single(BoundedByteRange(ByteArrays.concat(lo, minTier), ByteArrays.concat(hi, maxTier)))
+            case BoundedByteRange(lo, hi) =>
+              // bounded ranges - we can use the min/max tier on the endpoints
+              Iterator.single(BoundedByteRange(ByteArrays.concat(lo, minTier), ByteArrays.concat(hi, maxTier)))
 
-              case LowerBoundedByteRange(lo, hi) =>
-                // we can't use the upper tier
-                Iterator.single(BoundedByteRange(ByteArrays.concat(lo, minTier), hi))
+            case LowerBoundedByteRange(lo, hi) =>
+              // we can't use the upper tier
+              Iterator.single(BoundedByteRange(ByteArrays.concat(lo, minTier), hi))
 
-              case UpperBoundedByteRange(lo, hi) =>
-                // we can't use the lower tier
-                Iterator.single(BoundedByteRange(lo, ByteArrays.concat(hi, maxTier)))
+            case UpperBoundedByteRange(lo, hi) =>
+              // we can't use the lower tier
+              Iterator.single(BoundedByteRange(lo, ByteArrays.concat(hi, maxTier)))
 
-              case UnboundedByteRange(lo, hi) =>
-                // we can't use either side of the tiers
-                Iterator.single(BoundedByteRange(lo, hi))
+            case UnboundedByteRange(lo, hi) =>
+              // we can't use either side of the tiers
+              Iterator.single(BoundedByteRange(lo, hi))
 
-              case r =>
-                throw new IllegalArgumentException(s"Unexpected range type $r")
-            }
-
-            QueryStrategy(filter, byteRanges, keyRanges, tiers, ecql, hints, indexValues)
+            case r =>
+              throw new IllegalArgumentException(s"Unexpected range type $r")
           }
+
+          QueryStrategy(filter, byteRanges, keyRanges, tiers, ecql, hints, indexValues)
         }
     }
   }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/attribute/AttributeIndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/attribute/AttributeIndexKeySpace.scala
@@ -8,9 +8,6 @@
 
 package org.locationtech.geomesa.index.index.attribute
 
-import java.nio.charset.StandardCharsets
-import java.util.{Collections, Locale}
-
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.filter.{Bounds, FilterHelper, FilterValues, filterToString}
@@ -24,6 +21,8 @@ import org.locationtech.geomesa.utils.index.ByteArrays.{OneByteArray, ZeroByteAr
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
+import java.nio.charset.StandardCharsets
+import java.util.Collections
 import scala.util.Try
 
 /**
@@ -137,15 +136,14 @@ class AttributeIndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStra
   }
 
   override def getIndexValues(filter: Filter, explain: Explainer): AttributeIndexValues[Any] = {
-    val bounds = FilterHelper.extractAttributeBounds(filter, attributeField, binding)
+    val bounds = FilterHelper.extractAttributeBounds(filter, attributeField, binding.asInstanceOf[Class[Any]])
 
     if (bounds.isEmpty) {
       // we have an attribute, but weren't able to extract any bounds
       logger.warn(s"Unable to extract any attribute bounds from: ${filterToString(filter)}")
     }
 
-    AttributeIndexValues[Any](attributeField, fieldIndex,
-      bounds.asInstanceOf[FilterValues[Bounds[Any]]], binding.asInstanceOf[Class[Any]])
+    AttributeIndexValues[Any](attributeField, fieldIndex, bounds, binding.asInstanceOf[Class[Any]])
   }
 
   override def getRanges(values: AttributeIndexValues[Any],
@@ -157,6 +155,8 @@ class AttributeIndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStra
     if (values.values.isEmpty) {
       // we have an attribute, but weren't able to extract any bounds... scan all values
       Iterator.single(UnboundedRange(AttributeIndexKey(fieldIndexShort, null, inclusive = false)))
+    } else if (values.values.disjoint && !isList) {
+      Iterator.empty
     } else {
       values.values.values.iterator.flatMap { bounds =>
         bounds.bounds match {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/attribute/DateIndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/attribute/DateIndexKeySpace.scala
@@ -8,11 +8,8 @@
 
 package org.locationtech.geomesa.index.index.attribute
 
-import java.time.ZonedDateTime
-import java.util.Date
-
 import org.geotools.util.factory.Hints
-import org.locationtech.geomesa.filter.{Bounds, FilterHelper}
+import org.locationtech.geomesa.filter.{Bounds, FilterHelper, FilterValues}
 import org.locationtech.geomesa.index.api.IndexKeySpace.IndexKeySpaceFactory
 import org.locationtech.geomesa.index.api.ShardStrategy.NoShardStrategy
 import org.locationtech.geomesa.index.api._
@@ -22,12 +19,15 @@ import org.locationtech.geomesa.utils.index.ByteArrays
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
+import java.time.ZonedDateTime
+import java.util.Date
+
 /**
   * Encodes dates as lexicoded longs. Null values are encoded as Long.MinValue. This class is only used for
   * secondary tiering, so it never has sharing or shards
   */
 class DateIndexKeySpace(val sft: SimpleFeatureType, dtgField: String)
-    extends IndexKeySpace[Seq[Bounds[ZonedDateTime]], Long] {
+    extends IndexKeySpace[FilterValues[Bounds[ZonedDateTime]], Long] {
 
   import DateIndexKeySpace.{Empty, MaxUpperBound, MinLowerBound}
 
@@ -55,23 +55,29 @@ class DateIndexKeySpace(val sft: SimpleFeatureType, dtgField: String)
     SingleRowKeyValue(ByteArrays.toOrderedBytes(time), Empty, Empty, time, tier, Empty, Seq.empty)
   }
 
-  override def getIndexValues(filter: Filter, explain: Explainer): Seq[Bounds[ZonedDateTime]] =
-    FilterHelper.extractIntervals(filter, dtgField).values
+  override def getIndexValues(filter: Filter, explain: Explainer): FilterValues[Bounds[ZonedDateTime]] =
+    FilterHelper.extractIntervals(filter, dtgField)
 
-  override def getRanges(values: Seq[Bounds[ZonedDateTime]], multiplier: Int): Iterator[ScanRange[Long]] = {
-    values.iterator.map { bounds =>
-      if (bounds.isEquals) {
-        SingleRowRange(bounds.lower.value.get.toInstant.toEpochMilli)
-      } else {
-        val lower = bounds.lower.value.map { v =>
-          val millis = v.toInstant.toEpochMilli
-          if (bounds.lower.inclusive) { millis } else { millis + 1L }
+  override def getRanges(values: FilterValues[Bounds[ZonedDateTime]], multiplier: Int): Iterator[ScanRange[Long]] = {
+    if (values.isEmpty) {
+      Iterator.single(UnboundedRange(-1))
+    } else if (values.disjoint) {
+      Iterator.empty
+    } else {
+      values.values.iterator.map { bounds =>
+        if (bounds.isEquals) {
+          SingleRowRange(bounds.lower.value.get.toInstant.toEpochMilli)
+        } else {
+          val lower = bounds.lower.value.map { v =>
+            val millis = v.toInstant.toEpochMilli
+            if (bounds.lower.inclusive) { millis } else { millis + 1L }
+          }
+          val upper = bounds.upper.value.map { v =>
+            val millis = v.toInstant.toEpochMilli
+            if (bounds.upper.inclusive) { millis + 1L } else { millis }
+          }
+          BoundedRange(lower.getOrElse(MinLowerBound), upper.getOrElse(MaxUpperBound))
         }
-        val upper = bounds.upper.value.map { v =>
-          val millis = v.toInstant.toEpochMilli
-          if (bounds.upper.inclusive) { millis + 1L } else { millis }
-        }
-        BoundedRange(lower.getOrElse(MinLowerBound), upper.getOrElse(MaxUpperBound))
       }
     }
   }
@@ -89,16 +95,21 @@ class DateIndexKeySpace(val sft: SimpleFeatureType, dtgField: String)
           BoundedByteRange(ordered, ByteArrays.rowFollowingPrefix(ordered))
         }
 
+      case UnboundedRange(_) =>
+        val max = ByteArrays.rowFollowingPrefix(ByteArrays.toOrderedBytes(MaxUpperBound))
+        UnboundedByteRange(ByteArrays.toOrderedBytes(MinLowerBound), max)
+
       case r => throw new IllegalArgumentException(s"Unexpected range type $r")
     }
   }
 
-  override def useFullFilter(values: Option[Seq[Bounds[ZonedDateTime]]],
-                             config: Option[GeoMesaDataStoreConfig],
-                             hints: Hints): Boolean = false
+  override def useFullFilter(
+      values: Option[FilterValues[Bounds[ZonedDateTime]]],
+      config: Option[GeoMesaDataStoreConfig],
+      hints: Hints): Boolean = false
 }
 
-object DateIndexKeySpace extends IndexKeySpaceFactory[Seq[Bounds[ZonedDateTime]], Long] {
+object DateIndexKeySpace extends IndexKeySpaceFactory[FilterValues[Bounds[ZonedDateTime]], Long] {
 
   // note: add 1 to exclude null values
   private val MinLowerBound = Long.MinValue + 1

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/S2IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s2/S2IndexKeySpace.scala
@@ -148,8 +148,8 @@ class S2IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, g
     * @return
     */
   override def getRanges(values: S2IndexValues, multiplier: Int): Iterator[ScanRange[Long]] = {
-    val S2IndexValues(_, _, xy) = values
-    if (xy.isEmpty) {
+    val S2IndexValues(_, geoms, xy) = values
+    if (geoms.disjoint) {
       Iterator.empty
     } else {
       // note: `target` will always be Some, as ScanRangesTarget has a default value

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/S3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/s3/S3IndexKeySpace.scala
@@ -208,32 +208,37 @@ class S3IndexKeySpace(val sft: SimpleFeatureType,
     * @return
     */
   override def getRanges(values: S3IndexValues, multiplier: Int): Iterator[ScanRange[S3IndexKey]] = {
+    val S3IndexValues(s3, _, geoms, xy, intervals, timesByBin, unboundedBins) = values
 
-    val S3IndexValues(s3, _, _, xy, _, timesByBin, unboundedBins) = values
-
-    // note: `target` will always be Some, as ScanRangesTarget has a default value
-    val target = QueryProperties.ScanRangesTarget.option.map { t =>
-      math.max(1, if (timesByBin.isEmpty) { t.toInt } else { t.toInt / timesByBin.size } / multiplier)
-    }
-
-    val s2CellId = s3.ranges(xy, -1, target)
-
-    val bounded = timesByBin.iterator.flatMap { case (bin, times) =>
-      times.flatMap { time =>
-        s2CellId.map(s => BoundedRange(S3IndexKey(bin, s.lower, time._1), S3IndexKey(bin, s.upper, time._2)))
+    if (geoms.disjoint || intervals.disjoint) {
+      Iterator.empty
+    } else if (timesByBin.isEmpty && unboundedBins.isEmpty) {
+      Iterator.single(UnboundedRange(null))
+    } else {
+      // note: `target` will always be Some, as ScanRangesTarget has a default value
+      val target = QueryProperties.ScanRangesTarget.option.map { t =>
+        math.max(1, if (timesByBin.isEmpty) { t.toInt } else { t.toInt / timesByBin.size } / multiplier)
       }
-    }
 
-    val unbounded = unboundedBins.iterator.map {
-      case (0, Short.MaxValue)     => UnboundedRange(S3IndexKey(0, 0L, 0))
-      case (lower, Short.MaxValue) => LowerBoundedRange(S3IndexKey(lower, 0L, 0))
-      case (0, upper)              => UpperBoundedRange(S3IndexKey(upper, 0L, Int.MaxValue))
-      case (lower, upper) =>
-        logger.error(s"Unexpected unbounded bin endpoints: $lower:$upper")
-        UnboundedRange(S3IndexKey(0, 0L, 0))
-    }
+      val s2CellId = s3.ranges(xy, -1, target)
 
-    bounded ++ unbounded
+      val bounded = timesByBin.iterator.flatMap { case (bin, times) =>
+        times.flatMap { time =>
+          s2CellId.map(s => BoundedRange(S3IndexKey(bin, s.lower, time._1), S3IndexKey(bin, s.upper, time._2)))
+        }
+      }
+
+      val unbounded = unboundedBins.iterator.map {
+        case (0, Short.MaxValue)     => UnboundedRange(S3IndexKey(0, 0L, 0))
+        case (lower, Short.MaxValue) => LowerBoundedRange(S3IndexKey(lower, 0L, 0))
+        case (0, upper)              => UpperBoundedRange(S3IndexKey(upper, 0L, Int.MaxValue))
+        case (lower, upper) =>
+          logger.error(s"Unexpected unbounded bin endpoints: $lower:$upper")
+          UnboundedRange(S3IndexKey(0, 0L, 0))
+      }
+
+      bounded ++ unbounded
+    }
   }
 
   /**

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3IndexKeySpace.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/z3/XZ3IndexKeySpace.scala
@@ -117,7 +117,7 @@ class XZ3IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, 
     // disjoint geometries are ok since they could still intersect a polygon
     if (intervals.disjoint) {
       explain("Disjoint dates extracted, short-circuiting to empty query")
-      return XZ3IndexValues(sfc, FilterValues.empty, Seq.empty, FilterValues.empty, Map.empty, Seq.empty)
+      return XZ3IndexValues(sfc, geometries, Seq.empty, intervals, Map.empty, Seq.empty)
     }
 
     // compute our ranges based on the coarse bounds for our query
@@ -167,32 +167,38 @@ class XZ3IndexKeySpace(val sft: SimpleFeatureType, val sharding: ShardStrategy, 
   }
 
   override def getRanges(values: XZ3IndexValues, multiplier: Int): Iterator[ScanRange[Z3IndexKey]] = {
-    val XZ3IndexValues(sfc, _, xy, _, timesByBin, unboundedBins) = values
+    val XZ3IndexValues(sfc, geoms, xy, intervals, timesByBin, unboundedBins) = values
 
-    // note: `target` will always be Some, as ScanRangesTarget has a default value
-    val target = QueryProperties.ScanRangesTarget.option.map { t =>
-      math.max(1, if (timesByBin.isEmpty) { t.toInt } else { t.toInt / timesByBin.size } / multiplier)
+    if (geoms.disjoint || intervals.disjoint) {
+      Iterator.empty
+    } else if (timesByBin.isEmpty && unboundedBins.isEmpty) {
+      Iterator.single(UnboundedRange(null))
+    } else {
+      // note: `target` will always be Some, as ScanRangesTarget has a default value
+      val target = QueryProperties.ScanRangesTarget.option.map { t =>
+        math.max(1, if (timesByBin.isEmpty) { t.toInt } else { t.toInt / timesByBin.size } / multiplier)
+      }
+
+      def toZRanges(t: (Double, Double)): Seq[IndexRange] =
+        sfc.ranges(xy.map { case (xmin, ymin, xmax, ymax) => (xmin, ymin, t._1, xmax, ymax, t._2) }, target)
+
+      lazy val wholePeriodRanges = toZRanges(sfc.zBounds)
+
+      val bounded = timesByBin.iterator.flatMap { case (bin, times) =>
+        val zs = if (times.eq(sfc.zBounds)) { wholePeriodRanges } else { toZRanges(times) }
+        zs.map(r => BoundedRange(Z3IndexKey(bin, r.lower), Z3IndexKey(bin, r.upper)))
+      }
+
+      val unbounded = unboundedBins.iterator.map {
+        case (lower, Short.MaxValue) => LowerBoundedRange(Z3IndexKey(lower, 0L))
+        case (0, upper)              => UpperBoundedRange(Z3IndexKey(upper, Long.MaxValue))
+        case (lower, upper) =>
+          logger.error(s"Unexpected unbounded bin endpoints: $lower:$upper")
+          UnboundedRange(Z3IndexKey(0, 0L))
+      }
+
+      bounded ++ unbounded
     }
-
-    def toZRanges(t: (Double, Double)): Seq[IndexRange] =
-      sfc.ranges(xy.map { case (xmin, ymin, xmax, ymax) => (xmin, ymin, t._1, xmax, ymax, t._2) }, target)
-
-    lazy val wholePeriodRanges = toZRanges(sfc.zBounds)
-
-    val bounded = timesByBin.iterator.flatMap { case (bin, times) =>
-      val zs = if (times.eq(sfc.zBounds)) { wholePeriodRanges } else { toZRanges(times) }
-      zs.map(r => BoundedRange(Z3IndexKey(bin, r.lower), Z3IndexKey(bin, r.upper)))
-    }
-
-    val unbounded = unboundedBins.iterator.map {
-      case (lower, Short.MaxValue) => LowerBoundedRange(Z3IndexKey(lower, 0L))
-      case (0, upper)              => UpperBoundedRange(Z3IndexKey(upper, Long.MaxValue))
-      case (lower, upper) =>
-        logger.error(s"Unexpected unbounded bin endpoints: $lower:$upper")
-        UnboundedRange(Z3IndexKey(0, 0L))
-    }
-
-    bounded ++ unbounded
   }
 
   override def getRangeBytes(ranges: Iterator[ScanRange[Z3IndexKey]], tier: Boolean): Iterator[ByteRange] = {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryPlanner.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryPlanner.scala
@@ -147,7 +147,7 @@ class QueryPlanner[DS <: GeoMesaDataStore[DS]](ds: DS) extends QueryRunner with 
           val qs = strategy.getQueryStrategy(hints, output)
           // query guard hook
           interceptors(sft).foreach(_.guard(qs).foreach(e => throw e))
-          if (qs.values.isEmpty) {
+          if (qs.values.isEmpty && qs.ranges.nonEmpty) {
             qs.filter.secondary.foreach { f =>
               logger.warn(
                 s"Running full table scan on ${qs.index.name} index for schema " +

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/TestGeoMesaDataStore.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/TestGeoMesaDataStore.scala
@@ -90,6 +90,7 @@ object TestGeoMesaDataStore {
     override def createQueryPlan(strategy: QueryStrategy): QueryPlan[TestGeoMesaDataStore] = {
       import org.locationtech.geomesa.index.conf.QueryHints.RichHints
 
+      val tables = strategy.index.getTablesForQuery(strategy.filter.filter).flatMap(t => this.tables.get(t).map(t -> _))
       val ranges = strategy.ranges.map {
         case SingleRowByteRange(row)  => TestRange(row, ByteArrays.rowFollowingRow(row))
         case BoundedByteRange(lo, hi) => TestRange(lo, hi)
@@ -106,7 +107,7 @@ object TestGeoMesaDataStore {
       val sort = strategy.hints.getSortFields
       val project = strategy.hints.getProjection
 
-      TestQueryPlan(strategy.filter, tables, strategy.index.sft, serializer, ranges, reducer, ecql, sort, maxFeatures, project)
+      TestQueryPlan(strategy.filter, tables.toMap, strategy.index.sft, serializer, ranges, reducer, ecql, sort, maxFeatures, project)
     }
 
     override def createWriter(
@@ -127,7 +128,7 @@ object TestGeoMesaDataStore {
 
   case class TestQueryPlan(
       filter: FilterStrategy,
-      tables: scala.collection.Map[String, SortedSet[SingleRowKeyValue[_]]],
+      tables: Map[String, SortedSet[SingleRowKeyValue[_]]],
       sft: SimpleFeatureType,
       serializer: SimpleFeatureSerializer,
       ranges: Seq[TestRange],
@@ -147,9 +148,7 @@ object TestGeoMesaDataStore {
         ByteArrays.ByteOrdering.compare(range.start, row) <= 0 &&
             (range.end.isEmpty || ByteArrays.ByteOrdering.compare(range.end, row) > 0)
 
-      val names = filter.index.getTableNames(None)
-      val tbls = names.flatMap(tables.apply)
-      val matches = tbls.flatMap { kv =>
+      val matches = tables.values.flatten.flatMap { kv =>
         if (!ranges.exists(contained(_, kv.row))) {
           Iterator.empty
         } else {
@@ -164,6 +163,7 @@ object TestGeoMesaDataStore {
     }
 
     override def explain(explainer: Explainer, prefix: String): Unit = {
+      explainer(s"tables: ${tables.keys.mkString(", ")}")
       explainer(s"ranges (${ranges.length}): ${ranges.take(5).map(r =>
         s"[${r.start.map(ByteArrays.toHex).mkString(";")}::" +
             s"${r.end.map(ByteArrays.toHex).mkString(";")})").mkString(",")}")

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/conf/partition/TablePartitionTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/conf/partition/TablePartitionTest.scala
@@ -8,8 +8,6 @@
 
 package org.locationtech.geomesa.index.conf.partition
 
-import java.util.Date
-
 import org.geotools.filter.text.ecql.ECQL
 import org.geotools.util.Converters
 import org.junit.runner.RunWith
@@ -21,6 +19,7 @@ import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.Configs
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
+import java.util.Date
 import scala.util.Try
 
 @RunWith(classOf[JUnitRunner])
@@ -74,13 +73,19 @@ class TablePartitionTest extends Specification {
     }
 
     "extract partitions from disjoint filters" in {
-      val filter = ECQL.toFilter("dtg < '2018-01-01T00:00:00.000Z' AND dtg > '2018-02-01T00:00:00.000Z'")
-      val partitionOption = TablePartition(ds, sft)
-      partitionOption must beSome
-      val partition = partitionOption.get
-      val partitionsOption = partition.partitions(filter)
-      partitionsOption must beSome
-      partitionsOption.get must beEmpty
+      val filters = Seq(
+        "dtg < '2018-01-01T00:00:00.000Z' AND dtg > '2018-02-01T00:00:00.000Z'",
+        "dtg >= '2014-01-01T12:00:00.000Z' and dtg < '2014-01-01T12:00:00.001Z' and dtg < '2014-01-01T12:00:00.000Z'",
+        "dtg < '2022-04-18T17:36:47.042Z' AND dtg < '2022-05-17T16:00:00.000Z' AND dtg < '2022-05-20T17:36:46.000Z' AND dtg > '2022-04-20T17:36:46.000Z'"
+      )
+      foreach(filters.map(ECQL.toFilter)) { filter =>
+        val partitionOption = TablePartition(ds, sft)
+        partitionOption must beSome
+        val partition = partitionOption.get
+        val partitionsOption = partition.partitions(filter)
+        partitionsOption must beSome
+        partitionsOption.get must beEmpty
+      }
     }
 
     "extract nothing from non-selective filters" in {

--- a/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/AttributeIndexTest.scala
+++ b/geomesa-index-api/src/test/scala/org/locationtech/geomesa/index/index/AttributeIndexTest.scala
@@ -27,6 +27,7 @@ import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.geomesa.utils.io.WithClose
 import org.locationtech.geomesa.utils.stats.Cardinality
 import org.locationtech.geomesa.utils.text.WKTUtils
+import org.opengis.filter.Filter
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
@@ -36,7 +37,9 @@ import scala.util.Random
 class AttributeIndexTest extends Specification with LazyLogging {
 
   val typeName = "attr-idx-test"
-  val spec = "name:String:index=true,age:Int:index=true,height:Float:index=true,dtg:Date,*geom:Point:srid=4326"
+  val spec =
+    "name:String,age:Int,height:Float,dtg:Date,*geom:Point:srid=4326;" +
+      "geomesa.indices.enabled='attr:name:geom:dtg,attr:age:geom:dtg,attr:height:geom:dtg'"
 
   val sft = SimpleFeatureTypes.createType(typeName, spec)
 
@@ -353,6 +356,24 @@ class AttributeIndexTest extends Specification with LazyLogging {
         SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).toList mustEqual
             features.slice(2, 3)
       }
+    }
+
+    "handle filter.EXCLUDE with query hint" in {
+      val ds = new TestGeoMesaDataStore(true)
+      ds.createSchema(sft)
+
+      WithClose(ds.getFeatureWriterAppend(typeName, Transaction.AUTO_COMMIT)) { writer =>
+        features.foreach(FeatureUtils.write(writer, _, useProvidedFid = true))
+      }
+
+      val query = new Query(typeName, Filter.EXCLUDE)
+      query.getHints.put(QueryHints.QUERY_INDEX, "attr")
+
+      foreach(ds.getQueryPlan(query))(_.ranges must beEmpty)
+
+      val results = SelfClosingIterator(ds.getFeatureReader(query, Transaction.AUTO_COMMIT)).map(_.getID).toList
+
+      results must beEmpty
     }
   }
 }


### PR DESCRIPTION
* Return no ranges for disjoint scans
  * Check for no secondary ranges in tiered scans
* Fix edge cases in filter intersections
* Make test data store scan more realistically