### PR TITLE
GEOMESA-3452 Accumulo - Use number of tablets scanned for query planning

### DIFF
--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/data/AccumuloDataStoreQueryTest.scala
@@ -517,7 +517,7 @@ class AccumuloDataStoreQueryTest extends Specification with TestWithMultipleSfts
         }
         foreach(fullScans) { filter =>
           val query = new Query(sft.getTypeName, ECQL.toFilter(filter))
-          ds.getFeatureSource(sft.getTypeName).getFeatures(query).features must throwA[RuntimeException]
+          SelfClosingIterator(ds.getFeatureSource(sft.getTypeName).getFeatures(query).features).toList must throwA[RuntimeException]
         }
         // verify that we won't block if max features is set
         foreach(fullScans) { filter =>
@@ -538,7 +538,7 @@ class AccumuloDataStoreQueryTest extends Specification with TestWithMultipleSfts
         System.setProperty(s"geomesa.scan.${sft.getTypeName}.block-full-table", "true")
         foreach(fullScans) { filter =>
           val query = new Query(sft.getTypeName, ECQL.toFilter(filter))
-          ds.getFeatureSource(sft.getTypeName).getFeatures(query).features must throwA[RuntimeException]
+          SelfClosingIterator(ds.getFeatureSource(sft.getTypeName).getFeatures(query).features).toList must throwA[RuntimeException]
         }
       } finally {
         QueryProperties.BlockFullTableScans.threadLocalValue.remove()

--- a/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/AttributeIndexStrategyTest.scala
+++ b/geomesa-accumulo/geomesa-accumulo-datastore/src/test/scala/org/locationtech/geomesa/accumulo/index/AttributeIndexStrategyTest.scala
@@ -17,6 +17,7 @@ import org.geotools.filter.text.cql2.CQLException
 import org.geotools.filter.text.ecql.ECQL
 import org.geotools.geometry.jts.ReferencedEnvelope
 import org.geotools.util.Converters
+import org.geotools.util.factory.Hints
 import org.junit.runner.RunWith
 import org.locationtech.geomesa.accumulo.TestWithFeatureType
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloDataStoreParams}
@@ -1044,8 +1045,8 @@ class AttributeIndexStrategyTest extends Specification with TestWithFeatureType 
     "merge PropertyIsEqualTo primary filters" >> {
       val q1 = ff.equals(ff.property("name"), ff.literal("1"))
       val q2 = ff.equals(ff.property("name"), ff.literal("2"))
-      val qf1 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q1), None, temporal = false, 0L)
-      val qf2 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q2), None, temporal = false, 0L)
+      val qf1 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q1), None, temporal = false, 0L, new Hints())
+      val qf2 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q2), None, temporal = false, 0L, new Hints())
       val res = FilterSplitter.tryMergeAttrStrategy(qf1, qf2)
       res must not(beNull)
       res.primary must beSome(ff.or(q1, q2))
@@ -1055,9 +1056,9 @@ class AttributeIndexStrategyTest extends Specification with TestWithFeatureType 
       val q1 = ff.equals(ff.property("name"), ff.literal("1"))
       val q2 = ff.equals(ff.property("name"), ff.literal("2"))
       val q3 = ff.equals(ff.property("name"), ff.literal("3"))
-      val qf1 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q1), None, temporal = false, 0L)
-      val qf2 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q2), None, temporal = false, 0L)
-      val qf3 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q3), None, temporal = false, 0L)
+      val qf1 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q1), None, temporal = false, 0L, new Hints())
+      val qf2 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q2), None, temporal = false, 0L, new Hints())
+      val qf3 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q3), None, temporal = false, 0L, new Hints())
       val res = FilterSplitter.tryMergeAttrStrategy(FilterSplitter.tryMergeAttrStrategy(qf1, qf2), qf3)
       res must not(beNull)
       res.primary.map(decomposeOr) must beSome(containTheSameElementsAs(Seq[Filter](q1, q2, q3)))
@@ -1068,9 +1069,9 @@ class AttributeIndexStrategyTest extends Specification with TestWithFeatureType 
       val q1 = ff.equals(ff.property("name"), ff.literal("1"))
       val q2 = ff.equals(ff.property("name"), ff.literal("2"))
       val q3 = ff.equals(ff.property("name"), ff.literal("3"))
