### PR TITLE
GEOMESA-3347 Type inference for xml and (non-geo) json

### DIFF
--- a/geomesa-arrow/geomesa-arrow-tools/src/main/scala/org/locationtech/geomesa/arrow/tools/export/ArrowExportCommand.scala
+++ b/geomesa-arrow/geomesa-arrow-tools/src/main/scala/org/locationtech/geomesa/arrow/tools/export/ArrowExportCommand.scala
@@ -6,7 +6,7 @@
  * http://www.opensource.org/licenses/apache2.0.php.
  ***********************************************************************/
 
-package org.locationtech.geomesa.arrow.tools.export
+package org.locationtech.geomesa.arrow.tools.`export`
 
 import com.beust.jcommander.Parameters
 import org.locationtech.geomesa.arrow.data.ArrowDataStore

--- a/geomesa-convert/geomesa-convert-all/src/main/scala/org/locationtech/geomesa/convert/all/TypeAwareInference.scala
+++ b/geomesa-convert/geomesa-convert-all/src/main/scala/org/locationtech/geomesa/convert/all/TypeAwareInference.scala
@@ -10,27 +10,29 @@ package org.locationtech.geomesa.convert.all
 
 import com.typesafe.config.Config
 import org.geotools.api.feature.simple.SimpleFeatureType
+import org.locationtech.geomesa.convert.EvaluationContext
 import org.locationtech.geomesa.convert.avro.AvroConverterFactory
 import org.locationtech.geomesa.convert.json.JsonConverterFactory
 import org.locationtech.geomesa.convert.parquet.ParquetConverterFactory
 import org.locationtech.geomesa.convert.shp.ShapefileConverterFactory
 import org.locationtech.geomesa.convert.text.DelimitedTextConverterFactory
-import org.locationtech.geomesa.convert2.SimpleFeatureConverter
+import org.locationtech.geomesa.convert.xml.XmlConverterFactory
+import org.locationtech.geomesa.convert2.{SimpleFeatureConverter, SimpleFeatureConverterFactory}
 
 import java.io.InputStream
 import java.util.Locale
