### PR TITLE
GEOMESA-3211 Add Geomesa UDF support in PySpark

### DIFF
--- a/docs/user/spark/pyspark.rst
+++ b/docs/user/spark/pyspark.rst
@@ -1,17 +1,17 @@
 GeoMesa PySpark
----------------
+===============
 
 GeoMesa provides integration with the Spark Python API for accessing data in GeoMesa data stores.
 
 Prerequisites
-^^^^^^^^^^^^^
+-------------
 
 * `Spark`_ |spark_required_version| should be installed.
 * `Python`_ 2.7 or 3.x should be installed.
 * `pip`_ or ``pip3`` should be installed.
 
 Installation
-^^^^^^^^^^^^
+------------
 
 The ``geomesa_pyspark`` package is not available for download. Build the artifact locally with the profile
 ``-Ppython``. Then install using ``pip`` or ``pip3`` as below. You will also need an appropriate
@@ -25,7 +25,7 @@ the providers outlined in :ref:`spatial_rdd_providers`.
     cp  geomesa-accumulo/geomesa-accumulo-spark-runtime/target/geomesa-accumulo-spark-runtime_2.11-$VERSION.jar /path/to/
 
 Using GeoMesa PySpark
-^^^^^^^^^^^^^^^^^^^^^
+---------------------
 
 You may then access Spark using a Yarn master by default. Importantly, because of the way the ``geomesa_pyspark``
 library interacts with the underlying Java libraries, you must set up the GeoMesa configuration before referencing
@@ -93,8 +93,98 @@ can be done manually by invoking ``geomesa_pyspark.init_sql()`` on the Spark ses
 
 You can terminate the Spark job on YARN using ``spark.stop()``.
 
+Using Geomesa UDFs in PySpark
+-----------------------------
+
+There are 3 different ways to use the Geomesa UDFs from PySpark: from the SQL API, from the Fluent API via SQL expressions, or from the Fluent API via Python wrappers.
+These approaches are equivalent performance-wise, so choosing the best approach for your project comes down to preference.
+
+1. Accessing the Geomesa UDFs from the SQL API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We can access the Geomesa UDFs via the SQL API by simply including the functions in our SQL expressions.
+
+.. code-block:: python
+
+    df.createOrReplaceTempView("tbl")
+
+    spark.sql("""
+    select count(*) from tbl
+    where st_contains(st_makeBBOX(-72.0, 40.0, -71.0, 41.0), geom)
+    """).show()
+
+2. Accessing the Geomesa UDFs from the Fluent API via SQL Expressions 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We can also access the Geomesa UDFs from the Fluent API via the `pyspark.sql.functions` module. This module has an `expr` function that we can use to access the Geomesa UDFs.
+
+.. code-block:: python
+
+    import pyspark.sql.functions as F
+
+    # add a new column
+    df = df.withColumn("geom_wkt", F.expr("st_asText(geom)"))
+
+    # filter using SQL where expression
+    df = df.select("*").where("st_area(geom) > 0.001")
+
+    df.show()
+
+3. Accessing the Geomesa UDFs from the Fluent API via Python Wrappers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We also support using the Geomesa UDFs as standalone functions through the use of Python wrappers. The Python wrappers for the Geomesa UDFs run on the JVM and are faster than logically equivalent Python UDFs.
+
+.. code-block:: python
+
+    from geomesa_pyspark.scala.functions import st_asText, st_area
+
+    df = df.withColumn("geom_wkt", st_asText("geom"))
+
+    df = df.withColumn("geom_area", st_area("geom"))
+
+    df.show()
+
+Using Custom Scala UDFs from PySpark
+------------------------------------
+
+We provide some utility functions in `geomesa_pyspark` that allow you to use your own Scala UDFs as standalone functions from PySpark. The advantage here is that you can write your UDFs in java or scala (so they run on the JVM), but can be used naturally from PySpark as if it were part of the Fluent API. This gives us the ability to write and use performant UDFs from PySpark without having to rely on Python UDFs, which can often be prohibitively slow for larger datasets.
+
+.. code-block:: python
+
+    from functools import partial
+    from geomesa_pyspark.scala.udf import build_scala_udf, scala_udf, ColumnOrName
+    from pyspark import SparkContext
+    from pyspark.sql.column import Column
+
+    sc = SparkContext.getOrCreate()
+    custom_udfs = sc._jvm.path.to.your.CustomUserDefinedFunctions
+
+    # use the helper function for building your udf
+    def my_scala_udf(col: ColumnOrName) -> Column:
+        """helpful docstring that explains what col is"""
+        return build_scala_udf(sc, custom_udfs.my_scala_udf)(col)
+
+    # or alternatively, build it directly by partially applying the scala udf
+    my_other_udf = partial(scala_udf, sc, custom_udfs.my_other_udf())
+
+    df.withColumn("edited_field_1", my_scala_udf("field_1")).show()
+
+    df.withColumn("edited_field_2", my_other_udf("field_2")).show()
+
+Recall that these UDFs can actually take either a `pyspark.sql.column.Column` or the string name of the column we wish to operate on, so the following are equivalent:
+
+.. code-block:: python
+
+    # this is more readable
+    df.withColumn("edited_field_1", my_scala_udf("field_1")).show()
+
+    # but we can also do this
+    df.withColumn("edited_field_1", my_scala_udf(col("field_1"))).show()
+
+
 Jupyter
