### PR TITLE
GEOMESA-3326 Ingest from stdin even if an SFT and converter are not specified

### DIFF
--- a/docs/user/cli/export.rst
+++ b/docs/user/cli/export.rst
@@ -24,6 +24,7 @@ Argument                   Description
 ``--hints``                Query hints used to modify the query
 ``--gzip``                 Level of gzip compression to use for output, from 1-9
 ``--no-header``            Don't export the type header, for CSV and TSV formats
+``--src-list``             Input files are text files with lists of files, one per line, to ingest
 ``--suppress-empty``       If no features are converted, don't write any headers or other output
 ``--force``                Force execution without prompt
 ========================== ===================================================================================

--- a/docs/user/convert/function_usage.rst
+++ b/docs/user/convert/function_usage.rst
@@ -876,7 +876,7 @@ Here's some sample CSV data:
 
 ::
 
-    ID,Name,Age,LastSeen,Friends,Lat,Lon
+    ID,Name,Age,LastSeen,Friends,Lon,Lat
     23623,Harry,20,2015-05-06,"Will, Mark, Suzan",-100.236523,23
     26236,Hermione,25,2015-06-07,"Edward, Bill, Harry",40.232,-53.2356
     3233,Severus,30,2015-10-23,"Tom, Riddle, Voldemort",3,-62.23

--- a/docs/user/convert/usage_tools.rst
+++ b/docs/user/convert/usage_tools.rst
@@ -23,7 +23,7 @@ Given the following sample CSV file ``example.csv``:
 
 ::
 
-    ID,Name,Age,LastSeen,Friends,Lat,Lon
+    ID,Name,Age,LastSeen,Friends,Lon,Lat
     23623,Harry,20,2015-05-06,"Will, Mark, Suzan",-100.236523,23
     26236,Hermione,25,2015-06-07,"Edward, Bill, Harry",40.232,-53.2356
     3233,Severus,30,2015-10-23,"Tom, Riddle, Voldemort",3,-62.23

--- a/geomesa-accumulo/geomesa-accumulo-tools/src/test/resources/examples/example1.csv
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/test/resources/examples/example1.csv
@@ -1,4 +1,4 @@
-ID,Name,Age,LastSeen,Friends,Lat,Lon
+ID,Name,Age,LastSeen,Friends,Lon,Lat
 23623,Harry,20,2015-05-06,"Will, Mark, Suzan",-100.236523,23
 26236,Hermione,25,2015-06-07,"Edward, Bill, Harry",40.232,-53.2356
 3233,Severus,30,2015-10-23,"Tom, Riddle, Voldemort",3,-62.23

--- a/geomesa-accumulo/geomesa-accumulo-tools/src/test/resources/examples/example2.csv
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/test/resources/examples/example2.csv
@@ -1,3 +1,3 @@
-ID,Name,Age,LastSeen,Friends,Lat,Lon
+ID,Name,Age,LastSeen,Friends,Lon,Lat
 33623,Ron,20,2015-05-06,"Will, Mark, Suzan",-100.236523,23
 36236,Ginny,25,2015-06-07,"Edward, Bill, Harry",40.232,-53.2356

--- a/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterFactory.scala
@@ -37,6 +37,7 @@ class DelimitedTextConverterFactory
 
   import scala.collection.JavaConverters._
 
