### PR TITLE
GEOMESA-3221 PostGIS partitioning improvements

### DIFF
--- a/build/test/resources/log4j.xml
+++ b/build/test/resources/log4j.xml
@@ -121,7 +121,6 @@
     </category>
 
     <!-- uncomment the following line to enable verbose log messages from the index query-planner -->
-
     <!--
     <category name="org.locationtech.geomesa.index.utils.Explainer">
         <priority value="trace"/>
@@ -129,7 +128,6 @@
     -->
 
     <!-- uncomment the following lines to enable verbose log messages from the Spark SQL query-planner -->
-
     <!--
     <category name="org.locationtech.geomesa.spark">
         <priority value="info"/>
@@ -138,6 +136,13 @@
         <priority value="trace"/>
     </category>
     <category name="org.apache.spark.sql">
+        <priority value="debug"/>
+    </category>
+    -->
+
+    <!-- uncomment the following lines to enable logging SQL statements from the postgres dialect -->
+    <!--
+    <category name="org.locationtech.geomesa.gt">
         <priority value="debug"/>
     </category>
     -->

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/PartitionedPostgisDialect.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/PartitionedPostgisDialect.scala
@@ -10,7 +10,10 @@ package org.locationtech.geomesa.gt.partition.postgis.dialect
 
 import com.typesafe.scalalogging.StrictLogging
 import org.geotools.data.postgis.PostGISDialect
+import org.geotools.geometry.jts._
 import org.geotools.jdbc.JDBCDataStore
+import org.geotools.referencing.CRS
+import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.gt.partition.postgis.dialect.filter.LiteralFunctionVisitor
 import org.locationtech.geomesa.gt.partition.postgis.dialect.functions.{LogCleaner, TruncateToPartition, TruncateToTenMinutes}
 import org.locationtech.geomesa.gt.partition.postgis.dialect.procedures._
