### PR TITLE
GEOMESA-3375 Kafka admin client consumer props

### DIFF
--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaMetadata.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/data/KafkaMetadata.scala
@@ -112,6 +112,7 @@ class KafkaMetadata[T](val config: KafkaDataStoreConfig, val serializer: Metadat
     val props = new Properties()
     props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.brokers)
     config.producers.properties.foreach { case (k, v) => props.put(k, v) }
+    config.consumers.properties.foreach { case (k, v) => props.put(k, v) }
     WithClose(AdminClient.create(props)) { admin => fn(admin) }
   }
 


### PR DESCRIPTION
Ticket: https://geomesa.atlassian.net/browse/GEOMESA-3375

This fix allows for consumer properties set in the geoserver data store to be passed into the kafka admin client.

Use case: SASL connection properties set within geoserver were not making their way to the admin client causing failures communicating to the broker. This was only an issue when not using zookeeper.