### PR TITLE
GEOMESA-3222 PostGIS - Reduce locking during ingest

### DIFF
--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/PartitionedPostgisDialect.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/PartitionedPostgisDialect.scala
@@ -289,6 +289,7 @@ object PartitionedPostgisDialect {
   )
 
   private val Commands: Seq[Sql] = Seq(
+    SequenceTable,
     WriteAheadTable,
     WriteAheadTrigger,
     PartitionTables,

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/PartitionWriteAheadLog.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/PartitionWriteAheadLog.scala
@@ -9,7 +9,7 @@
 package org.locationtech.geomesa.gt.partition.postgis.dialect
 package procedures
 
-import org.locationtech.geomesa.gt.partition.postgis.dialect.tables.{PartitionTablespacesTable, WriteAheadTable}
+import org.locationtech.geomesa.gt.partition.postgis.dialect.tables.{PartitionTablespacesTable, SequenceTable}
 
 /**
  * Partitions the write ahead table into the recent and/or main partition tables
@@ -33,6 +33,8 @@ object PartitionWriteAheadLog extends SqlProcedure {
     s"""CREATE OR REPLACE PROCEDURE ${name(info).quoted}(cur_time timestamp without time zone) LANGUAGE plpgsql AS
        |  $$BODY$$
        |    DECLARE
+       |      seq_val smallint;
+       |      write_partition text;                        -- current partition receiving writes
        |      min_dtg timestamp without time zone;         -- min date in our partitioned tables
        |      main_cutoff timestamp without time zone;     -- max age of the records for main tables
        |      write_ahead record;
@@ -47,6 +49,10 @@ object PartitionWriteAheadLog extends SqlProcedure {
        |      -- constants
        |      main_cutoff := truncate_to_partition(cur_time, $hours) - INTERVAL '$hours HOURS';
        |
+       |      SELECT value from ${info.schema.quoted}.${SequenceTable.Name.quoted}
+       |        WHERE type_name = ${literal(info.typeName)} INTO seq_val;
+       |      write_partition := ${literal(writeAhead.name.raw + "_")} || lpad(seq_val::text, 3, '0');
+       |
        |      -- check for write ahead partitions and move the data into the time partitioned tables
        |      FOR write_ahead IN
        |        SELECT pg_class.relname AS name
@@ -54,7 +60,7 @@ object PartitionWriteAheadLog extends SqlProcedure {
        |          INNER JOIN pg_catalog.pg_class ON (pg_inherits.inhrelid = pg_class.oid)
        |          INNER JOIN pg_catalog.pg_namespace ON (pg_class.relnamespace = pg_namespace.oid)
        |          WHERE inhparent = ${writeAhead.name.asRegclass}
-       |          AND relname != ${WriteAheadTable.writesPartition(info).asLiteral}
+       |          AND relname != write_partition
        |          ORDER BY name
        |      LOOP
        |

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/RollWriteAheadLog.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/procedures/RollWriteAheadLog.scala
@@ -9,9 +9,7 @@
 package org.locationtech.geomesa.gt.partition.postgis.dialect
 package procedures
 
-import org.locationtech.geomesa.gt.partition.postgis.dialect.tables.{PartitionTablespacesTable, WriteAheadTable}
-
-import java.util.Locale
+import org.locationtech.geomesa.gt.partition.postgis.dialect.tables.{PartitionTablespacesTable, SequenceTable}
 
 /**
  * Moves the current write ahead table to a sequential name, and creates a new write ahead table
@@ -31,11 +29,7 @@ object RollWriteAheadLog extends SqlProcedure with CronSchedule {
     Seq(proc(info)) ++ super.createStatements(info)
 
   private def proc(info: TypeInfo): String = {
-    def literalPrefix(string0: String, string1: String, stringN: String*): String =
-      literal(string0, string1, stringN ++ Seq(""): _*)
-
     val table = info.tables.writeAhead
-    val writePartition = WriteAheadTable.writesPartition(info).qualified
     val partitionsTable = s"${info.schema.quoted}.${PartitionTablespacesTable.Name.quoted}"
 
     s"""CREATE OR REPLACE PROCEDURE ${name(info).quoted}() LANGUAGE plpgsql AS
@@ -46,20 +40,32 @@ object RollWriteAheadLog extends SqlProcedure with CronSchedule {
        |      next_partition text;       -- next partition that will be created from the _writes table
        |      partition_tablespace text; -- table space command
        |      index_space text;          -- index table space command
+       |      pexists boolean;           -- table exists check
        |    BEGIN
+       |
+       |      SELECT value from ${info.schema.quoted}.${SequenceTable.Name.quoted}
+       |        WHERE type_name = ${literal(info.typeName)} INTO seq_val;
+       |      cur_partition := ${literal(table.name.raw + "_")} || lpad(seq_val::text, 3, '0');
        |
        |      -- get the required locks up front to avoid deadlocks with inserts
        |      LOCK TABLE ONLY ${table.name.qualified} IN SHARE UPDATE EXCLUSIVE MODE;
-       |      LOCK TABLE $writePartition IN ACCESS EXCLUSIVE MODE;
        |
        |      -- don't re-create the table if there hasn't been any data inserted
-       |      -- call to format fixes errors with non-lower-case identifiers
-       |      IF EXISTS(SELECT 1 FROM $writePartition) THEN
-       |        SELECT nextval(format('%I', ${literal(table.name.raw, "seq")})) INTO seq_val;
+       |      EXECUTE 'SELECT EXISTS(SELECT 1 FROM ${info.schema.quoted}.' || quote_ident(cur_partition) || ')'
+       |          INTO pexists;
+       |      IF pexists THEN
+       |
+       |        IF seq_val < 999 THEN
+       |          seq_val := seq_val + 1;
+       |        ELSE
+       |          seq_val := 0;
+       |        END IF;
+       |
+       |        UPDATE ${info.schema.quoted}.${SequenceTable.Name.quoted} SET value = seq_val
+       |          WHERE type_name = ${literal(info.typeName)};
        |
        |        -- format the table name to be 3 digits, with leading zeros as needed
-       |        cur_partition := lpad((seq_val - 1)::text, 3, '0');
-       |        next_partition := lpad(seq_val::text, 3, '0');
+       |        next_partition := ${literal(table.name.raw + "_")} || lpad(seq_val::text, 3, '0');
        |        SELECT table_space INTO partition_tablespace FROM $partitionsTable
        |          WHERE type_name = ${literal(info.typeName)} AND table_type = ${WriteAheadTableSuffix.quoted};
        |        IF partition_tablespace IS NULL THEN
@@ -70,28 +76,26 @@ object RollWriteAheadLog extends SqlProcedure with CronSchedule {
        |          index_space := ' USING INDEX' || partition_tablespace;
        |        END IF;
        |
-       |        -- requires ACCESS EXCLUSIVE
-       |        EXECUTE 'ALTER TABLE $writePartition RENAME TO ' || quote_ident(${literal(table.name.raw + "_")} || cur_partition);
        |        -- requires SHARE UPDATE EXCLUSIVE
-       |        EXECUTE 'CREATE TABLE IF NOT EXISTS $writePartition (' ||
-       |          ' CONSTRAINT ' || quote_ident(${literalPrefix(table.name.raw, "pkey")} || next_partition) ||
+       |        EXECUTE 'CREATE TABLE IF NOT EXISTS ${info.schema.quoted}.' || quote_ident(next_partition) || '(' ||
+       |          'CONSTRAINT ' || quote_ident(next_partition || '_pkey') ||
        |          ' PRIMARY KEY (fid, ${info.cols.dtg.quoted})' || index_space || ')' ||
        |          ' INHERITS (${table.name.qualified})${table.storage.opts}' || partition_tablespace;
-       |        EXECUTE 'CREATE INDEX IF NOT EXISTS ' ||
-       |          quote_ident(${literalPrefix(table.name.raw, info.cols.dtg.raw)} || next_partition) ||
-       |          ' ON $writePartition (${info.cols.dtg.quoted})' || partition_tablespace;
+       |        EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(next_partition || '_' || ${info.cols.dtg.asLiteral}) ||
+       |          ' ON ${info.schema.quoted}.' || quote_ident(next_partition) || ' (${info.cols.dtg.quoted})' ||
+       |          partition_tablespace;
        |${info.cols.geoms.map { col =>
-    s"""        EXECUTE 'CREATE INDEX IF NOT EXISTS ' ||
-       |          quote_ident(${literalPrefix("spatial", table.name.raw, col.raw.toLowerCase(Locale.US))} || next_partition) ||
-       |          ' ON $writePartition USING gist(${col.quoted})' || partition_tablespace;""".stripMargin }.mkString("\n") }
+    s"""        EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(next_partition || '_spatial_' || ${col.asLiteral}) ||
+       |          ' ON ${info.schema.quoted}.' || quote_ident(next_partition) || ' USING gist(${col.quoted})' ||
+       |          partition_tablespace;""".stripMargin}.mkString("\n")}
        |${info.cols.indexed.map { col =>
-    s"""        EXECUTE 'CREATE INDEX IF NOT EXISTS ' ||
-       |          quote_ident(${literalPrefix(table.name.raw, col.raw)} || next_partition) ||
-       |          ' ON $writePartition (${col.quoted})' || partition_tablespace;""".stripMargin }.mkString("\n") }
+    s"""        EXECUTE 'CREATE INDEX IF NOT EXISTS ' || quote_ident(next_partition || '_' || ${col.asLiteral}) ||
+       |          ' ON ${info.schema.quoted}.' || quote_ident(next_partition) || '(${col.quoted})' ||
+       |          partition_tablespace;""".stripMargin}.mkString("\n")}
        |
        |        COMMIT; -- releases our locks
        |
-       |        EXECUTE 'ANALYZE ' || quote_ident(${literal(table.name.raw + "_")} || cur_partition);
+       |        EXECUTE 'ANALYZE ' || quote_ident(cur_partition);
        |
        |      END IF;
        |    END;

--- a/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/SequenceTable.scala
+++ b/geomesa-gt/geomesa-gt-partitioning/src/main/scala/org/locationtech/geomesa/gt/partition/postgis/dialect/tables/SequenceTable.scala
@@ -1,0 +1,40 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.gt.partition.postgis.dialect
+package tables
+
+object SequenceTable extends Sql {
+
+  val Name: TableName = TableName("geomesa_wa_seq")
+
+  override def create(info: TypeInfo)(implicit ex: ExecutionContext): Unit = {
+    val table = TableIdentifier(info.schema.raw, Name.raw)
+    val create =
+      s"""CREATE TABLE IF NOT EXISTS ${table.qualified} (
+         |  type_name text PRIMARY KEY,
+         |  value smallint NOT NULL CHECK (value >= 0 AND value <= 999)
+         |);""".stripMargin
+
+    ex.execute(create)
+
+    val insertSql =
+      s"INSERT INTO ${table.qualified} (type_name, value) VALUES (?, ?) " +
+          s"ON CONFLICT (type_name) DO NOTHING;"
+
+    ex.executeUpdate(insertSql, Seq(info.typeName, 0))
+  }
+
+  override def drop(info: TypeInfo)(implicit ex: ExecutionContext): Unit = {
+    val rs = ex.cx.getMetaData.getTables(null, info.schema.raw, Name.raw, null)
+    val exists = try { rs.next() } finally { rs.close() }
+    if (exists) {
+      ex.executeUpdate(s"DELETE FROM ${info.schema.quoted}.${Name.quoted} WHERE type_name = ?;", Seq(info.typeName))
+    }
+  }
+}


### PR DESCRIPTION
* Use rolling _wa tables for writes instead of renaming _wa_writes,
  avoiding ACCESS EXCLUSIVE lock for rename