### PR TITLE
GEOMESA-3345 Fix PySpark init_sql

### DIFF
--- a/geomesa-spark/geomesa_pyspark/src/main/python/geomesa_pyspark/__init__.py
+++ b/geomesa-spark/geomesa_pyspark/src/main/python/geomesa_pyspark/__init__.py
@@ -112,4 +112,10 @@ def zip_package(package_path, zip_path):
 
 
 def init_sql(spark):
-    spark._jvm.org.apache.spark.sql.SQLTypes.init(spark._jwrapped)
+    version = spark.version.split('.')
+    if version[0] == '3' and version[1] <= '2':
+        spark._jvm.org.locationtech.geomesa.spark.sql.SQLTypes.init(spark._jwrapped)
+    else:  # Spark 3.3 and up
+        spark._jvm.org.locationtech.geomesa.spark.sql.SQLTypes.init(
+            spark._jsparkSession.sqlContext()
+        )


### PR DESCRIPTION
* Fix for SQLTypes package move in Geomesa 4.0.
* Fix for PySpark 3.3+ removing the JVM SQLContext (https://github.com/apache/spark/commit/88696ebcb72fd3057b1546831f653b29b7e0abb2#diff-896993d91855da90bd5a11f9d43008bc053eabc3bf540bcd253dab86e92fb732L323).