### PR TITLE
GEOMESA-3362 Adds optional flattened arrow output

### DIFF
--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DictionaryBuildingWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/DictionaryBuildingWriter.scala
@@ -43,7 +43,8 @@ class DictionaryBuildingWriter(
     dictionaries: Seq[String],
     encoding: SimpleFeatureEncoding,
     ipcOpts: IpcOption,
-    maxSize: Int = Short.MaxValue
+    maxSize: Int = Short.MaxValue,
+    flattenStruct: Option[Boolean] = Some(false)
   ) extends Closeable {
 
   import org.locationtech.geomesa.utils.geotools.RichAttributeDescriptors.RichAttributeDescriptor
@@ -63,7 +64,14 @@ class DictionaryBuildingWriter(
 
   private val root = {
     val fields = Collections.singletonList[Field](underlying.getField)
-    new VectorSchemaRoot(fields, Collections.singletonList[FieldVector](underlying), 0)
+
+    val potentialRoot = new VectorSchemaRoot(fields, Collections.singletonList[FieldVector](underlying), 0)
+    flattenStruct match {
+      case Some(toFlatten) if toFlatten == true =>
+        new VectorSchemaRoot(potentialRoot.getVector(sft.getTypeName))
+      case _ =>
+        potentialRoot
+    }
   }
 
   private var index = 0

--- a/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/SimpleFeatureArrowFileWriter.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/main/scala/org/locationtech/geomesa/arrow/io/SimpleFeatureArrowFileWriter.scala
@@ -9,6 +9,7 @@
 package org.locationtech.geomesa.arrow.io
 
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.dictionary.{Dictionary, DictionaryProvider}
 import org.apache.arrow.vector.ipc.ArrowStreamWriter
 import org.apache.arrow.vector.ipc.message.IpcOption
@@ -35,11 +36,19 @@ class SimpleFeatureArrowFileWriter private (
     provider: DictionaryProvider with Closeable,
     os: OutputStream,
     ipcOpts: IpcOption,
-    sort: Option[(String, Boolean)]
+    sort: Option[(String, Boolean)],
+    flattenStruct: Option[Boolean]
   ) extends Closeable with Flushable with LazyLogging {
-
   private val metadata = sort.map { case (field, reverse) => getSortAsMetadata(field, reverse) }.orNull
-  private val root = createRoot(vector.underlying, metadata)
+  private val root = {
+    val potentialRoot = createRoot(vector.underlying, metadata)
+    flattenStruct match {
+      case Some(toFlatten) if toFlatten == true =>
+        new VectorSchemaRoot(potentialRoot.getVector(sft.getTypeName))
+      case _ =>
+        potentialRoot
+    }
+  }
   private val writer = new ArrowStreamWriter(root, provider, Channels.newChannel(os), ipcOpts)
 
   private var index = 0
@@ -106,7 +115,8 @@ object SimpleFeatureArrowFileWriter {
       dictionaries: Map[String, ArrowDictionary],
       encoding: SimpleFeatureEncoding,
       ipcOpts: IpcOption,
-      sort: Option[(String, Boolean)]): SimpleFeatureArrowFileWriter = {
+      sort: Option[(String, Boolean)],
+      flattenStruct: Option[Boolean] = Some(false)): SimpleFeatureArrowFileWriter = {
     val vector = SimpleFeatureVector.create(sft, dictionaries, encoding)
     // convert the dictionary values into arrow vectors
     // make sure we load dictionaries before instantiating the stream writer
@@ -116,7 +126,7 @@ object SimpleFeatureArrowFileWriter {
       override def getDictionaryIds: java.util.Set[java.lang.Long] = dictionaries.keys.map(Long.box).toSet.asJava
       override def close(): Unit = CloseWithLogging(dictionaries.values)
     }
-    new SimpleFeatureArrowFileWriter(vector, provider, os, ipcOpts, sort)
+    new SimpleFeatureArrowFileWriter(vector, provider, os, ipcOpts, sort, flattenStruct)
   }
 
   // convert the dictionary values into arrow vectors

--- a/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/io/SimpleFeatureArrowFileTest.scala
+++ b/geomesa-arrow/geomesa-arrow-gt/src/test/scala/org/locationtech/geomesa/arrow/io/SimpleFeatureArrowFileTest.scala
@@ -8,7 +8,10 @@
 
 package org.locationtech.geomesa.arrow.io
 
-import org.apache.arrow.vector.ipc.message.IpcOption
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.VarCharVector
+import org.apache.arrow.vector.ipc.{ArrowFileReader, ArrowStreamReader}
+import org.apache.arrow.vector.ipc.message.{ArrowBlock, IpcOption}
 import org.geotools.filter.text.ecql.ECQL
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.arrow.vector.ArrowDictionary
@@ -22,7 +25,7 @@ import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
-import java.io.{File, FileInputStream, FileOutputStream}
+import java.io.{ByteArrayInputStream, File, FileInputStream, FileOutputStream}
 import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -102,6 +105,31 @@ class SimpleFeatureArrowFileTest extends Specification {
         }
       }
     }
+    "write and read values with flatten" >> {
+      withTestFile("simple") { file =>
+        WithClose(SimpleFeatureArrowFileWriter(new FileOutputStream(file), sft, Map.empty, SimpleFeatureEncoding.Max, ipcOpts, None, Some(true))) { writer =>
+          features0.foreach(writer.add)
+          writer.flush()
+          features1.foreach(writer.add)
+        }
+
+        var totalRecords = 0
+        val rootAllocator = new RootAllocator()
+
+        val bytes = Files.readAllBytes(file.toPath)
+        val reader = new ArrowStreamReader(new ByteArrayInputStream(bytes), rootAllocator)
+
+        while (reader.loadNextBatch()) {
+          val root = reader.getVectorSchemaRoot
+
+          // Flatten removes the outer StructVector which is the SFT name
+          root.getFieldVectors.get(0) must haveClass[VarCharVector]
+          totalRecords += root.getRowCount
+        }
+
+        totalRecords mustEqual (features0.size + features1.size)
+      }
+    }
     "optimize queries for sorted files" >> {
       withTestFile("sorted") { file =>
         WithClose(SimpleFeatureArrowFileWriter(new FileOutputStream(file), sft, Map.empty, SimpleFeatureEncoding.Max, ipcOpts, Some(("dtg", false)))) { writer =>
@@ -164,6 +192,32 @@ class SimpleFeatureArrowFileTest extends Specification {
         WithClose(SimpleFeatureArrowFileReader.caching(new FileInputStream(file))) { reader =>
           WithClose(reader.features())(f => f.map(ScalaSimpleFeature.copy).toSeq mustEqual features0 ++ features1)
         }
+      }
+    }
+    "write and read dictionary encoded values with flatten" >> {
+      val dictionaries = Map("foo:String" -> ArrowDictionary.create(sft.getTypeName, 0, Array("foo0", "foo1", "foo2")))
+      withTestFile("dictionary") { file =>
+        WithClose(SimpleFeatureArrowFileWriter(new FileOutputStream(file), sft, dictionaries, SimpleFeatureEncoding.Max, ipcOpts, None, Some(true))) { writer =>
+          features0.foreach(writer.add)
+          writer.flush()
+          features1.foreach(writer.add)
+        }
+
+        var totalRecords = 0
+        val rootAllocator = new RootAllocator()
+
+        val bytes = Files.readAllBytes(file.toPath)
+        val reader = new ArrowStreamReader(new ByteArrayInputStream(bytes), rootAllocator)
+
+        while (reader.loadNextBatch()) {
+          val root = reader.getVectorSchemaRoot
+
+          // Flatten removes the outer StructVector which is the SFT name
+          root.getFieldVectors.get(0) must haveClass[VarCharVector]
+          totalRecords += root.getRowCount
+        }
+
+        totalRecords mustEqual (features0.size + features1.size)
       }
     }
     "write and read dictionary encoded ints" >> {

--- a/geomesa-features/geomesa-feature-exporters/src/main/scala/org/locationtech/geomesa/features/exporters/ArrowExporter.scala
+++ b/geomesa-features/geomesa-feature-exporters/src/main/scala/org/locationtech/geomesa/features/exporters/ArrowExporter.scala
@@ -29,6 +29,7 @@ class ArrowExporter(out: OutputStream, hints: Hints) extends FeatureExporter {
   private lazy val ipc = hints.getArrowFormatVersion.getOrElse(FormatVersion.ArrowFormatVersion.get)
   private lazy val batchSize = hints.getArrowBatchSize.getOrElse(ArrowProperties.BatchSize.get.toInt)
   private lazy val dictionaryFields = hints.getArrowDictionaryFields
+  private lazy val flattenFields = hints.isArrowFlatten
 
   private var delegate: FeatureExporter = _
 
@@ -37,12 +38,12 @@ class ArrowExporter(out: OutputStream, hints: Hints) extends FeatureExporter {
       new EncodedDelegate(out)
     } else if (dictionaryFields.isEmpty) {
       // note: features should be sorted already, even if arrow encoding wasn't performed
-      new BatchDelegate(out, encoding, FormatVersion.options(ipc), sort, batchSize, Map.empty)
+      new BatchDelegate(out, encoding, FormatVersion.options(ipc), sort, batchSize, Map.empty, flattenFields)
     } else {
       if (sort.isDefined) {
         throw new NotImplementedError("Sorting and calculating dictionaries at the same time is not supported")
       }
-      new DictionaryDelegate(out, dictionaryFields, encoding, FormatVersion.options(ipc), batchSize)
+      new DictionaryDelegate(out, dictionaryFields, encoding, FormatVersion.options(ipc), batchSize, flattenFields)
     }
     delegate.start(sft)
   }
@@ -72,14 +73,15 @@ object ArrowExporter {
       dictionaryFields: Seq[String],
       encoding: SimpleFeatureEncoding,
       ipcOpts: IpcOption,
-      batchSize: Int
+      batchSize: Int,
+      flattenStruct: Option[Boolean] = Some(false)
     ) extends FeatureExporter {
 
     private var writer: DictionaryBuildingWriter = _
     private var count = 0L
 
     override def start(sft: SimpleFeatureType): Unit = {
-      writer = new DictionaryBuildingWriter(sft, dictionaryFields, encoding, ipcOpts)
+      writer = new DictionaryBuildingWriter(sft, dictionaryFields, encoding, ipcOpts, flattenStruct = flattenStruct)
     }
 
     override def export(features: Iterator[SimpleFeature]): Option[Long] = {
@@ -112,14 +114,15 @@ object ArrowExporter {
       ipcOpts: IpcOption,
       sort: Option[(String, Boolean)],
       batchSize: Int,
-      dictionaries: Map[String, ArrowDictionary]
+      dictionaries: Map[String, ArrowDictionary],
+      flattenStruct: Option[Boolean] = Some(false)
     ) extends FeatureExporter {
 
     private var writer: SimpleFeatureArrowFileWriter = _
     private var count = 0L
 
     override def start(sft: SimpleFeatureType): Unit = {
-      writer = SimpleFeatureArrowFileWriter(os, sft, dictionaries, encoding, ipcOpts, sort)
+      writer = SimpleFeatureArrowFileWriter(os, sft, dictionaries, encoding, ipcOpts, sort, flattenStruct = flattenStruct)
     }
 
     override def export(features: Iterator[SimpleFeature]): Option[Long] = {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryHints.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryHints.scala
@@ -60,6 +60,7 @@ object QueryHints {
   val ARROW_FORMAT_VERSION     = new ClassKey(classOf[String])
   val ARROW_DICTIONARY_FIELDS  = new ClassKey(classOf[java.lang.String])
   val ARROW_PROCESS_DELTAS     = new ClassKey(classOf[java.lang.Boolean])
+  val ARROW_FLATTEN            = new ClassKey(classOf[java.lang.Boolean])
 
   val LAMBDA_QUERY_PERSISTENT  = new ClassKey(classOf[java.lang.Boolean])
   val LAMBDA_QUERY_TRANSIENT   = new ClassKey(classOf[java.lang.Boolean])
@@ -141,6 +142,7 @@ object QueryHints {
     def getArrowFormatVersion: Option[String] = Option(hints.get(ARROW_FORMAT_VERSION).asInstanceOf[String])
     def isArrowProcessDeltas: Boolean =
       Option(hints.get(ARROW_PROCESS_DELTAS).asInstanceOf[java.lang.Boolean]).forall(Boolean.unbox)
+    def isArrowFlatten: Option[Boolean] = Option(hints.get(ARROW_FLATTEN).asInstanceOf[java.lang.Boolean])
 
     def isStatsQuery: Boolean = hints.containsKey(STATS_STRING)
     def getStatsQuery: String = hints.get(STATS_STRING).asInstanceOf[String]

--- a/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/transform/ArrowConversionProcess.scala
+++ b/geomesa-process/geomesa-process-vector/src/main/scala/org/locationtech/geomesa/process/transform/ArrowConversionProcess.scala
@@ -65,7 +65,9 @@ class ArrowConversionProcess extends GeoMesaProcess with LazyLogging {
               @DescribeParameter(name = "sortReverse", description = "Reverse the default sort order", min = 0)
               sortReverse: java.lang.Boolean,
               @DescribeParameter(name = "batchSize", description = "Number of features to include in each record batch", min = 0)
-              batchSize: java.lang.Integer
+              batchSize: java.lang.Integer,
+              @DescribeParameter(name = "flattenStruct", description = "Removes the outer SFT struct yielding top level feature access", min = 0)
+              flattenStruct: java.lang.Boolean
              ): java.util.Iterator[Array[Byte]] = {
 
     import scala.collection.JavaConverters._
@@ -86,9 +88,10 @@ class ArrowConversionProcess extends GeoMesaProcess with LazyLogging {
     val ipcVersion = Option(formatVersion).getOrElse(FormatVersion.ArrowFormatVersion.get)
     val reverse = Option(sortReverse).map(_.booleanValue())
     val batch = Option(batchSize).map(_.intValue).getOrElse(ArrowProperties.BatchSize.get.toInt)
+    val flatten = Option(flattenStruct).map(_.booleanValue())
 
     val visitor =
-      new ArrowVisitor(sft, encoding, ipcVersion, toEncode, Option(sortField), reverse, false, batch)
+      new ArrowVisitor(sft, encoding, ipcVersion, toEncode, Option(sortField), reverse, false, batch, flatten)
     GeoMesaFeatureCollection.visit(features, visitor)
     visitor.getResult.results
   }
@@ -104,7 +107,8 @@ object ArrowConversionProcess {
       sortField: Option[String],
       sortReverse: Option[Boolean],
       preSorted: Boolean,
-      batchSize: Int
+      batchSize: Int,
+      flattenStruct: Option[Boolean]
     ) extends GeoMesaProcessVisitor with LazyLogging {
 
     import scala.collection.JavaConverters._
@@ -114,9 +118,9 @@ object ArrowConversionProcess {
       val sort = sortField.map(s => (s, sortReverse.getOrElse(false)))
       val ipcOpts = FormatVersion.options(ipcVersion)
       if (dictionaryFields.isEmpty && (sortField.isEmpty || preSorted)) {
-        new SimpleArrowManualVisitor(sft, encoding, ipcOpts, sort, batchSize)
+        new SimpleArrowManualVisitor(sft, encoding, ipcOpts, sort, batchSize, flattenStruct)
       } else {
-        new ComplexArrowManualVisitor(sft, encoding, ipcOpts, dictionaryFields, sort, preSorted, batchSize)
+        new ComplexArrowManualVisitor(sft, encoding, ipcOpts, dictionaryFields, sort, preSorted, batchSize, flattenStruct)
       }
     }
 
@@ -148,6 +152,7 @@ object ArrowConversionProcess {
       query.getHints.put(QueryHints.ARROW_PROXY_FID, encoding.fids.contains(Encoding.Min))
       query.getHints.put(QueryHints.ARROW_BATCH_SIZE, batchSize)
       query.getHints.put(QueryHints.ARROW_FORMAT_VERSION, ipcVersion)
+      query.getHints.put(QueryHints.ARROW_FLATTEN, flattenStruct)
       sortField.foreach(query.getHints.put(QueryHints.ARROW_SORT_FIELD, _))
       sortReverse.foreach(query.getHints.put(QueryHints.ARROW_SORT_REVERSE, _))
 
@@ -174,7 +179,8 @@ object ArrowConversionProcess {
       encoding: SimpleFeatureEncoding,
       ipcOpts: IpcOption,
       sort: Option[(String, Boolean)],
-      batchSize: Int
+      batchSize: Int,
+      flattenStruct: Option[Boolean]
     ) extends ArrowManualVisitor {
 
     private val out = new ByteArrayOutputStream()
@@ -182,7 +188,7 @@ object ArrowConversionProcess {
     private var count = 0L
 
     private val writer =
-      SimpleFeatureArrowFileWriter(out, sft, Map.empty[String, ArrowDictionary], encoding, ipcOpts, sort)
+      SimpleFeatureArrowFileWriter(out, sft, Map.empty[String, ArrowDictionary], encoding, ipcOpts, sort, flattenStruct)
 
     override def visit(feature: SimpleFeature): Unit = {
       writer.add(feature)
@@ -217,7 +223,8 @@ object ArrowConversionProcess {
       dictionaryFields: Seq[String],
       sort: Option[(String, Boolean)],
       preSorted: Boolean,
-      batchSize: Int
+      batchSize: Int,
+      flattenStruct: Option[Boolean]
     ) extends ArrowManualVisitor {
 
     private val features = ArrayBuffer.empty[SimpleFeature]
@@ -256,7 +263,7 @@ object ArrowConversionProcess {
       val out = new ByteArrayOutputStream()
       val bytes = ListBuffer.empty[Array[Byte]]
 
-      WithClose(SimpleFeatureArrowFileWriter(out, sft, dictionaries, encoding, ipcOpts, sort)) { writer =>
+      WithClose(SimpleFeatureArrowFileWriter(out, sft, dictionaries, encoding, ipcOpts, sort, flattenStruct)) { writer =>
         while (sorted.hasNext) { // send batches
           var i = 0
           while (i < batchSize && sorted.hasNext) {

--- a/geomesa-process/geomesa-process-vector/src/test/scala/org/locationtech/geomesa/process/transform/ArrowConversionProcessTest.scala
+++ b/geomesa-process/geomesa-process-vector/src/test/scala/org/locationtech/geomesa/process/transform/ArrowConversionProcessTest.scala
@@ -9,6 +9,9 @@
 package org.locationtech.geomesa.process.transform
 
 import org.apache.arrow.memory.{BufferAllocator, RootAllocator}
+import org.apache.arrow.vector.VarCharVector
+import org.apache.arrow.vector.complex.StructVector
+import org.apache.arrow.vector.ipc.ArrowStreamReader
 import org.geotools.api.feature.simple.SimpleFeature
 import org.geotools.data.collection.ListFeatureCollection
 import org.junit.runner.RunWith
@@ -46,7 +49,7 @@ class ArrowConversionProcessTest extends Specification {
 
   "ArrowConversionProcess" should {
     "encode an empty feature collection" in {
-      val bytes = process.execute(new ListFeatureCollection(sft), null, null, null, null, null, null, null).asScala.reduce(_ ++ _)
+      val bytes = process.execute(new ListFeatureCollection(sft), null, null, null, null, null, null, null, null).asScala.reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()) must beEmpty
@@ -54,7 +57,7 @@ class ArrowConversionProcessTest extends Specification {
     }
 
     "encode a generic feature collection" in {
-      val bytes = process.execute(collection, null, null, null, null, null, null, null).asScala.reduce(_ ++ _)
+      val bytes = process.execute(collection, null, null, null, null, null, null, null, null).asScala.reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
@@ -62,14 +65,31 @@ class ArrowConversionProcessTest extends Specification {
       }
     }
 
+    "encode a generic feature collection with flattened struct" in {
+      val bytes = process.execute(collection, null, null, null, null, null, null, null, true).asScala.reduce(_ ++ _)
+      val rootAllocator = new RootAllocator()
+      val reader = new ArrowStreamReader(new ByteArrayInputStream(bytes), rootAllocator)
+
+      var totalRecords: Int = 0
+      while(reader.loadNextBatch()){
+        val root = reader.getVectorSchemaRoot
+
+        // Flatten removes the outer StructVector which is the SFT name
+        root.getFieldVectors.get(0) must haveClass[VarCharVector]
+        totalRecords += root.getRowCount
+      }
+
+      totalRecords mustEqual collection.size()
+    }
+
     "encode a generic empty feature collection with dictionary values without leaking memory" in {
       // This returns an empty iterator.
-      process.execute(new ListFeatureCollection(sft), null, null, null, Collections.singletonList("name"), null, null, null)
+      process.execute(new ListFeatureCollection(sft), null, null, null, Collections.singletonList("name"), null, null, null, null)
       ArrowAllocator.getAllocatedMemory(sft.getTypeName) must equalTo(0)
     }
 
     "encode a generic feature collection with dictionary values" in {
-      val bytes = process.execute(collection, null, null, null, Collections.singletonList("name"), null, null, null).asScala.reduce(_ ++ _)
+      val bytes = process.execute(collection, null, null, null, Collections.singletonList("name"), null, null, null, null).asScala.reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(bytes))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq must
@@ -78,13 +98,30 @@ class ArrowConversionProcessTest extends Specification {
       }
     }
 
+    "encode a generic feature collection with dictionary values and flattened struct" in {
+      val bytes = process.execute(collection, null, null, null, Collections.singletonList("name"), null, null, null, true).asScala.reduce(_ ++ _)
+      val rootAllocator = new RootAllocator()
+      val reader = new ArrowStreamReader(new ByteArrayInputStream(bytes), rootAllocator)
+
+      var totalRecords: Int = 0
+      while (reader.loadNextBatch()) {
+        val root = reader.getVectorSchemaRoot
+
+        // Flatten removes the outer StructVector which is the SFT name
+        root.getFieldVectors.get(0) must haveClass[VarCharVector]
+        totalRecords += root.getRowCount
+      }
+
+      totalRecords mustEqual collection.size()
+    }
+
     "encode a generic feature collection with sorting" in {
-      val ascending = process.execute(collection, null, null, null, null, "dtg", null, null).asScala.reduce(_ ++ _)
+      val ascending = process.execute(collection, null, null, null, null, "dtg", null, null, null).asScala.reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(ascending))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq mustEqual features
       }
-      val descending = process.execute(collection, null, null, null, null, "dtg", true, null).asScala.reduce(_ ++ _)
+      val descending = process.execute(collection, null, null, null, null, "dtg", true, null, null).asScala.reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(descending))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq mustEqual features.reverse
@@ -92,13 +129,13 @@ class ArrowConversionProcessTest extends Specification {
     }
 
     "encode a generic feature collection with sorting and dictionary values" in {
-      val ascending = process.execute(collection, null, null, null, Collections.singletonList("name"), "dtg", null, null).asScala.reduce(_ ++ _)
+      val ascending = process.execute(collection, null, null, null, Collections.singletonList("name"), "dtg", null, null, null).asScala.reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(ascending))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq mustEqual features
         reader.dictionaries.get("name") must beSome
       }
-      val descending = process.execute(collection, null, null, null, Collections.singletonList("name"), "dtg", true, null).asScala.reduce(_ ++ _)
+      val descending = process.execute(collection, null, null, null, Collections.singletonList("name"), "dtg", true, null, null).asScala.reduce(_ ++ _)
       WithClose(SimpleFeatureArrowFileReader.streaming(() => new ByteArrayInputStream(descending))) { reader =>
         reader.sft mustEqual sft
         SelfClosingIterator(reader.features()).map(ScalaSimpleFeature.copy).toSeq mustEqual features.reverse


### PR DESCRIPTION
Ticket: https://geomesa.atlassian.net/browse/GEOMESA-3362

## Testing

The airports shape file was obtained and loaded into geoserver:
https://hub.arcgis.com/documents/f74df2ed82ba4440a2059e8dc2ec9a5d/explore

Execute the following curl commands which exercise various arrow output options with and without the new flatten parameter.

This python snippit was used for display of the arrow data:

arrow_print.py
```
import pyarrow.ipc as ipc
import pandas as pd
import sys

# Specify the path to your Arrow file
file_path = sys.argv[1]

#pd.option_context('display.max_rows', None, 'display.max_columns', None)

# Open the Arrow file
with open(file_path, 'rb') as f:
    reader = ipc.open_stream(f)
    # Convert each record batch to a Pandas DataFrame
    dfs = [rb.to_pandas() for rb in reader]
    # Concatenate all DataFrames (if there are multiple record batches)
    df = pd.concat(dfs, ignore_index=True)

# Display the DataFrame
print(df.head().to_string())
```

### Default return:
```
curl 'http://localhost:8080/geoserver/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=geomesa:Airports&outputFormat=application/vnd.arrow' > airports_default.arrow
```
```
python arrow_print.py airports_default.arrow
```

Output:
```
Airports
0   {'id': 'Airports.1', 'the_geom': [51.883583, -176.6425], 'OBJECTID': 1, 'GLOBAL_ID': '656D38F0-F1FE-49A8-AB4F-677281616EF8', 'IDENT': 'ADK', 'NAME': 'Adak', 'LATITUDE': '51-53-00.8980N', 'LONGITUDE': '176-38-32.9360W', 'ELEVATION': 19.5, 'ICAO_ID': 'PADK', 'TYPE_CODE': 'AD', 'SERVCITY': 'ADAK ISLAND', 'STATE': 'AK', 'COUNTRY': 'UNITED STATES', 'OPERSTATUS': 'OPERATIONAL', 'PRIVATEUSE': 0, 'IAPEXISTS': 1, 'DODHIFLIP': 0, 'FAR91': 0, 'FAR93': 0, 'MIL_CODE': 'CIVIL', 'AIRANAL': 'NO OBJECTION', 'US_HIGH': 0, 'US_LOW': 0, 'AK_HIGH': 1, 'AK_LOW': 1, 'US_AREA': 0, 'PACIFIC': 0}
1     {'id': 'Airports.2', 'the_geom': [56.938694, -154.18257], 'OBJECTID': 2, 'GLOBAL_ID': 'F39AFCD2-D07F-4F41-96CF-08B79A271EAB', 'IDENT': 'AKK', 'NAME': 'Akhiok', 'LATITUDE': '56-56-19.2870N', 'LONGITUDE': '154-10-57.2000W', 'ELEVATION': 44.4, 'ICAO_ID': 'PAKH', 'TYPE_CODE': 'AD', 'SERVCITY': 'AKHIOK', 'STATE': 'AK', 'COUNTRY': 'UNITED STATES', 'OPERSTATUS': 'OPERATIONAL', 'PRIVATEUSE': 0, 'IAPEXISTS': 1, 'DODHIFLIP': 0, 'FAR91': 0, 'FAR93': 0, 'MIL_CODE': 'CIVIL', 'AIRANAL': 'NO OBJECTION', 'US_HIGH': 0, 'US_LOW': 0, 'AK_HIGH': 0, 'AK_LOW': 1, 'US_AREA': 0, 'PACIFIC': 0}
2  {'id': 'Airports.3', 'the_geom': [60.91381, -161.49335], 'OBJECTID': 3, 'GLOBAL_ID': 'C0EE48D3-E3AD-404E-945D-F404E345020D', 'IDENT': 'Z13', 'NAME': 'Akiachak', 'LATITUDE': '60-54-49.7150N', 'LONGITUDE': '161-29-35.9850W', 'ELEVATION': 22.8, 'ICAO_ID': 'PFZK', 'TYPE_CODE': 'AD', 'SERVCITY': 'AKIACHAK', 'STATE': 'AK', 'COUNTRY': 'UNITED STATES', 'OPERSTATUS': 'OPERATIONAL', 'PRIVATEUSE': 0, 'IAPEXISTS': 0, 'DODHIFLIP': 0, 'FAR91': 0, 'FAR93': 0, 'MIL_CODE': 'CIVIL', 'AIRANAL': 'NO OBJECTION', 'US_HIGH': 0, 'US_LOW': 0, 'AK_HIGH': 0, 'AK_LOW': 1, 'US_AREA': 0, 'PACIFIC': 0}
...

```


### With flatten
```
curl 'http://localhost:8080/geoserver/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=geomesa:Airports&outputFormat=application/vnd.arrow&format_options=flattenStruct:true;' > airports_flatten.arrow
```
```
python arrow_print.py airports_flatten.arrow
```

Output:
```


Airports
           id                 the_geom  OBJECTID                             GLOBAL_ID IDENT      NAME        LATITUDE        LONGITUDE  ELEVATION ICAO_ID TYPE_CODE     SERVCITY STATE        COUNTRY   OPERSTATUS  PRIVATEUSE  IAPEXISTS  DODHIFLIP  FAR91  FAR93 MIL_CODE       AIRANAL  US_HIGH  US_LOW  AK_HIGH  AK_LOW  US_AREA  PACIFIC
0  Airports.1   [51.883583, -176.6425]         1  656D38F0-F1FE-49A8-AB4F-677281616EF8   ADK      Adak  51-53-00.8980N  176-38-32.9360W       19.5    PADK        AD  ADAK ISLAND    AK  UNITED STATES  OPERATIONAL           0          1          0      0      0    CIVIL  NO OBJECTION        0       0        1       1        0        0
1  Airports.2  [56.938694, -154.18257]         2  F39AFCD2-D07F-4F41-96CF-08B79A271EAB   AKK    Akhiok  56-56-19.2870N  154-10-57.2000W       44.4    PAKH        AD       AKHIOK    AK  UNITED STATES  OPERATIONAL           0          1          0      0      0    CIVIL  NO OBJECTION        0       0        0       1        0        0
2  Airports.3   [60.91381, -161.49335]         3  C0EE48D3-E3AD-404E-945D-F404E345020D   Z13  Akiachak  60-54-49.7150N  161-29-35.9850W       22.8    PFZK        AD     AKIACHAK    AK  UNITED STATES  OPERATIONAL           0          0          0      0      0    CIVIL  NO OBJECTION        0       0        0       1        0        0
3  Airports.4   [60.907864, -161.4351]         4  26D96486-FA29-4866-93EB-2EEEB7FA7144   KKI  Akiachak  60-54-28.3130N  161-26-06.2780W       18.0                SP     AKIACHAK    AK  UNITED STATES  OPERATIONAL           0          0          0      0      0    CIVIL  NO OBJECTION        0       0        0       0        0        0

...
```

### Return only desired properties
```
curl 'http://localhost:8080/geoserver/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=geomesa:Airports&outputFormat=application/vnd.arrow&propertyName=NAME' > airports_only_name.arrow
```

```
python arrow_print.py airports_only_name.arrow
```

Output:
```
                                   Airports
0      {'id': 'Airports.1', 'NAME': 'Adak'}
1    {'id': 'Airports.2', 'NAME': 'Akhiok'}
2  {'id': 'Airports.3', 'NAME': 'Akiachak'}
3  {'id': 'Airports.4', 'NAME': 'Akiachak'}
4     {'id': 'Airports.5', 'NAME': 'Akiak'}

```

### Return only desired properties w/ flatten
```
curl 'http://localhost:8080/geoserver/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=geomesa:Airports&outputFormat=application/vnd.arrow&propertyName=NAME&format_options=flattenStruct:true;' > airports_only_name_flatten.arrow
```

```
python arrow_print.py airports_only_name_flatten.arrow
```

Output:
```
           id      NAME
0  Airports.1      Adak
1  Airports.2    Akhiok
2  Airports.3  Akiachak
3  Airports.4  Akiachak
4  Airports.5     Akiak
```

### Reverse Sort
```
curl 'http://localhost:8080/geoserver/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=geomesa:Airports&outputFormat=application/vnd.arrow&propertyName=NAME&format_options=flattenStruct:false;sortField:NAME;sortReverse:true;' > airports_only_name_reverse.arrow
```

```
python arrow_print.py airports_only_name_reverse.arrow
```

Output:
```
                                           Airports
0  {'id': 'Airports.16130', 'NAME': 'Zwainz Farms'}
1   {'id': 'Airports.5562', 'NAME': 'Zupancic Fld'}
2         {'id': 'Airports.14575', 'NAME': 'Zuehl'}
3        {'id': 'Airports.8928', 'NAME': 'Zortman'}
4    {'id': 'Airports.11254', 'NAME': 'Zorn Acres'}

```

### Reverse sort w/ flatten
```
curl 'http://localhost:8080/geoserver/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=geomesa:Airports&outputFormat=application/vnd.arrow&propertyName=NAME&format_options=flattenStruct:true;sortField:NAME;sortReverse:true;' > airports_only_name_reverse_flatten.arrow
```
```
python arrow_print.py airports_only_name_reverse_flatten.arrow
```

Output:
```
               id          NAME
0  Airports.16130  Zwainz Farms
1   Airports.5562  Zupancic Fld
2  Airports.14575         Zuehl
3   Airports.8928       Zortman
4  Airports.11254    Zorn Acres
```