-      val qf1 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q1), Some(bbox), temporal = false, 0L)
-      val qf2 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q2), Some(bbox), temporal = false, 0L)
-      val qf3 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q3), Some(bbox), temporal = false, 0L)
+      val qf1 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q1), Some(bbox), temporal = false, 0L, new Hints())
+      val qf2 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q2), Some(bbox), temporal = false, 0L, new Hints())
+      val qf3 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q3), Some(bbox), temporal = false, 0L, new Hints())
       val res = FilterSplitter.tryMergeAttrStrategy(FilterSplitter.tryMergeAttrStrategy(qf1, qf2), qf3)
       res must not(beNull)
       res.primary.map(decomposeOr) must beSome(containTheSameElementsAs(Seq[Filter](q1, q2, q3)))
@@ -1081,8 +1082,8 @@ class AttributeIndexStrategyTest extends Specification with TestWithFeatureType 
       val bbox = ff.bbox(ff.property("geom"), new ReferencedEnvelope(1, 3, 2, 4, CRS_EPSG_4326))
       val q1 = ff.equals(ff.property("name"), ff.literal("1"))
       val q2 = ff.equals(ff.property("name"), ff.literal("2"))
-      val qf1 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q1), Some(bbox), temporal = false, 0L)
-      val qf2 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q2), None, temporal = false, 0L)
+      val qf1 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q1), Some(bbox), temporal = false, 0L, new Hints())
+      val qf2 = FilterStrategy(new AttributeIndex(ds, sft, "name", Seq.empty, IndexMode.ReadWrite), Some(q2), None, temporal = false, 0L, new Hints())
       val res = FilterSplitter.tryMergeAttrStrategy(qf1, qf2)
       res must beNull
     }

--- a/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/accumulo/jobs/AccumuloJobUtils.scala
+++ b/geomesa-accumulo/geomesa-accumulo-jobs/src/main/scala/org/locationtech/geomesa/accumulo/jobs/AccumuloJobUtils.scala
@@ -17,7 +17,7 @@ import org.locationtech.geomesa.accumulo.data.AccumuloQueryPlan.EmptyPlan
 import org.locationtech.geomesa.accumulo.data.{AccumuloDataStore, AccumuloQueryPlan}
 import org.locationtech.geomesa.accumulo.index._
 import org.locationtech.geomesa.filter._
-import org.locationtech.geomesa.index.api.FilterStrategy
+import org.locationtech.geomesa.index.api.{FilterStrategy, QueryStrategy}
 import org.locationtech.geomesa.jobs.JobUtils
 import org.locationtech.geomesa.utils.classpath.ClassPathUtils
 import org.locationtech.geomesa.utils.index.IndexMode
