### PR TITLE
GEOMESA-3378 Fix CLI "find" warning output

### DIFF
--- a/geomesa-tools/conf-filtered/geomesa-env.sh
+++ b/geomesa-tools/conf-filtered/geomesa-env.sh
@@ -172,7 +172,7 @@ function find_jars() {
     local find_args
     find_args=("-type" "f" "-iname" "*.jar" "-not" "-iname" "*-sources.jar" "-not" "-iname" "*-tests.jar" "-print0")
     if [[ "$2" == "true" ]]; then
-      find_args+=("-maxdepth" "1")
+      find_args=("-maxdepth" "1" "${find_args[@]}")
     fi
     # read results of find into jars array
     mapfile -d '' jars < <(find "-L" "$home" "${find_args[@]}")


### PR DESCRIPTION
* The warning in RHEL8 is "find: warning you have specified the -maxdepth option after a non-argument -type"