-^^^^^^^
+-------
 
 To use the ``geomesa_pyspark`` package within Jupyter, you only needs a Python2 or Python3 kernel, which is
 provided by default. Substitute the appropriate Spark home and runtime JAR paths in the above code blocks. Be sure

--- a/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/udf/GeomesaPysparkFunctions.scala
+++ b/geomesa-spark/geomesa-spark-jts/src/main/scala/org/locationtech/geomesa/spark/jts/udf/GeomesaPysparkFunctions.scala
@@ -1,0 +1,109 @@
+/***********************************************************************
+ * Copyright (c) 2013-2019 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.spark.jts.udf
+
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions.udf
+import org.locationtech.geomesa.spark.jts.udf.GeometricAccessorFunctions._
+import org.locationtech.geomesa.spark.jts.udf.GeometricCastFunctions._
+import org.locationtech.geomesa.spark.jts.udf.GeometricConstructorFunctions._
+import org.locationtech.geomesa.spark.jts.udf.GeometricOutputFunctions._
+import org.locationtech.geomesa.spark.jts.udf.GeometricProcessingFunctions.{ST_BufferPoint, ST_antimeridianSafeGeom}
+import org.locationtech.geomesa.spark.jts.udf.SpatialRelationFunctions._
+
+/**
+ * Re-wrapping the UDFs so we can access them from PySpark without using the SQL API.
+ */
+object GeomesaPysparkFunctions {
+
+  /* Geometric Accessor Functions */
+  def st_boundary: UserDefinedFunction = udf(ST_Boundary)
+  def st_coordDim: UserDefinedFunction = udf(ST_CoordDim)
+  def st_dimension: UserDefinedFunction = udf(ST_Dimension)
+  def st_envelope: UserDefinedFunction = udf(ST_Envelope)
+  def st_exteriorRing: UserDefinedFunction = udf(ST_ExteriorRing)
+  def st_geometryN: UserDefinedFunction = udf(ST_GeometryN)
+  def st_geometryType: UserDefinedFunction = udf(ST_GeometryType)
+  def st_interiorRingN: UserDefinedFunction = udf(ST_InteriorRingN)
+  def st_isClosed: UserDefinedFunction = udf(ST_IsClosed)
+  def st_isCollection: UserDefinedFunction = udf(ST_IsCollection)
+  def st_isEmpty: UserDefinedFunction = udf(ST_IsEmpty)
+  def st_isRing: UserDefinedFunction = udf(ST_IsRing)
+  def st_isSimple: UserDefinedFunction = udf(ST_IsSimple)
+  def st_isValid: UserDefinedFunction = udf(ST_IsValid)
+  def st_numGeometries: UserDefinedFunction = udf(ST_NumGeometries)
+  def st_numPoints: UserDefinedFunction = udf(ST_NumPoints)
+  def st_pointN: UserDefinedFunction = udf(ST_PointN)
+  def st_x: UserDefinedFunction = udf(ST_X)
+  def st_y: UserDefinedFunction = udf(ST_Y)
+
+  /* Geometric Cast Functions */
+  def st_castToPoint: UserDefinedFunction = udf(ST_CastToPoint)
+  def st_castToPolygon: UserDefinedFunction = udf(ST_CastToPolygon)
+  def st_castToLineString: UserDefinedFunction = udf(ST_CastToLineString)
+  def st_castToGeometry: UserDefinedFunction = udf(ST_CastToGeometry)
+  def st_byteArray: UserDefinedFunction = udf(ST_ByteArray)
+
+  /* Geometric Constructor Functions */
+  def st_geomFromGeoHash: UserDefinedFunction = udf(ST_GeomFromGeoHash)
+  def st_box2DFromGeoHash: UserDefinedFunction = udf(ST_GeomFromGeoHash)
+  def st_geomFromText: UserDefinedFunction = udf(ST_GeomFromWKT)
+  def st_geometryFromText: UserDefinedFunction = udf(ST_GeomFromWKT)
+  def st_geomFromWKT: UserDefinedFunction = udf(ST_GeomFromWKT)
+  def st_geomFromWKB: UserDefinedFunction = udf(ST_GeomFromWKB)
+  def st_lineFromText: UserDefinedFunction = udf(ST_LineFromText)
+  def st_makeBox2D: UserDefinedFunction = udf(ST_MakeBox2D)
+  def st_makeBBOX: UserDefinedFunction = udf(ST_MakeBBOX)
+  def st_makePolygon: UserDefinedFunction = udf(ST_MakePolygon)
+  def st_makePoint: UserDefinedFunction = udf(ST_MakePoint)
+  def st_makeLine: UserDefinedFunction = udf(ST_MakeLine)
+  def st_makePointM: UserDefinedFunction = udf(ST_MakePointM)
+  def st_mLineFromText: UserDefinedFunction = udf(ST_MLineFromText)
+  def st_mPointFromText: UserDefinedFunction = udf(ST_MPointFromText)
+  def st_mPolyFromText: UserDefinedFunction = udf(ST_MPolyFromText)
+  def st_point: UserDefinedFunction = udf(ST_Point)
+  def st_pointFromGeoHash: UserDefinedFunction = udf(ST_PointFromGeoHash)
+  def st_pointFromText: UserDefinedFunction = udf(ST_PointFromText)
+  def st_pointFromWKB: UserDefinedFunction = udf(ST_PointFromWKB)
+  def st_polygon: UserDefinedFunction = udf(ST_Polygon)
+  def st_polygonFromText: UserDefinedFunction = udf(ST_PolygonFromText)
+
+  /* Geometric Output Functions */
+  def st_asBinary: UserDefinedFunction = udf(ST_AsBinary)
+  def st_asGeoJSON: UserDefinedFunction = udf(ST_AsGeoJSON)
+  def st_asLatLonText: UserDefinedFunction = udf(ST_AsLatLonText)
+  def st_asText: UserDefinedFunction = udf(ST_AsText)
+  def st_geoHash: UserDefinedFunction = udf(ST_GeoHash)
+
+  /* Geometric Processing Functions */
+  def st_antimeridianSafeGeom: UserDefinedFunction = udf(ST_antimeridianSafeGeom)
+  def st_bufferPoint: UserDefinedFunction = udf(ST_BufferPoint)
+
+  /* Spatial Relation Functions */
+  def st_translate: UserDefinedFunction = udf(ST_Translate)
+  def st_contains: UserDefinedFunction = udf(ST_Contains)
+  def st_covers: UserDefinedFunction = udf(ST_Covers)
+  def st_crosses: UserDefinedFunction = udf(ST_Crosses)
+  def st_disjoint: UserDefinedFunction = udf(ST_Disjoint)
+  def st_equals: UserDefinedFunction = udf(ST_Equals)
+  def st_intersects: UserDefinedFunction = udf(ST_Intersects)
+  def st_overlaps: UserDefinedFunction = udf(ST_Overlaps)
+  def st_touches: UserDefinedFunction = udf(ST_Touches)
+  def st_within: UserDefinedFunction = udf(ST_Within)
+  def st_relate: UserDefinedFunction = udf(ST_Relate)
+  def st_relateBool: UserDefinedFunction = udf(ST_RelateBool)
+  def st_area: UserDefinedFunction = udf(ST_Area)
+  def st_centroid: UserDefinedFunction = udf(ST_Centroid)
+  def st_closestPoint: UserDefinedFunction = udf(ST_ClosestPoint)
+  def st_distance: UserDefinedFunction = udf(ST_Distance)
+  def st_distanceSphere: UserDefinedFunction = udf(ST_DistanceSphere)
+  def st_length: UserDefinedFunction = udf(ST_Length)
+  def st_aggregateDistanceSphere: UserDefinedFunction = udf(ST_AggregateDistanceSphere)
+  def st_lengthSphere: UserDefinedFunction = udf(ST_LengthSphere)
+}

