### PR TITLE
GEOMESA-3249 HBase - Fix Spark Kerberos authentication

### DIFF
--- a/docs/user/hbase/configuration.rst
+++ b/docs/user/hbase/configuration.rst
@@ -107,6 +107,11 @@ geomesa.hbase.write.batch
 
 Specify the number of bytes that will be buffered before flushing to disk during write operations.
 
+geomesa.hbase.write.flush.timeout.millis
+++++++++++++++++++++++++++++++++++++++++
+
+Specify the maximum number of milliseconds before data will be flushed to disk during write operations.
+
 geomesa.hbase.query.block.caching.enabled
 +++++++++++++++++++++++++++++++++++++++++
 

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreFactory.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/HBaseDataStoreFactory.scala
@@ -16,6 +16,7 @@ import org.apache.hadoop.hbase.security.User
 import org.apache.hadoop.hbase.security.visibility.VisibilityClient
 import org.geotools.data.DataAccessFactory.Param
 import org.geotools.data.{DataStore, DataStoreFactorySpi}
+import org.apache.hadoop.security.UserGroupInformation
 import org.locationtech.geomesa.hbase.data.HBaseConnectionPool.ConnectionWrapper
 import org.locationtech.geomesa.hbase.data.HBaseDataStore.NoAuthsProvider
 import org.locationtech.geomesa.hbase.data.HBaseDataStoreFactory.{CoprocessorConfig, EnabledCoprocessors, HBaseDataStoreConfig, HBaseQueryConfig}
@@ -215,7 +216,7 @@ object HBaseDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogging {
     }
 
     // master auths is the superset of auths this connector/user can support
