### PR TITLE
GEOMESA-3299 Deprecate query planner threaded hints

### DIFF
--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryPlanner.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/QueryPlanner.scala
@@ -162,15 +162,19 @@ object QueryPlanner extends LazyLogging {
 
   import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
-  private [planning] val threadedHints = new SoftThreadLocal[Map[AnyRef, AnyRef]]
+  private[planning] val threadedHints = new SoftThreadLocal[Map[AnyRef, AnyRef]]
 
   object CostEvaluation extends Enumeration {
     type CostEvaluation = Value
     val Stats, Index = Value
   }
 
+  // threaded hints were used as a work-around with wfs output formats, but now we use GetFeatureCallback instead
+  @deprecated("Deprecated with no replacement")
   def setPerThreadQueryHints(hints: Map[AnyRef, AnyRef]): Unit = threadedHints.put(hints)
+  @deprecated("Deprecated with no replacement")
   def getPerThreadQueryHints: Option[Map[AnyRef, AnyRef]] = threadedHints.get
+  @deprecated("Deprecated with no replacement")
   def clearPerThreadQueryHints(): Unit = threadedHints.clear()
 
   /**

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/MergedQueryRunner.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/view/MergedQueryRunner.scala
@@ -120,6 +120,7 @@ class MergedQueryRunner(
     val query = new Query(original)
 
     // set the thread-local hints once, so that we have them for each data store that is being queried
+    // noinspection ScalaDeprecation
     QueryPlanner.getPerThreadQueryHints.foreach { hints =>
       hints.foreach { case (k, v) => query.getHints.put(k, v) }
       // clear any configured hints so we don't process them again


### PR DESCRIPTION
* Threaded hints are not working as intended, and usages should be replaced