+  // @param path is unused in this class
   override def infer(
       is: InputStream,
       sft: Option[SimpleFeatureType],

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ConvertCommand.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/export/ConvertCommand.scala
@@ -8,7 +8,7 @@
 
 package org.locationtech.geomesa.tools.export
 
-import com.beust.jcommander.{ParameterException, Parameters}
+import com.beust.jcommander.{Parameter, ParameterException, Parameters}
 import com.typesafe.scalalogging.LazyLogging
 import org.geotools.api.data.Query
 import org.geotools.api.feature.simple.{SimpleFeature, SimpleFeatureType}
@@ -19,15 +19,15 @@ import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.index.planning.LocalQueryRunner
 import org.locationtech.geomesa.index.planning.LocalQueryRunner.ArrowDictionaryHook
 import org.locationtech.geomesa.index.stats.RunnableStats
+import org.locationtech.geomesa.tools._
 import org.locationtech.geomesa.tools.export.ConvertCommand.ConvertParameters
 import org.locationtech.geomesa.tools.export.ExportCommand.{ChunkedExporter, ExportOptions, ExportParams, Exporter}
 import org.locationtech.geomesa.tools.ingest.IngestCommand
 import org.locationtech.geomesa.tools.ingest.IngestCommand.Inputs
-import org.locationtech.geomesa.tools._
 import org.locationtech.geomesa.utils.collection.CloseableIterator
+import org.locationtech.geomesa.utils.io.WithClose
 import org.locationtech.geomesa.utils.io.fs.FileSystemDelegate.FileHandle
 import org.locationtech.geomesa.utils.io.fs.LocalDelegate.StdInHandle
-import org.locationtech.geomesa.utils.io.{PathUtils, WithClose}
 import org.locationtech.geomesa.utils.stats.{MethodProfiling, Stat}
 import org.locationtech.geomesa.utils.text.TextTools.getPlural
 
@@ -49,11 +49,21 @@ class ConvertCommand extends Command with MethodProfiling with LazyLogging {
 
     import scala.collection.JavaConverters._
 
-    if (params.files.isEmpty && !StdInHandle.isAvailable) {
-      throw new ParameterException("Missing option: <files>... is required")
+    val inputs: Inputs = {
+      val files = Inputs(params.files.asScala.toSeq)
+      if (files.stdin && !StdInHandle.isAvailable) {
+        if (files.paths.isEmpty) {
+          throw new ParameterException("Missing option: <files>... is required, or use `-` to ingest from standard in")
+        } else {
+          Command.user.info("Waiting for input...")
+          while (!StdInHandle.isAvailable) {
+            Thread.sleep(10)
+          }
+        }
+      }
+      if (params.srcList) { files.asSourceList } else { files }
     }
 
-    val inputs = Inputs(params.files.asScala.toSeq)
     val format = IngestCommand.getDataFormat(params, inputs.paths)
 
     // use .get to re-throw the exception if we fail
@@ -152,5 +162,8 @@ object ConvertCommand extends LazyLogging {
 
   @Parameters(commandDescription = "Convert files using GeoMesa's internal converter framework")
   class ConvertParameters extends ExportParams with OptionalInputFormatParam with OptionalTypeNameParam
-      with OptionalFeatureSpecParam with ConverterConfigParam with OptionalForceParam
+      with OptionalFeatureSpecParam with ConverterConfigParam with OptionalForceParam {
+    @Parameter(names = Array("--src-list"), description = "Input files are text files with lists of files, one per line, to ingest.")
+    var srcList: Boolean = false
+  }
 }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/LocalConverterIngest.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/LocalConverterIngest.scala
@@ -24,7 +24,7 @@ import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.locationtech.geomesa.utils.concurrent.CachedThreadPool
 import org.locationtech.geomesa.utils.geotools.FeatureUtils
 import org.locationtech.geomesa.utils.io.fs.FileSystemDelegate.FileHandle
-import org.locationtech.geomesa.utils.io.fs.LocalDelegate.StdInHandle
+import org.locationtech.geomesa.utils.io.fs.LocalDelegate.{CachingStdInHandle, StdInHandle}
 import org.locationtech.geomesa.utils.io.{CloseQuietly, CloseWithLogging, CloseablePool, WithClose}
 import org.locationtech.geomesa.utils.text.TextTools
 
@@ -65,9 +65,9 @@ class LocalConverterIngest(
           IngestCommand.LocalBatchSize.get)
   }
 
-  if (inputs.stdin && !StdInHandle.isAvailable) {
+  if (inputs.stdin && !CachingStdInHandle.isAvailable) {
     Command.user.info("Waiting for input...")
-    while (!StdInHandle.isAvailable) {
+    while (!CachingStdInHandle.isAvailable) {
       Thread.sleep(10)
     }
   }

--- a/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/LocalConverterIngest.scala
+++ b/geomesa-tools/src/main/scala/org/locationtech/geomesa/tools/ingest/LocalConverterIngest.scala
@@ -24,7 +24,6 @@ import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.locationtech.geomesa.utils.concurrent.CachedThreadPool
 import org.locationtech.geomesa.utils.geotools.FeatureUtils
 import org.locationtech.geomesa.utils.io.fs.FileSystemDelegate.FileHandle
-import org.locationtech.geomesa.utils.io.fs.LocalDelegate.{CachingStdInHandle, StdInHandle}
 import org.locationtech.geomesa.utils.io.{CloseQuietly, CloseWithLogging, CloseablePool, WithClose}
 import org.locationtech.geomesa.utils.text.TextTools
 
@@ -63,13 +62,6 @@ class LocalConverterIngest(
     throw new IllegalArgumentException(
       s"Invalid batch size for property ${IngestCommand.LocalBatchSize.property}: " +
           IngestCommand.LocalBatchSize.get)
-  }
-
-  if (inputs.stdin && !CachingStdInHandle.isAvailable) {
-    Command.user.info("Waiting for input...")
-    while (!CachingStdInHandle.isAvailable) {
-      Thread.sleep(10)
-    }
   }
 
   private val es = Executors.newFixedThreadPool(threads)

--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/export/ConvertCommandTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/export/ConvertCommandTest.scala
@@ -15,6 +15,7 @@ import org.geotools.api.feature.simple.SimpleFeatureType
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.tools.export.formats.ExportFormat
 import org.locationtech.geomesa.tools.ingest.IngestCommand
+import org.locationtech.geomesa.tools.ingest.IngestCommand.Inputs
 import org.locationtech.geomesa.utils.io.PathUtils
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -84,7 +85,7 @@ class ConvertCommandTest extends Specification with LazyLogging {
       forall(inFormats) { inFmt =>
         forall(outFormats) { outFmt =>
           val command = createCommand(inFmt, outFmt)
-          val sftAndConverter = IngestCommand.getSftAndConverter(command.params, Seq.empty, None, None)
+          val sftAndConverter = IngestCommand.getSftAndConverter(command.params, Inputs(Seq.empty), None, None)
           sftAndConverter must beASuccessfulTry(beSome[(SimpleFeatureType, Config)])
         }
       }

--- a/geomesa-utils-parent/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/CopyingInputStream.scala
+++ b/geomesa-utils-parent/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/io/CopyingInputStream.scala
@@ -108,6 +108,30 @@ class CopyingInputStream(wrapped: InputStream, initialBuffer: Int = 16) extends 
     }
   }
 
+  override def readNBytes(len: Int): Array[Byte] = {
+    val buf = super.readNBytes(len)
+    if (buf.nonEmpty) {
+      copy.enqueue(buf, 0, buf.length)
+    }
+    buf
+  }
+
+  override def readNBytes(b: Array[Byte], off: Int, len: Int): Int = {
+    val count = super.readNBytes(b, off, len)
+    if (count > 0) {
+      copy.enqueue(b, off, len)
+    }
+    count
+  }
+
+  override def readAllBytes(): Array[Byte] = {
+    val buf = super.readAllBytes()
+    if (buf.nonEmpty) {
+      copy.enqueue(buf, 0, buf.length)
+    }
+    buf
+  }
+
   override def available(): Int = wrapped.available()
 
   // note: mark/reset not supported, defer to default implementation that throws IllegalArgumentExceptions

--- a/geomesa-utils-parent/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/io/fs/LocalFileHandleTest.scala
+++ b/geomesa-utils-parent/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/io/fs/LocalFileHandleTest.scala
@@ -1,0 +1,70 @@
+/***********************************************************************
+ * Copyright (c) 2013-2024 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.locationtech.geomesa.utils.io.fs
+
+import org.apache.commons.io.IOUtils
+import org.junit.runner.RunWith
+import org.locationtech.geomesa.utils.collection.SelfClosingIterator
+import org.locationtech.geomesa.utils.io.WithClose
+import org.locationtech.geomesa.utils.io.fs.LocalDelegate.{CachingStdInHandle, StdInHandle}
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import java.io.{BufferedInputStream, ByteArrayInputStream, IOException, InputStream}
+
+@RunWith(classOf[JUnitRunner])
+class LocalFileHandleTest extends Specification {
+
+  "LocalFileHandle" should {
+    "cache bytes when reading from stdin" in {
+      @throws[IOException]
+      def readNBytes(stream: InputStream, n: Int): Array[Byte] = {
+        val buffer = new Array[Byte](n)
+        var totalBytesRead = 0
+
+        while (totalBytesRead < n) {
+          val bytesRead = stream.read(buffer, totalBytesRead, n - totalBytesRead)
+          if (bytesRead == -1) {
+            throw new IOException("End of stream reached before reading 'n' bytes.")
+          }
+          totalBytesRead += bytesRead
+        }
+
+        buffer
+      }
+
+      val dataFile = WithClose(getClass.getClassLoader.getResourceAsStream("geomesa-fake.xml")) { in =>
+        IOUtils.toByteArray(in)
+      }
+
+      // Feed all the bytes to stdin
+      val input = new BufferedInputStream(new ByteArrayInputStream(dataFile))
+      StdInHandle.SystemIns.set(input)
+      try {
+        val handle = CachingStdInHandle.get()
+        handle.length mustEqual dataFile.length
+        val List(stream1) = SelfClosingIterator(handle.open).map(_._2).toList
+        val first3Bytes = try { readNBytes(stream1, 3) } finally {
+          stream1.close()
+        }
+        handle.length mustEqual dataFile.length
+        val List(stream2) = SelfClosingIterator(handle.open).map(_._2).toList
+        try { readNBytes(stream2, 3) mustEqual first3Bytes } finally {
+          stream2.close()
+        }
+        val List(stream3) = SelfClosingIterator(handle.open).map(_._2).toList
+        try { readNBytes(stream3, 6).take(3) mustEqual first3Bytes } finally {
+          stream3.close()
+        }
+      } finally {
+        StdInHandle.SystemIns.remove()
+      }
+    }
+  }
+}

--- a/geomesa-utils-parent/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/io/fs/LocalFileHandleTest.scala
+++ b/geomesa-utils-parent/geomesa-utils/src/test/scala/org/locationtech/geomesa/utils/io/fs/LocalFileHandleTest.scala
@@ -31,7 +31,7 @@ class LocalFileHandleTest extends Specification {
         while (totalBytesRead < n) {
           val bytesRead = stream.read(buffer, totalBytesRead, n - totalBytesRead)
           if (bytesRead == -1) {
-            throw new IOException("End of stream reached before reading 'n' bytes.")
+            throw new IOException(s"End of stream reached before reading $n bytes.")
           }
           totalBytesRead += bytesRead
         }


### PR DESCRIPTION
* Cache any bytes that the schema inference functions read from the `stdin` input stream - preventing those functions from consuming those bytes and leaving behind nothing for the actual ingest to read
  * Create a new wrapper class for `StdInHandle`
  * Create a new wrapper class for `CopyingInputStream`, which overrides the `close()` method and prevents `stdin` from being prematurely closed
  * Mark the starting position of the `stdin` stream before starting schema inference, and reset the stream back to that point after the inference is complete, so that the ingest can re-read those bytes
* Change unit tests in the `IngestCommandTest` class to use buffered input streams, replicating how the CLI tools process command-line input

Minor changes:
* Flip the lat/lon columns - this fixes a bug where a SimpleFeature wasn't getting ingested due to a latitude < -90
* Add a comment about an unused parameter