### PR TITLE
GEOMESA-3467 Upgrade to Parquet 1.15.1

### DIFF
--- a/build/cqs.tsv
+++ b/build/cqs.tsv
@@ -134,6 +134,7 @@ jakarta.inject:jakarta.inject-api	2.0.0	compile
 jakarta.inject:jakarta.inject-api	2.0.1	compile
 jakarta.transaction:jakarta.transaction-api	1.3.3	compile
 javax.annotation:javax.annotation-api	1.2	compile
+javax.annotation:javax.annotation-api	1.3.2	compile
 javax.measure:unit-api	2.2	compile
 joda-time:joda-time	2.12.6	compile
 net.java.dev.jna:jna	5.14.0	compile
@@ -194,11 +195,11 @@ org.apache.httpcomponents:httpcore	4.4.16	compile
 org.apache.orc:orc-core	nohive:1.9.5	compile
 org.apache.orc:orc-mapreduce	nohive:1.9.5	compile
 org.apache.orc:orc-shims	1.9.5	compile
-org.apache.parquet:parquet-column	1.13.1	compile
-org.apache.parquet:parquet-common	1.13.1	compile
-org.apache.parquet:parquet-encoding	1.13.1	compile
-org.apache.parquet:parquet-format-structures	1.13.1	compile
-org.apache.parquet:parquet-hadoop	1.13.1	compile
+org.apache.parquet:parquet-column	1.15.1	compile
+org.apache.parquet:parquet-common	1.15.1	compile
+org.apache.parquet:parquet-encoding	1.15.1	compile
+org.apache.parquet:parquet-format-structures	1.15.1	compile
+org.apache.parquet:parquet-hadoop	1.15.1	compile
 org.apache.thrift:libthrift	0.12.0	compile
 org.apache.thrift:libthrift	0.17.0	compile
 org.apache.xml:xml-commons-resolver	1.2	compile

--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -102,6 +102,7 @@ The following dependencies have been upgraded:
 * json4s ``3.6.12`` -> ``4.0.7``
 * json-smart ``2.5.1`` -> ``2.5.2``
 * netty ``4.1.114.Final`` -> ``4.1.118.Final``
+* parquet ``1.13.1`` -> ``1.15.1``
 * spark ``3.5.0`` -> ``3.5.5``
 
 NiFi 2 Support

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/fs/storage/parquet/ParquetPathReader.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/main/scala/org/locationtech/geomesa/fs/storage/parquet/ParquetPathReader.scala
@@ -48,7 +48,7 @@ class ParquetPathReader(
   private class ParquetFileIterator(path: Path) extends CloseableIterator[SimpleFeature] {
 
     private val reader: ParquetReader[SimpleFeature] =
-      ParquetReader.builder(new SimpleFeatureReadSupport, path).withFilter(parquetFilter).withConf(conf).build()
+      ParquetReader.builder(new SimpleFeatureReadSupport, path).withConf(conf).withFilter(parquetFilter).build()
 
     private var staged: SimpleFeature = _
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/ParquetStorageTest.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/ParquetStorageTest.scala
@@ -355,7 +355,7 @@ class ParquetStorageTest extends Specification with AllExpectations with LazyLog
       }
 
       // note: this is somewhat of a magic number, in that it works the first time through with no remainder
-      val targetSize = 2100L
+      val targetSize = 2400L
 
       withTestDir { dir =>
         val context = FileSystemContext(dir, config)

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <orc.version>1.9.5</orc.version>
         <parboiled.version>1.4.1</parboiled.version>
         <parboiled.scala.version>1.3.1</parboiled.scala.version>
-        <parquet.version>1.13.1</parquet.version>
+        <parquet.version>1.15.1</parquet.version>
         <postgres.version>42.7.2</postgres.version>
         <prometheus.version>1.3.1</prometheus.version>
         <pureconfig.version>0.17.4</pureconfig.version>


### PR DESCRIPTION
* Allows for hadoop `parquet.hadoop.vectored.io.enabled` flag