### PR TITLE
GEOMESA-3435. mention scylladb in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ geospatial analytics.
 * Quick Starts:
   [Accumulo](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-accumulo.html) |
   [HBase](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-hbase.html) |
-  [Cassandra](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-cassandra.html) |
+  [Cassandra / ScyllaDB](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-cassandra.html) |
   [Kafka](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-kafka.html) |
   [Redis](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-redis.html) |
   [FileSystem](https://www.geomesa.org/documentation/current/tutorials/geomesa-quickstart-fsds.html)
@@ -42,7 +42,7 @@ geospatial analytics.
   &nbsp;&nbsp;&nbsp;&nbsp;
   [**Accumulo**](https://github.com/locationtech/geomesa/releases/download/geomesa-5.1.0/geomesa-accumulo_2.12-5.1.0-bin.tar.gz) |
   [**HBase**](https://github.com/locationtech/geomesa/releases/download/geomesa-5.1.0/geomesa-hbase_2.12-5.1.0-bin.tar.gz) |
-  [**Cassandra**](https://github.com/locationtech/geomesa/releases/download/geomesa-5.1.0/geomesa-cassandra_2.12-5.1.0-bin.tar.gz) |
+  [**Cassandra / ScyllaDB**](https://github.com/locationtech/geomesa/releases/download/geomesa-5.1.0/geomesa-cassandra_2.12-5.1.0-bin.tar.gz) |
   [**Kafka**](https://github.com/locationtech/geomesa/releases/download/geomesa-5.1.0/geomesa-kafka_2.12-5.1.0-bin.tar.gz) |
   [**Redis**](https://github.com/locationtech/geomesa/releases/download/geomesa-5.1.0/geomesa-redis_2.12-5.1.0-bin.tar.gz) |
   [**FileSystem**](https://github.com/locationtech/geomesa/releases/download/geomesa-5.1.0/geomesa-fs_2.12-5.1.0-bin.tar.gz) |

--- a/build/templates/README.md
+++ b/build/templates/README.md
@@ -29,7 +29,7 @@ geospatial analytics.
 * Quick Starts:
   [Accumulo](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-accumulo.html) |
   [HBase](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-hbase.html) |
-  [Cassandra](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-cassandra.html) |
+  [Cassandra / ScyllaDB](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-cassandra.html) |
   [Kafka](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-kafka.html) |
   [Redis](https://www.geomesa.org/documentation/tutorials/geomesa-quickstart-redis.html) |
   [FileSystem](https://www.geomesa.org/documentation/current/tutorials/geomesa-quickstart-fsds.html)
@@ -42,7 +42,7 @@ geospatial analytics.
   &nbsp;&nbsp;&nbsp;&nbsp;
   [**Accumulo**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-accumulo_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
   [**HBase**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-hbase_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
-  [**Cassandra**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-cassandra_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
+  [**Cassandra / ScyllaDB**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-cassandra_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
   [**Kafka**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-kafka_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
   [**Redis**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-redis_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |
   [**FileSystem**](https://github.com/locationtech/geomesa/releases/download/geomesa-${geomesa.release.version}/geomesa-fs_${scala.binary.version}-${geomesa.release.version}-bin.tar.gz) |

--- a/docs/common.py
+++ b/docs/common.py
@@ -99,6 +99,8 @@ rst_epilog = """
 
 .. |cassandra_version| replace:: 3
 
+.. |scylladb_version| replace:: 6.2
+
 .. |redis_supported_versions| replace:: versions 5.0 and later
 
 .. |spark_required_version| replace:: %(spark_version)s

--- a/docs/tutorials/geomesa-quickstart-cassandra.rst
+++ b/docs/tutorials/geomesa-quickstart-cassandra.rst
@@ -1,7 +1,7 @@
-GeoMesa Cassandra Quick Start
-=============================
+GeoMesa Cassandra / ScyllaDB Quick Start
+========================================
 
-This tutorial is the fastest and easiest way to get started with GeoMesa using Cassandra.
+This tutorial is the fastest and easiest way to get started with GeoMesa using Cassandra / ScyllaDB.
 It is a good stepping-stone on the path to the other tutorials, that present increasingly
 involved examples of how to use GeoMesa.
 
@@ -12,9 +12,9 @@ In the spirit of keeping things simple, the code in this tutorial only
 does a few small things:
 
 1. Establishes a new (static) SimpleFeatureType
-2. Prepares the Cassandra tables to store this type of data
+2. Prepares the Cassandra / ScyllaDB tables to store this type of data
 3. Creates a few thousand example SimpleFeatures
-4. Writes these SimpleFeatures to Cassandra
+4. Writes these SimpleFeatures to Cassandra / ScyllaDB
 5. Queries for a given geographic rectangle, time range, and attribute
    filter, writing out the entries in the result set
 6. Uses GeoServer to visualize the data (optional)
@@ -27,14 +27,14 @@ Before you begin, you must have the following installed and configured:
 -  `Java <https://adoptium.net/temurin/releases/>`__ JDK 1.8
 -  Apache `Maven <https://maven.apache.org/>`__ |maven_version|
 -  a GitHub client
--  a Cassandra |cassandra_version| instance, either standalone or cluster
--  a Cassandra user that has both create-table and write permissions
+-  a Cassandra |cassandra_version| instance or a ScyllaDB |scylladb_version| instance, either standalone or cluster
+-  a Cassandra / ScyllaDB user that has both create-table and write permissions
    (not needed for standalone instances)
 
-Create A Cassandra Namespace
-----------------------------
+Create A Cassandra / ScyllaDB Namespace
+---------------------------------------
 
-You will need a namespace in Cassandra to contain the tutorial tables. The easiest way to do
+You will need a namespace in Cassandra / ScyllaDB to contain the tutorial tables. The easiest way to do
 this is with the ``cqlsh`` tool provided with Cassandra distributions. Start ``cqlsh``, then type:
 
 .. code-block:: bash
@@ -42,7 +42,7 @@ this is with the ``cqlsh`` tool provided with Cassandra distributions. Start ``c
     cqlsh>  CREATE KEYSPACE geomesa WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor' : 3};
 
 This creates a key space called "geomesa". This is a top-level name
-space within Cassandra and it will provide a place for GeoMesa to put
+space within Cassandra / ScyllaDB and it will provide a place for GeoMesa to put
 all of its data, including data for spatial features and associated
 metadata.
 
@@ -88,20 +88,20 @@ On the command line, run:
 
 where you provide the following arguments:
 
-- ``<host:port>`` the hostname and port your Cassandra instance is
-  running on. For Cassandra standalone this will be ``localhost:9042``. More
+- ``<host:port>`` the hostname and port your Cassandra / ScyllaDB instance is
+  running on. For Cassandra / ScyllaDB standalone this will be ``localhost:9042``. More
   information on how to find your connection is available
-  `here <https://www.geomesa.org/documentation/user/cassandra/install.html#connecting-to-cassandra>`__.
+  `here <https://www.geomesa.org/documentation/user/cassandra/install.html#connecting-to-cassandra-/-scylladb>`__.
 - ``<keyspace>`` keyspace your table will be put into. If you followed the instructions above,
   this will be ``geomesa``. More information on how to setup keyspaces is available
-  `here <https://www.geomesa.org/documentation/user/cassandra/install.html#connecting-to-cassandra>`__.
+  `here <https://www.geomesa.org/documentation/user/cassandra/install.html#connecting-to-cassandra-/-scylladb>`__.
 - ``<table>`` the name of the destination table that will
   accept these test records. This table should either not exist or
   should be empty
-- ``<user>`` (optional) the name of a Cassandra user that has
+- ``<user>`` (optional) the name of a Cassandra / ScyllaDB user that has
   permissions to create, read and write tables
 - ``<password>`` (optional) the password for the previously-mentioned
-  Cassandra user
+  Cassandra / ScyllaDB user
 
 Optionally, you can also specify that the quick start should delete its data upon completion. Use the
 ``--cleanup`` flag when you run to enable this behavior.
@@ -256,7 +256,7 @@ Register the GeoMesa Store with GeoServer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Log into GeoServer using your user and password credentials. Click
-"Stores" and "Add new Store". Select the ``Cassandra (GeoMesa)`` vector data
+"Stores" and "Add new Store". Select the ``Cassandra / ScyllaDB (GeoMesa)`` vector data
 source, and fill in the required parameters.
 
 Basic store info:
@@ -269,7 +269,7 @@ Connection parameters:
 
 -  these are the same parameter values that you supplied on the
    command line when you ran the tutorial; they describe how to connect
-   to the Cassandra instance where your data reside
+   to the Cassandra / ScyllaDB instance where your data reside
 
 Click "Save", and GeoServer will search your Cassandra table for any
 GeoMesa-managed feature types.

--- a/docs/user/cassandra/commandline.rst
+++ b/docs/user/cassandra/commandline.rst
@@ -15,12 +15,12 @@ Once installed, the tools should be available through the command ``geomesa-cass
       Commands:
         ...
 
-All Cassandra commands are described in the common tools chapter :doc:`/user/cli/index`.
+All Cassandra / ScyllaDB commands are described in the common tools chapter :doc:`/user/cli/index`.
 
 General Arguments
 -----------------
 
-Most commands require you to specify the connection to Cassandra. This generally includes a contact point,
+Most commands require you to specify the connection to Cassandra / ScyllaDB. This generally includes a contact point,
 key space, username and password. Specify the contact point and key space with ``--contact-point`` and
 ``--key-space`` (or ``-P`` and ``-k``). Specify the username and password with ``--user`` and ``--password``
 (or ``-u`` and ``-p``). In order to avoid plaintext passwords in the bash history

--- a/docs/user/cassandra/configuration.rst
+++ b/docs/user/cassandra/configuration.rst
@@ -1,13 +1,13 @@
-Cassandra Configuration
-=======================
+Cassandra / ScyllaDB Configuration
+==================================
 
-This section details Cassandra-specific configuration properties. For general properties,
+This section details Cassandra / ScyllaDB specific configuration properties. For general properties,
 see :ref:`geomesa_site_xml`.
 
 Connection Properties
 ---------------------
 
-The following properties control the configuration of the Cassandra session.
+The following properties control the configuration of the Cassandra / ScyllaDB session.
 
 geomesa.cassandra.connection.timeout
 ++++++++++++++++++++++++++++++++++++

--- a/docs/user/cassandra/geoserver.rst
+++ b/docs/user/cassandra/geoserver.rst
@@ -12,11 +12,11 @@ interface by clicking "Data > Stores" in the left-hand menu and then
 clicking "Add new Store".
 
 If you have properly installed the GeoMesa Cassandra GeoServer plugin as described
-in :ref:`install_cassandra_geoserver`, "Cassandra (GeoMesa)" should be included in the list
+in :ref:`install_cassandra_geoserver`, "Cassandra  / ScyllaDB (GeoMesa)" should be included in the list
 under **Vector Data Sources**. If you do not see this, check that you unpacked the
 plugin JARs into in the right directory and restart GeoServer.
 
-On the "Add Store" page, select "Cassandra (GeoMesa)", and fill out the
+On the "Add Store" page, select "Cassandra / ScyllaDB (GeoMesa)", and fill out the
 parameters. The parameters are described in :ref:`cassandra_parameters`.
 
-Click "Save", and GeoServer will search Cassandra for any GeoMesa-managed feature types.
+Click "Save", and GeoServer will search Cassandra / ScyllaDB for any GeoMesa-managed feature types.

--- a/docs/user/cassandra/heatmaps.rst
+++ b/docs/user/cassandra/heatmaps.rst
@@ -1,7 +1,7 @@
 Cassandra Heatmaps
 ==================
 
-Cassandra can generate client-side heatmaps in GeoServer by defining a style and using the built in ``gs:Heatmap``
+Cassandra / ScyllaDB can generate client-side heatmaps in GeoServer by defining a style and using the built in ``gs:Heatmap``
 process within GeoServer.
 
 To start, add a new SLD style to GeoServer named "heatmap" and use this sld

--- a/docs/user/cassandra/index.rst
+++ b/docs/user/cassandra/index.rst
@@ -1,16 +1,24 @@
-Cassandra Data Store
+Cassandra / ScyllaDB Data Store
 ====================
 
 .. note::
 
     GeoMesa currently supports Cassandra version |cassandra_version|.
 
+.. note::
+
+    GeoMesa currently supports ScyllaDB version |scylladb_version|.
+
 The GeoMesa Cassandra Data Store is an implementation of the GeoTools
-``DataStore`` interface that is backed by `Apache Cassandra`_.
+``DataStore`` interface that is backed by `Apache Cassandra`_ or `ScyllaDB`.
 It is found in the ``geomesa-cassandra`` directory of the GeoMesa
-source distribution.
+source distribution. As `ScyllaDB` is API-compatible with `Apache Cassandra`_,
+it is also supported and work with the same configuration
+just by pointing to `ScyllaDB`_ in connection string.
 
 .. _Apache Cassandra: https://cassandra.apache.org/
+
+.. _ScyllaDB: https://www.scylladb.com/
 
 .. toctree::
     :maxdepth: 1

--- a/docs/user/cassandra/install.rst
+++ b/docs/user/cassandra/install.rst
@@ -7,6 +7,10 @@ Installing GeoMesa Cassandra
 
 .. note::
 
+    GeoMesa currently supports ScyllaDB version |scylladb_version|.
+
+.. note::
+
     The examples below expect a version to be set in the environment:
 
     .. parsed-literal::
@@ -14,23 +18,25 @@ Installing GeoMesa Cassandra
         $ export TAG="|release_version|"
         $ export VERSION="|scala_binary_version|-${TAG}" # note: |scala_binary_version| is the Scala build version
 
-Connecting to Cassandra
------------------------
+Connecting to Cassandra or ScyllaDB
+-----------------------------------
 
-The first step to getting started with Cassandra and GeoMesa is to install
-Cassandra itself. You can find good directions for downloading and installing
-Cassandra online. For example, see Cassandra's official `getting started`_ documentation.
+The first step to getting started with Cassandra / ScyllaDB and GeoMesa is to install
+Cassandra / ScyllaDB itself. You can find good directions for downloading and installing
+Cassandra / ScyllaDB online. For example, see Cassandra's official `getting started`_ or official `ScyllaDB's getting started`_  documentation.
 
 .. _getting started: https://cassandra.apache.org/doc/latest/getting_started/index.html
 
-Once you have Cassandra installed, the next step is to prepare your Cassandra installation
-to integrate with GeoMesa. First, create a key space within Cassandra. The easiest way to
-do this with ``cqlsh``, which should have been installed as part of your Cassandra installation.
+.. _ScyllaDB's getting started: https://opensource.docs.scylladb.com/stable/getting-started/index.html
+
+Once you have Cassandra / ScyllaDB installed, the next step is to prepare your Cassandra / ScyllaDB installation
+to integrate with GeoMesa. First, create a key space within Cassandra / ScyllaDB. The easiest way to
+do this with ``cqlsh``, which should have been installed as part of your Cassandra / ScyllaDB installation.
 Start ``cqlsh``, then type::
 
     CREATE KEYSPACE mykeyspace WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor' : 3};
 
-This creates a key space called "mykeyspace". This is a top-level name space within Cassandra
+This creates a key space called "mykeyspace". This is a top-level name space within Cassandra / ScyllaDB
 and it will provide a place for GeoMesa to put all of its data, including data for spatial features
 and associated metadata.
 
@@ -40,12 +46,12 @@ installation. To set the variable add the following line to your ``.profile`` or
 
     export CASSANDRA_HOME=/path/to/cassandra
 
-Finally, make sure you know a contact point for your Cassandra instance.
-If you are just trying things locally, and using the default Cassandra settings,
+Finally, make sure you know a contact point for your Cassandra / ScyllaDB instance.
+If you are just trying things locally, and using the default Cassandra / ScyllaDB settings,
 the contact point would be ``127.0.0.1:9042``. You can check and configure the
-port you are using using the ``native_transport_port`` in the Cassandra
+port you are using using the ``native_transport_port`` in the Cassandra / ScyllaDB
 configuration file (located at ``conf/cassandra.yaml`` in your Cassandra
-installation directory).
+installation directory, ``/etc/scylla/scylla.yaml`` for ScyllaDB accordingly).
 
 Installing from the Binary Distribution
 ---------------------------------------

--- a/docs/user/cassandra/usage.rst
+++ b/docs/user/cassandra/usage.rst
@@ -3,7 +3,7 @@
 Cassandra Data Store Parameters
 ===============================
 
-Use the following parameters for a Cassandra data store (required parameters are marked with ``*``):
+Use the following parameters for a Cassandra / ScyllaDB data store (required parameters are marked with ``*``):
 
 ==================================== ======= ========================================================================================
 Parameter                            Type    Description
@@ -11,9 +11,9 @@ Parameter                            Type    Description
 ``cassandra.catalog *``              String  The name of the GeoMesa catalog table (previously ``geomesa.cassandra.catalog.table``)
 ``cassandra.contact.point *``        String  The connection point for Cassandra, in the form ``<host>:<port>`` - for a default
                                              local installation this will be ``localhost:9042``
-``cassandra.keyspace *``             String  The Cassandra keyspace to use (must exist already)
-``cassandra.username``               String  Cassandra user
-``cassandra.password``               String  Cassandra password
+``cassandra.keyspace *``             String  The Cassandra / ScyllaDB keyspace to use (must exist already)
+``cassandra.username``               String  Cassandra / ScyllaDB user
+``cassandra.password``               String  Cassandra / ScyllaDB password
 ``geomesa.query.audit``              Boolean Audit queries being run. Queries will be written to a log file
 ``geomesa.query.timeout``            String  The max time a query will be allowed to run before being killed. The
                                              timeout is specified as a duration, e.g. ``1 minute`` or ``60 seconds``
@@ -25,7 +25,7 @@ Parameter                            Type    Description
 Programmatic Access
 -------------------
 
-An instance of a Cassandra data store can be obtained through the normal GeoTools discovery methods,
+An instance of a Cassandra / ScyllaDB data store can be obtained through the normal GeoTools discovery methods,
 assuming that the GeoMesa code is on the classpath.
 
 .. code-block:: java

--- a/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>geomesa-cassandra-datastore_2.12</artifactId>
-    <name>GeoMesa Cassandra DataStore</name>
+    <name>GeoMesa Cassandra / ScyllaDB DataStore</name>
 
     <dependencies>
         <dependency>

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreFactory.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraDataStoreFactory.scala
@@ -130,8 +130,8 @@ object CassandraDataStoreFactory extends GeoMesaDataStoreInfo {
       null,
       Map(Parameter.DEPRECATED -> true, Parameter.IS_PASSWORD -> true).asJava)
 
-  override val DisplayName = "Cassandra (GeoMesa)"
-  override val Description = "Apache Cassandra\u2122 distributed key/value store"
+  override val DisplayName = "Cassandra / ScyllaDB (GeoMesa)"
+  override val Description = "Apache Cassandra / ScyllaDB \u2122 distributed key/value store"
 
   override val ParameterInfo: Array[GeoMesaParam[_ <: AnyRef]] =
     Array(

--- a/geomesa-cassandra/geomesa-cassandra-gs-plugin/pom.xml
+++ b/geomesa-cassandra/geomesa-cassandra-gs-plugin/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>geomesa-cassandra-gs-plugin_2.12</artifactId>
-    <name>GeoMesa Cassandra GeoServer Plugin</name>
+    <name>GeoMesa Cassandra / ScyllaDB GeoServer Plugin</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/geomesa-cassandra/pom.xml
+++ b/geomesa-cassandra/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>geomesa-cassandra_2.12</artifactId>
-    <name>GeoMesa Cassandra</name>
+    <name>GeoMesa Cassandra / ScyllaDB</name>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
ScyllaDB is a drop in more performant replacement for Cassandra. It works out of the box with GeoMesa just by replacing connection string from Cassandra to ScyllaDB. Lets mention this in docs so people will be aware of such option.