@@ -18,11 +21,13 @@ import org.locationtech.geomesa.gt.partition.postgis.dialect.tables._
 import org.locationtech.geomesa.gt.partition.postgis.dialect.triggers.{DeleteTrigger, InsertTrigger, UpdateTrigger, WriteAheadTrigger}
 import org.locationtech.geomesa.utils.geotools.{Conversions, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.io.WithClose
-import org.opengis.feature.`type`.AttributeDescriptor
+import org.locationtech.jts.geom._
+import org.opengis.feature.`type`.{AttributeDescriptor, GeometryDescriptor}
 import org.opengis.feature.simple.SimpleFeatureType
 import org.opengis.filter.Filter
 
 import java.sql.{Connection, DatabaseMetaData, ResultSet, Types}
+import scala.util.Try
 
 class PartitionedPostgisDialect(store: JDBCDataStore) extends PostGISDialect(store) with StrictLogging {
 
@@ -50,8 +55,26 @@ class PartitionedPostgisDialect(store: JDBCDataStore) extends PostGISDialect(sto
     override def initialValue(): Boolean = false
   }
 
+  /**
+   * Re-create the PLPG/SQL procedures associated with a feature type. This can be used
+   * to 'upgrade in place' if the code is changed.
+   *
+   * @param schemaName database schema, e.g. "public"
+   * @param sft feature type
+   * @param cx connection
+   */
+  def upgrade(schemaName: String, sft: SimpleFeatureType, cx: Connection): Unit =
+    postCreateTable(schemaName, sft, cx)
+
+  @deprecated("Replaced with `upgrade`")
+  def recreateFunctions(schemaName: String, sft: SimpleFeatureType, cx: Connection): Unit =
+    upgrade(schemaName, sft, cx)
+
   // filter out the partition tables from exposed feature types
   override def getDesiredTablesType: Array[String] = Array("VIEW")
+
+  override def encodeCreateTable(sql: StringBuffer): Unit =
+    sql.append("CREATE TABLE IF NOT EXISTS ")
 
   override def encodeTableName(raw: String, sql: StringBuffer): Unit = {
     if (dropping.get) {
@@ -70,37 +93,23 @@ class PartitionedPostgisDialect(store: JDBCDataStore) extends PostGISDialect(sto
     sql.append(" character varying NOT NULL")
   }
 
-  override def postCreateTable(schemaName: String, sft: SimpleFeatureType, cx: Connection): Unit = {
-    val info = TypeInfo(schemaName, sft)
-
-    super.postCreateTable(schemaName, sft, cx)
-
-    implicit val ex: ExecutionContext = new ExecutionContext(cx)
-    try {
-      PartitionedPostgisDialect.Commands.foreach(_.create(info))
-    } finally {
-      ex.close()
+  override def encodePostCreateTable(tableName: String, sql: StringBuffer): Unit = {
+    val i = sql.indexOf(tableName)
+    if (i == -1) {
+      logger.warn(s"Did not find table name '$tableName' in CREATE TABLE statement: $sql")
+    } else {
+      // rename to the write ahead table
+      sql.insert(i + tableName.length, WriteAheadTableSuffix.raw)
     }
   }
 
-  /**
-   * Re-create the PLPG/SQL procedures associated with a feature type. This can be used
-   * to 'upgrade in place' if the code is changed.
-   *
-   * @param schemaName database schema, e.g. "public"
-   * @param sft feature type
-   * @param cx connection
-   */
-  def recreateFunctions(schemaName: String, sft: SimpleFeatureType, cx: Connection): Unit = {
+  override def postCreateTable(schemaName: String, sft: SimpleFeatureType, cx: Connection): Unit = {
+    // note: we skip the call to `super`, which creates a spatial index (that we don't want), and which
+    // alters the geometry column types (which we handle in the create statement)
     val info = TypeInfo(schemaName, sft)
     implicit val ex: ExecutionContext = new ExecutionContext(cx)
     try {
-      val commands = PartitionedPostgisDialect.Commands.filter {
-        case _: SqlProcedure => true
-        case _               => false
-      }
-      commands.reverse.foreach(_.drop(info))
-      commands.foreach(_.create(info))
+      PartitionedPostgisDialect.Commands.foreach(_.create(info))
     } finally {
       ex.close()
     }
@@ -173,23 +182,51 @@ class PartitionedPostgisDialect(store: JDBCDataStore) extends PostGISDialect(sto
   }
 
   override def encodePostColumnCreateTable(att: AttributeDescriptor, sql: StringBuffer): Unit = {
-    super.encodePostColumnCreateTable(att, sql)
-    if (att.isJson()) {
-      // replace 'VARCHAR' with jsonb
-      val i = sql.lastIndexOf(" VARCHAR")
-      if (i == sql.length() - 8) {
-        sql.replace(i + 1, i + 8, "JSONB")
-      } else {
-        logger.warn(s"Found JSON-type attribute but no CHARACTER VARYING column binding: $sql")
-      }
-    } else if (att.isList) {
-      // go back and encode the array type in the CQL create statement
-      val i = sql.lastIndexOf(" ARRAY")
-      if (i == sql.length() - 6) {
-        sql.insert(i, " " + getListTypeMapping(att.getListType()))
-      } else {
-        logger.warn(s"Found list-type attribute but no ARRAY column binding: $sql")
-      }
+    att match {
+      case gd: GeometryDescriptor =>
+        val nullable = gd.getMinOccurs <= 0 || gd.isNillable
+        val i = sql.lastIndexOf("geometry")
+        // expect `geometry NOT NULL` or `geometry` depending on nullable flag
+        if (i == -1 || (nullable && i != sql.length() - 8) || (!nullable && i != sql.length() - 17)) {
+          logger.warn(s"Found geometry-type attribute but no geometry column binding: $sql")
+        } else {
+          val srid =
+            Option(gd.getUserData.get(JDBCDataStore.JDBC_NATIVE_SRID).asInstanceOf[Integer])
+                .orElse(Option(gd.getCoordinateReferenceSystem).flatMap(crs => Try(CRS.lookupEpsgCode(crs, true)).filter(_ != null).toOption))
+                .map(_.intValue())
+                .getOrElse(-1)
+          val geomType = PartitionedPostgisDialect.GeometryMappings.getOrElse(gd.getType.getBinding, "GEOMETRY")
+          val geomTypeWithDims =
+            Option(gd.getUserData.get(Hints.COORDINATE_DIMENSION).asInstanceOf[Integer]).map(_.intValue) match {
+              case None | Some(2) => geomType
+              case Some(3) => s"${geomType}Z"
+              case Some(4) => s"${geomType}ZM"
+              case Some(d) =>
+                throw new IllegalArgumentException(
+                  s"PostGIS only supports geometries with 2, 3 and 4 dimensions, but found: $d")
+            }
+          sql.insert(i + 8, s" ($geomTypeWithDims, $srid)")
+        }
+
+      case _ if att.isJson() =>
+        // replace 'VARCHAR' with jsonb
+        val i = sql.lastIndexOf(" VARCHAR")
+        if (i == sql.length() - 8) {
+          sql.replace(i + 1, i + 8, "JSONB")
+        } else {
+          logger.warn(s"Found JSON-type attribute but no CHARACTER VARYING column binding: $sql")
+        }
+
+      case _ if att.isList =>
+        // go back and encode the array type in the CQL create statement
+        val i = sql.lastIndexOf(" ARRAY")
+        if (i == sql.length() - 6) {
+          sql.insert(i, " " + getListTypeMapping(att.getListType()))
+        } else {
+          logger.warn(s"Found list-type attribute but no ARRAY column binding: $sql")
+        }
+
+      case _ => // no-op
     }
   }
 
@@ -235,6 +272,22 @@ class PartitionedPostgisDialect(store: JDBCDataStore) extends PostGISDialect(sto
 
 object PartitionedPostgisDialect {
 
+  private val GeometryMappings = Map[Class[_], String](
+    classOf[Geometry]           -> "GEOMETRY",
+    classOf[Point]              -> "POINT",
+    classOf[LineString]         -> "LINESTRING",
+    classOf[Polygon]            -> "POLYGON",
+    classOf[MultiPoint]         -> "MULTIPOINT",
+    classOf[MultiLineString]    -> "MULTILINESTRING",
+    classOf[MultiPolygon]       -> "MULTIPOLYGON",
+    classOf[GeometryCollection] -> "GEOMETRYCOLLECTION",
+    classOf[CircularString]     -> "CIRCULARSTRING",
+    classOf[CircularRing]       -> "CIRCULARSTRING",
+    classOf[MultiCurve]         -> "MULTICURVE",
+    classOf[CompoundCurve]      -> "COMPOUNDCURVE",
+    classOf[CompoundRing]       -> "COMPOUNDCURVE"
+  )
+
   private val Commands: Seq[Sql] = Seq(
     WriteAheadTable,
     WriteAheadTrigger,
@@ -256,6 +309,7 @@ object PartitionedPostgisDialect {
     DropAgedOffPartitions,
     PartitionMaintenance,
     AnalyzePartitions,
+    CompactPartitions,
     PartitionSort,
     LogCleaner
   )

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/PartitionedPostgisPsDialect.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/PartitionedPostgisPsDialect.scala
@@ -56,9 +56,11 @@ class PartitionedPostgisPsDialect(store: JDBCDataStore, delegate: PartitionedPos
   }
 
   // fix bug with PostGISPSDialect dialect not delegating these methods
-
+  override def encodeCreateTable(sql: StringBuffer): Unit = delegate.encodeCreateTable(sql)
   override def getDefaultVarcharSize: Int = delegate.getDefaultVarcharSize
   override def encodeTableName(raw: String, sql: StringBuffer): Unit = delegate.encodeTableName(raw, sql)
+  override def encodePostCreateTable(tableName: String, sql: StringBuffer): Unit =
+    delegate.encodePostCreateTable(tableName, sql)
   override def postCreateFeatureType(
       featureType: SimpleFeatureType,
       metadata: DatabaseMetaData,

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/MainView.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/MainView.scala
@@ -19,7 +19,8 @@ object MainView extends SqlStatements {
       s"""CREATE OR REPLACE VIEW ${info.tables.view.name.qualified} AS
          |  SELECT * FROM ${info.tables.writeAhead.name.qualified} UNION ALL
          |  SELECT * FROM ${info.tables.writeAheadPartitions.name.qualified} UNION ALL
-         |  SELECT * FROM ${info.tables.mainPartitions.name.qualified};""".stripMargin
+         |  SELECT * FROM ${info.tables.mainPartitions.name.qualified} UNION ALL
+         |  SELECT * FROM ${info.tables.spillPartitions.name.qualified};""".stripMargin
     )
   }
 

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/PartitionTables.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/PartitionTables.scala
@@ -16,7 +16,8 @@ object PartitionTables extends SqlStatements {
 
   override protected def createStatements(info: TypeInfo): Seq[String] =
     statements(info, info.tables.writeAheadPartitions, "gist") ++
-        statements(info, info.tables.mainPartitions, "brin")
+        statements(info, info.tables.mainPartitions, "brin") ++
+        statements(info, info.tables.spillPartitions, "gist")
 
   private def statements(info: TypeInfo, table: TableConfig, indexType: String): Seq[String] = {
     // note: don't include storage opts since these are parent partition tables

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/PartitionTablespacesTable.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/PartitionTablespacesTable.scala
@@ -30,7 +30,8 @@ class PartitionTablespacesTable extends Sql {
          |);""".stripMargin
     ex.execute(create)
 
-    val insertSql = s"INSERT INTO $table (type_name, table_type, table_space) VALUES (?, ?, ?);"
+    val insertSql =
+      s"INSERT INTO $table (type_name, table_type, table_space) VALUES (?, ?, ?) ON CONFLICT DO NOTHING;"
 
     def insert(suffix: String, table: TableConfig): Unit =
       ex.executeUpdate(insertSql, Seq(info.typeName, suffix, table.tablespace.map(_.raw).orNull))

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/UserDataTable.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/UserDataTable.scala
@@ -25,16 +25,27 @@ class UserDataTable extends Sql {
   import PartitionedPostgisDialect.Config
 
   override def create(info: TypeInfo)(implicit ex: ExecutionContext): Unit = {
-    val table = s"${info.schema.quoted}.${Name.quoted}"
+    val table = TableIdentifier(info.schema.raw, Name.raw)
+    val cName = TableName(Name.raw + "_pkey")
     val create =
-      s"""CREATE TABLE IF NOT EXISTS $table (
+      s"""CREATE TABLE IF NOT EXISTS ${table.quoted} (
          |  type_name text not null,
          |  key text not null,
          |  value text not null
          |);""".stripMargin
-    ex.execute(create)
+    val constraint =
+      s"""DO $$$$
+         |BEGIN
+         |  IF NOT EXISTS (SELECT FROM pg_constraint WHERE conname = ${cName.asLiteral} AND conrelid = ${table.asRegclass}) THEN
+         |    ALTER TABLE ${table.quoted} ADD CONSTRAINT ${cName.quoted} PRIMARY KEY (type_name, key);
+         |  END IF;
+         |END$$$$;""".stripMargin
 
-    val insertSql = s"INSERT INTO $table (type_name, key, value) VALUES (?, ?, ?);"
+    Seq(create, constraint).foreach(ex.execute)
+
+    val insertSql =
+      s"INSERT INTO ${table.quoted} (type_name, key, value) VALUES (?, ?, ?) " +
+          s"ON CONFLICT (type_name, key) DO UPDATE SET value = EXCLUDED.value;"
 
     def insert(config: String, value: Option[String]): Unit =
       value.foreach(v => ex.executeUpdate(insertSql, Seq(info.typeName, config, v)))

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/DeleteTrigger.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/DeleteTrigger.scala
@@ -41,7 +41,11 @@ object DeleteTrigger extends SqlTriggerFunction {
        |          ${delete(info.tables.mainPartitions)};
        |          GET DIAGNOSTICS del_count := ROW_COUNT;
        |          IF del_count = 0 THEN
-       |            RETURN NULL;
+       |            ${delete(info.tables.spillPartitions)};
+       |            GET DIAGNOSTICS del_count := ROW_COUNT;
+       |            IF del_count = 0 THEN
+       |              RETURN NULL;
+       |            END IF;
        |          END IF;
        |        END IF;
        |      END IF;

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/UpdateTrigger.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/triggers/UpdateTrigger.scala
@@ -44,7 +44,13 @@ object UpdateTrigger extends SqlTriggerFunction {
        |          IF del_count > 0 THEN
        |            INSERT INTO ${info.tables.writeAhead.name.qualified} VALUES(NEW.*);
        |          ELSE
-       |            RETURN NULL;
+       |            DELETE FROM ${info.tables.spillPartitions.name.qualified} WHERE $where;
+       |            GET DIAGNOSTICS del_count := ROW_COUNT;
+       |            IF del_count > 0 THEN
+       |              INSERT INTO ${info.tables.writeAhead.name.qualified} VALUES(NEW.*);
+       |            ELSE
+       |              RETURN NULL;
+       |            END IF;
        |          END IF;
        |        END IF;
        |      END IF;

--- a/geomesa-gt/geomesa-gt-tools/pom.xml
+++ b/geomesa-gt/geomesa-gt-tools/pom.xml
@@ -18,6 +18,10 @@
     <dependencies>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-gt-partitioning_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-tools_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>

--- a/geomesa-gt/geomesa-gt-tools/src/main/scala/org/locationtech/geomesa/geotools/tools/GeoToolsRunner.scala
+++ b/geomesa-gt/geomesa-gt-tools/src/main/scala/org/locationtech/geomesa/geotools/tools/GeoToolsRunner.scala
@@ -23,6 +23,7 @@ object GeoToolsRunner extends Runner {
       new data.GeoToolsGetTypeNamesCommand,
       new data.GeoToolsRemoveSchemaCommand,
       new data.GeoToolsUpdateSchemaCommand,
+      new data.PostgisUpgradeSchemaCommand(),
       new export.GeoToolsExportCommand,
       new export.GeoToolsPlaybackCommand,
       new ingest.GeoToolsIngestCommand

--- a/geomesa-gt/geomesa-gt-tools/src/main/scala/org/locationtech/geomesa/geotools/tools/data/PostgisUpgradeSchemaCommand.scala
+++ b/geomesa-gt/geomesa-gt-tools/src/main/scala/org/locationtech/geomesa/geotools/tools/data/PostgisUpgradeSchemaCommand.scala
@@ -1,0 +1,55 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.geotools.tools.data
+
+import com.beust.jcommander.Parameters
+import org.geotools.data.Transaction
+import org.geotools.data.postgis.PostGISPSDialect
+import org.geotools.jdbc.{JDBCDataStore, JDBCDataStoreFactory}
+import org.locationtech.geomesa.geotools.tools.GeoToolsDataStoreCommand
+import org.locationtech.geomesa.geotools.tools.GeoToolsDataStoreCommand.GeoToolsDataStoreParams
+import org.locationtech.geomesa.geotools.tools.data.PostgisUpgradeSchemaCommand.PostgisUpgradeSchemaParams
+import org.locationtech.geomesa.gt.partition.postgis.dialect.PartitionedPostgisDialect
+import org.locationtech.geomesa.tools.{Command, RequiredTypeNameParam}
+import org.locationtech.geomesa.utils.io.WithClose
+
+import scala.annotation.tailrec
+
+class PostgisUpgradeSchemaCommand extends GeoToolsDataStoreCommand {
+
+  override val params = new PostgisUpgradeSchemaParams()
+
+  override val name: String = "partition-upgrade"
+
+  override def execute(): Unit = withDataStore { case ds: JDBCDataStore =>
+    Command.user.info(s"Running upgrade on schema: ${params.featureName}")
+    val sft = ds.getSchema(params.featureName)
+    WithClose(ds.getConnection(Transaction.AUTO_COMMIT)) { cx =>
+      val dialect = ds.dialect match {
+        case p: PartitionedPostgisDialect => p
+        case p: PostGISPSDialect =>
+          @tailrec
+          def unwrap(c: Class[_]): Class[_] =
+            if (c == classOf[PostGISPSDialect]) { c } else { unwrap(c.getSuperclass) }
+          val m = unwrap(p.getClass).getDeclaredMethod("getDelegate")
+          m.setAccessible(true)
+          m.invoke(p).asInstanceOf[PartitionedPostgisDialect]
+      }
+      val schema = connection.getOrElse(JDBCDataStoreFactory.SCHEMA.key, "public")
+      dialect.upgrade(schema, sft, cx)
+    }
+    Command.user.info("Upgrade complete")
+  }
+}
+
+object PostgisUpgradeSchemaCommand {
+  @Parameters(commandDescription = "Update the GeoMesa partitioning functions to the latest version")
+  class PostgisUpgradeSchemaParams extends GeoToolsDataStoreParams with RequiredTypeNameParam
+}
+


### PR DESCRIPTION
* Add "spill" table for time-latent data
* Add "compact" procedure to merge and re-sort the spill table
* Add "upgrade" command-line tool to update existing tables and procedures
* Make table and procedure creation work cleanly even if some things exist already
* Improve "sort" procedure to replace the partition instead of truncate/insert