### PR TITLE
Fixed Databricks Spark compatibility issue

### DIFF
--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/apache/spark/sql/Aggregates.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/apache/spark/sql/Aggregates.scala
@@ -1,0 +1,31 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.plans.logical.Aggregate
+
+object Aggregates {
+  /** Create a new instance of Aggregate allowing to pass varargs */
+  def instance(args: Any*): Aggregate = {
+    import scala.reflect.runtime.{universe => ru}
+    val rm = ru.runtimeMirror(getClass.getClassLoader)
+    val objSymbol = rm.staticModule("org.apache.spark.sql.catalyst.plans.logical.Aggregate")
+    val objMirror = rm.reflectModule(objSymbol)
+    val obj = objMirror.instance
+    val objTyp = objSymbol.typeSignature
+    val applyTerm = objTyp.decl(ru.TermName("apply"))
+    require(applyTerm.isMethod, "Aggregate.apply is not defined")
+    val methodSymbol = applyTerm.asMethod
+    val instanceMirror = rm.reflect(obj)
+    val methodMirror = instanceMirror.reflectMethod(methodSymbol)
+    val size = methodMirror.symbol.paramLists.head.size
+    require(size <= args.length, s"Aggregate.apply requires $size arguments but was passed at most ${args.length}")
+    methodMirror(args.take(size): _*).asInstanceOf[Aggregate]
+  }
+}


### PR DESCRIPTION
If we use spark geomesa library while running in Databricks Runtime (which is the most popular provider of Spark at the moment) via

```scala
spark.withJTS
```

And execute any aggregation or group by operation, there will be the following error:
```
NoSuchMethodException: java.lang.NoSuchMethodError: org.apache.spark.sql.catalyst.plans.logical.Aggregate.<init>
```

The thing is - Geomesa is using Spark private API which does not guarantee any contract stability and turned out that Databricks maintains a fork of the planner and for `Aggregate` constructor has 4 instead of 3 arguments. 

The fix is to allow to the relaxed way of calling that constructor which would work in both cases. 

We use that patch for more than a year in production and looks like that is the only issue we noticed so far. 