### PR TITLE
GEOMESA-3385 Kafka - Check for features with null geometries loaded into cache

### DIFF
--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/index/KafkaFeatureCacheImpl.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/index/KafkaFeatureCacheImpl.scala
@@ -48,6 +48,10 @@ class KafkaFeatureCacheImpl(sft: SimpleFeatureType, config: IndexConfig, layerVi
     * due to kafka consumer partitioning
     */
   override def put(feature: SimpleFeature): Unit = {
+    if(feature.getDefaultGeometry == null){
+      logger.warn(s"Null geometry detected for feature ${feature.getID}. Skipping loading into cache.")
+      return
+    }
     val featureState = factory.createState(feature)
     logger.trace(s"${featureState.id} adding feature $featureState")
     val old = state.put(featureState.id, featureState)

--- a/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/index/KafkaFeatureCacheImpl.scala
+++ b/geomesa-kafka/geomesa-kafka-datastore/src/main/scala/org/locationtech/geomesa/kafka/index/KafkaFeatureCacheImpl.scala
@@ -48,7 +48,7 @@ class KafkaFeatureCacheImpl(sft: SimpleFeatureType, config: IndexConfig, layerVi
     * due to kafka consumer partitioning
     */
   override def put(feature: SimpleFeature): Unit = {
-    if(feature.getDefaultGeometry == null){
+    if (feature.getDefaultGeometry == null) {
       logger.warn(s"Null geometry detected for feature ${feature.getID}. Skipping loading into cache.")
       return
     }


### PR DESCRIPTION
Fixes an issue where if features with null geometries exist in the kafka topic, geoserver will error out on this layer and the KDS cache will be corrupt until the next geoserver restart.