### PR TITLE
GEOMESA-3276 Confluent Kafka - support logical date types

### DIFF
--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -90,6 +90,23 @@ Compatibility Matrix
 | Dependencies | N     | N     | Y     |
 +--------------+-------+-------+-------+
 
+Version 4.1.0 Upgrade Guide
++++++++++++++++++++++++++++
+
+Dependency Version Upgrades
+---------------------------
+
+The following dependencies have been upgraded:
+
+* Spring security ``5.8.0`` -> ``5.8.3``
+
+Deprecated Classes and Methods
+------------------------------
+
+The following classes have been deprecated and will be removed in a future version:
+
+* org.locationtech.geomesa.kafka.confluent.SchemaParser.GeoMesaAvroDeserializableEnumProperty
+
 Version 4.0.0 Upgrade Guide
 +++++++++++++++++++++++++++
 

--- a/geomesa-kafka/geomesa-kafka-confluent/src/main/scala/org/locationtech/geomesa/kafka/confluent/ConfluentKafkaDataStoreFactory.scala
+++ b/geomesa-kafka/geomesa-kafka-confluent/src/main/scala/org/locationtech/geomesa/kafka/confluent/ConfluentKafkaDataStoreFactory.scala
@@ -78,11 +78,8 @@ object ConfluentKafkaDataStoreFactory extends GeoMesaDataStoreInfo with LazyLogg
   override val ParameterInfo: Array[GeoMesaParam[_ <: AnyRef]] =
     SchemaRegistryUrl +: KafkaDataStoreFactory.ParameterInfo :+ SchemaOverrides
 
