### PR TITLE
GEOMESA-3306 Send client version info with distributed processing calls

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/FilterTransformIterator.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/main/scala/org/locationtech/geomesa/accumulo/iterators/FilterTransformIterator.scala
@@ -20,6 +20,7 @@ import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
 import org.locationtech.geomesa.index.conf.FilterCompatibility
 import org.locationtech.geomesa.index.conf.FilterCompatibility.FilterCompatibility
 import org.locationtech.geomesa.index.iterators.{IteratorCache, SamplingIterator}
+import org.locationtech.geomesa.utils.conf.GeoMesaProperties
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
@@ -174,12 +175,15 @@ object FilterTransformIterator {
       }
       sampling.foreach(SamplingIterator.configure(sft, _).foreach { case (k, v) => is.addOption(k, v) })
 
-      compatibility.foreach {
-        case FilterCompatibility.`1.3` =>
+      compatibility match {
+        case None =>
+          is.addOption(VersionOpt, GeoMesaProperties.ProjectVersion)
+
+        case Some(FilterCompatibility.`1.3`) =>
           is.setIteratorClass("org.locationtech.geomesa.accumulo.iterators.KryoLazyFilterTransformIterator")
           is.addOption(IndexOpt, s"${index.name}:${index.version}")
 
-        case c =>
+        case Some(c) =>
           throw new NotImplementedError(s"Unknown compatibility flag: '$c'")
       }
       Some(is)

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z2Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z2Filter.scala
@@ -11,6 +11,7 @@ package org.locationtech.geomesa.index.filters
 import org.locationtech.geomesa.index.filters.RowFilter.RowFilterFactory
 import org.locationtech.geomesa.index.filters.Z3Filter._
 import org.locationtech.geomesa.index.index.z2.Z2IndexValues
+import org.locationtech.geomesa.utils.conf.GeoMesaProperties
 import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.geomesa.zorder.sfcurve.Z2
 
@@ -69,7 +70,7 @@ object Z2Filter extends RowFilterFactory[Z2Filter] {
 
   override def serializeToStrings(filter: Z2Filter): Map[String, String] = {
     val xy = filter.xy.map(bounds => bounds.mkString(RangeSeparator)).mkString(TermSeparator)
-    Map(XYKey -> xy)
+    Map(XYKey -> xy, VersionKey -> GeoMesaProperties.ProjectVersion)
   }
 
   override def deserializeFromStrings(serialized: scala.collection.Map[String, String]): Z2Filter = {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/filters/Z3Filter.scala
@@ -10,6 +10,7 @@ package org.locationtech.geomesa.index.filters
 
 import org.locationtech.geomesa.index.filters.RowFilter.RowFilterFactory
 import org.locationtech.geomesa.index.index.z3.Z3IndexValues
+import org.locationtech.geomesa.utils.conf.GeoMesaProperties
 import org.locationtech.geomesa.utils.index.ByteArrays
 import org.locationtech.geomesa.zorder.sfcurve.Z3
 
@@ -69,9 +70,10 @@ object Z3Filter extends RowFilterFactory[Z3Filter] {
   private val TermSeparator  = ";"
   private val EpochSeparator = ","
 
-  val XYKey     = "zxy"
-  val TKey      = "zt"
-  val EpochKey  = "epoch"
+  val XYKey      = "zxy"
+  val TKey       = "zt"
+  val EpochKey   = "epoch"
+  val VersionKey = "v"
 
   def apply(values: Z3IndexValues): Z3Filter = {
     val Z3IndexValues(sfc, _, spatialBounds, _, temporalBounds, _) = values
@@ -160,9 +162,10 @@ object Z3Filter extends RowFilterFactory[Z3Filter] {
     val epoch = s"${filter.minEpoch}$RangeSeparator${filter.maxEpoch}"
 
     Map(
-      XYKey    -> xy,
-      TKey     -> t,
-      EpochKey -> epoch
+      XYKey      -> xy,
+      TKey       -> t,
+      EpochKey   -> epoch,
+      VersionKey -> GeoMesaProperties.ProjectVersion
     )
   }
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/iterators/AggregatingScan.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/iterators/AggregatingScan.scala
@@ -16,6 +16,7 @@ import org.locationtech.geomesa.features.TransformSimpleFeature
 import org.locationtech.geomesa.features.kryo.KryoBufferSimpleFeature
 import org.locationtech.geomesa.index.api.GeoMesaFeatureIndex
 import org.locationtech.geomesa.index.iterators.AggregatingScan.{AggregateCallback, CqlSampleValidator, CqlValidator, RowValidator, RowValue, SampleValidator, ValidateAll}
+import org.locationtech.geomesa.utils.conf.GeoMesaProperties
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
@@ -223,6 +224,7 @@ object AggregatingScan {
     val TransformSchemaOpt = "tsft"
     val TransformDefsOpt   = "tdefs"
     val BatchSizeOpt       = "batch"
+    val VersionOpt         = "v"
   }
 
   def configure(
@@ -243,7 +245,8 @@ object AggregatingScan {
       Configuration.CqlOpt             -> filter.map(ECQL.toCQL),
       Configuration.TransformDefsOpt   -> transform.map(_._1),
       Configuration.TransformSchemaOpt -> transform.map(t => SimpleFeatureTypes.encodeType(t._2)),
-      Configuration.BatchSizeOpt       -> batchSize.toString
+      Configuration.BatchSizeOpt       -> batchSize.toString,
+      Configuration.VersionOpt         -> GeoMesaProperties.ProjectVersion
     )
   }
 

--- a/geomesa-utils-parent/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/conf/IndexId.scala
+++ b/geomesa-utils-parent/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/conf/IndexId.scala
@@ -26,6 +26,8 @@ case class IndexId(name: String, version: Int, attributes: Seq[String], mode: In
     val state = Seq(encoded)
     state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
   }
+
+  override def toString: String = encoded
 }
 
 object IndexId {


### PR DESCRIPTION
Eventually we may be able to support older clients talking to newer distributed runtimes - this makes sure that our older clients are at least sending the version info (which is currently disregarded by the receiver)