### PR TITLE
GEOMESA-3036 Throw a useful error if attempting to parse non-GeoJSON features

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-tools/src/test/resources/examples/example1-json.conf
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/test/resources/examples/example1-json.conf
@@ -1,0 +1,33 @@
+geomesa {
+  sfts {
+    "renegades" {
+      attributes = [
+        { name = "name",     type = "String",       index = true                              }
+        { name = "age",      type = "Integer",      index = false                             }
+        { name = "lastseen", type = "Date",         index = false                             }
+        { name = "friends",  type = "List[String]", index = true                              }
+        { name = "geom",     type = "Point",        index = true, srid = 4326, default = true }
+      ]
+    }
+  }
+  converters {
+    "renegades-csv" {
+      type = "json",
+      format = "json",
+      options {
+        skip-lines = 1
+      },
+      id-field = "toString($id)",
+      fields = [
+        { name = "id",       transform = "$1::int"                 }
+        { name = "name",     transform = "$2::string"              }
+        { name = "age",      transform = "$3::int"                 }
+        { name = "lastseen", transform = "date('yyyy-MM-dd', $4)"  }
+        { name = "friends",  transform = "parseList('string', $5)" }
+        { name = "lon",      transform = "$6::double"              }
+        { name = "lat",      transform = "$7::double"              }
+        { name = "geom",     transform = "point($lon, $lat)"       }
+      ]
+    }
+  }
+}

--- a/geomesa-accumulo/geomesa-accumulo-tools/src/test/resources/examples/json-data-avro.json
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/test/resources/examples/json-data-avro.json
@@ -1,0 +1,3 @@
+{"__version__":5,"__fid__":"23623","fid":{"int":23623},"name":{"string":"Harry"},"age":{"int":20},"lastseen":{"long":1430870400000},"geom":{"bytes":"\u0000\u0000\u0000\u0000\u0001ÀY\u000F\"Ðå`B@7\u0000\u0000\u0000\u0000\u0000\u0000"},"__userdata__":[]}
+{"__version__":5,"__fid__":"26236","fid":{"int":26236},"name":{"string":"Hermione"},"age":{"int":25},"lastseen":{"long":1433635200000},"geom":{"bytes":"\u0000\u0000\u0000\u0000\u0001@D\u001D²-\u000EV\u0004ÀJ($\u000Bx\u0003"},"__userdata__":[]}
+{"__version__":5,"__fid__":"3233","fid":{"int":3233},"name":{"string":"Severus"},"age":{"int":30},"lastseen":{"long":1445558400000},"geom":{"bytes":"\u0000\u0000\u0000\u0000\u0001@\b\u0000\u0000\u0000\u0000\u0000\u0000ÀO\u001Dp£×\n="},"__userdata__":[]}

--- a/geomesa-tools/src/test/resources/convert/example1-json.conf
+++ b/geomesa-tools/src/test/resources/convert/example1-json.conf
@@ -1,0 +1,33 @@
+geomesa {
+  sfts {
+    "renegades" {
+      attributes = [
+        { name = "name",     type = "String",       index = true                              }
+        { name = "age",      type = "Integer",      index = false                             }
+        { name = "lastseen", type = "Date",         index = false                             }
+        { name = "friends",  type = "List[String]", index = true                              }
+        { name = "geom",     type = "Point",        index = true, srid = 4326, default = true }
+      ]
+    }
+  }
+  converters {
+    "renegades-csv" {
+      type = "json",
+      format = "json",
+      options {
+        skip-lines = 1
+      },
+      id-field = "toString($id)",
+      fields = [
+        { name = "id",       transform = "$1::int"                 }
+        { name = "name",     transform = "$2::string"              }
+        { name = "age",      transform = "$3::int"                 }
+        { name = "lastseen", transform = "date('yyyy-MM-dd', $4)"  }
+        { name = "friends",  transform = "parseList('string', $5)" }
+        { name = "lon",      transform = "$6::double"              }
+        { name = "lat",      transform = "$7::double"              }
+        { name = "geom",     transform = "point($lon, $lat)"       }
+      ]
+    }
+  }
+}

--- a/geomesa-tools/src/test/resources/convert/json-data-avro.json
+++ b/geomesa-tools/src/test/resources/convert/json-data-avro.json
@@ -1,0 +1,3 @@
+{"__version__":5,"__fid__":"23623","fid":{"int":23623},"name":{"string":"Harry"},"age":{"int":20},"lastseen":{"long":1430870400000},"geom":{"bytes":"\u0000\u0000\u0000\u0000\u0001ÀY\u000F\"Ðå`B@7\u0000\u0000\u0000\u0000\u0000\u0000"},"__userdata__":[]}
+{"__version__":5,"__fid__":"26236","fid":{"int":26236},"name":{"string":"Hermione"},"age":{"int":25},"lastseen":{"long":1433635200000},"geom":{"bytes":"\u0000\u0000\u0000\u0000\u0001@D\u001D²-\u000EV\u0004ÀJ($\u000Bx\u0003"},"__userdata__":[]}
+{"__version__":5,"__fid__":"3233","fid":{"int":3233},"name":{"string":"Severus"},"age":{"int":30},"lastseen":{"long":1445558400000},"geom":{"bytes":"\u0000\u0000\u0000\u0000\u0001@\b\u0000\u0000\u0000\u0000\u0000\u0000ÀO\u001Dp£×\n="},"__userdata__":[]}


### PR DESCRIPTION
* Throw an error during schema inference if we were able to parse json elements but couldn't convert them to GeoJSON
* Implement unit tests for ingesting/converting non-GeoJSON features