-    val userName = User.getCurrent.getName
+    val userName = UserGroupInformation.getLoginUser.getUserName
     val masterAuths = VisibilityClient.getAuths(connection, userName).getAuthList.asScala.map(_.toStringUtf8)
 
     // get the auth params passed in as a comma-delimited string

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/LoginUserProvider.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/data/LoginUserProvider.scala
@@ -1,0 +1,19 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.hbase.data
+
+import org.apache.hadoop.hbase.security.User.SecureHadoopUser
+import org.apache.hadoop.hbase.security.UserProvider
+import org.apache.hadoop.security.UserGroupInformation
+
+class LoginUserProvider extends UserProvider {
+  override def getCurrent = {
+    new SecureHadoopUser(UserGroupInformation.getLoginUser)
+  }
+}

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/package.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/package.scala
@@ -16,6 +16,7 @@ package object hbase {
     val CoprocessorUrl           : SystemProperty = SystemProperty("geomesa.hbase.coprocessor.url")
     val CoprocessorMaxThreads    : SystemProperty = SystemProperty("geomesa.hbase.coprocessor.maximize.threads", "true")
     val WriteBatchSize           : SystemProperty = SystemProperty("geomesa.hbase.write.batch")
+    val WriteFlushTimeout        : SystemProperty = SystemProperty("geomesa.hbase.write.flushTimeout")
     val WalDurability            : SystemProperty = SystemProperty("geomesa.hbase.wal.durability")
     val ScannerCaching           : SystemProperty = SystemProperty("geomesa.hbase.client.scanner.caching.size")
     val ScannerBlockCaching      : SystemProperty = SystemProperty("geomesa.hbase.query.block.caching.enabled", "true")

--- a/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/package.scala
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/main/scala/org/locationtech/geomesa/hbase/package.scala
@@ -16,7 +16,7 @@ package object hbase {
     val CoprocessorUrl           : SystemProperty = SystemProperty("geomesa.hbase.coprocessor.url")
     val CoprocessorMaxThreads    : SystemProperty = SystemProperty("geomesa.hbase.coprocessor.maximize.threads", "true")
     val WriteBatchSize           : SystemProperty = SystemProperty("geomesa.hbase.write.batch")
-    val WriteFlushTimeout        : SystemProperty = SystemProperty("geomesa.hbase.write.flushTimeout")
+    val WriteFlushTimeout        : SystemProperty = SystemProperty("geomesa.hbase.write.flush.timeout.millis")
     val WalDurability            : SystemProperty = SystemProperty("geomesa.hbase.wal.durability")
     val ScannerCaching           : SystemProperty = SystemProperty("geomesa.hbase.client.scanner.caching.size")
     val ScannerBlockCaching      : SystemProperty = SystemProperty("geomesa.hbase.query.block.caching.enabled", "true")

--- a/geomesa-hbase/geomesa-hbase-jobs/src/main/scala/org/locationtech/geomesa/hbase/jobs/GeoMesaHBaseInputFormat.scala
+++ b/geomesa-hbase/geomesa-hbase-jobs/src/main/scala/org/locationtech/geomesa/hbase/jobs/GeoMesaHBaseInputFormat.scala
@@ -40,7 +40,9 @@ class GeoMesaHBaseInputFormat extends InputFormat[Text, SimpleFeature] with Conf
     * Gets splits for a job.
     */
   override def getSplits(context: JobContext): java.util.List[InputSplit] = {
-    val splits = delegate.getSplits(context)
+    val splits = Security.doAuthorized(context.getConfiguration) {
+      delegate.getSplits(context)
+    }
     logger.debug(s"Got ${splits.size()} splits")
     splits
   }
@@ -51,7 +53,9 @@ class GeoMesaHBaseInputFormat extends InputFormat[Text, SimpleFeature] with Conf
     ): RecordReader[Text, SimpleFeature] = {
     val toFeatures = GeoMesaConfigurator.getResultsToFeatures[Result](context.getConfiguration)
     val reducer = GeoMesaConfigurator.getReducer(context.getConfiguration)
-    new GeoMesaHBaseRecordReader(toFeatures, reducer, delegate.createRecordReader(split, context))
+    Security.doAuthorized(context.getConfiguration) {
+      new GeoMesaHBaseRecordReader(toFeatures, reducer, delegate.createRecordReader(split, context))
+    }
   }
 
   override def setConf(conf: Configuration): Unit = {

--- a/geomesa-hbase/geomesa-hbase-jobs/src/main/scala/org/locationtech/geomesa/hbase/jobs/Security.scala
+++ b/geomesa-hbase/geomesa-hbase-jobs/src/main/scala/org/locationtech/geomesa/hbase/jobs/Security.scala
@@ -1,0 +1,55 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.hbase.jobs
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.security.UserGroupInformation
+import org.locationtech.geomesa.hbase.data.HBaseDataStoreFactory.{HBaseGeoMesaKeyTab, HBaseGeoMesaPrincipal}
+
+import java.io.StringWriter
+import java.security.PrivilegedAction
+
+object Security extends LazyLogging {
+
+  private def asString(conf: Configuration): String = {
+    val writer = new StringWriter()
+    Configuration.dumpConfiguration(conf, writer)
+    writer.toString
+  }
+
+  // We cannot rely on a current user to be available when we run any HBase tasks
+  // on the worker nodes there will be no security configured, or if that is
+  // for some reason HBase would peek the current user which is not always a login user (root on Databriks)
+  def doAuthorized[A](conf: Configuration)(action: => A): A = {
+    logger.debug(s"Running doAuthorized on ${Thread.currentThread()} with config: ${asString(conf)}")
+    // the keytab should be available as local file on master an executors
+    // we might also convert keytab as base64 string, replicate via conf property and write into a local file
+    val principal = conf.get(HBaseGeoMesaPrincipal)
+    val keytab = conf.get(HBaseGeoMesaKeyTab)
+    if (principal != null && keytab != null) {
+      logger.debug(s"Logging in as $principal using keytab $keytab")
+      // setting config is required so Hadoop lib would know that security is enabled
+      UserGroupInformation.setConfiguration(conf)
+      val user = UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, keytab)
+      user.doAs {
+        new PrivilegedAction[A] {
+          override def run() = {
+            logger.debug(s"Execution action under ${UserGroupInformation.getLoginUser} user...")
+            val result = action
+            logger.debug(s"The action is complete, finishing secured session for ${UserGroupInformation.getLoginUser} user...")
+            result
+          }
+        }
+      }
+    } else {
+      action
+    }
+  }
+}

--- a/geomesa-spark/geomesa-spark-sql/src/main/scala/org/apache/spark/sql/Aggregates.scala
+++ b/geomesa-spark/geomesa-spark-sql/src/main/scala/org/apache/spark/sql/Aggregates.scala
@@ -1,0 +1,31 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.plans.logical.Aggregate
+
+object Aggregates {
+  /** Create a new instance of Aggregate allowing to pass varargs */
+  def instance(args: Any*): Aggregate = {
+    import scala.reflect.runtime.{universe => ru}
+    val rm = ru.runtimeMirror(getClass.getClassLoader)
+    val objSymbol = rm.staticModule("org.apache.spark.sql.catalyst.plans.logical.Aggregate")
+    val objMirror = rm.reflectModule(objSymbol)
+    val obj = objMirror.instance
+    val objTyp = objSymbol.typeSignature
+    val applyTerm = objTyp.decl(ru.TermName("apply"))
+    require(applyTerm.isMethod, "Aggregate.apply is not defined")
+    val methodSymbol = applyTerm.asMethod
+    val instanceMirror = rm.reflect(obj)
+    val methodMirror = instanceMirror.reflectMethod(methodSymbol)
+    val size = methodMirror.symbol.paramLists.head.size
+    require(size <= args.length, s"Aggregate.apply requires $size arguments but was passed at most ${args.length}")
+    methodMirror(args.take(size): _*).asInstanceOf[Aggregate]
+  }
+}

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/concurrent/ExitingExecutor.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/concurrent/ExitingExecutor.scala
@@ -8,6 +8,7 @@
 
 package org.locationtech.geomesa.utils.concurrent
 
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{ThreadFactory, ThreadPoolExecutor, TimeUnit}
 
 object ExitingExecutor {
@@ -39,6 +40,25 @@ object ExitingExecutor {
     override def newThread(r: Runnable): Thread = {
       val thread = underlying.newThread(r)
       thread.setDaemon(true)
+      thread
+    }
+  }
+
+  /**
+   * Thread factory that creates threads with custom names putting a thread number
+   * replacing `%d` pattern. For example `thread-%d`, will produce `thread-1`, `thread-2`, ... threads
+   * @param namePattern Thread name
+   */
+  class NamedThreadFactory(namePattern: String) extends ThreadFactory {
+    require(namePattern.contains("%d"), "name pattern should contain %d to set the thread number")
+    private val group = Option(System.getSecurityManager)
+      .map(_.getThreadGroup)
+      .getOrElse(Thread.currentThread.getThreadGroup)
+    private val counter = new AtomicInteger(0)
+    override def newThread(r: Runnable): Thread = {
+      val thread = new Thread(group, r, namePattern.format(counter.getAndIncrement()), 0)
+      if (thread.isDaemon) thread.setDaemon(false)
+      if (thread.getPriority != Thread.NORM_PRIORITY) thread.setPriority(Thread.NORM_PRIORITY)
       thread
     }
   }

--- a/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/HadoopUtils.scala
+++ b/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/HadoopUtils.scala
@@ -85,9 +85,9 @@ object HadoopUtils extends LazyLogging {
 
     override def run(): Unit = {
       try {
-        logger.debug(s"Checking whether TGT needs renewing for ${UserGroupInformation.getCurrentUser}")
-        logger.debug(s"Logged in from keytab? ${UserGroupInformation.getCurrentUser.isFromKeytab}")
-        UserGroupInformation.getCurrentUser.checkTGTAndReloginFromKeytab()
+        logger.debug(s"Checking whether TGT needs renewing for ${UserGroupInformation.getLoginUser}")
+        logger.debug(s"Logged in from keytab? ${UserGroupInformation.getLoginUser.isFromKeytab}")
+        UserGroupInformation.getLoginUser.checkTGTAndReloginFromKeytab()
       } catch {
         case NonFatal(e) => logger.warn("Error checking and renewing TGT", e)
       }

--- a/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/concurrent/ExitingExecutorTest.scala
+++ b/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/concurrent/ExitingExecutorTest.scala
@@ -1,0 +1,35 @@
+/***********************************************************************
+ * Copyright (c) 2013-2022 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.concurrent
+
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.utils.concurrent.ExitingExecutor.NamedThreadFactory
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import java.util.concurrent.{Executors, TimeUnit}
+
+@RunWith(classOf[JUnitRunner])
+class ExitingExecutorTest extends Specification {
+
+  "NamedThreadFactory" should {
+    "create new threads with specified name pattern" in {
+      val pool = Executors.newFixedThreadPool(2, new NamedThreadFactory("geomesa-%d"))
+      val name = pool.submit(() => {
+        val first = Thread.currentThread().getName
+        val second = pool.submit(() => Thread.currentThread().getName).get()
+        Seq(first, second)
+      }).get()
+      name must equalTo(Seq("geomesa-0", "geomesa-1"))
+      pool.shutdown()
+      pool.awaitTermination(15, TimeUnit.SECONDS)
+      pool.isTerminated must beTrue
+    }
+  }
+}


### PR DESCRIPTION
Once we started using Geomesa with Kerberos-secured HBase on different runtimes (regular APIs in docker, Flink, Spark on Databricks) we faced a number of issues that prevented Geomesa to work at all. The issues are:

- While running on managed env such as Databricks there is already a current user present on the workers. And simply running `HBaseConnectionPool.configureSecurity` which does `UserGroupInformation.loginUserFromKeytab` does not set the current user as logged-in user and current authorization basically does nothing. There are 2 ways to make a fix:
  - The most simple which affects less code which I applied. Switch from `UserGroupInformation.getCurrentUser` to `UserGroupInformation.getLoginUser` which always would used logged-in user.
  - The best way, yet will require lots of refactoring. The connection to the HBase should be created with an explicit user via `ConnectionFactory.createConnection(conf, user)`. In case there is any nested code that relies on the current user (for example, hadoop hbase data format) is called - that should be wrapped with `user.doAs { ... }`
- `HBaseIndexAdapter` leaks on long-running jobs. There is a known HBase defect and passing the explicit thread pool and closing it manually solves the issue. 
- While writing into HBase that is a good idea to control the flush timeout, otherwise, we cannot guarantee the latency of writing into HBase.
- While working with Spark we need to handle hadoop configuration changes as well as authorization in every `mapPartition` . Note, that explicit reauth is not expensive cause  the user will be statically cached on every node anyway. Also for some reason a piece of code with token auth never worked for us (I am not even sure how it was supposed to be working)
- While ingesting spark DataFrame data into Geomesa if there is an existing Geomesa schema we should prefer it if compatible and not try to force Spark inferred schema which might be slightly different yet compatible and will cause the crash. 

Note, those changes were already working in Geomesa running on Kerberos-secured Azure HD Insights HBase for more than a year on different workloads. We were adding more and more fixes as we faced different situations. I believe the code might be improved a lot yet that will require rewriting a bunch of original code and a new cycle of E2E tests.