@@ -75,7 +75,9 @@ object AccumuloJobUtils extends LazyLogging {
       val queryPlans = ds.getQueryPlan(query)
 
       if (queryPlans.isEmpty) {
-        EmptyPlan(FilterStrategy(fallbackIndex, None, Some(Filter.EXCLUDE), temporal = false, Float.PositiveInfinity))
+        val filter =
+          FilterStrategy(fallbackIndex, None, Some(Filter.EXCLUDE), temporal = false, Float.PositiveInfinity, query.getHints)
+        EmptyPlan(QueryStrategy(filter, Seq.empty, Seq.empty, Seq.empty, filter.filter, None))
       } else if (queryPlans.lengthCompare(1) > 0) {
         // this query requires multiple scans, which we can't execute from some input formats
         // instead, fall back to a full table scan
@@ -121,7 +123,9 @@ object AccumuloJobUtils extends LazyLogging {
 
       val queryPlans = ds.getQueryPlan(query)
       if (queryPlans.isEmpty) {
-        Seq(EmptyPlan(FilterStrategy(fallbackIndex, None, Some(Filter.EXCLUDE), temporal = false, Float.PositiveInfinity)))
+        val filter =
+          FilterStrategy(fallbackIndex, None, Some(Filter.EXCLUDE), temporal = false, Float.PositiveInfinity, query.getHints)
+        Seq(EmptyPlan(QueryStrategy(filter, Seq.empty, Seq.empty, Seq.empty, filter.filter, None)))
       } else {
         queryPlans
       }

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraQueryPlan.scala
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/main/scala/org/locationtech/geomesa/cassandra/data/CassandraQueryPlan.scala
@@ -13,7 +13,7 @@ import com.datastax.driver.core.{Row, Statement}
 import org.geotools.api.filter.Filter
 import org.locationtech.geomesa.cassandra.utils.CassandraBatchScan
 import org.locationtech.geomesa.index.api.QueryPlan.{FeatureReducer, ResultsToFeatures}
-import org.locationtech.geomesa.index.api.{FilterStrategy, QueryPlan}
+import org.locationtech.geomesa.index.api.{QueryPlan, QueryStrategy}
 import org.locationtech.geomesa.index.utils.Explainer
 import org.locationtech.geomesa.index.utils.Reprojection.QueryReferenceSystems
 import org.locationtech.geomesa.index.utils.ThreadManagement.Timeout
@@ -50,7 +50,7 @@ object CassandraQueryPlan {
 }
 
 // plan that will not actually scan anything
-case class EmptyPlan(filter: FilterStrategy, reducer: Option[FeatureReducer] = None) extends CassandraQueryPlan {
+case class EmptyPlan(strategy: QueryStrategy, reducer: Option[FeatureReducer] = None) extends CassandraQueryPlan {
   override val tables: Seq[String] = Seq.empty
   override val ranges: Seq[Statement] = Seq.empty
   override val numThreads: Int = 0
@@ -63,7 +63,7 @@ case class EmptyPlan(filter: FilterStrategy, reducer: Option[FeatureReducer] = N
 }
 
 case class StatementPlan(
-    filter: FilterStrategy,
+    strategy: QueryStrategy,
     tables: Seq[String],
     ranges: Seq[Statement],
     numThreads: Int,
@@ -76,6 +76,8 @@ case class StatementPlan(
     projection: Option[QueryReferenceSystems]
   ) extends CassandraQueryPlan {
 
-  override def scan(ds: CassandraDataStore): CloseableIterator[Row] =
+  override def scan(ds: CassandraDataStore): CloseableIterator[Row] = {
+    strategy.runGuards(ds) // query guard hook - also handles full table scan checks
     CassandraBatchScan(this, ds.session, ranges, numThreads, ds.config.queries.timeout.map(Timeout.apply))
+  }
 }

--- a/geomesa-hbase/geomesa-hbase-rpc/src/main/scala/org/locationtech/geomesa/hbase/rpc/filter/CqlTransformFilter.scala
+++ b/geomesa-hbase/geomesa-hbase-rpc/src/main/scala/org/locationtech/geomesa/hbase/rpc/filter/CqlTransformFilter.scala
@@ -567,7 +567,7 @@ object CqlTransformFilter extends StrictLogging {
 
     override def tieredKeySpace: Option[IndexKeySpace[_, _]] = throw new NotImplementedError()
 
-    override def getFilterStrategy(filter: Filter, transform: Option[SimpleFeatureType]): Option[FilterStrategy] =
+    override def getFilterStrategy(filter: Filter, hints: Hints): Option[FilterStrategy] =
       throw new NotImplementedError()
 
     override def getIdFromRow(row: Array[Byte], offset: Int, length: Int, feature: SimpleFeature): String = ""

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/IndexAdapter.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/IndexAdapter.scala
@@ -13,6 +13,7 @@ import org.locationtech.geomesa.index.api.IndexAdapter.IndexWriter
 import org.locationtech.geomesa.index.api.WritableFeature.FeatureWrapper
 import org.locationtech.geomesa.index.conf.ColumnGroups
 import org.locationtech.geomesa.index.geotools.GeoMesaDataStore
+import org.locationtech.geomesa.index.utils.{ExplainNull, Explainer}
 import org.locationtech.geomesa.security.VisibilityChecker
 
 import java.io.{Closeable, Flushable}
@@ -83,6 +84,16 @@ trait IndexAdapter[DS <: GeoMesaDataStore[DS]] {
     * @return
     */
   def createQueryPlan(strategy: QueryStrategy): QueryPlan[DS]
+
+  /**
+   * Gets the cost of running a filter strategy, if possible. The exact values returned do not matter, as long as they
+   * are consistent relative to each other
+   *
+   * @param strategy strategy to evaluate
+   * @param explain explainer
+   * @return
+   */
+  def getStrategyCost(strategy: FilterStrategy, explain: Explainer = ExplainNull): Option[Long]
 }
 
 object IndexAdapter {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/QueryPlan.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/api/QueryPlan.scala
@@ -36,11 +36,18 @@ trait QueryPlan[DS <: GeoMesaDataStore[DS]] {
   type Results
 
   /**
-    * Reference back to the strategy
+    * Reference back to the query strategy
     *
     * @return
     */
-  def filter: FilterStrategy
+  def strategy: QueryStrategy
+
+  /**
+   * Reference back to the filter strategy
+   *
+   * @return
+   */
+  def filter: FilterStrategy = strategy.filter
 
   /**
     * Runs the query plan against the underlying database

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryHints.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryHints.scala
@@ -36,7 +36,6 @@ object QueryHints {
 
   val STATS_STRING     = new ClassKey(classOf[java.lang.String])
   val ENCODE_STATS     = new ClassKey(classOf[java.lang.Boolean])
-  val MAP_AGGREGATION  = new ClassKey(classOf[java.lang.String])
 
   val EXACT_COUNT      = new ClassKey(classOf[java.lang.Boolean])
   val LOOSE_BBOX       = new ClassKey(classOf[java.lang.Boolean])
@@ -148,10 +147,7 @@ object QueryHints {
 
     def isStatsQuery: Boolean = hints.containsKey(STATS_STRING)
     def getStatsQuery: String = hints.get(STATS_STRING).asInstanceOf[String]
-    // noinspection ExistsEquals
-    def isStatsEncode: Boolean = Option(hints.get(ENCODE_STATS).asInstanceOf[Boolean]).exists(_ == true)
-    def isMapAggregatingQuery: Boolean = hints.containsKey(MAP_AGGREGATION)
-    def getMapAggregatingAttribute: String = hints.get(MAP_AGGREGATION).asInstanceOf[String]
+    def isStatsEncode: Boolean = Option(hints.get(ENCODE_STATS).asInstanceOf[java.lang.Boolean]).exists(Boolean.unbox)
     def getTransformDefinition: Option[String] = Option(hints.get(Internal.TRANSFORMS).asInstanceOf[String])
     def getTransformSchema: Option[SimpleFeatureType] =
       Option(hints.get(Internal.TRANSFORM_SCHEMA).asInstanceOf[SimpleFeatureType])

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryProperties.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/conf/QueryProperties.scala
@@ -37,7 +37,7 @@ object QueryProperties {
   val S2MaxCells: Int = S2CoverConfig(3)
 
   // allow for full table scans or preempt them due to size of data set
-  val BlockFullTableScans = SystemProperty("geomesa.scan.block-full-table", "false")
+  val BlockFullTableScans: SystemProperty = SystemProperty("geomesa.scan.block-full-table")
 
   val BlockMaxThreshold: SystemProperty = SystemProperty("geomesa.scan.block-full-table.threshold", "1000")
 
@@ -49,6 +49,7 @@ object QueryProperties {
    */
   def blockFullTableScansForFeatureType(typeName: String): Option[Boolean] = {
     Option(GeoMesaSystemProperties.getProperty(s"geomesa.scan.$typeName.block-full-table"))
-        .map(java.lang.Boolean.parseBoolean)
+      .map(java.lang.Boolean.parseBoolean)
+      .orElse(BlockFullTableScans.toBoolean)
   }
 }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/EmptyIndex.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/index/EmptyIndex.scala
@@ -29,7 +29,7 @@ class EmptyIndex(ds: GeoMesaDataStore[_], sft: SimpleFeatureType)
     extends GeoMesaFeatureIndex[String, String](ds, sft, EmptyIndex.name, EmptyIndex.version, Seq.empty, IndexMode.Read) {
   override val keySpace: IndexKeySpace[String, String] = new EmptyKeySpace(sft)
   override def tieredKeySpace: Option[IndexKeySpace[_, _]] = None
-  override def getFilterStrategy(filter: Filter, transform: Option[SimpleFeatureType]): Option[FilterStrategy] = None
+  override def getFilterStrategy(filter: Filter, hints: Hints): Option[FilterStrategy] = None
 }
 
 object EmptyIndex extends NamedIndex {

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/guard/DefaultQueryGuard.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/planning/guard/DefaultQueryGuard.scala
@@ -10,15 +10,18 @@ package org.locationtech.geomesa.index.planning.guard
 
 import org.geotools.api.data.{DataStore, Query}
 import org.geotools.api.feature.simple.SimpleFeatureType
-import org.locationtech.geomesa.index.api._
+import org.locationtech.geomesa.index.api.QueryStrategy
 import org.locationtech.geomesa.index.planning.QueryInterceptor
 
-class FullTableScanQueryGuard extends QueryInterceptor {
+/**
+ * Query guard that enforces the default full table scan checks
+ */
+class DefaultQueryGuard extends QueryInterceptor {
 
   override def init(ds: DataStore, sft: SimpleFeatureType): Unit = {}
 
   override def guard(strategy: QueryStrategy): Option[IllegalArgumentException] =
-    strategy.index.checkQueryBlock(strategy, blockByDefault = true)
+    strategy.index.checkQueryBlock(strategy, blockByDefault = false)
 
   override def rewrite(query: Query): Unit = {}
 

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/strategies/AttributeFilterStrategy.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/strategies/AttributeFilterStrategy.scala
@@ -12,6 +12,7 @@ import org.geotools.api.feature.simple.SimpleFeatureType
 import org.geotools.api.filter._
 import org.geotools.api.filter.expression.{Expression, PropertyName}
 import org.geotools.api.filter.temporal.{After, Before, During, TEquals}
+import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.filter.visitor.FilterExtractingVisitor
 import org.locationtech.geomesa.index.api.{FilterStrategy, GeoMesaFeatureIndex}
@@ -29,7 +30,7 @@ trait AttributeFilterStrategy[T, U] extends GeoMesaFeatureIndex[T, U] {
   private val isList = descriptor.isList
   private val binding = if (isList) { descriptor.getListType() } else { descriptor.getType.getBinding }
 
-  override def getFilterStrategy(filter: Filter, transform: Option[SimpleFeatureType]): Option[FilterStrategy] = {
+  override def getFilterStrategy(filter: Filter, hints: Hints): Option[FilterStrategy] = {
 
     val (primary, secondary) =
       FilterExtractingVisitor(filter, attribute, sft, AttributeFilterStrategy.attributeCheck(sft))
@@ -54,7 +55,7 @@ trait AttributeFilterStrategy[T, U] extends GeoMesaFeatureIndex[T, U] {
           case Cardinality.UNKNOWN => basePriority
           case Cardinality.LOW     => basePriority * 10f
         }
-        Some(FilterStrategy(this, primary, secondary, temporal, priority))
+        Some(FilterStrategy(this, primary, secondary, temporal, priority, hints))
       }
     }
   }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/strategies/IdFilterStrategy.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/strategies/IdFilterStrategy.scala
@@ -8,25 +8,25 @@
 
 package org.locationtech.geomesa.index.strategies
 
-import org.geotools.api.feature.simple.SimpleFeatureType
 import org.geotools.api.filter.{And, Filter, Id, Or}
+import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.filter.visitor.IdExtractingVisitor
 import org.locationtech.geomesa.index.api.{FilterStrategy, GeoMesaFeatureIndex}
 
 trait IdFilterStrategy[T, U] extends GeoMesaFeatureIndex[T, U] {
 
-  override def getFilterStrategy(filter: Filter, transform: Option[SimpleFeatureType]): Option[FilterStrategy] = {
+  override def getFilterStrategy(filter: Filter, hints: Hints): Option[FilterStrategy] = {
     if (filter == Filter.INCLUDE) {
-      Some(FilterStrategy(this, None, None, temporal = false, Float.PositiveInfinity))
+      Some(FilterStrategy(this, None, None, temporal = false, Float.PositiveInfinity, hints))
     } else {
       val (ids, notIds) = IdExtractingVisitor(filter)
       if (ids.isDefined) {
         // top-priority index if there are actually ID filters
         // note: although there's no temporal predicate, there's an implied exact date for the given feature
-        Some(FilterStrategy(this, ids, notIds, temporal = true, .001f))
+        Some(FilterStrategy(this, ids, notIds, temporal = true, .001f, hints))
       } else {
-        Some(FilterStrategy(this, None, Some(filter), temporal = false, Float.PositiveInfinity))
+        Some(FilterStrategy(this, None, Some(filter), temporal = false, Float.PositiveInfinity, hints))
       }
     }
   }

--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/strategies/SpatialFilterStrategy.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/strategies/SpatialFilterStrategy.scala
@@ -8,8 +8,8 @@
 
 package org.locationtech.geomesa.index.strategies
 
-import org.geotools.api.feature.simple.SimpleFeatureType
 import org.geotools.api.filter.{And, Filter, Or}
+import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.filter._
 import org.locationtech.geomesa.filter.visitor.FilterExtractingVisitor
 import org.locationtech.geomesa.index.api.{FilterStrategy, GeoMesaFeatureIndex}
@@ -21,15 +21,15 @@ trait SpatialFilterStrategy[T, U] extends GeoMesaFeatureIndex[T, U] {
   // attributes are assumed to be a single geometry field
   lazy private val Seq(geom) = attributes
 
-  override def getFilterStrategy(filter: Filter, transform: Option[SimpleFeatureType]): Option[FilterStrategy] = {
+  override def getFilterStrategy(filter: Filter, hints: Hints): Option[FilterStrategy] = {
     if (filter == Filter.INCLUDE) {
-      Some(FilterStrategy(this, None, None, temporal = false, Float.PositiveInfinity))
+      Some(FilterStrategy(this, None, None, temporal = false, Float.PositiveInfinity, hints))
     } else {
       val (spatial, nonSpatial) = FilterExtractingVisitor(filter, geom, sft, spatialCheck)
       if (spatial.nonEmpty) {
-        Some(FilterStrategy(this, spatial, nonSpatial, temporal = false, 1.2f))
+        Some(FilterStrategy(this, spatial, nonSpatial, temporal = false, 1.2f, hints))
       } else {
-        Some(FilterStrategy(this, None, Some(filter), temporal = false, Float.PositiveInfinity))
+        Some(FilterStrategy(this, None, Some(filter), temporal = false, Float.PositiveInfinity, hints))
       }
     }
   }

--- a/geomesa-utils-parent/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/conf/GeoMesaSystemProperties.scala
+++ b/geomesa-utils-parent/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/conf/GeoMesaSystemProperties.scala
@@ -41,6 +41,8 @@ object GeoMesaSystemProperties extends LazyLogging {
       }
     }
 
+    def toJavaDuration: Option[java.time.Duration] = toDuration.map(d => java.time.Duration.ofMillis(d.toMillis))
+
     def toMillis: Option[Long] = toDuration.map(_.toMillis)
 
     def toUnboundedDuration: Option[Duration] = option.flatMap { value =>

--- a/geomesa-utils-parent/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
+++ b/geomesa-utils-parent/geomesa-utils/src/main/scala/org/locationtech/geomesa/utils/geotools/Conversions.scala
@@ -340,6 +340,8 @@ object RichSimpleFeatureType extends Conversions {
 
     def getRemoteVersion: Option[SemanticVersion] = userData[String](RemoteVersion).map(SemanticVersion.apply)
 
+    def getQueryInterceptors: Seq[String] = userData[String](QueryInterceptors).toSeq.flatMap(_.split(","))
+
     def getKeywords: Set[String] =
       userData[String](Keywords).map(_.split(KeywordsDelimiter).toSet).getOrElse(Set.empty)
 


### PR DESCRIPTION
* `stats` cost evaluation for Accumulo now uses tablets scanned instead of cached stat estimates
* Query interceptors moved to a scan-time check instead of plan time