### PR TITLE
Fix jars included in Accumulo distribution lib

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-dist/pom.xml
+++ b/geomesa-accumulo/geomesa-accumulo-dist/pom.xml
@@ -20,6 +20,22 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- manage these out from the libdir -->
+            <dependency>
+                <groupId>org.apache.thrift</groupId>
+                <artifactId>libthrift</artifactId>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Accumulo (dist) -->
         <dependency>
@@ -81,18 +97,6 @@
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-native_${scala.binary.version}</artifactId>
-        </dependency>
-
-        <!-- manage these out from the libdir -->
-        <dependency>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libthrift</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
* The 3.7 maven assembly plugin behaves differently than previous versions
* This fix restores the dist tar.gzs to match the old assembly plugin behavior