-  override def canProcess(params: java.util.Map[String, _]): Boolean = {
-    KafkaDataStoreParams.Brokers.exists(params) &&
-      KafkaDataStoreParams.Zookeepers.exists(params) &&
-      SchemaRegistryUrl.exists(params)
-  }
+  override def canProcess(params: java.util.Map[String, _]): Boolean =
+    KafkaDataStoreParams.Brokers.exists(params) && SchemaRegistryUrl.exists(params)
 
   private[confluent] def parseSchemaOverrides(config: Option[String]): Map[String, (SimpleFeatureType, Schema)] = {
     try {

--- a/geomesa-kafka/geomesa-kafka-confluent/src/test/scala/org/locationtech/geomesa/kafka/confluent/ConfluentKafkaDataStoreTest.scala
+++ b/geomesa-kafka/geomesa-kafka-confluent/src/test/scala/org/locationtech/geomesa/kafka/confluent/ConfluentKafkaDataStoreTest.scala
@@ -227,6 +227,31 @@ class ConfluentKafkaDataStoreTest extends ConfluentContainerTest {
       }
     }
 
+    "support logical date types" in {
+      val topic = newTopic()
+      val id = "1"
+      val record = new GenericData.Record(logicalDateTypeSchema)
+      val expectedGeom = generatePoint(-12.2d, 120.7d)
+      record.put("geom", WKTUtils.write(expectedGeom))
+      record.put("dtg", 1639145281285L)
+
+      producer.send(new ProducerRecord[String, GenericRecord](topic, id, record)).get
+
+      WithClose(getStore()) { kds =>
+        val fs = kds.getFeatureSource(topic)
+
+        eventually(20, 100.millis) {
+          val features = SelfClosingIterator(fs.getFeatures.features).toList
+          features must haveLength(1)
+          val feature = features.head
+          SimpleFeatureTypes.encodeType(feature.getType, includeUserData = false) mustEqual encodedSftLogicalDate
+          feature.getID mustEqual id
+          feature.getAttribute("geom") mustEqual expectedGeom
+          feature.getAttribute("dtg") mustEqual new Date(1639145281285L)
+        }
+      }
+    }
+
     "support the GeoMessage control operation for update" in {
       val topic = newTopic()
       val id = "1"
@@ -378,7 +403,7 @@ object ConfluentKafkaDataStoreTest {
        |  ]
        |}""".stripMargin
   val schema1: Schema = new Schema.Parser().parse(schemaJson1)
-  val encodedSft1: String = s"id:String:cardinality=high,*position:Point:srid=4326,speed:Double,date:Date"
+  val encodedSft1: String = s"id:String:cardinality=high,*position:Point:srid=4326,speed:Double,date:Date:geomesa.date.format='iso-datetime'"
 
   val schemaJson2: String =
     s"""{
@@ -400,7 +425,7 @@ object ConfluentKafkaDataStoreTest {
        |  ]
        |}""".stripMargin
   val schema2: Schema = new Schema.Parser().parse(schemaJson2)
-  val encodedSft2: String = s"*shape:Geometry:srid=4326,date:Date"
+  val encodedSft2: String = "*shape:Geometry:srid=4326,date:Date:geomesa.date.format='epoch-millis'"
 
   val schemaJson2_NoGeoMesa: String =
     s"""{
@@ -433,4 +458,24 @@ object ConfluentKafkaDataStoreTest {
        |  ]
        |}""".stripMargin
   val badSchema: Schema = new Schema.Parser().parse(badSchemaJson)
+
+  val logicalDateTypeSchemaJson: String =
+    s"""{
+       |  "type":"record",
+       |  "name":"schema3",
+       |  "fields":[
+       |    {
+       |      "name":"geom",
+       |      "type":"string",
+       |      "${GeoMesaAvroGeomFormat.KEY}":"wkt",
+       |      "${GeoMesaAvroGeomType.KEY}":"point"
+       |    },
+       |    {
+       |      "name":"dtg",
+       |      "type": { "type": "long", "logicalType": "timestamp-millis" }
+       |    }
+       |  ]
+       |}""".stripMargin
+  val logicalDateTypeSchema: Schema = new Schema.Parser().parse(logicalDateTypeSchemaJson)
+  val encodedSftLogicalDate: String = "*geom:Point:srid=4326,dtg:Date"
 }

--- a/geomesa-kafka/geomesa-kafka-tools/conf-filtered/confluent-dependencies.sh
+++ b/geomesa-kafka/geomesa-kafka-tools/conf-filtered/confluent-dependencies.sh
@@ -19,6 +19,7 @@ function dependencies() {
   declare -a gavs=(
     "io.confluent:kafka-schema-registry-client:${confluent_install_version}:jar"
     "io.confluent:kafka-avro-serializer:${confluent_install_version}:jar"
+    "io.confluent:kafka-schema-serializer:${confluent_install_version}:jar"
     "io.confluent:common-utils:${confluent_install_version}:jar"
     "io.confluent:common-config:${confluent_install_version}:jar"
   )

--- a/geomesa-utils-parent/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SchemaBuilder.scala
+++ b/geomesa-utils-parent/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/SchemaBuilder.scala
@@ -388,7 +388,9 @@ object SchemaBuilder {
       * @param value option value
       * @return attribute builder for chaining calls
       */
-    def withOption(key: String, value: String): A = { specification.append(s":$key=$value"); this }
+    def withOption(key: String, value: String): A = {
+      specification.append(SimpleFeatureSpec.encodeAttributeOption(key, value)); this
+    }
 
     /**
       * Add multiple attribute-level options at once

--- a/geomesa-utils-parent/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/sft/SimpleFeatureSpec.scala
+++ b/geomesa-utils-parent/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/sft/SimpleFeatureSpec.scala
@@ -62,13 +62,7 @@ object SimpleFeatureSpec {
       * @return a partial spec string
       */
     def toSpec: String = {
-      val opts = specOptions.map { case (k, v) =>
-        if (simpleOptionPattern.matcher(v).matches()) {
-          s":$k=$v"
-        } else {
-          s":$k='${StringEscapeUtils.escapeJava(v)}'"
-        }
-      }
+      val opts = specOptions.map { case (k, v) => encodeAttributeOption(k, v) }
       s"$name:$getClassSpec${opts.mkString}"
     }
 
@@ -155,6 +149,21 @@ object SimpleFeatureSpec {
       MapAttributeSpec(name, keyClass, valueClass, options)
     } else {
       throw new IllegalArgumentException(s"Unknown type binding $binding")
+    }
+  }
+
+  /**
+   * Encode an attribute option for a spec string
+   *
+   * @param key key for the option
+   * @param value value for the option
+   * @return
+   */
+  def encodeAttributeOption(key: String, value: String): String = {
+    if (simpleOptionPattern.matcher(value).matches()) {
+      s":$key=$value"
+    } else {
+      s":$key='${StringEscapeUtils.escapeJava(value)}'"
     }
   }
 


### PR DESCRIPTION
* Deprecated org.locationtech.geomesa.kafka.confluent.SchemaParser.GeoMesaAvroDeserializableEnumProperty
* Include date format in feature type attribute user data
* Fix SchemaBuilder to properly escape attribute user data