### PR TITLE
Bump dependency versions

### DIFF
--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -117,8 +117,8 @@ jakarta.transaction:jakarta.transaction-api	1.3.3	compile
 javax.annotation:javax.annotation-api	1.2	compile
 javax.measure:unit-api	2.1.2	compile
 joda-time:joda-time	2.12.6	compile
-net.java.dev.jna:jna	4.5.2	compile
-net.java.dev.jna:jna-platform	4.5.2	compile
+net.java.dev.jna:jna	5.14.0	compile
+net.java.dev.jna:jna-platform	5.14.0	compile
 net.jodah:typetools	0.6.1	compile
 net.sf.geographiclib:GeographicLib-Java	1.49	compile
 net.sf.saxon:Saxon-HE	12.4	compile
@@ -179,8 +179,8 @@ org.apache.thrift:libthrift	0.17.0	compile
 org.apache.xml:xml-commons-resolver	1.2	compile
 org.apache.yetus:audience-annotations	0.12.0	compile
 org.apache.yetus:audience-annotations	0.13.0	compile
-org.apache.zookeeper:zookeeper	3.9.1	compile
-org.apache.zookeeper:zookeeper-jute	3.9.1	compile
+org.apache.zookeeper:zookeeper	3.9.2	compile
+org.apache.zookeeper:zookeeper-jute	3.9.2	compile
 org.apiguardian:apiguardian-api	1.1.2	compile
 org.calrissian.mango:mango-core	3.0.0	compile
 org.checkerframework:checker-qual	3.37.0	compile
@@ -291,7 +291,7 @@ org.apache.spark:spark-core_2.12	3.5.0	provided
 org.apache.spark:spark-sql_2.12	3.5.0	provided
 org.scala-lang:scala-compiler	2.12.19	provided
 org.slf4j:slf4j-reload4j	1.7.36	provided
-org.springframework.security:spring-security-core	5.8.9	provided
+org.springframework.security:spring-security-core	5.8.11	provided
 
 com.sun.xml.bind:jaxb-impl	2.2.3	test
 com.uber:h3	4.1.1	test

--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -190,12 +190,12 @@ The following dependencies have been upgraded:
 * sedona ``1.3.1-incubating`` -> ``1.5.0``
 * si.uom ``2.0.1`` -> ``2.1``
 * spark ``3.3.1`` -> ``3.5.0``
-* spring-security ``5.8.0`` -> ``5.8.9``
+* spring-security ``5.8.0`` -> ``5.8.11``
 * systems.uom ``2.0.2`` -> ``2.1``
 * tech.units:indriya ``2.0.2`` -> ``2.2``
 * tech.uom.lib ``2.0`` -> ``2.1``
 * xmlresolver ``4.4.3`` -> ``5.2.2``
-* zookeeper ``3.5.10`` -> ``3.9.1``
+* zookeeper ``3.5.10`` -> ``3.9.2``
 
 Deprecated Classes and Methods
 ------------------------------

--- a/geomesa-hbase/geomesa-hbase-tools/conf-filtered/dependencies.sh
+++ b/geomesa-hbase/geomesa-hbase-tools/conf-filtered/dependencies.sh
@@ -69,7 +69,7 @@ function dependencies() {
     "io.netty:netty-transport-classes-epoll:%%netty.version%%:jar"
     "io.netty:netty-transport-native-epoll:%%netty.version%%:jar:linux-x86_64"
     "io.netty:netty-transport-native-unix-common:%%netty.version%%:jar"
-    "io.netty:netty:3.6.2.Final:jar"
+    "io.netty:netty:3.10.6.Final:jar"
     # htrace 3 required for hadoop before 2.8
     # htrace 4 required for hadoop 2.8 and later
     # since they have separate package names, should be safe to install both

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <rhino.js.version>1.7.14</rhino.js.version>
         <s2.geometry.version>1.0.1</s2.geometry.version>
         <sizeof.version>0.4.3</sizeof.version>
-        <spring.security.version>5.8.9</spring.security.version> <!-- geoserver is still on 5.x -->
+        <spring.security.version>5.8.11</spring.security.version> <!-- geoserver is still on 5.x -->
         <typesafe.config.version>1.4.3</typesafe.config.version>
 
         <!-- standardized transitive dependencies -->
@@ -106,6 +106,7 @@
         <fasterxml.jackson.databind.version>2.16.1</fasterxml.jackson.databind.version> <!-- used by geoserver, spark and arrow -->
         <h2.version>2.2.224</h2.version>
         <hsql.version>2.7.2</hsql.version>
+        <jna.version>5.14.0</jna.version>
         <json.smart.version>2.5.0</json.smart.version> <!-- used by json-path and hadoop-auth -->
         <netty.version>4.1.106.Final</netty.version>
         <commons.cli.version>1.6.0</commons.cli.version>
@@ -125,7 +126,7 @@
         <!-- provided artifacts, not bundled to support multiple environments -->
         <accumulo.version>2.1.2</accumulo.version>
         <accumulo-20.version>2.0.1</accumulo-20.version>
-        <zookeeper.version>3.9.1</zookeeper.version>
+        <zookeeper.version>3.9.2</zookeeper.version>
         <thrift.version>0.17.0</thrift.version>
         <thrift-accumulo-20.version>0.12.0</thrift-accumulo-20.version>
         <thrift-cassandra.version>0.12.0</thrift-cassandra.version>
@@ -1858,6 +1859,16 @@
                 <version>${fasterxml.jackson.version}</version>
                 <scope>provided</scope> <!-- from spark -->
             </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId> <!-- used by nailgun and testcontainers -->
+                <version>${jna.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna-platform</artifactId>
+                <version>${jna.version}</version>
+            </dependency>
 
             <!-- provided dependencies -->
             <dependency>
@@ -2044,6 +2055,10 @@
                 <scope>provided</scope>
                 <exclusions>
                     <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
@@ -2055,6 +2070,10 @@
                 <version>${hadoop.version}</version>
                 <scope>provided</scope>
                 <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>*</artifactId>
@@ -2096,6 +2115,10 @@
                 <scope>provided</scope>
                 <exclusions>
                     <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
@@ -2122,6 +2145,12 @@
                 <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
                 <version>${hadoop.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
@@ -2427,13 +2456,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- specific to hadoop not to be confused with above-->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
-                <version>3.6.2.Final</version>
-            </dependency>
-
             <!-- geoserver spring version -->
             <dependency>
                 <groupId>org.springframework.security</groupId>
@@ -2633,6 +2655,10 @@
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
@@ -2648,6 +2674,10 @@
                 <version>${hadoop.version}</version>
                 <scope>test</scope>
                 <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>*</artifactId>
@@ -2665,6 +2695,12 @@
                 <classifier>tests</classifier>
                 <version>${hadoop.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
* zookeeper `3.9.1` -> `3.9.2`
* spring-security `5.8.9` -> `5.8.11`
* jna `4.5.2` -> `5.14.0`
* exclude old netty version used by hadoop