### PR TITLE
GEOMESA-3447 FSDS - Support allow-list for attribute partition scheme

### DIFF
--- a/docs/user/filesystem/partition_schemes.rst
+++ b/docs/user/filesystem/partition_schemes.rst
@@ -146,3 +146,9 @@ Attribute schemes lay out data based on a lexicoded attribute value.
 **Configuration:**
 
 * ``partitioned-attribute`` - The name of an attribute from the SimpleFeatureType to use for partitioning data.
+* ``allow-list`` - An optional comma separated list of allowed paths to use for partitioning data that must
+  equal the value of the specified ``partitioned-attribute`` from partitioned SimpleFeatures, otherwise it will return
+  an empty list of partitions.
+* ``default-partition`` - An optional config for setting the default partition for null or not allowed attribute values.
+  If not set, if an ``allow-list`` is set then ``default-partition`` will be set to the head of the list, otherwise
+  ``default-partition`` will equal "".

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/partitions/AttributeScheme.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/partitions/AttributeScheme.scala
@@ -36,15 +36,15 @@ case class AttributeScheme(attribute: String, index: Int, binding: Class[_], def
 
   override def getPartitionName(feature: SimpleFeature): String = {
     val value = feature.getAttribute(index)
-    if (value == null)
-      return defaultPartition
-    val encodedValue = AttributeIndexKey.typeEncode(value)
-    if (allowedValues.nonEmpty) {
-      if (allowedValues.contains(value))
-        return encodedValue
+    if (value == null) {
       return defaultPartition
     }
-    encodedValue
+    val encodedValue = AttributeIndexKey.typeEncode(value)
+    if (allowedValues.isEmpty || allowedValues.contains(encodedValue)) {
+      encodedValue
+    } else {
+      defaultPartition
+    }
   }
 
   override def getSimplifiedFilters(filter: Filter, partition: Option[String]): Option[Seq[SimplifiedFilter]] = {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/partitions/AttributeScheme.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/partitions/AttributeScheme.scala
@@ -115,6 +115,7 @@ object AttributeScheme {
           s"Invalid type binding '${binding.getName}' of attribute '$attribute'")
         val allowedValues: Seq[String] = config.options.get(Config.AllowedListOpt).map(_.split(',').toSeq).getOrElse(Seq.empty).map(allowed => AttributeIndexKey.encodeForQuery(allowed.trim(),binding))
         val defaultPartition = AttributeIndexKey.encodeForQuery(config.options.getOrElse(Config.DefaultPartitionOpt, allowedValues.headOption.getOrElse("")), binding)
+        require(allowedValues.isEmpty || allowedValues.contains(defaultPartition), "Default partition must be one of the allowed values")
         Some(AttributeScheme(attribute, index, binding, defaultPartition, allowedValues))
       }
     }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/partitions/AttributeScheme.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/partitions/AttributeScheme.scala
@@ -113,7 +113,7 @@ object AttributeScheme {
         val binding = sft.getDescriptor(index).getType.getBinding
         require(AttributeIndexKey.encodable(binding),
           s"Invalid type binding '${binding.getName}' of attribute '$attribute'")
-        val allowedValues: Seq[String] = config.options.get(Config.AllowedListOpt).map(_.split(',').toSeq).getOrElse(Seq.empty).map(AttributeIndexKey.encodeForQuery(_,binding))
+        val allowedValues: Seq[String] = config.options.get(Config.AllowedListOpt).map(_.split(',').toSeq).getOrElse(Seq.empty).map(allowed => AttributeIndexKey.encodeForQuery(allowed.trim(),binding))
         val defaultPartition = AttributeIndexKey.encodeForQuery(config.options.getOrElse(Config.DefaultPartitionOpt, allowedValues.headOption.getOrElse("")), binding)
         Some(AttributeScheme(attribute, index, binding, defaultPartition, allowedValues))
       }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/partitions/AttributeScheme.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/main/scala/org/locationtech/geomesa/fs/storage/common/partitions/AttributeScheme.scala
@@ -22,8 +22,9 @@ import org.locationtech.geomesa.index.index.attribute.AttributeIndexKey
   * @param attribute attribute name
   * @param index attribute index in the sft
   * @param binding type binding
+  * @param allowedValues list of allowedValues to partition
   */
-case class AttributeScheme(attribute: String, index: Int, binding: Class[_]) extends PartitionScheme {
+case class AttributeScheme(attribute: String, index: Int, binding: Class[_], defaultPartition: String, allowedValues: Seq[String]) extends PartitionScheme {
 
   import FilterHelper.ff
 
@@ -35,7 +36,15 @@ case class AttributeScheme(attribute: String, index: Int, binding: Class[_]) ext
 
   override def getPartitionName(feature: SimpleFeature): String = {
     val value = feature.getAttribute(index)
-    if (value == null) { "" } else { AttributeIndexKey.typeEncode(value) }
+    if (value == null)
+      return defaultPartition
+    val encodedValue = AttributeIndexKey.typeEncode(value)
+    if (allowedValues.nonEmpty) {
+      if (allowedValues.contains(value))
+        return encodedValue
+      return defaultPartition
+    }
+    encodedValue
   }
 
   override def getSimplifiedFilters(filter: Filter, partition: Option[String]): Option[Seq[SimplifiedFilter]] = {
@@ -57,10 +66,11 @@ case class AttributeScheme(attribute: String, index: Int, binding: Class[_]) ext
     if (bounds.disjoint) {
       Some(Seq.empty)
     } else if (bounds.isEmpty || !bounds.precise || !bounds.forall(_.isEquals)) {
-      None
+      if (allowedValues.nonEmpty) Some(allowedValues) else None
     } else {
       // note: we verified they are all single values above
-      Some(bounds.values.map(bound => AttributeIndexKey.encodeForQuery(bound.lower.value.get, binding)))
+      val partitions = bounds.values.map(bound => AttributeIndexKey.encodeForQuery(bound.lower.value.get, binding))
+      if (allowedValues.nonEmpty) Some(partitions.filter(partition => allowedValues.contains(partition))) else Some(partitions)
     }
   }
 
@@ -89,6 +99,8 @@ object AttributeScheme {
 
   object Config {
     val AttributeOpt: String = "partitioned-attribute"
+    val AllowedListOpt: String = "allow-list"
+    val DefaultPartitionOpt: String = "default-partition"
   }
 
   class AttributePartitionSchemeFactory extends PartitionSchemeFactory {
@@ -101,7 +113,9 @@ object AttributeScheme {
         val binding = sft.getDescriptor(index).getType.getBinding
         require(AttributeIndexKey.encodable(binding),
           s"Invalid type binding '${binding.getName}' of attribute '$attribute'")
-        Some(AttributeScheme(attribute, index, binding))
+        val allowedValues: Seq[String] = config.options.get(Config.AllowedListOpt).map(_.split(',').toSeq).getOrElse(Seq.empty).map(AttributeIndexKey.encodeForQuery(_,binding))
+        val defaultPartition = AttributeIndexKey.encodeForQuery(config.options.getOrElse(Config.DefaultPartitionOpt, allowedValues.headOption.getOrElse("")), binding)
+        Some(AttributeScheme(attribute, index, binding, defaultPartition, allowedValues))
       }
     }
   }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/test/scala/org/locationtech/geomesa/fs/storage/common/partitions/PartitionSchemeTest.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/test/scala/org/locationtech/geomesa/fs/storage/common/partitions/PartitionSchemeTest.scala
@@ -10,6 +10,7 @@ package org.locationtech.geomesa.fs.storage.common.partitions
 
 import org.geotools.api.filter.{Filter, PropertyIsLessThan}
 import org.geotools.filter.text.ecql.ECQL
+import org.junit.Assert.assertThrows
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.filter.expression.AttributeExpression.FunctionLiteral
@@ -18,6 +19,7 @@ import org.locationtech.geomesa.fs.storage.api.PartitionScheme.SimplifiedFilter
 import org.locationtech.geomesa.fs.storage.api.{NamedOptions, PartitionSchemeFactory}
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.text.DateParsing
+import org.specs2.control.eff.Interpret.intercept
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.AllExpectations
@@ -61,6 +63,12 @@ class PartitionSchemeTest extends Specification with AllExpectations {
       ps.getPartitionName(sf) mustEqual "bar"
       ps.getSimplifiedFilters(ECQL.toFilter("name IN ('test')")) must beSome(Seq(SimplifiedFilter(Filter.INCLUDE, Seq.empty, partial = false)))
     }
+
+    "exception thrown for when allow-list does not contain default-partition" >> {
+        PartitionSchemeFactory.load(sft, NamedOptions("attribute", Map("partitioned-attribute" -> "name", "allow-list" -> "bar", "default-partition" -> "foo"))) must
+          throwAn[IllegalArgumentException]
+    }
+
 
     "partition based on date" >> {
       val ps = DateTimeScheme("yyyy-MM-dd", ChronoUnit.DAYS, 1, "dtg", 2)

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/test/scala/org/locationtech/geomesa/fs/storage/common/partitions/PartitionSchemeTest.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-common/src/test/scala/org/locationtech/geomesa/fs/storage/common/partitions/PartitionSchemeTest.scala
@@ -62,12 +62,6 @@ class PartitionSchemeTest extends Specification with AllExpectations {
       ps.getSimplifiedFilters(ECQL.toFilter("name IN ('test')")) must beSome(Seq(SimplifiedFilter(Filter.INCLUDE, Seq.empty, partial = false)))
     }
 
-    "partition based on allow list not containing attribute value and default partition is set" >> {
-      val ps = PartitionSchemeFactory.load(sft, NamedOptions("attribute", Map("partitioned-attribute" -> "name", "allow-list" -> "bar", "default-partition" -> "foo")))
-      ps.getPartitionName(sf) mustEqual "foo"
-      ps.getSimplifiedFilters(ECQL.toFilter("name IN ('test')")) must beSome(Seq(SimplifiedFilter(Filter.INCLUDE, Seq.empty, partial = false)))
-    }
-
     "partition based on date" >> {
       val ps = DateTimeScheme("yyyy-MM-dd", ChronoUnit.DAYS, 1, "dtg", 2)
       ps.getPartitionName(sf) mustEqual "2017-02-03"


### PR DESCRIPTION
- Added the ability to provided a comma separated list of allowed paths to AttributeScheme
- Allows AttributeScheme to be configured to only partition specific pre-defined allowed paths in FSDS