### PR TITLE
Use symlinks for shared test resources

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/shared-resources
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/test/shared-resources
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-accumulo/geomesa-accumulo-spark-runtime-accumulo20/src/test/shared-resources
+++ b/geomesa-accumulo/geomesa-accumulo-spark-runtime-accumulo20/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-accumulo/geomesa-accumulo-tools/src/test/shared-resources
+++ b/geomesa-accumulo/geomesa-accumulo-tools/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-arrow/geomesa-arrow-datastore/src/test/shared-resources
+++ b/geomesa-arrow/geomesa-arrow-datastore/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-arrow/geomesa-arrow-gt/src/test/shared-resources
+++ b/geomesa-arrow/geomesa-arrow-gt/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-arrow/geomesa-arrow-jts/src/test/shared-resources
+++ b/geomesa-arrow/geomesa-arrow-jts/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/test/shared-resources
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-all/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-all/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-avro/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-avro/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-common/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-common/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-fixedwidth/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-fixedwidth/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-jdbc/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-jdbc/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-json/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-json/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-osm/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-osm/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-parquet/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-parquet/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-redis-cache/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-redis-cache/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-shp/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-shp/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-simplefeature/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-simplefeature/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-text/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-text/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-convert/geomesa-convert-xml/src/test/shared-resources
+++ b/geomesa-convert/geomesa-convert-xml/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-features/geomesa-feature-all/src/test/shared-resources
+++ b/geomesa-features/geomesa-feature-all/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-features/geomesa-feature-avro/src/test/shared-resources
+++ b/geomesa-features/geomesa-feature-avro/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-features/geomesa-feature-common/src/test/shared-resources
+++ b/geomesa-features/geomesa-feature-common/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-features/geomesa-feature-kryo/src/test/shared-resources
+++ b/geomesa-features/geomesa-feature-kryo/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-filter/src/test/shared-resources
+++ b/geomesa-filter/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../build/test/resources

--- a/geomesa-fs/geomesa-fs-datastore/src/test/shared-resources
+++ b/geomesa-fs/geomesa-fs-datastore/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-fs/geomesa-fs-spark-runtime/src/test/shared-resources
+++ b/geomesa-fs/geomesa-fs-spark-runtime/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/test/shared-resources
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../../build/test/resources

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/test/shared-resources
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../../build/test/resources

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/test/shared-resources
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-orc/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../../build/test/resources

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/shared-resources
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../../build/test/resources

--- a/geomesa-fs/geomesa-fs-tools/src/test/shared-resources
+++ b/geomesa-fs/geomesa-fs-tools/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-gt/geomesa-gt-partitioning/src/test/shared-resources
+++ b/geomesa-gt/geomesa-gt-partitioning/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-gt/geomesa-gt-spark/src/test/shared-resources
+++ b/geomesa-gt/geomesa-gt-spark/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-gt/geomesa-gt-tools/src/test/shared-resources
+++ b/geomesa-gt/geomesa-gt-tools/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-hbase/geomesa-hbase-datastore/src/test/shared-resources
+++ b/geomesa-hbase/geomesa-hbase-datastore/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-hbase/geomesa-hbase-rpc/src/test/shared-resources
+++ b/geomesa-hbase/geomesa-hbase-rpc/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-hbase/geomesa-hbase-spark-runtime-hbase1/src/test/shared-resources
+++ b/geomesa-hbase/geomesa-hbase-spark-runtime-hbase1/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-index-api/src/test/shared-resources
+++ b/geomesa-index-api/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../build/test/resources

--- a/geomesa-jobs/src/test/shared-resources
+++ b/geomesa-jobs/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../build/test/resources

--- a/geomesa-kafka/geomesa-kafka-confluent/src/test/shared-resources
+++ b/geomesa-kafka/geomesa-kafka-confluent/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-kafka/geomesa-kafka-datastore/src/test/shared-resources
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-lambda/geomesa-lambda-datastore/src/test/shared-resources
+++ b/geomesa-lambda/geomesa-lambda-datastore/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-memory/geomesa-cqengine-datastore/src/test/shared-resources
+++ b/geomesa-memory/geomesa-cqengine-datastore/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-memory/geomesa-cqengine/src/test/shared-resources
+++ b/geomesa-memory/geomesa-cqengine/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-metrics/geomesa-metrics-prometheus/src/test/shared-resources
+++ b/geomesa-metrics/geomesa-metrics-prometheus/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-process/geomesa-process-vector/src/test/shared-resources
+++ b/geomesa-process/geomesa-process-vector/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-redis/geomesa-redis-datastore/src/test/shared-resources
+++ b/geomesa-redis/geomesa-redis-datastore/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-security/src/test/shared-resources
+++ b/geomesa-security/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../build/test/resources

--- a/geomesa-spark/geomesa-spark-converter/src/test/shared-resources
+++ b/geomesa-spark/geomesa-spark-converter/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-spark/geomesa-spark-jts/src/test/shared-resources
+++ b/geomesa-spark/geomesa-spark-jts/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-spark/geomesa-spark-jupyter-leaflet/src/test/shared-resources
+++ b/geomesa-spark/geomesa-spark-jupyter-leaflet/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-spark/geomesa-spark-sql/src/test/shared-resources
+++ b/geomesa-spark/geomesa-spark-sql/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-spark/geomesa-spark-test-with-sedona/src/test/shared-resources
+++ b/geomesa-spark/geomesa-spark-test-with-sedona/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-spark/geomesa-spark-test-without-sedona/src/test/shared-resources
+++ b/geomesa-spark/geomesa-spark-test-without-sedona/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-spark/geomesa_pyspark/src/test/shared-resources
+++ b/geomesa-spark/geomesa_pyspark/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-tools/src/test/shared-resources
+++ b/geomesa-tools/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../build/test/resources

--- a/geomesa-utils-parent/geomesa-hadoop-utils/src/test/shared-resources
+++ b/geomesa-utils-parent/geomesa-hadoop-utils/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-utils-parent/geomesa-utils/src/test/shared-resources
+++ b/geomesa-utils-parent/geomesa-utils/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../../build/test/resources

--- a/geomesa-z3/src/test/shared-resources
+++ b/geomesa-z3/src/test/shared-resources
@@ -1,0 +1,1 @@
+../../../build/test/resources

--- a/pom.xml
+++ b/pom.xml
@@ -2870,8 +2870,7 @@
                 <filtering>false</filtering>
             </testResource>
             <testResource>
-                <!-- user.dir points to the directory mvn was executed in, i.e. the top-level folder -->
-                <directory>${user.dir}/build/test/resources</directory>
+                <directory>src/test/shared-resources</directory>
                 <filtering>false</filtering>
             </testResource>
         </testResources>


### PR DESCRIPTION
* Resolves issues with IDEs not properly using shared resource dir