--- a/geomesa-spark/geomesa_pyspark/src/main/python/geomesa_pyspark/scala/functions.py
+++ b/geomesa-spark/geomesa_pyspark/src/main/python/geomesa_pyspark/scala/functions.py
@@ -1,0 +1,358 @@
+"""
+Build PySpark UDFs from the Geomesa UDFs (scala UDFs).
+"""
+from geomesa_pyspark.scala.udf import build_scala_udf, ColumnOrName
+from pyspark import SparkContext
+from pyspark.sql.column import Column
+
+spark_context = SparkContext.getOrCreate()
+geomesa_udfs = spark_context._jvm.org.locationtech.geomesa.spark.jts.udf.GeomesaPysparkFunctions
+
+# Geometric Accessor Functions
+
+def st_boundary(col: ColumnOrName) -> Column:
+    """Returns the boundary, or an empty geometry of appropriate dimension, if
+    geom is empty."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_boundary)(col)
+
+def st_coordDim(col: ColumnOrName) -> Column:
+    """Returns the number of dimensions of the coordinates of Geometry geom."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_coordDim)(col)
+
+def st_dimension(col: ColumnOrName) -> Column:
+    """Returns the inherent number of dimensions of this Geometry object, which
+    must be less than or equal to the coordinate dimension."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_dimension)(col)
+
+def st_envelope(col: ColumnOrName) -> Column:
+    """Returns a Geometry representing the bounding box of geom."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_envelope)(col)
+
+def st_exteriorRing(col: ColumnOrName) -> Column:
+    """Returns a LineString representing the exterior ring of the geometry;
+    returns null if the Geometry is not a Polygon."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_exteriorRing)(col)
+
+def st_geometryN(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns the n-th Geometry (1-based index) of geom if the Geometry is a
+    GeometryCollection, or geom if it is not."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_geometryN)(col1, col2)
+
+def st_geometryType(col: ColumnOrName) -> Column:
+    """Returns the type of this Geometry."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_geometryType)(col)
+
+def st_interiorRingN(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns the n-th interior LineString ring of the Polygon geom. Returns
+    null if the geometry is not a Polygon or the given n is out of range."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_interiorRingN)(col1, col2)
+
+def st_isClosed(col: ColumnOrName) -> Column:
+    """Returns true if geom is a LineString or MultiLineString and its start
+    and end points are coincident. Returns true for all other Geometry types."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_isClosed)(col)
+
+def st_isCollection(col: ColumnOrName) -> Column:
+    """Returns true if geom is a GeometryCollection."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_isCollection)(col)
+
+def st_isEmpty(col: ColumnOrName) -> Column:
+    """Returns true if geom is empty."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_isEmpty)(col)
+
+def st_isRing(col: ColumnOrName) -> Column:
+    """Returns true if geom is a LineString or a MultiLineString and is both
+    closed and simple."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_isRing)(col)
+
+def st_isSimple(col: ColumnOrName) -> Column:
+    """Returns true if geom has no anomalous geometric points, such as self
+    intersection or self tangency."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_isSimple)(col)
+
+def st_isValid(col: ColumnOrName) -> Column:
+    """Returns true if the Geometry is topologically valid according to the
+    OGC SFS specification."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_isValid)(col)
+
+def st_numGeometries(col: ColumnOrName) -> Column:
+    """If geom is a GeometryCollection, returns the number of geometries. For
+    single geometries, returns 1."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_numGeometries)(col)
+
+def st_numPoints(col: ColumnOrName) -> Column:
+    """Returns the number of vertices in Geometry geom."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_numPoints)(col)
+
+def st_pointN(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """If geom is a LineString, returns the n-th vertex of geom as a Point.
+    Negative values are counted backwards from the end of the LineString.
+    Returns null if geom is not a LineString."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_pointN)(col1, col2)
+
+def st_x(col: ColumnOrName) -> Column:
+    """If geom is a Point, return the X coordinate of that point."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_x)(col)
+
+def st_y(col: ColumnOrName) -> Column:
+    """If geom is a Point, return the Y coordinate of that point."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_y)(col)
+
+# Geometric Cast Functions
+
+def st_castToPoint(col: ColumnOrName) -> Column:
+    """Casts Geometry g to a Point."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_castToPoint)(col)
+
+def st_castToPolygon(col: ColumnOrName) -> Column:
+    """Casts Geometry g to a Polygon."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_castToPolygon)(col)
+
+def st_castToLineString(col: ColumnOrName) -> Column:
+    """Casts Geometry g to a LineString."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_castToLineString)(col)
+
+def st_castToGeometry(col: ColumnOrName) -> Column:
+    """Casts Geometry subclass g to a Geometry. This can be necessary e.g. when
+    storing the output of st_makePoint as a Geometry in a case class."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_castToGeometry)(col)
+
+def st_byteArray(col: ColumnOrName) -> Column:
+    """Encodes string s into an array of bytes using the UTF-8 charset."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_byteArray)(col)
+
+# Geometric Constructor Functions
+
+def st_geomFromGeoHash(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns the Geometry of the bounding box corresponding to the Geohash
+    string geohash (base-32 encoded) with a precision of prec bits. See Geohash
+    for more information on GeoHashes."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_geomFromGeoHash)(col1, col2)
+
+def st_box2DFromGeoHash(col: ColumnOrName) -> Column:
+    """Alias of st_geomFromGeoHash."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_box2DFromGeoHash)(col)
+
+def st_geomFromText(col: ColumnOrName) -> Column:
+    """Alias of st_geomFromWKT."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_geomFromText)(col)
+
+def st_geometryFromText(col: ColumnOrName) -> Column:
+    """Alias of st_geomFromWKT"""
+    return build_scala_udf(spark_context, geomesa_udfs.st_geometryFromText)(col)
+
+def st_geomFromWKT(col: ColumnOrName) -> Column:
+    """Creates a Geometry from the given Well-Known Text representation (WKT)."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_geomFromWKT)(col)
+
+def st_geomFromWKB(col: ColumnOrName) -> Column:
+    """Creates a Geometry from the given Well-Known Binary representation (WKB)."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_geomFromWKB)(col)
+
+def st_lineFromText(col: ColumnOrName) -> Column:
+    """Creates a LineString from the given WKT representation."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_lineFromText)(col)
+
+def st_makeBox2D(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Creates a Geometry representing a bounding box defined by the given Points."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_makeBox2D)(col1, col2)
+
+def st_makeBBOX(col1: ColumnOrName, col2: ColumnOrName, col3: ColumnOrName, col4: ColumnOrName) -> Column:
+    """Creates a Geometry representing a bounding box with the given boundaries."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_makeBBOX)(col1, col2, col3, col4)
+
+def st_makePolygon(col: ColumnOrName) -> Column:
+    """Creates a Polygon formed by the given LineString shell, which must be closed."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_makePolygon)(col)
+
+def st_makePoint(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Creates a Point with an x and y coordinate."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_makePoint)(col1, col2)
+
+def st_makeLine(col: ColumnOrName) -> Column:
+    """Creates a LineString using the given sequence of vertices in points."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_makeLine)(col)
+
+def st_makePointM(col1: ColumnOrName, col2: ColumnOrName, col3: ColumnOrName) -> Column:
+    """Creates a Point with an x, y, and m coordinate."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_makePointM)(col1, col2, col3)
+
+def st_mLineFromText(col: ColumnOrName) -> Column:
+    """Creates a MultiLineString corresponding to the given WKT representation."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_mLineFromText)(col)
+
+def st_mPointFromText(col: ColumnOrName) -> Column:
+    """Creates a MultiPoint corresponding to the given WKT representation."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_mPointFromText)(col)
+
+def st_mPolyFromText(col: ColumnOrName) -> Column:
+    """Creates a MultiPolygon corresponding to the given WKT representation."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_mPolyFromText)(col)
+
+def st_point(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns a Point with the given coordinate values. This is an OGC alias
+    for st_makePoint."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_point)(col1, col2)
+
+def st_pointFromGeoHash(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Return the Point at the geometric center of the bounding box defined by
+    the Geohash string geohash (base-32 encoded) with a precision of prec bits.
+    See Geohash for more information on Geohashes."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_pointFromGeoHash)(col1, col2)
+
+def st_pointFromText(col: ColumnOrName) -> Column:
+    """Creates a Point corresponding to the given WKT representation."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_pointFromText)(col)
+
+def st_pointFromWKB(col: ColumnOrName) -> Column:
+    """Creates a Point corresponding to the given WKB representation."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_pointFromWKB)(col)
+
+def st_polygon(col: ColumnOrName) -> Column:
+    """Creates a Polygon formed by the given LineString shell, which must be
+    closed."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_polygon)(col)
+
+def st_polygonFromText(col: ColumnOrName) -> Column:
+    """Creates a Polygon corresponding to the given WKT representation."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_polygonFromText)(col)
+
+# Geometric Output Functions
+
+def st_asBinary(col: ColumnOrName) -> Column:
+    """Returns Geometry geom in WKB representation."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_asBinary)(col)
+
+def st_asGeoJSON(col: ColumnOrName) -> Column:
+    """Returns Geometry geom in GeoJSON representation."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_asGeoJSON)(col)
+
+def st_asLatLonText(col: ColumnOrName) -> Column:
+    """Returns a String describing the latitude and longitude of Point p in
+    degrees, minutes, and seconds. (This presumes that the units of the
+    coordinates of p are latitude and longitude.)"""
+    return build_scala_udf(spark_context, geomesa_udfs.st_asLatLonText)(col)
+
+def st_asText(col: ColumnOrName) -> Column:
+    """Returns Geometry geom in WKT representation."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_asText)(col)
+
+def st_geoHash(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns the Geohash (in base-32 representation) of an interior point of
+    Geometry geom. See Geohash for more information on Geohashes."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_geoHash)(col1, col2)
+
+# Geometric Processing Functions
+
+def st_antimeridianSafeGeom(col: ColumnOrName) -> Column:
+    """If geom spans the antimeridian, attempt to convert the geometry into an
+    equivalent form that is “antimeridian-safe” (i.e. the output geometry is
+    covered by BOX(-180 -90, 180 90)). In certain circumstances, this method
+    may fail, in which case the input geometry will be returned and an error
+    will be logged."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_antimeridianSafeGeom)(col)
+
+def st_bufferPoint(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns a Geometry covering all points within a given radius of Point p,
+    where radius is given in meters."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_bufferPoint)(col1, col2)
+
+# Spatial Relation Functions
+
+def st_translate(col1: ColumnOrName, col2: ColumnOrName, col3: ColumnOrName) -> Column:
+    """Returns the Geometry produced when geom is translated by deltaX and deltaY."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_translate)(col1, col2, col3)
+
+def st_contains(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns true if and only if no points of b lie in the exterior of a, and
+    at least one point of the interior of b lies in the interior of a."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_contains)(col1, col2)
+
+def st_covers(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns true if no point in Geometry b is outside Geometry a."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_covers)(col1, col2)
+
+def st_crosses(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns true if the supplied geometries have some, but not all, interior
+    points in common."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_crosses)(col1, col2)
+
+def st_disjoint(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns true if the geometries do not “spatially intersect”; i.e., they
+    do not share any space together. Equivalent to NOT st_intersects(a, b)."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_disjoint)(col1, col2)
+
+def st_equals(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns true if the given Geometries represent the same logical
+    Geometry. Directionality is ignored."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_equals)(col1, col2)
+
+def st_intersects(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns true if the geometries spatially intersect in 2D (i.e. share any
+    portion of space). Equivalent to NOT st_disjoint(a, b)."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_intersects)(col1, col2)
+
+def st_overlaps(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns true if the geometries have some but not all points in common,
+    are of the same dimension, and the intersection of the interiors of the two
+    geometries has the same dimension as the geometries themselves."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_overlaps)(col1, col2)
+
+def st_touches(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns true if the geometries have at least one point in common, but
+    their interiors do not intersect."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_touches)(col1, col2)
+
+def st_within(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns true if geometry a is completely inside geometry b."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_within)(col1, col2)
+
+def st_relate(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns the DE-9IM 3x3 interaction matrix pattern describing the
+    dimensionality of the intersections between the interior, boundary and
+    exterior of the two geometries."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_relate)(col1, col2)
+
+def st_relateBool(col1: ColumnOrName, col2: ColumnOrName, col3: ColumnOrName) -> Column:
+    """Returns true if the DE-9IM interaction matrix mask mask matches the
+    interaction matrix pattern obtained from st_relate(a, b)."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_relateBool)(col1, col2, col3)
+
+def st_area(col: ColumnOrName) -> Column:
+    """If Geometry g is areal, returns the area of its surface in square units
+    of the coordinate reference system (for example, degrees^2 for EPSG:4326).
+    Returns 0.0 for non-areal geometries (e.g. Points, non-closed LineStrings,
+    etc.)."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_area)(col)
+
+def st_centroid(col: ColumnOrName) -> Column:
+    """Returns the geometric center of a geometry."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_centroid)(col)
+
+def st_closestPoint(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns the Point on a that is closest to b. This is the first point of
+    the shortest line."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_closestPoint)(col1, col2)
+
+def st_distance(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Returns the 2D Cartesian distance between the two geometries in units of
+    the coordinate reference system (e.g. degrees for EPSG:4236)."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_distance)(col1, col2)
+
+def st_distanceSphere(col1: ColumnOrName, col2: ColumnOrName) -> Column:
+    """Approximates the minimum distance between two longitude/latitude
+    geometries assuming a spherical earth."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_distanceSphere)(col1, col2)
+
+def st_length(col: ColumnOrName) -> Column:
+    """Returns the 2D path length of linear geometries, or perimeter of areal
+    geometries, in units of the the coordinate reference system (e.g. degrees
+    for EPSG:4236). Returns 0.0 for other geometry types (e.g. Point)."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_length)(col)
+
+def st_lengthSphere(col: ColumnOrName) -> Column:
+    """Approximates the 2D path length of a LineString geometry using a
+    spherical earth model. The returned length is in units of meters. The
+    approximation is within 0.3% of st_lengthSpheroid and is computationally
+    more efficient."""
+    return build_scala_udf(spark_context, geomesa_udfs.st_lengthSphere)(col)

--- a/geomesa-spark/geomesa_pyspark/src/main/python/geomesa_pyspark/scala/udf.py
+++ b/geomesa-spark/geomesa_pyspark/src/main/python/geomesa_pyspark/scala/udf.py
@@ -1,0 +1,53 @@
+"""
+Utility functions for creating Pyspark UDFs (from Scala UDFs) that run on the JVM.
+"""
+from functools import partial
+from pyspark.context import SparkContext
+from pyspark.sql.column import Column, _to_java_column, _to_seq
+from py4j.java_gateway import JavaMember, JavaObject
+from typing import Union
+
+ColumnOrName = Union[Column, str]
+
+def scala_udf(
+        sc: SparkContext,
+        udf: JavaObject,
+        *cols: ColumnOrName) -> Column:
+    """
+    Create Column for applying the Scala UDF.
+
+    Parameters
+    ----------
+    sc : SparkContext
+        The Spark Context object.
+    udf : JavaObject
+        The UDF as a Java Object.
+    *cols : ColumnOrName
+        The Columns for the UDF to operate on.
+
+    Returns
+    -------
+    Column
+        A new Column with the UDF applied to the supplied Columns.
+    """
+    return Column(udf.apply(_to_seq(sc, cols, _to_java_column)))
+
+def build_scala_udf(
+        sc: SparkContext,
+        udf: JavaMember) -> partial:
+    """
+    Build a Scala UDF for PySpark by partially applying the scala_udf function.
+
+    Parameters
+    ----------
+    sc : SparkContext
+        The Spark Context object.
+    udf : JavaMember
+        The UDF as a Java Member.
+
+    Returns
+    -------
+    partial
+        A partially applied Scala UDF that accepts ColumnOrNames.
+    """
+    return partial(scala_udf, sc, udf())


### PR DESCRIPTION
* updates the geomesa pyspark documentation
* wraps geomesa nullableUDFs as UserDefinedFunctions
* adds utility functions for creating scala UDFs in pyspark
* adds python wrappers for the geomesa UDFs