### PR TITLE
Introducing Geomesa Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ geospatial analytics.
   [Redis](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-redis.html) |
   [FileSystem](https://www.geomesa.org/documentation/current/tutorials/geomesa-quickstart-fsds.html)
 * [Tutorials](https://www.geomesa.org/tutorials/)
+* [![](https://img.shields.io/badge/Gurubase-Ask%20Geomesa%20Guru-006BFF)](https://gurubase.io/g/geomesa)  Geomesa-focused AI to answer your questions.
+
 
 ## Downloads
 


### PR DESCRIPTION
Hello @elahrvivaz 

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Geomesa Guru](https://gurubase.io/g/geomesa) to Gurubase. Geomesa Guru uses the data from this repo and data from the [docs](https://www.geomesa.org/documentation/stable/user/index.html) to answer questions by leveraging the LLM.

In this PR, I showcased the "Geomesa Guru" badge, which highlights that Geomesa now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Geomesa Guru in Gurubase, just let me know that's totally fine.