+import scala.util.Try
 
 object TypeAwareInference {
 
-  import org.locationtech.geomesa.convert2.SimpleFeatureConverter.factories
-
-  private val mappings = Map[String, Any => Boolean](
-    "avro"    -> (_.isInstanceOf[AvroConverterFactory]),
-    "json"    -> (_.isInstanceOf[JsonConverterFactory]),
-    "csv"     -> (_.isInstanceOf[DelimitedTextConverterFactory]),
-    "tsv"     -> (_.isInstanceOf[DelimitedTextConverterFactory]),
-    "parquet" -> (_.isInstanceOf[ParquetConverterFactory]),
-    "shp"     -> (_.isInstanceOf[ShapefileConverterFactory])
+  private val mappings = Map[String, Class[_ <: SimpleFeatureConverterFactory]](
+    "avro"    -> classOf[AvroConverterFactory],
+    "json"    -> classOf[JsonConverterFactory],
+    "csv"     -> classOf[DelimitedTextConverterFactory],
+    "tsv"     -> classOf[DelimitedTextConverterFactory],
+    "parquet" -> classOf[ParquetConverterFactory],
+    "shp"     -> classOf[ShapefileConverterFactory],
+    "xml"     -> classOf[XmlConverterFactory]
   )
 
   /**
@@ -42,12 +44,32 @@ object TypeAwareInference {
     * @param path file path, if known
     * @return
     */
+  @deprecated("replaced with `infer(String, () => InputStream, Option[SimpleFeatureType], Map[String, Any])`")
   def infer(
       format: String,
       is: () => InputStream,
       sft: Option[SimpleFeatureType],
-      path: Option[String]): Option[(SimpleFeatureType, Config)] = {
-    val opt = mappings.get(format.toLowerCase(Locale.US)).flatMap(check => factories.find(check.apply))
-    opt.flatMap(_.infer(is.apply, sft, path)).orElse(SimpleFeatureConverter.infer(is, sft, path))
+      path: Option[String]): Option[(SimpleFeatureType, Config)] =
+    infer(format, is, sft, path.map(EvaluationContext.inputFileParam).getOrElse(Map.empty)).toOption
+
+
+  /**
+   * Infer a converter based on a data sample
+   *
+   * @param format data format (e.g. csv, avro, json, etc)
+   * @param is input stream to convert
+   * @param sft simple feature type, if known
+   * @param hints implementation specific hints about the input
+   * @return
+   */
+  def infer(
+      format: String,
+      is: () => InputStream,
+      sft: Option[SimpleFeatureType],
+      hints: Map[String, AnyRef]): Try[(SimpleFeatureType, Config)] = {
+    val priority = mappings.get(format.toLowerCase(Locale.US)).map { clas =>
+      Ordering.by[SimpleFeatureConverterFactory, Boolean](f => !clas.isAssignableFrom(f.getClass)) // note: false sorts first
+    }
+    SimpleFeatureConverter.infer(is, sft, hints, priority)
   }
 }

--- a/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-avro-schema-registry/src/main/scala/org/locationtech/geomesa/convert/avro/registry/AvroSchemaRegistryConverterFactory.scala
@@ -9,6 +9,7 @@
 package org.locationtech.geomesa.convert.avro.registry
 
 import com.typesafe.config.Config
+import org.geotools.api.feature.simple.SimpleFeatureType
 import org.locationtech.geomesa.convert.avro.registry.AvroSchemaRegistryConverter.AvroSchemaRegistryConfig
 import org.locationtech.geomesa.convert.avro.registry.AvroSchemaRegistryConverterFactory.AvroSchemaRegistryConfigConvert
 import org.locationtech.geomesa.convert2.AbstractConverter.{BasicField, BasicOptions}
@@ -18,9 +19,18 @@ import org.locationtech.geomesa.convert2.transforms.Expression
 import pureconfig.ConfigObjectCursor
 import pureconfig.error.ConfigReaderFailures
 
+import java.io.InputStream
+import scala.util.{Failure, Try}
+
 class AvroSchemaRegistryConverterFactory
     extends AbstractConverterFactory[AvroSchemaRegistryConverter, AvroSchemaRegistryConfig, BasicField, BasicOptions](
-      "avro-schema-registry", AvroSchemaRegistryConfigConvert, BasicFieldConvert, BasicOptionsConvert)
+      "avro-schema-registry", AvroSchemaRegistryConfigConvert, BasicFieldConvert, BasicOptionsConvert) {
+
+  override def infer(
+      is: InputStream,
+      sft: Option[SimpleFeatureType],
+      hints: Map[String, AnyRef]): Try[(SimpleFeatureType, Config)] = Failure(new NotImplementedError())
+}
 
 object AvroSchemaRegistryConverterFactory {
 

--- a/geomesa-convert/geomesa-convert-avro/src/test/scala/org/locationtech/geomesa/convert/avro/AvroConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-avro/src/test/scala/org/locationtech/geomesa/convert/avro/AvroConverterTest.scala
@@ -195,9 +195,9 @@ class AvroConverterTest extends Specification with AvroUtils with LazyLogging {
 
       val bytes = out.toByteArray
 
-      val inferred = new AvroConverterFactory().infer(new ByteArrayInputStream(bytes))
+      val inferred = new AvroConverterFactory().infer(new ByteArrayInputStream(bytes), None, Map.empty[String, AnyRef])
 
-      inferred must beSome
+      inferred must beASuccessfulTry
       inferred.get._1 mustEqual sft
 
       logger.trace(inferred.get._2.root().render(ConfigRenderOptions.concise().setFormatted(true)))
@@ -224,9 +224,9 @@ class AvroConverterTest extends Specification with AvroUtils with LazyLogging {
       val bytes = out.toByteArray
 
       val updated = SimpleFeatureTypes.createType("test", "name:String,age:Int,dtg:Date,*geom:Point:srid=4326,tag:String")
-      val inferred = new AvroConverterFactory().infer(new ByteArrayInputStream(bytes), Some(updated))
+      val inferred = new AvroConverterFactory().infer(new ByteArrayInputStream(bytes), Some(updated), Map.empty[String, AnyRef])
 
-      inferred must beSome
+      inferred must beASuccessfulTry
       inferred.get._1 mustEqual sft
 
       logger.trace(inferred.get._2.root().render(ConfigRenderOptions.concise().setFormatted(true)))
@@ -289,9 +289,9 @@ class AvroConverterTest extends Specification with AvroUtils with LazyLogging {
 
       val bytes = out.toByteArray
 
-      val inferred = new AvroConverterFactory().infer(new ByteArrayInputStream(bytes))
+      val inferred = new AvroConverterFactory().infer(new ByteArrayInputStream(bytes), None, Map.empty[String, AnyRef])
 
-      inferred must beSome
+      inferred must beASuccessfulTry
 
       val expectedSft = SimpleFeatureTypes.createType(inferred.get._1.getTypeName,
         "lat:Double,lon:Double,label:String,list:List[String],map:Map[String,Int],age:Int,weight:Float,*geom:Point:srid=4326")

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/TypeInference.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/TypeInference.scala
@@ -94,8 +94,9 @@ object TypeInference {
         def findBestMatch(names: Seq[String]): Option[InferredType] = {
           // determine priority order
           val potentials = nums.flatMap { t =>
-            val i = names.indexOf(t.name)
-            val j = names.indexWhere(n => t.name.endsWith(s"_$n"))
+            val name = t.name.toLowerCase(Locale.US)
+            val i = names.indexOf(name)
+            val j = names.indexWhere(n => name.endsWith(s"_$n"))
             if (i != -1) {
               Some(i -> t)
             } else if (j != -1) {

--- a/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/TypeInference.scala
+++ b/geomesa-convert/geomesa-convert-common/src/main/scala/org/locationtech/geomesa/convert2/TypeInference.scala
@@ -17,90 +17,67 @@ import org.locationtech.jts.geom._
 
 import java.lang.{Boolean => jBoolean, Double => jDouble, Float => jFloat, Long => jLong}
 import java.util.{Date, Locale}
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.util.Try
 
 object TypeInference {
 
-  import LatLon.{Lat, Lon, NotLatLon}
   import ObjectType._
-  import org.locationtech.geomesa.utils.text.TextTools.isWhitespace
+
+  import scala.collection.JavaConverters._
 
   private val geometries =
     Seq(POINT, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, MULTIPOLYGON, GEOMETRY_COLLECTION, GEOMETRY)
 
-  private val latitudeNames = Seq("lat", "latitude")
-  private val longitudeNames = Seq("lon", "long", "longitude")
+  // fields to match for lat/lon - in priority order, from most to least specific
+  private val latitudeNames = Seq("latitude", "lat")
+  private val longitudeNames = Seq("longitude", "lon", "long")
+
+  // map of priorities and transforms for merging different number types
+  private val mergeUpNumbers = Map(
+    DOUBLE -> (0, CastToDouble),
+    FLOAT  -> (1, CastToFloat),
+    LONG   -> (2, CastToLong),
+    INT    -> (3, CastToInt),
+  )
 
   /**
-    * Infer attribute types based on input data
-    *
-    * @param data rows of columns
-    * @param failureRate per column, max percentage of values that can fail a conversion to a particular type,
-    *                    and still consider the column to be that type
-    * @return
-    */
-  def infer(data: Iterable[Iterable[Any]],
-            names: Iterable[String] = Seq.empty,
-            failureRate: Float = 0.1f): IndexedSeq[InferredType] = {
-    // list of inferred types for each column
-    val rawTypes = ArrayBuffer.empty[ListBuffer[InferredType]]
-    var i = 0
-    data.iterator.foreach { row =>
-      // skip empty rows or rows consisting of a single whitespace-only string
-      if (row.nonEmpty && (row.size > 1 || row.headOption.collect { case s: String if isWhitespace(s) => s }.isEmpty)) {
-        i = 0
-        row.foreach { col =>
-          if (i == rawTypes.length) {
-            // grow our column array if needed, we don't assume all rows have the same number of columns
-            rawTypes += ListBuffer.empty[InferredType]
-          }
-          // add the inferred type for this column value - it won't have a name at this point
-          rawTypes(i) += InferredType.infer(col)
-          i += 1
-        }
-      }
-    }
-
-    // track the names we use for each column to ensure no duplicates
-    val uniqueNames = scala.collection.mutable.HashSet.empty[String]
-    // names that were provided
-    val nameIterator = names.iterator
-
-    val types = rawTypes.map { raw =>
-
+   * Infer types
+   *
+   * @param pathsAndValues paths (xpath, jsonpath, etc) to values
+   * @param sft simple feature type, or name for inferred type
+   * @param namer naming for inferred attributes
+   * @param failureRate allowed failure rate for conversion to a given type
+   * @return
+   */
+  def infer(
+      pathsAndValues: Seq[PathWithValues],
+      sft: Either[String, SimpleFeatureType],
+      namer: String => String = new Namer(),
+      failureRate: Float = 0.1f): InferredTypesWithPaths = {
+    val inferred = pathsAndValues.map { case PathWithValues(path, values) =>
+      val rawTypes = values.map(InferredType.infer)
       // merge the types for this column from each row
-      val typ = merge(raw.toSeq, failureRate)
-
-      // determine the column name
-      var base: String = null
-      var name: String = null
-      var i = 0
-
-      if (nameIterator.hasNext) {
-        // if the name was passed in, start with that
-        base = nameIterator.next
-        name = base
-      } else {
-        // use the type with an _i, e.g. int_0, string_1
-        base = String.valueOf(typ.typed).toLowerCase(Locale.US)
-        name = s"${base}_0"
-        i += 1
-      }
-
-      while (FeatureUtils.ReservedWords.contains(name.toUpperCase(Locale.US)) || !uniqueNames.add(name)) {
-        name = s"${base}_$i"
-        i += 1
-      }
-
-      // set the name for the column
-      typ.copy(name = name)
+      val typed = merge(rawTypes.toSeq, failureRate)
+      val baseName = if (path.nonEmpty) { path } else { String.valueOf(typed.typed).toLowerCase(Locale.US) }
+      TypeWithPath(path, typed.copy(name = namer(baseName)))
     }
+    val geom = deriveGeometry(inferred.map(_.inferredType), namer).map(TypeWithPath("", _))
 
-    // if there is no geometry field, see if we can derive one
-    deriveGeometry(types.toSeq).foreach(types += _)
+    val typesWithPaths = inferred ++ geom
 
-    types.toIndexedSeq
+    sft match {
+      case Left(name) =>
+        val schema = TypeInference.schema(name, typesWithPaths.map(_.inferredType))
+        InferredTypesWithPaths(schema, typesWithPaths)
+
+      case Right(sft) =>
+        // validate the existing schema
+        AbstractConverterFactory.validateInferredType(sft, typesWithPaths.map(_.inferredType.typed))
+        val renamed = typesWithPaths.zip(sft.getAttributeDescriptors.asScala.map(_.getLocalName)).map {
+          case (inferred, name) => inferred.copy(inferredType = inferred.inferredType.copy(name = name))
+        }
+        InferredTypesWithPaths(sft, renamed)
+    }
   }
 
   /**
@@ -109,50 +86,32 @@ object TypeInference {
     * @param types known types
     * @return
     */
-  def deriveGeometry(types: Seq[InferredType]): Option[InferredType] = {
+  def deriveGeometry(types: Seq[InferredType], namer: String => String): Option[InferredType] = {
     // if there is no geometry field, see if we can derive one
-    if (types.lengthCompare(2) < 0 || types.map(_.typed).exists(geometries.contains)) { None } else {
-      var lat, lon: String = null
-
-      // if we have lat/lon columns, use those
-      types.exists { t =>
-        val name = t.name.toLowerCase(Locale.US)
-        if (latitudeNames.contains(name)) {
-          lat = t.name
-        } else if (longitudeNames.contains(name)) {
-          lon = t.name
-        }
-        // stop iterating if we find them both
-        lat != null && lon != null
-      }
-
-      if (lat == null || lon == null) {
-        // as a fallback, check for 2 consecutive numbers that could be valid lat/lon pairs
-        // if ambiguous, assume longitude first
-        // note that this is pretty brittle, but hopefully better than nothing
-        var i = 1
-        while (i < types.length) {
-          val left = types(i - 1)
-          val right = types(i)
-          // note that valid latitudes are also valid longitudes
-          (left.latlon, right.latlon) match {
-            case (Lat, Lon) => lon = right.name; lat = left.name; i = types.length // break out of the loop
-            case (Lon, Lat) => lon = left.name; lat = right.name; i = types.length // break out of the loop
-            case (Lat, Lat) => lon = left.name; lat = right.name; i = types.length // break out of the loop
-            case _ => // no-op
+    if (types.map(_.typed).exists(geometries.contains)) { None } else {
+      val nums = types.filter(t => t.typed == ObjectType.DOUBLE || t.typed == ObjectType.FLOAT)
+      if (nums.lengthCompare(2) < 0) { None } else {
+        def findBestMatch(names: Seq[String]): Option[InferredType] = {
+          // determine priority order
+          val potentials = nums.flatMap { t =>
+            val i = names.indexOf(t.name)
+            val j = names.indexWhere(n => t.name.endsWith(s"_$n"))
+            if (i != -1) {
+              Some(i -> t)
+            } else if (j != -1) {
+              Some(j + names.length -> t) // add names.length to make exact matches sort first
+            } else {
+              None
+            }
           }
-          i += 1
+          potentials.sortBy(_._1).collectFirst { case (_, t) => t }
         }
-      }
-
-      if (lat == null || lon == null) { None } else {
-        var name = "geom"
-        var i = 0
-        while (types.exists(_.name == name)) {
-          name = s"geom_$i"
-          i += 1
+        for {
+          lat <- findBestMatch(latitudeNames)
+          lon <- findBestMatch(longitudeNames)
+        } yield {
+          InferredType(namer("geom"), POINT, DerivedTransform("point", lon.name, lat.name))
         }
-        Some(InferredType(name, POINT, DerivedTransform("point", lon, lat)))
       }
     }
   }
@@ -248,28 +207,18 @@ object TypeInference {
     } else if (left.typed == null || right.typed == STRING) {
       Some(right)
     } else if (geometries.contains(left.typed) && geometries.contains(right.typed)) {
-      Some(InferredType("", GEOMETRY, FunctionTransform("geometry(", ")")))
+      Some(InferredType("", GEOMETRY, IdentityTransform))
     } else {
-      lazy val latlon = merge(left.latlon, right.latlon)
-      left.typed match {
-        case INT    if Seq(INT, LONG, FLOAT, DOUBLE).contains(right.typed) => Some(right.copy(latlon = latlon))
-        case LONG   if right.typed == INT | right.typed == LONG            => Some(left.copy(latlon = latlon))
-        case LONG   if Seq(LONG, FLOAT, DOUBLE).contains(right.typed)      => Some(right.copy(latlon = latlon))
-        case FLOAT  if Seq(INT, FLOAT, LONG).contains(right.typed)         => Some(left.copy(latlon = latlon))
-        case FLOAT  if right.typed == FLOAT | right.typed == DOUBLE        => Some(right.copy(latlon = latlon))
-        case DOUBLE if Seq(INT, LONG, FLOAT, DOUBLE).contains(right.typed) => Some(left.copy(latlon = latlon))
-        case _ => None
+      for {
+        (leftPriority, leftTransform) <- mergeUpNumbers.get(left.typed)
+        (rightPriority, rightTransform) <- mergeUpNumbers.get(right.typed)
+      } yield {
+        if (leftPriority <= rightPriority) {
+          left.copy(transform = leftTransform)
+        } else {
+          right.copy(transform = rightTransform)
+        }
       }
-    }
-  }
-
-  private def merge(left: LatLon, right: LatLon): LatLon = {
-    if (left == NotLatLon || right == NotLatLon) {
-      NotLatLon
-    } else if (left == Lon || right == Lon) {
-      Lon
-    } else { // implies both equal Lat
-      Lat
     }
   }
 
@@ -303,14 +252,63 @@ object TypeInference {
   }
 
   /**
+   * Helper for naming attributes during type inference
+   */
+  class Namer(existing: Seq[String] = Seq.empty) extends (String => String) {
+
+    // track the names we use for each column to ensure no duplicates
+    private val uniqueNames = scala.collection.mutable.HashSet[String](existing: _*)
+
+    /**
+     * Get a valid attribute name based on the element name
+     *
+     * @param key json key
+     * @return
+     */
+    override def apply(key: String): String = {
+      val base = key.replaceAll("[^A-Za-z0-9]+", "_").replaceAll("^_|_$", "")
+      var candidate = base
+      var i = 0
+      while (FeatureUtils.ReservedWords.contains(candidate.toUpperCase(Locale.US)) || !uniqueNames.add(candidate)) {
+        candidate = s"${base}_$i"
+        i += 1
+      }
+      candidate
+    }
+  }
+
+  /**
+   * Path to an attribute (xpath, json path, column number) and the values of that attribute
+   *
+   * @param path path
+   * @param values sample values
+   */
+  case class PathWithValues(path: String, values: Iterable[Any])
+
+  /**
+   * Inferred feature type
+   *
+   * @param sft simple feature type
+   * @param types types and paths to the attributes
+   */
+  case class InferredTypesWithPaths(sft: SimpleFeatureType, types: Seq[TypeWithPath])
+
+  /**
+   * An attribute type with a path to the attribute (xpath, json path, column number, etc)
+   *
+   * @param path path
+   * @param inferredType type
+   */
+  case class TypeWithPath(path: String, inferredType: InferredType)
+
+  /**
     * Inferred type of a converter field
     *
     * @param name name of the field
     * @param typed type of the field
     * @param transform converter transform
-    * @param latlon possibility that this column could be a latitude or longitude
     */
-  case class InferredType(name: String, typed: ObjectType, transform: InferredTransform, latlon: LatLon = NotLatLon) {
+  case class InferredType(name: String, typed: ObjectType, transform: InferredTransform) {
     def binding: String = TypeInference.binding(typed)
   }
 
@@ -354,39 +352,6 @@ object TypeInference {
     def apply(i: Int): String = s"$name${fields.mkString("($", ",$", ")")}"
   }
 
-  /**
-    * Indicator that the field may be a latitude or longitude
-    */
-  sealed trait LatLon
-
-  object LatLon {
-
-    // note that latitudes are also valid longitudes
-    case object Lat extends LatLon
-    case object Lon extends LatLon
-    case object NotLatLon extends LatLon
-
-    def apply(value: Int): LatLon = {
-      val pos = math.abs(value)
-      if (pos <= 90) { Lat } else if (pos <= 180) { Lon } else { NotLatLon }
-    }
-
-    def apply(value: Long): LatLon = {
-      val pos = math.abs(value)
-      if (pos <= 90) { Lat } else if (pos <= 180) { Lon } else { NotLatLon }
-    }
-
-    def apply(value: Float): LatLon = {
-      val pos = math.abs(value)
-      if (pos <= 90f) { Lat } else if (pos <= 180f) { Lon } else { NotLatLon }
-    }
-
-    def apply(value: Double): LatLon = {
-      val pos = math.abs(value)
-      if (pos <= 90d) { Lat } else if (pos <= 180d) { Lon } else { NotLatLon }
-    }
-  }
-
   object InferredType {
 
     private val dateParsers = TransformerFunction.functions.values.collect { case f: StandardDateParser => f }.toArray
@@ -400,15 +365,11 @@ object TypeInference {
     def infer(value: Any): InferredType = {
       value match {
         case null | ""                => InferredType("", null, IdentityTransform)
-        case v: Int                   => InferredType("", INT, CastToInt, LatLon(v))
-        case v: Integer               => InferredType("", INT, CastToInt, LatLon(v))
-        case v: Long                  => InferredType("", LONG, CastToLong, LatLon(v))
-        case v: jLong                 => InferredType("", LONG, CastToLong, LatLon(v))
-        case v: Float                 => InferredType("", FLOAT, CastToFloat, LatLon(v))
-        case v: jFloat                => InferredType("", FLOAT, CastToFloat, LatLon(v))
-        case v: Double                => InferredType("", DOUBLE, CastToDouble, LatLon(v))
-        case v: jDouble               => InferredType("", DOUBLE, CastToDouble, LatLon(v))
-        case _: Boolean | _: jBoolean => InferredType("", BOOLEAN, CastToBoolean)
+        case _: Int | _: Integer      => InferredType("", INT, IdentityTransform)
+        case _: Long | _: jLong       => InferredType("", LONG, IdentityTransform)
+        case _: Float | _: jFloat     => InferredType("", FLOAT, IdentityTransform)
+        case _: Double | _: jDouble   => InferredType("", DOUBLE, IdentityTransform)
+        case _: Boolean | _: jBoolean => InferredType("", BOOLEAN, IdentityTransform)
         case _: Date                  => InferredType("", DATE, IdentityTransform)
         case _: Array[Byte]           => InferredType("", BYTES, IdentityTransform)
         case _: java.util.UUID        => InferredType("", UUID, IdentityTransform)
@@ -419,6 +380,7 @@ object TypeInference {
         case _: MultiLineString       => InferredType("", MULTILINESTRING, IdentityTransform)
         case _: MultiPolygon          => InferredType("", MULTIPOLYGON, IdentityTransform)
         case _: GeometryCollection    => InferredType("", GEOMETRY_COLLECTION, IdentityTransform)
+        case _: java.util.List[_]     => InferredType("", LIST, IdentityTransform)
 
         case s: String =>
           val trimmed = s.trim
@@ -427,7 +389,7 @@ object TypeInference {
               .orElse(tryGeometryParsing(trimmed))
               .orElse(tryBooleanParsing(trimmed))
               .orElse(tryUuidParsing(trimmed))
-              .getOrElse(InferredType("", STRING, CastToString))
+              .getOrElse(InferredType("", STRING, IdentityTransform))
 
         case _ => InferredType("", STRING, CastToString)
       }
@@ -435,10 +397,10 @@ object TypeInference {
 
     private def tryNumberParsing(s: String): Option[InferredType] = {
       Try(BigDecimal(s)).toOption.collect {
-        case n if s.indexOf('.') == -1 && n.isValidInt  => InferredType("", INT, CastToInt, LatLon(n.toInt))
-        case n if s.indexOf('.') == -1 && n.isValidLong => InferredType("", LONG, CastToLong, LatLon(n.toLong))
-        case n if n.isDecimalFloat                      => InferredType("", FLOAT, CastToFloat, LatLon(n.toFloat))
-        case n if n.isDecimalDouble                     => InferredType("", DOUBLE, CastToDouble, LatLon(n.toDouble))
+        case n if s.indexOf('.') == -1 && n.isValidInt  => InferredType("", INT, CastToInt)
+        case n if s.indexOf('.') == -1 && n.isValidLong => InferredType("", LONG, CastToLong)
+        // don't consider floats - even valid floats cause rounding changes when using as doubles in geometries
+        case n if n.isDecimalDouble                     => InferredType("", DOUBLE, CastToDouble)
       }
     }
 

--- a/geomesa-convert/geomesa-convert-fixedwidth/src/main/scala/org/locationtech/geomesa/convert/fixedwidth/FixedWidthConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-fixedwidth/src/main/scala/org/locationtech/geomesa/convert/fixedwidth/FixedWidthConverterFactory.scala
@@ -8,6 +8,8 @@
 
 package org.locationtech.geomesa.convert.fixedwidth
 
+import com.typesafe.config.Config
+import org.geotools.api.feature.simple.SimpleFeatureType
 import org.locationtech.geomesa.convert.fixedwidth.FixedWidthConverter._
 import org.locationtech.geomesa.convert.fixedwidth.FixedWidthConverterFactory.FixedWidthFieldConvert
 import org.locationtech.geomesa.convert2.AbstractConverter.{BasicConfig, BasicOptions}
@@ -17,9 +19,18 @@ import org.locationtech.geomesa.convert2.transforms.Expression
 import pureconfig.ConfigObjectCursor
 import pureconfig.error.ConfigReaderFailures
 
+import java.io.InputStream
+import scala.util.{Failure, Try}
+
 class FixedWidthConverterFactory
     extends AbstractConverterFactory[FixedWidthConverter, BasicConfig, FixedWidthField, BasicOptions](
-      "fixed-width", BasicConfigConvert, FixedWidthFieldConvert, BasicOptionsConvert)
+      "fixed-width", BasicConfigConvert, FixedWidthFieldConvert, BasicOptionsConvert) {
+
+  override def infer(
+      is: InputStream,
+      sft: Option[SimpleFeatureType],
+      hints: Map[String, AnyRef]): Try[(SimpleFeatureType, Config)] = Failure(new NotImplementedError())
+}
 
 object FixedWidthConverterFactory {
 

--- a/geomesa-convert/geomesa-convert-jdbc/src/main/scala/org/locationtech/geomesa/convert/jdbc/JdbcConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-jdbc/src/main/scala/org/locationtech/geomesa/convert/jdbc/JdbcConverterFactory.scala
@@ -9,6 +9,7 @@
 package org.locationtech.geomesa.convert.jdbc
 
 import com.typesafe.config.Config
+import org.geotools.api.feature.simple.SimpleFeatureType
 import org.locationtech.geomesa.convert.jdbc.JdbcConverter.JdbcConfig
 import org.locationtech.geomesa.convert.jdbc.JdbcConverterFactory.JdbcConfigConvert
 import org.locationtech.geomesa.convert2.AbstractConverter.{BasicField, BasicOptions}
@@ -18,8 +19,17 @@ import org.locationtech.geomesa.convert2.transforms.Expression
 import pureconfig.ConfigObjectCursor
 import pureconfig.error.ConfigReaderFailures
 
+import java.io.InputStream
+import scala.util.{Failure, Try}
+
 class JdbcConverterFactory extends AbstractConverterFactory[JdbcConverter, JdbcConfig, BasicField, BasicOptions](
-  "jdbc", JdbcConfigConvert, BasicFieldConvert, BasicOptionsConvert)
+  "jdbc", JdbcConfigConvert, BasicFieldConvert, BasicOptionsConvert) {
+
+  override def infer(
+      is: InputStream,
+      sft: Option[SimpleFeatureType],
+      hints: Map[String, AnyRef]): Try[(SimpleFeatureType, Config)] = Failure(new NotImplementedError())
+}
 
 object JdbcConverterFactory {
 

--- a/geomesa-convert/geomesa-convert-json/src/main/scala/org/locationtech/geomesa/convert/json/JsonCompositeConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-json/src/main/scala/org/locationtech/geomesa/convert/json/JsonCompositeConverterFactory.scala
@@ -17,6 +17,8 @@ import org.locationtech.geomesa.convert2.transforms.Predicate
 import org.locationtech.geomesa.convert2.{AbstractConverterFactory, ParsingConverter, SimpleFeatureConverter, SimpleFeatureConverterFactory}
 import pureconfig.{ConfigConvert, ConfigSource}
 
+import java.io.InputStream
+import scala.util.{Failure, Try}
 import scala.util.control.NonFatal
 
 class JsonCompositeConverterFactory extends SimpleFeatureConverterFactory with LazyLogging {
@@ -47,6 +49,11 @@ class JsonCompositeConverterFactory extends SimpleFeatureConverterFactory with L
       }
     }
   }
+
+  override def infer(
+      is: InputStream,
+      sft: Option[SimpleFeatureType],
+      hints: Map[String, AnyRef]): Try[(SimpleFeatureType, Config)] = Failure(new NotImplementedError())
 }
 
 object JsonCompositeConverterFactory {

--- a/geomesa-convert/geomesa-convert-parquet/src/test/scala/org/locationtech/geomesa/convert/parquet/ParquetConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-parquet/src/test/scala/org/locationtech/geomesa/convert/parquet/ParquetConverterTest.scala
@@ -74,8 +74,8 @@ class ParquetConverterTest extends Specification {
       val path = new File(file.toURI).getAbsolutePath
 
       val factory = new ParquetConverterFactory()
-      val inferred: Option[(SimpleFeatureType, Config)] = factory.infer(file.openStream(), path = Some(path))
-      inferred must beSome
+      val inferred = factory.infer(file.openStream(), None, EvaluationContext.inputFileParam(path))
+      inferred must beASuccessfulTry
 
       val (sft, config) = inferred.get
 
@@ -103,8 +103,8 @@ class ParquetConverterTest extends Specification {
       val path = new File(file.toURI).getAbsolutePath
 
       val factory = new ParquetConverterFactory()
-      val inferred: Option[(SimpleFeatureType, Config)] = factory.infer(file.openStream(), path = Some(path))
-      inferred must beSome
+      val inferred = factory.infer(file.openStream(), None, EvaluationContext.inputFileParam(path))
+      inferred must beASuccessfulTry
 
       val (sft, config) = inferred.get
 
@@ -128,8 +128,8 @@ class ParquetConverterTest extends Specification {
       val path = new File(file.toURI).getAbsolutePath
 
       val factory = new ParquetConverterFactory()
-      val inferred: Option[(SimpleFeatureType, Config)] = factory.infer(file.openStream(), path = Some(path))
-      inferred must beSome
+      val inferred = factory.infer(file.openStream(), None, EvaluationContext.inputFileParam(path))
+      inferred must beASuccessfulTry
 
       val (sft, config) = inferred.get
 

--- a/geomesa-convert/geomesa-convert-parquet/src/test/scala/org/locationtech/geomesa/convert/parquet/ParquetConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-parquet/src/test/scala/org/locationtech/geomesa/convert/parquet/ParquetConverterTest.scala
@@ -8,8 +8,7 @@
 
 package org.locationtech.geomesa.convert.parquet
 
-import com.typesafe.config.{Config, ConfigFactory}
-import org.geotools.api.feature.simple.SimpleFeatureType
+import com.typesafe.config.ConfigFactory
 import org.geotools.util.factory.Hints
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.convert.EvaluationContext

--- a/geomesa-convert/geomesa-convert-parquet/src/test/scala/org/locationtech/geomesa/convert/parquet/ParquetConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-parquet/src/test/scala/org/locationtech/geomesa/convert/parquet/ParquetConverterTest.scala
@@ -109,7 +109,7 @@ class ParquetConverterTest extends Specification {
       val (sft, config) = inferred.get
 
       SimpleFeatureTypes.encodeType(sft) mustEqual
-          "color:String,id:Long,lat:Double,lon:Double,number:Long,height:String,weight:Double,*geom:Point:srid=4326"
+          "color:String,id_0:Long,lat:Double,lon:Double,number:Long,height:String,weight:Double,*geom:Point:srid=4326"
 
       val converter = factory.apply(sft, config)
       converter must beSome

--- a/geomesa-convert/geomesa-convert-shp/src/test/scala/org/locationtech/geomesa/convert/shp/ShapefileConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-shp/src/test/scala/org/locationtech/geomesa/convert/shp/ShapefileConverterTest.scala
@@ -76,8 +76,9 @@ class ShapefileConverterTest extends Specification {
     }
 
     "infer converters" in {
-      val inferred = new ShapefileConverterFactory().infer(new ByteArrayInputStream(Array.empty), None, Some(shpFile))
-      inferred must beSome
+      val hints = EvaluationContext.inputFileParam(shpFile)
+      val inferred = new ShapefileConverterFactory().infer(new ByteArrayInputStream(Array.empty), None, hints)
+      inferred must beASuccessfulTry
 
       val (sft, conf) = inferred.get
 

--- a/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert2/simplefeature/FeatureToFeatureConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-simplefeature/src/main/scala/org/locationtech/geomesa/convert2/simplefeature/FeatureToFeatureConverterFactory.scala
@@ -20,6 +20,8 @@ import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypeLoader
 import pureconfig.error.ConfigReaderFailures
 import pureconfig.{ConfigObjectCursor, ConfigSource}
 
+import java.io.InputStream
+import scala.util.{Failure, Try}
 import scala.util.control.NonFatal
 
 class FeatureToFeatureConverterFactory extends SimpleFeatureConverterFactory with LazyLogging {
@@ -81,6 +83,11 @@ class FeatureToFeatureConverterFactory extends SimpleFeatureConverterFactory wit
       Some(new FeatureToFeatureConverter(sft, id, columns ++ defaults, opts))
     }
   }
+
+  override def infer(
+      is: InputStream,
+      sft: Option[SimpleFeatureType],
+      hints: Map[String, AnyRef]): Try[(SimpleFeatureType, Config)] = Failure(new NotImplementedError())
 }
 
 object FeatureToFeatureConverterFactory {

--- a/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-text/src/main/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterFactory.scala
@@ -12,24 +12,27 @@ import com.typesafe.config.Config
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.io.IOUtils
 import org.geotools.api.feature.simple.SimpleFeatureType
+import org.locationtech.geomesa.convert.EvaluationContext
 import org.locationtech.geomesa.convert.Modes.{ErrorMode, ParseMode}
 import org.locationtech.geomesa.convert.text.DelimitedTextConverter._
 import org.locationtech.geomesa.convert.text.DelimitedTextConverterFactory.{DelimitedTextConfigConvert, DelimitedTextOptionsConvert}
+import org.locationtech.geomesa.convert2
 import org.locationtech.geomesa.convert2.AbstractConverter.BasicField
 import org.locationtech.geomesa.convert2.AbstractConverterFactory.{BasicFieldConvert, ConverterConfigConvert, ConverterOptionsConvert, PrimitiveConvert}
-import org.locationtech.geomesa.convert2.TypeInference.FunctionTransform
+import org.locationtech.geomesa.convert2.TypeInference.{FunctionTransform, PathWithValues, TypeWithPath}
 import org.locationtech.geomesa.convert2.transforms.Expression
 import org.locationtech.geomesa.convert2.transforms.Expression.{LiteralNull, TryExpression}
 import org.locationtech.geomesa.convert2.validators.SimpleFeatureValidator
 import org.locationtech.geomesa.convert2.{AbstractConverterFactory, TypeInference}
 import org.locationtech.geomesa.utils.geotools.{ObjectType, SimpleFeatureTypes}
 import org.locationtech.geomesa.utils.io.WithClose
+import org.locationtech.geomesa.utils.text.TextTools
 import pureconfig.error.ConfigReaderFailures
 import pureconfig.{ConfigObjectCursor, ConfigReader}
 
 import java.io.{InputStream, StringReader}
 import java.nio.charset.{Charset, StandardCharsets}
-import scala.util.Try
+import scala.util.{Failure, Try}
 
 class DelimitedTextConverterFactory
     extends AbstractConverterFactory[DelimitedTextConverter, DelimitedTextConfig, BasicField, DelimitedTextOptions](
@@ -37,56 +40,77 @@ class DelimitedTextConverterFactory
 
   import scala.collection.JavaConverters._
 
-  // @param path is unused in this class
   override def infer(
       is: InputStream,
       sft: Option[SimpleFeatureType],
-      path: Option[String]): Option[(SimpleFeatureType, Config)] = {
-    val sampleSize = AbstractConverterFactory.inferSampleSize
-    val lines = IOUtils.lineIterator(is, StandardCharsets.UTF_8.displayName).asScala.take(sampleSize).toSeq
-    // if only a single line, assume that it isn't actually delimited text
-    if (lines.lengthCompare(2) < 0) { None } else {
-      magic(lines, sft).orElse(DelimitedTextConverter.inferences.flatMap(infer(_, lines, sft)).headOption)
+      path: Option[String]): Option[(SimpleFeatureType, Config)] =
+    infer(is, sft, path.map(EvaluationContext.inputFileParam).getOrElse(Map.empty)).toOption
+
+  override def infer(
+      is: InputStream,
+      sft: Option[SimpleFeatureType],
+      hints: Map[String, AnyRef]): Try[(SimpleFeatureType, Config)] = {
+    val tryLines = Try {
+      val sampleSize = AbstractConverterFactory.inferSampleSize
+      IOUtils.lineIterator(is, StandardCharsets.UTF_8.displayName).asScala.take(sampleSize).toSeq
+    }
+    tryLines.flatMap { lines =>
+      // if only a single line, assume that it isn't actually delimited text
+      if (lines.lengthCompare(2) < 0) { Failure(new RuntimeException("Not enough lines in input data")) } else {
+        val attempts = Iterator.single(magic(lines, sft)) ++
+            DelimitedTextConverter.inferences.iterator.map(infer(_, lines, sft))
+        convert2.multiTry(attempts, new RuntimeException("Could not parse input as delimited text"))
+      }
     }
   }
 
   private def infer(
       format: CSVFormat,
       lines: Seq[String],
-      sft: Option[SimpleFeatureType]): Option[(SimpleFeatureType, Config)] = {
-
+      sft: Option[SimpleFeatureType]): Try[(SimpleFeatureType, Config)] = {
     // : Seq[List[String]]
     val rows = lines.flatMap { line =>
-      Try(format.parse(new StringReader(line)).iterator().next.iterator.asScala.toList).toOption
+      if (TextTools.isWhitespace(line)) { None } else {
+        Try(format.parse(new StringReader(line)).iterator().next.iterator.asScala.toList).toOption
+      }
     }
     val counts = rows.map(_.length).distinct
     // try to verify that we actually have a delimited file
     // ensure that some lines parsed, that there were at most 3 different col counts, and that there were at least 2 cols
-    if (counts.isEmpty || counts.lengthCompare(3) > 0 || counts.max < 2) { None } else {
+    if (counts.isEmpty || counts.lengthCompare(3) > 0 || counts.max < 2) {
+      val f = if (format == Formats.Tabs) { "tsv" } else if (format == Formats.Quoted) { "quoted csv" }  else { "csv" }
+      return Failure(new RuntimeException(s"Not a valid delimited text file using format: $f"))
+    }
+    Try {
       val names = sft match {
         case Some(s) =>
           s.getAttributeDescriptors.asScala.map(_.getLocalName)
 
         case None =>
-          val firstRowTypes = TypeInference.infer(Seq(rows.head))
-          if (firstRowTypes.exists(_.typed != ObjectType.STRING)) { Seq.empty } else {
+          val values = rows.head.map(v => PathWithValues("", Seq(v)))
+          if (TypeInference.infer(values, Left("")).types.forall(_.inferredType.typed == ObjectType.STRING)) {
             // assume the first row is headers
-            rows.head.map(_.replaceAll("[^A-Za-z0-9]+", "_"))
+            rows.head
+          } else {
+            Seq.empty
           }
       }
-      val types = TypeInference.infer(rows.drop(1), names)
-      val schema =
-        sft.filter(AbstractConverterFactory.validateInferredType(_, types.map(_.typed)))
-            .getOrElse(TypeInference.schema("inferred-delimited-text", types))
-
+      val nameIter = names.iterator
+      val pathsAndValues = Seq.tabulate(counts.max) { col =>
+        val values = rows.drop(1).map(vals => if (vals.lengthCompare(col) > 0) { vals(col) } else { null })
+        PathWithValues(if (nameIter.hasNext) { nameIter.next } else { "" }, values)
+      }
+      val inferred =
+        TypeInference.infer(pathsAndValues,
+          sft.toRight(s"inferred-${if (format == Formats.Tabs) { "tsv" } else { "csv" }}"))
       val converterConfig = DelimitedTextConfig(typeToProcess, formats.find(_._2 == format).get._1,
         Some(Expression("md5(string2bytes($0))")), Map.empty, Map.empty)
 
       val fields = {
-        var i = -1
-        schema.getAttributeDescriptors.asScala.map { d =>
+        var i = 0 // 0 is the whole record
+        inferred.types.map { case TypeWithPath(_, inferredType) =>
           i += 1
-          BasicField(d.getLocalName, Some(Expression(types(i).transform(i + 1)))) // 0 is the whole record
+          BasicField(inferredType.name, Some(Expression(inferredType.transform(i))))
         }
       }
 
@@ -98,13 +122,13 @@ class DelimitedTextConverterFactory
           .withFallback(optsConvert.to(options))
           .toConfig
 
-      Some((schema, config))
+      (inferred.sft, config)
     }
   }
 
-  private def magic(lines: Seq[String], sft: Option[SimpleFeatureType]): Option[(SimpleFeatureType, Config)] = {
-    if (!lines.head.startsWith("id,")) { None } else {
-      val attempt = Try {
+  private def magic(lines: Seq[String], sft: Option[SimpleFeatureType]): Try[(SimpleFeatureType, Config)] = {
+    if (!lines.head.startsWith("id,")) { Failure(new RuntimeException("Not a geomesa delimited export")) } else {
+      Try {
         val spec = WithClose(Formats.QuotedMinimal.parse(new StringReader(lines.head.drop(3)))) { result =>
           result.iterator().next.asScala.mkString(",")
         }
@@ -156,7 +180,6 @@ class DelimitedTextConverterFactory
 
         (sft.getOrElse(schema), config)
       }
-      attempt.toOption
     }
   }
 }

--- a/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterTest.scala
+++ b/geomesa-convert/geomesa-convert-text/src/test/scala/org/locationtech/geomesa/convert/text/DelimitedTextConverterTest.scala
@@ -757,17 +757,18 @@ class DelimitedTextConverterTest extends Specification {
 
       val data =
         """
+          |num,word,lat,lon
           |1,hello,45.0,45.0
           |2,world,90.0,90.0
         """.stripMargin
 
       val factory = new DelimitedTextConverterFactory()
-      val inferred = factory.infer(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)))
-      inferred must beSome
+      val inferred = factory.infer(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)), None, Map.empty[String, AnyRef])
+      inferred must beASuccessfulTry
 
       val (sft, config) = inferred.get
       sft.getAttributeDescriptors.asScala.map(_.getType.getBinding) mustEqual
-          Seq(classOf[Integer], classOf[String], classOf[java.lang.Float], classOf[java.lang.Float], classOf[Point])
+          Seq(classOf[Integer], classOf[String], classOf[java.lang.Double], classOf[java.lang.Double], classOf[Point])
 
       val converter = factory.apply(sft, config)
       converter must beSome
@@ -789,12 +790,12 @@ class DelimitedTextConverterTest extends Specification {
         """.stripMargin
 
       val factory = new DelimitedTextConverterFactory()
-      val inferred = factory.infer(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)))
-      inferred must beSome
+      val inferred = factory.infer(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)), None, Map.empty[String, AnyRef])
+      inferred must beASuccessfulTry
 
       val (sft, config) = inferred.get
       sft.getAttributeDescriptors.asScala.map(_.getType.getBinding) mustEqual
-          Seq(classOf[Integer], classOf[String], classOf[java.lang.Float], classOf[java.lang.Float], classOf[Point])
+          Seq(classOf[Integer], classOf[String], classOf[java.lang.Double], classOf[java.lang.Double], classOf[Point])
 
       val converter = factory.apply(sft, config)
       converter must beSome
@@ -833,8 +834,8 @@ class DelimitedTextConverterTest extends Specification {
           |""".stripMargin
 
       val factory = new DelimitedTextConverterFactory()
-      val inferred = factory.infer(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)))
-      inferred must beSome
+      val inferred = factory.infer(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)), None, Map.empty[String, AnyRef])
+      inferred must beASuccessfulTry
 
       val (sft, config) = inferred.get
 

--- a/geomesa-convert/geomesa-convert-xml/src/main/resources/xml-converter-defaults.conf
+++ b/geomesa-convert/geomesa-convert-xml/src/main/resources/xml-converter-defaults.conf
@@ -5,7 +5,7 @@
     "validators" = [ "index" ]
     "parse-mode" = "incremental"
     "error-mode" = "skip-bad-records"
-    "line-mode"  = "single"
+    "line-mode"  = "multi"
     "encoding"   = "UTF-8"
   }
   "user-data" = {}

--- a/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlCompositeConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlCompositeConverterFactory.scala
@@ -19,6 +19,8 @@ import org.locationtech.geomesa.convert2.{AbstractConverterFactory, ParsingConve
 import org.w3c.dom.Element
 import pureconfig.{ConfigConvert, ConfigSource}
 
+import java.io.InputStream
+import scala.util.{Failure, Try}
 import scala.util.control.NonFatal
 
 class XmlCompositeConverterFactory extends SimpleFeatureConverterFactory with LazyLogging {
@@ -53,6 +55,11 @@ class XmlCompositeConverterFactory extends SimpleFeatureConverterFactory with La
       }
     }
   }
+
+  override def infer(
+      is: InputStream,
+      sft: Option[SimpleFeatureType],
+      hints: Map[String, AnyRef]): Try[(SimpleFeatureType, Config)] = Failure(new NotImplementedError())
 }
 
 object XmlCompositeConverterFactory {

--- a/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-xml/src/main/scala/org/locationtech/geomesa/convert/xml/XmlConverterFactory.scala
@@ -10,26 +10,139 @@ package org.locationtech.geomesa.convert.xml
 
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
+import org.geotools.api.feature.simple.SimpleFeatureType
+import org.locationtech.geomesa.convert.EvaluationContext
 import org.locationtech.geomesa.convert.Modes.{ErrorMode, LineMode, ParseMode}
 import org.locationtech.geomesa.convert.xml.XmlConverter._
-import org.locationtech.geomesa.convert.xml.XmlConverterFactory.{XmlConfigConvert, XmlFieldConvert, XmlOptionsConvert}
-import org.locationtech.geomesa.convert2.AbstractConverterFactory
+import org.locationtech.geomesa.convert.xml.XmlConverterFactory.{XmlConfigConvert, XmlFieldConvert, XmlNamer, XmlOptionsConvert}
 import org.locationtech.geomesa.convert2.AbstractConverterFactory.{ConverterConfigConvert, ConverterOptionsConvert, FieldConvert, OptionConvert}
+import org.locationtech.geomesa.convert2.TypeInference.{Namer, PathWithValues, TypeWithPath}
 import org.locationtech.geomesa.convert2.transforms.Expression
-import pureconfig.ConfigObjectCursor
+import org.locationtech.geomesa.convert2.{AbstractConverterFactory, TypeInference}
+import org.locationtech.geomesa.utils.io.WithClose
+import org.locationtech.geomesa.utils.text.TextTools
+import org.w3c.dom._
 import pureconfig.error.{CannotConvert, ConfigReaderFailures}
+import pureconfig.{ConfigObjectCursor, ConfigSource}
 
-import java.nio.charset.Charset
+import java.io.InputStream
+import java.nio.charset.{Charset, StandardCharsets}
+import java.util.regex.Pattern
+import javax.xml.xpath.XPathConstants
+import scala.collection.mutable.ListBuffer
+import scala.reflect.classTag
+import scala.util.{Failure, Try}
 
 class XmlConverterFactory extends AbstractConverterFactory[XmlConverter, XmlConfig, XmlField, XmlOptions](
   XmlConverterFactory.TypeToProcess, XmlConfigConvert, XmlFieldConvert, XmlOptionsConvert) {
+
   override protected def withDefaults(conf: Config): Config =
     super.withDefaults(conf).withFallback(ConfigFactory.load("xml-converter-defaults"))
+
+  override def infer(
+      is: InputStream,
+      sft: Option[SimpleFeatureType],
+      path: Option[String]): Option[(SimpleFeatureType, Config)] =
+    infer(is, sft, path.map(EvaluationContext.inputFileParam).getOrElse(Map.empty)).toOption
+
+  /**
+   * Infer a configuration and simple feature type from an input stream, if possible
+   *
+   * Available hints:
+   *  - `featurePath` - xpath expression pointing to the feature element
+   *
+   * @param is input
+   * @param sft simple feature type, if known ahead of time
+   * @param hints implementation specific hints about the input
+   * @return
+   */
+  override def infer(
+      is: InputStream,
+      sft: Option[SimpleFeatureType],
+      hints: Map[String, AnyRef]): Try[(SimpleFeatureType, Config)] = {
+    val tryElements = Try {
+      val parser = new DocParser(None)
+      WithClose(XmlConverter.iterator(parser, is, StandardCharsets.UTF_8, LineMode.Multi, EvaluationContext.empty)) { iter =>
+        iter.take(AbstractConverterFactory.inferSampleSize).toList
+      }
+    }
+
+    tryElements.flatMap { elements =>
+      val featurePath = hints.get(XmlConverterFactory.FeaturePathKey).map(_.toString)
+      val namespaces = elements.headOption.map(XmlConverterFactory.getNamespaces).getOrElse(Map.empty)
+      val xpathFactory =
+        ConfigSource.fromConfig(withDefaults(XmlConverterFactory.TypeConfig))
+            .loadOrThrow[XmlConfig](classTag[XmlConfig], XmlConfigConvert)
+            .xpathFactory
+
+      val tryFeatures = Try {
+        featurePath match {
+          case None => elements
+          case Some(p) =>
+            val xpath = XmlConverter.createXPath(xpathFactory, namespaces).compile(p)
+            val features = elements.flatMap { element =>
+              val nodeList = xpath.evaluate(element, XPathConstants.NODESET).asInstanceOf[NodeList]
+              Seq.tabulate(nodeList.getLength)(i => nodeList.item(i).asInstanceOf[Element])
+            }
+            features.take(AbstractConverterFactory.inferSampleSize)
+        }
+      }
+
+      tryFeatures.flatMap { features =>
+        if (features.isEmpty) {
+          Failure(new RuntimeException("Could not parse input as XML"))
+        } else {
+          Try {
+            // track the properties in each feature
+            // use linkedHashMap to retain insertion order
+            val props = scala.collection.mutable.LinkedHashMap.empty[String, ListBuffer[Any]]
+
+            val namer = new XmlNamer()
+            features.foreach { feature =>
+              namer.addRootElement(feature)
+              XmlConverterFactory.parseNode(feature, "").foreach { case (k, v) =>
+                props.getOrElseUpdate(k, ListBuffer.empty) += v
+              }
+            }
+
+            val pathsAndValues = props.toSeq.map { case (path, values) => PathWithValues(path, values) }
+            val inferredTypes = TypeInference.infer(pathsAndValues, sft.toRight("inferred-xml"), namer)
+
+            val fieldConfig = inferredTypes.types.map { case TypeWithPath(path, inferredType) =>
+              // account for optional nodes by wrapping transform with a try/null
+              val transform = Some(Expression(s"try(${inferredType.transform.apply(0)},null)"))
+              if (path.isEmpty) {
+                DerivedField(inferredType.name, transform)
+              } else {
+                XmlPathField(inferredType.name, path, transform)
+              }
+            }
+
+            val idField = Some(Expression("md5(stringToBytes(toString($0)))"))
+
+            val xmlConfig =
+              XmlConfig(typeToProcess, xpathFactory, namespaces, None, featurePath, idField, Map.empty, Map.empty)
+
+            val config =
+              configConvert.to(xmlConfig)
+                  .withFallback(fieldConvert.to(fieldConfig))
+                  .toConfig
+
+            (inferredTypes.sft, config)
+          }
+        }
+      }
+    }
+  }
 }
 
 object XmlConverterFactory {
 
   val TypeToProcess = "xml"
+
+  val FeaturePathKey = "featurePath"
+
+  private val TypeConfig = ConfigFactory.parseString(s"{type = $TypeToProcess}")
 
   object XmlConfigConvert extends ConverterConfigConvert[XmlConfig] with OptionConvert with StrictLogging {
 
@@ -76,7 +189,7 @@ object XmlConverterFactory {
 
     override protected def encodeField(field: XmlField, base: java.util.Map[String, AnyRef]): Unit = {
       field match {
-        case f: XmlPathField => base.put("path", f.path.toString)
+        case f: XmlPathField => base.put("path", f.path)
         case _ => // no-op
       }
     }
@@ -94,7 +207,7 @@ object XmlConverterFactory {
         cur.atKey(key).right.flatMap { value =>
           value.asString.right.flatMap { string =>
             values.find(_.toString.equalsIgnoreCase(string)) match {
-              case Some(v) => Right(v.asInstanceOf[T])
+              case Some(v) => Right(v)
               case None =>
                 val msg = s"Must be one of: ${values.mkString(", ")}"
                 value.failed(CannotConvert(value.valueOpt.map(_.toString).orNull, values.head.getClass.getSimpleName, msg))
@@ -113,5 +226,80 @@ object XmlConverterFactory {
     override protected def encodeOptions(options: XmlOptions, base: java.util.Map[String, AnyRef]): Unit = {
       base.put("line-mode", options.lineMode.toString)
     }
+  }
+
+  /**
+   * Attribute namer for xml elements
+   */
+  private class XmlNamer extends Namer {
+
+    private val rootPrefixes = scala.collection.mutable.HashSet.empty[String]
+    private val namespaceMatcher = Pattern.compile("(/@?)[^:/@]*:")
+
+    /**
+     * Add a root element, whose tag will be removed from any derived attribute names
+     *
+     * @param elem element
+     */
+    def addRootElement(elem: Element): Unit =
+      rootPrefixes += s"/${elem.getTagName}/"
+
+    override def apply(key: String): String = {
+      val withoutRoot = rootPrefixes.find(key.startsWith) match {
+        case None    => key
+        case Some(p) => key.substring(p.length - 1)
+      }
+      // remove namespace prefixes from the attribute names
+      val withoutPrefixes = namespaceMatcher.matcher(withoutRoot).replaceAll("$1")
+      super.apply(withoutPrefixes)
+    }
+  }
+
+  /**
+   * Extract xmlns declarations from this element
+   *
+   * @param doc element
+   * @return
+   */
+  private def getNamespaces(doc: Element): Map[String, String] = {
+    val namespaces = Map.newBuilder[String, String]
+    val attributes = doc.getAttributes
+    var i = 0
+    while (i < attributes.getLength) {
+      val attr = attributes.item(i).asInstanceOf[Attr]
+      if (attr.getName.startsWith("xmlns:")) {
+        namespaces += attr.getName.substring(6) -> attr.getValue
+      }
+      i += 1
+    }
+    namespaces.result
+  }
+
+  /**
+   * Parse an xml node
+   *
+   * @param node node
+   * @param path xpath to the parent of the object
+   * @return map of key is xpath to value, value is a string
+   */
+  private def parseNode(node: Node, path: String): Seq[(String, String)] = {
+    // use linkedHashMap to preserve insertion order
+    val builder = scala.collection.mutable.LinkedHashMap.empty[String, String]
+    node match {
+      case n: Element =>
+        val p = s"$path/${n.getTagName}"
+        Seq.tabulate(n.getAttributes.getLength)(n.getAttributes.item(_).asInstanceOf[Attr])
+            .filterNot(_.getName.startsWith("xmlns:"))
+            .sortBy(_.getLocalName)
+            .foreach(attr => builder += s"$p/@${attr.getName}" -> attr.getValue)
+        Seq.tabulate(n.getChildNodes.getLength)(n.getChildNodes.item)
+            .foreach(child => builder ++= parseNode(child, p))
+
+      case n: Text if !TextTools.isWhitespace(n.getData) =>
+        builder += path -> n.getData
+
+      case _ => // no-op
+    }
+    builder.toSeq
   }
 }

--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/export/ConvertCommandTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/export/ConvertCommandTest.scala
@@ -6,7 +6,7 @@
  * http://www.opensource.org/licenses/apache2.0.php.
  ***********************************************************************/
 
-package org.locationtech.geomesa.tools.export
+package org.locationtech.geomesa.tools.`export`
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging

--- a/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/export/ExportCommandTest.scala
+++ b/geomesa-tools/src/test/scala/org/locationtech/geomesa/tools/export/ExportCommandTest.scala
@@ -24,6 +24,7 @@ import org.geotools.util.factory.Hints
 import org.geotools.wfs.GML
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.arrow.io.SimpleFeatureArrowFileReader
+import org.locationtech.geomesa.convert.EvaluationContext
 import org.locationtech.geomesa.convert.text.DelimitedTextConverter
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.features.ScalaSimpleFeature
@@ -48,6 +49,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.{Collections, Date}
+import scala.util.{Failure, Success}
 
 @RunWith(classOf[JUnitRunner])
 class ExportCommandTest extends Specification with Retries {
@@ -256,9 +258,9 @@ class ExportCommandTest extends Specification with Retries {
     DelimitedTextConverter.magicParsing(sft.getTypeName, new FileInputStream(file)).toList
 
   def readJson(file: String, sft: SimpleFeatureType): Seq[SimpleFeature] = {
-    SimpleFeatureConverter.infer(() => new FileInputStream(file), None, Some(file)) match {
-      case None => Seq.empty // empty json file
-      case Some((s, c)) =>
+    SimpleFeatureConverter.infer(() => new FileInputStream(file), None, EvaluationContext.inputFileParam(file)) match {
+      case Failure(_) => Seq.empty // empty json file
+      case Success((s, c)) =>
         val converter = SimpleFeatureConverter(s, c)
         val result = Seq.newBuilder[SimpleFeature]
         val names = sft.getAttributeDescriptors.asScala.map(_.getLocalName)


### PR DESCRIPTION
* Make inference method use a Try
* Change all float inference to doubles
  * floats cause rounding errors when used as doubles in geometries
* Remove creating points from consecutive number fields
* Improve error messages in CLI tools