### PR TITLE
GEOMESA-3578 FSDS - Standardize target file size

### DIFF
--- a/docs/user/filesystem/commandline.rst
+++ b/docs/user/filesystem/commandline.rst
@@ -44,7 +44,6 @@ Argument                 Description
 ``-p, --path *``         The filesystem root path used to store data
 ``-f, --feature-name *`` The name of the schema
 ``--partitions``         Partitions to compact (omit to compact all partitions)
-``--target-file-size``   Target size for data files (e.g. 500MB or 1GB)
 ``--mode``               One of ``local`` or ``distributed`` (to use map/reduce)
 ``--temp-path``          Path to a temp directory used for working files
 ======================== =========================================================
@@ -113,7 +112,6 @@ Argument                 Description
 ``-p, --path *``         The filesystem root path used to store data
 ``--partition-scheme``   Partition schemes
 ``--num-reducers``       Number of reducers to use (required for distributed ingest)
-``--target-file-size``   Target size for data files (e.g. 500MB or 1GB)
 ``--temp-path``          Path to a temp directory used for working files
 ``--storage-opt``        Additional storage options to set as SimpleFeatureType user data, in the form ``key=value``
 ======================== =============================================================
@@ -137,6 +135,7 @@ sub-commands:
 
 * ``register`` - create a new metadata entry for an existing data file
 * ``unregister`` - remove a metadata entry for an existing data file
+* ``configure`` - set or unset metadata configuration values
 * ``migrate`` - migrate metadata from one type to another
 * ``check-consistency`` - check consistency between the metadata and data files
 
@@ -174,6 +173,17 @@ The ``unregister`` sub-command will the delete metadata associated with a partic
 Argument                 Description
 ======================== =====================================================================================================
 ``<file> *``             The path of the file to unregister, relative to the storage root path
+======================== =====================================================================================================
+
+``configure``
+~~~~~~~~~~~~~
+
+The ``configure`` sub-command lets you set storage-level configuration options.
+
+======================== =====================================================================================================
+Argument                 Description
+======================== =====================================================================================================
+``--set *``              The configuration to set, in the form ``key=value``. To remove a key, use an empty value
 ======================== =====================================================================================================
 
 ``migrate``

--- a/docs/user/filesystem/index_config.rst
+++ b/docs/user/filesystem/index_config.rst
@@ -75,9 +75,9 @@ the user data key ``geomesa.fs.file-size``:
         // or set directly in the user data as a string
         sft.getUserData.put("geomesa.fs.file-size", "1GB")
 
-Note that target file size can also be specified in some operations, which will override any default configured
-in the feature type. See :ref:`fsds_compact_command` and :ref:`fsds_ingest_command` for details. See
-:ref:`fsds_size_threshold_prop` for controlling the file size error margin.
+Once the schema has been created, the file size can be configured through the storage metadata key ``target-file-size``. See
+:ref:`fsds_manage_metadata_command` for setting metadata keys, and see :ref:`fsds_size_threshold_prop` for controlling the file
+size error margin.
 
 Configuring Visibility Persistence
 ----------------------------------

--- a/geomesa-features/geomesa-feature-exporters/src/main/scala/org/locationtech/geomesa/features/exporters/GeoParquetExporter.scala
+++ b/geomesa-features/geomesa-feature-exporters/src/main/scala/org/locationtech/geomesa/features/exporters/GeoParquetExporter.scala
@@ -54,7 +54,7 @@ class GeoParquetExporter(path: String) extends FeatureExporter with LazyLogging 
     Some(i)
   }
 
-  override def bytes: Long = if (writer == null) { 0 } else { writer.getDataSize }
+  override def bytes: Long = if (writer == null) { 0 } else { writer.size }
 
   override def close(): Unit = CloseWithLogging(Seq(writer, fs).filter(_ != null))
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterStorage.scala
@@ -44,7 +44,7 @@ class ConverterStorage(
     new ConverterFileSystemReader(fs, context.root, converter, filter, transform, pathFiltering)
   }
 
-  override def compact(partition: Partition, fileSize: Option[Long], threads: Int): Unit =
+  override def compact(partition: Partition, threads: Int): Unit =
     throw new UnsupportedOperationException("Converter storage does not support compactions")
 
   override def register(file: URI): StorageFile =

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/FileSystemStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/FileSystemStorage.scala
@@ -171,13 +171,11 @@ abstract class FileSystemStorage(val context: FileSystemContext, val metadata: S
    * multiple threads or storage instances attempt to compact the same partition simultaneously.
    *
    * @param partition partition to compact, or all partitions
-   * @param fileSize approximate target size of files, in bytes
    * @param threads suggested threads to use for file system operations
    */
-  def compact(partition: Partition, fileSize: Option[Long] = None, threads: Int = 1): Unit = {
-    val target = fileSize.orElse(this.sizer.targetSize)
+  def compact(partition: Partition, threads: Int = 1): Unit = {
     val files = metadata.getFiles(partition)
-    val toCompact = target match {
+    val toCompact = sizer.targetSize match {
       case None => files
       case Some(t) =>
         files.filter { f =>
@@ -201,7 +199,7 @@ abstract class FileSystemStorage(val context: FileSystemContext, val metadata: S
       // tracks newly added files so we can register them atomically
       val fileTracker = new FileTracker(metadata.sft, metadata.schemes)
 
-      WithClose(createWriter(partition, StorageFileAction.Append, FileType.Compacted, target, fileTracker)) { writer =>
+      WithClose(createWriter(partition, StorageFileAction.Append, FileType.Compacted, fileTracker)) { writer =>
         WithClose(FileSystemThreadedReader(reader, toCompact, threads)) { reader =>
           while (reader.hasNext) {
             val feature = reader.next()
@@ -265,7 +263,7 @@ abstract class FileSystemStorage(val context: FileSystemContext, val metadata: S
       case StorageFileAction.Modify => FileType.Modified
       case StorageFileAction.Delete => FileType.Deleted
     }
-    createWriter(partition, action, fileType, sizer.targetSize, metadata)
+    createWriter(partition, action, fileType, metadata)
   }
 
   /**
@@ -274,7 +272,6 @@ abstract class FileSystemStorage(val context: FileSystemContext, val metadata: S
    * @param partition partition being written to
    * @param action write type
    * @param fileType file type
-   * @param targetFileSize target file size
    * @param metadata metata to track added files
    * @return
    */
@@ -282,22 +279,21 @@ abstract class FileSystemStorage(val context: FileSystemContext, val metadata: S
       partition: Partition,
       action: StorageFileAction,
       fileType: FileType,
-      targetFileSize: Option[Long],
       metadata: StorageMetadata): FileSystemWriter = {
 
-    def pathAndWriter: (URI, FileSystemWriter) = {
+    def newWriter(): FileSystemWriter = {
       val file = FileSystemStorage.newFilePath(metadata.sft.getTypeName, fileType, encoding)
       val path = context.root.resolve(file)
       val updateObserver = new MetadataObserver(metadata, file, partition, action)
       val observer = if (observers.isEmpty) { updateObserver } else {
         new CompositeObserver(observers.map(_.apply(path)).+:(updateObserver))
       }
-      (path, createWriter(path, partition, observer))
+      createWriter(path, partition, observer)
     }
 
-    targetFileSize match {
-      case None => pathAndWriter._2
-      case Some(s) => new ChunkedFileSystemWriter(fs, Iterator.continually(pathAndWriter), sizer.estimator(s))
+    sizer.targetSize match {
+      case None => newWriter()
+      case Some(s) => new ChunkedFileSystemWriter(Iterator.continually(newWriter()), sizer.estimator(s))
     }
   }
 }
@@ -345,46 +341,53 @@ object FileSystemStorage {
       * @param feature feature
       */
     def write(feature: SimpleFeature): Unit
+
+    /**
+     * Gets the size of the data written so far, in bytes. May not be accurate until the writer is
+     * closed, due to buffering, etc
+     *
+     * @return
+     */
+    def size: Long
   }
 
   /**
    * Writes files up to a given size, then starts a new file
    *
-   * @param fs file system
    * @param writers iterator of files to write
    * @param estimator target file size estimator
    */
-  private class ChunkedFileSystemWriter(
-      fs: ObjectStore,
-      writers: Iterator[(URI, FileSystemWriter)],
-      estimator: UpdatingFileSizeEstimator
-    ) extends FileSystemWriter {
+  class ChunkedFileSystemWriter(writers: Iterator[FileSystemWriter], estimator: UpdatingFileSizeEstimator)
+      extends FileSystemWriter {
 
-    private var count = 0L // number of features written
-    private var total = 0L // sum size of all finished chunks
+    private var totalCount = 0L // total number of features written across all chunks
+    private var totalBytes = 0L // sum size of all finished chunks
     private var remaining = estimator.estimate(0L)
-
-    private var path: URI = _
     private var writer: FileSystemWriter = _
 
     override def write(feature: SimpleFeature): Unit = {
       if (writer == null) {
-        val (path, writer) = writers.next()
-        this.path = path
-        this.writer = writer
+        writer = writers.next()
       }
       writer.write(feature)
-      count += 1
+      totalCount += 1
       remaining -= 1
       if (remaining == 0) {
-        writer.close()
-        writer = null
-        // adjust our estimate to account for the actual bytes written
-        total += fs.size(path)
-        estimator.update(total, count)
-        remaining = estimator.estimate(0L)
+        val dataSize = writer.size
+        if (estimator.done(dataSize)) {
+          writer.close()
+          totalBytes += writer.size // re-calculate now that writer is closed, so we get the final, accurate size
+          writer = null
+          // adjust our estimate to account for the actual bytes written
+          estimator.update(totalBytes, totalCount)
+          remaining = estimator.estimate(0L)
+        } else {
+          remaining = math.max(100L, estimator.estimate(dataSize))
+        }
       }
     }
+
+    override def size: Long = totalBytes + Option(writer).fold(0L)(_.size)
 
     override def flush(): Unit = if (writer != null) { writer.flush() }
 

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/StorageMetadata.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/StorageMetadata.scala
@@ -98,7 +98,7 @@ trait StorageMetadata extends Closeable {
    * Set a key-value pair
    *
    * @param key key
-   * @param value value
+   * @param value value - may be null
    */
   def set(key: String, value: String): Unit = throw new UnsupportedOperationException()
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/metadata/FileBasedMetadata.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/metadata/FileBasedMetadata.scala
@@ -62,7 +62,11 @@ class FileBasedMetadata(fs: ObjectStore, meta: Metadata, directory: URI)
 
   // note: this isn't synchronized across jvms
   override def set(key: String, value: String): Unit = FileBasedMetadata.synchronized {
-    kvs.put(key, value)
+    if (value == null) {
+      kvs.remove(key)
+    } else {
+      kvs.put(key, value)
+    }
     WithClose(fs.overwrite(metadataFilePath)) { out =>
       MetadataSerialization.serialize(out, meta.copy(config = kvs.asScala.toMap))
     }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/metadata/JdbcMetadata.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/metadata/JdbcMetadata.scala
@@ -118,7 +118,11 @@ class JdbcMetadata(
   override def get(key: String): Option[String] = Option(kvs.get(key))
 
   override def set(key: String, value: String): Unit = {
-    kvs.put(key, value)
+    if (value == null) {
+      kvs.remove(key)
+    } else {
+      kvs.put(key, value)
+    }
     WithClose(pool.getConnection()) { connection =>
       metaTable.update(connection, root, meta.copy(config = kvs.asScala.toMap))
     }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/metadata/JdbcMetadata.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/metadata/JdbcMetadata.scala
@@ -345,7 +345,7 @@ object JdbcMetadata extends LazyLogging {
     private val spatialBoundsTable = s""""$schema"."${tablePrefix}spatial_bounds""""
     private val attrBoundsTable = s""""$schema"."${tablePrefix}attr_bounds""""
 
-    def create(cx: Connection): FilesTable = {
+    def create(cx: Connection): Unit = {
       WithClose(cx.createStatement()) { st =>
         st.executeUpdate(
           s"""CREATE TABLE IF NOT EXISTS $filesTable (
@@ -403,7 +403,6 @@ object JdbcMetadata extends LazyLogging {
         st.executeUpdate(s"""CREATE INDEX IF NOT EXISTS ${tablePrefix}attr_bounds_idx_bounds ON $attrBoundsTable(attribute, lower, upper);""")
         st.executeUpdate(s"""CREATE INDEX IF NOT EXISTS ${tablePrefix}spatial_bounds_idx_bounds ON $spatialBoundsTable(attribute, x_min, x_max, y_min, y_max);""")
       }
-      this
     }
 
     def insert(cx: Connection, file: StorageFile): Unit = {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/metadata/JdbcMetadata.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/metadata/JdbcMetadata.scala
@@ -14,17 +14,15 @@ import org.apache.commons.dbcp2.{PoolableConnection, PoolingDataSource}
 import org.geotools.api.feature.simple.SimpleFeatureType
 import org.geotools.api.filter.Filter
 import org.locationtech.geomesa.fs.storage.core.StorageMetadata.{AttributeBounds, SpatialBounds, StorageFile}
-import org.locationtech.geomesa.fs.storage.core.metadata.JdbcMetadata.MetadataTable
+import org.locationtech.geomesa.fs.storage.core.metadata.JdbcMetadata.{FilesTable, MetadataTable}
 import org.locationtech.geomesa.fs.storage.core.metadata.SchemeFilterExtraction.{AttributeBound, AttributeOr, SpatialBound, SpatialOr}
 import org.locationtech.geomesa.fs.storage.core.schemes.ZeroChar
 import org.locationtech.geomesa.fs.storage.core.{PartitionScheme, PartitionSchemeFactory}
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.io.WithClose
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
-import java.nio.charset.StandardCharsets
 import java.sql._
 import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
 import scala.Array
 import scala.util.control.NonFatal
 
@@ -40,8 +38,9 @@ import scala.util.control.NonFatal
  *
  * ** root varchar(256) not null
  * ** typeName varchar(256) not null
- * ** meta text not null
- * ** primary key (root, typeName)
+ * ** key varchar(256) not null,
+ * ** value text not null,
+ * ** primary key (root, typeName, key)
  *
  * `storage_files`
  *
@@ -49,6 +48,7 @@ import scala.util.control.NonFatal
  *
  * ** id bigint primary key (generated identity)
  * ** root varchar(256) not null
+ * ** typeName varchar(256) not null
  * ** file varchar(256) not null
  * ** count bigint not null
  * ** action char(1) not null (A=Append, M=Modify, D=Delete)
@@ -87,44 +87,36 @@ import scala.util.control.NonFatal
  * ** primary key (file_id, attribute)
  *
  * @param pool connection pool
- * @param root storage root path
- * @param schema database schema name
- * @param tablePrefix table name prefix
- * @param meta basic metadata config
+ * @param meta metadata table reference
+ * @param files files table reference
+ * @param namespace feature type namespace
  **/
 class JdbcMetadata(
     pool: PoolingDataSource[PoolableConnection],
-    root: String,
-    schema: String,
-    tablePrefix: String,
-    meta: Metadata
+    meta: MetadataTable,
+    files: FilesTable,
+    namespace: Option[String],
   ) extends StorageMetadata with SchemeFilterExtraction with LazyLogging {
 
   // TODO allow for partition changes
 
-  import JdbcMetadata.FilesTable
-
-  import scala.collection.JavaConverters._
-
-  private val metaTable = new MetadataTable(schema, tablePrefix)
-  private val filesTable = new FilesTable(schema, tablePrefix)
-
-  private val kvs = new ConcurrentHashMap[String, String](meta.config.asJava)
-
   override val `type`: String = JdbcMetadata.MetadataType
-  override val sft: SimpleFeatureType = meta.sft
-  override val schemes: Set[PartitionScheme] = meta.partitions.map(PartitionSchemeFactory.load(sft, _)).toSet
 
-  override def get(key: String): Option[String] = Option(kvs.get(key))
+  override val sft: SimpleFeatureType =
+    WithClose(pool.getConnection())(cx => namespaced(meta.selectFeatureType(cx), namespace))
+
+  override val schemes: Set[PartitionScheme] =
+    WithClose(pool.getConnection())(meta.selectPartitionSchemes).map(PartitionSchemeFactory.load(sft, _))
+
+  override def get(key: String): Option[String] = WithClose(pool.getConnection())(meta.select(_, key))
 
   override def set(key: String, value: String): Unit = {
-    if (value == null) {
-      kvs.remove(key)
-    } else {
-      kvs.put(key, value)
-    }
-    WithClose(pool.getConnection()) { connection =>
-      metaTable.update(connection, root, meta.copy(config = kvs.asScala.toMap))
+    WithClose(pool.getConnection()) { cx =>
+      if (value == null) {
+        meta.delete(cx, key)
+      } else {
+        meta.insert(cx, key, value)
+      }
     }
   }
 
@@ -132,7 +124,7 @@ class JdbcMetadata(
     WithClose(pool.getConnection()) { cx =>
       cx.setAutoCommit(false)
       try {
-        filesTable.insert(cx, root, file)
+        files.insert(cx, file)
         cx.commit()
       } catch {
         case NonFatal(e) =>
@@ -148,7 +140,7 @@ class JdbcMetadata(
     WithClose(pool.getConnection()) { cx =>
       cx.setAutoCommit(false)
       try {
-        filesTable.delete(cx, root, file)
+        files.delete(cx, file)
         cx.commit()
       } catch {
         case NonFatal(e) =>
@@ -164,8 +156,8 @@ class JdbcMetadata(
     WithClose(pool.getConnection()) { cx =>
       cx.setAutoCommit(false)
       try {
-        existing.foreach(filesTable.delete(cx, root, _))
-        replacements.foreach(filesTable.insert(cx, root, _))
+        existing.foreach(files.delete(cx, _))
+        replacements.foreach(files.insert(cx, _))
         cx.commit()
       } catch {
         case NonFatal(e) =>
@@ -178,11 +170,11 @@ class JdbcMetadata(
   }
 
   override def getFiles(): Seq[StorageFile] =
-    WithClose(pool.getConnection())(filesTable.select(_, root, Seq.empty, Seq.empty, Seq.empty))
+    WithClose(pool.getConnection())(files.select(_, Seq.empty, Seq.empty, Seq.empty))
 
   override def getFiles(partition: Partition): Seq[StorageFile] = {
     val filters = partition.values.toSeq.map(p => PartitionRange(p.name, p.value, p.value + ZeroChar))
-    WithClose(pool.getConnection())(filesTable.select(_, root, filters, Seq.empty, Seq.empty))
+    WithClose(pool.getConnection())(files.select(_, filters, Seq.empty, Seq.empty))
   }
 
   override def getFiles(filter: Filter): Seq[StorageFile] = {
@@ -195,13 +187,12 @@ class JdbcMetadata(
       } else {
         WithClose(pool.getConnection()) { cx =>
           filters.flatMap { f =>
-            filesTable.select(cx, root, f.partitions, f.spatialBounds, f.attributeBounds)
+            files.select(cx, f.partitions, f.spatialBounds, f.attributeBounds)
           }
         }
       }
     }
   }
-
 
   override def close(): Unit = pool.close()
 }
@@ -265,48 +256,27 @@ object JdbcMetadata extends LazyLogging {
       )
   }
 
-  class MetadataTable(val schema: String, tablePrefix: String) {
+  class MetadataTable(val schema: String, tablePrefix: String, root: String, typeName: String) {
 
     val tableName: String = s"${tablePrefix}meta"
 
     private val qualifiedTableName = s""""$schema"."$tableName""""
 
-    def create(connection: Connection): Unit = {
-      WithClose(connection.createStatement()) { st =>
+    def create(cx: Connection): Unit = {
+      WithClose(cx.createStatement()) { st =>
         st.executeUpdate(
           s"""create table if not exists $qualifiedTableName (
               root varchar(256) not null,
               typeName varchar(256) not null,
-              meta text not null,
-              primary key (root, typeName))"""
+              key varchar(256) not null,
+              value text not null,
+              primary key (root, typeName, key))"""
         )
       }
     }
 
-    def insert(connection: Connection, root: String, metadata: Metadata): Unit = {
-      val serialized = new ByteArrayOutputStream()
-      MetadataSerialization.serialize(serialized, metadata)
-      WithClose(connection.prepareStatement(s"insert into $qualifiedTableName (root, typeName, meta) values (?, ?, ?)")) { st =>
-        st.setString(1, root)
-        st.setString(2, metadata.sft.getTypeName)
-        st.setString(3, new String(serialized.toByteArray, StandardCharsets.UTF_8))
-        st.executeUpdate()
-      }
-    }
-
-    def update(connection: Connection, root: String, metadata: Metadata): Unit = {
-      val serialized = new ByteArrayOutputStream()
-      MetadataSerialization.serialize(serialized, metadata)
-      WithClose(connection.prepareStatement(s"update $qualifiedTableName set meta= ? where root = ? and typeName = ?")) { st =>
-        st.setString(1, new String(serialized.toByteArray, StandardCharsets.UTF_8))
-        st.setString(2, root)
-        st.setString(3, metadata.sft.getTypeName)
-        st.executeUpdate()
-      }
-    }
-
-    def selectTypeNames(connection: Connection, root: String): Seq[String] = {
-      WithClose(connection.prepareStatement(s"select typeName from $qualifiedTableName where root = ?")) { st =>
+    def selectTypeNames(cx: Connection, root: String): Seq[String] = {
+      WithClose(cx.prepareStatement(s"SELECT DISTINCT typeName FROM $qualifiedTableName WHERE root = ?")) { st =>
         st.setString(1, root)
         val builder = Seq.newBuilder[String]
         WithClose(st.executeQuery()) { rs =>
@@ -318,17 +288,49 @@ object JdbcMetadata extends LazyLogging {
       }
     }
 
-    def selectMetadata(connection: Connection, root: String, typeName: String): Metadata = {
-      WithClose(connection.prepareStatement(s"select meta from $qualifiedTableName where root = ? and typeName = ?")) { st =>
+    def insert(cx: Connection, sft: SimpleFeatureType): Unit =
+      insert(cx, "__sft__", SimpleFeatureTypes.encodeType(sft, includeUserData = true))
+
+    def insert(cx: Connection, partitions: Seq[String]): Unit = insert(cx, "__partitions__", partitions.mkString(","))
+
+    def insert(cx: Connection, key: String, value: String): Unit = {
+      val sql =
+        s"INSERT INTO $qualifiedTableName (root, typeName, key, value) " +
+          "VALUES (?, ?, ?, ?) ON CONFLICT (root, typeName, key) DO UPDATE SET value = EXCLUDED.value"
+      WithClose(cx.prepareStatement(sql)) { st =>
         st.setString(1, root)
         st.setString(2, typeName)
+        st.setString(3, key)
+        st.setString(4, value)
+        st.executeUpdate()
+      }
+    }
+
+    def selectFeatureType(cx: Connection): SimpleFeatureType = SimpleFeatureTypes.createType(typeName, select(cx, "__sft__").get)
+
+    def selectPartitionSchemes(cx: Connection): Set[String] = select(cx, "__partitions__").fold(Set.empty[String])(_.split(",").toSet)
+
+    def select(cx: Connection, key: String): Option[String] = {
+      WithClose(cx.prepareStatement(s"SELECT value FROM $qualifiedTableName WHERE root = ? AND typeName = ? AND key = ?")) { st =>
+        st.setString(1, root)
+        st.setString(2, typeName)
+        st.setString(3, key)
         WithClose(st.executeQuery()) { rs =>
           if (rs.next()) {
-            MetadataSerialization.deserialize(new ByteArrayInputStream(rs.getString(1).getBytes(StandardCharsets.UTF_8)))
+            Option(rs.getString(1))
           } else {
-            throw new IllegalArgumentException(s"Type '$typeName' does not exist under root $root")
+            None
           }
         }
+      }
+    }
+
+    def delete(cx: Connection, key: String): Unit = {
+      WithClose(cx.prepareStatement(s"DELETE FROM $qualifiedTableName WHERE root = ? AND typeName = ? AND key = ?")) { st =>
+        st.setString(1, root)
+        st.setString(2, typeName)
+        st.setString(3, key)
+        st.executeUpdate()
       }
     }
   }
@@ -336,19 +338,20 @@ object JdbcMetadata extends LazyLogging {
   /**
     * An add/update/delete partition action. Files associated with each action are stored in the FilesTable
     */
-  class FilesTable(val schema: String, tablePrefix: String) {
+  class FilesTable(val schema: String, tablePrefix: String, root: String, typeName: String) {
 
     private val filesTable = s""""$schema"."${tablePrefix}files""""
     private val partitionsTable = s""""$schema"."${tablePrefix}partitions""""
     private val spatialBoundsTable = s""""$schema"."${tablePrefix}spatial_bounds""""
     private val attrBoundsTable = s""""$schema"."${tablePrefix}attr_bounds""""
 
-    def create(cx: Connection): Unit = {
+    def create(cx: Connection): FilesTable = {
       WithClose(cx.createStatement()) { st =>
         st.executeUpdate(
           s"""CREATE TABLE IF NOT EXISTS $filesTable (
              |  id BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
              |  root VARCHAR(256) NOT NULL,
+             |  typeName varchar(256) not null,
              |  file VARCHAR(256) NOT NULL,
              |  count BIGINT NOT NULL,
              |  action CHAR(1) NOT NULL,
@@ -400,22 +403,24 @@ object JdbcMetadata extends LazyLogging {
         st.executeUpdate(s"""CREATE INDEX IF NOT EXISTS ${tablePrefix}attr_bounds_idx_bounds ON $attrBoundsTable(attribute, lower, upper);""")
         st.executeUpdate(s"""CREATE INDEX IF NOT EXISTS ${tablePrefix}spatial_bounds_idx_bounds ON $spatialBoundsTable(attribute, x_min, x_max, y_min, y_max);""")
       }
+      this
     }
 
-    def insert(cx: Connection, root: String, file: StorageFile): Unit = {
+    def insert(cx: Connection, file: StorageFile): Unit = {
       val id = WithClose(cx.prepareStatement(
-        s"INSERT INTO $filesTable (root, file, count, action, sort, ts) " +
-          "VALUES (?, ?, ?, ?, ?, ?) RETURNING id", Statement.RETURN_GENERATED_KEYS)) { st =>
+        s"INSERT INTO $filesTable (root, typeName, file, count, action, sort, ts) " +
+          "VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id", Statement.RETURN_GENERATED_KEYS)) { st =>
         st.setString(1, root)
-        st.setString(2, file.file)
-        st.setLong(3, file.count)
-        st.setString(4, file.action.toString.substring(0, 1))
+        st.setString(2, typeName)
+        st.setString(3, file.file)
+        st.setLong(4, file.count)
+        st.setString(5, file.action.toString.substring(0, 1))
         if (file.sort.isEmpty) {
-          st.setNull(5, java.sql.Types.ARRAY)
+          st.setNull(6, java.sql.Types.ARRAY)
         } else {
-          st.setArray(5, cx.createArrayOf("integer", file.sort.map(Int.box).toArray[AnyRef]))
+          st.setArray(6, cx.createArrayOf("integer", file.sort.map(Int.box).toArray[AnyRef]))
         }
-        st.setTimestamp(6, Timestamp.from(Instant.ofEpochMilli(file.timestamp)))
+        st.setTimestamp(7, Timestamp.from(Instant.ofEpochMilli(file.timestamp)))
         st.executeUpdate()
         WithClose(st.getGeneratedKeys) { rs =>
           if (rs.next()) {
@@ -459,17 +464,17 @@ object JdbcMetadata extends LazyLogging {
       }
     }
 
-    def delete(cx: Connection, root: String, file: StorageFile): Unit = {
-      WithClose(cx.prepareStatement(s"DELETE FROM $filesTable WHERE root = ? AND file = ?")) { st =>
+    def delete(cx: Connection, file: StorageFile): Unit = {
+      WithClose(cx.prepareStatement(s"DELETE FROM $filesTable WHERE root = ? AND typeName = ? AND file = ?")) { st =>
         st.setString(1, root)
-        st.setString(2, file.file)
+        st.setString(2, typeName)
+        st.setString(3, file.file)
         st.executeUpdate()
       }
     }
 
     def select(
         cx: Connection,
-        root: String,
         partitions: Seq[PartitionRange],
         spatialBounds: Seq[SpatialOr],
         attributeBounds: Seq[AttributeOr],
@@ -515,9 +520,9 @@ object JdbcMetadata extends LazyLogging {
       // in subqueries. This ensures each file returns exactly one row with no Cartesian products.
       // The sp_filter, sb_filter, and ab_filter joins are used for filtering and must remain on the raw tables.
       val whereClause = if (allWhereClauses.isEmpty) {
-        "WHERE sf.root = ?"
+        "WHERE sf.root = ? AND sf.typeName = ?"
       } else {
-        s"WHERE sf.root = ? AND ${allWhereClauses.mkString(" AND ")}"
+        s"WHERE sf.root = ? AND sf.typeName = ? AND ${allWhereClauses.mkString(" AND ")}"
       }
 
       val query =
@@ -573,6 +578,8 @@ object JdbcMetadata extends LazyLogging {
         }
         // set root parameter
         st.setString(paramIndex, root)
+        paramIndex += 1
+        st.setString(paramIndex, typeName)
         paramIndex += 1
         // set spatial bound WHERE clause parameters
         spatialBoundJoins.foreach { join =>

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/metadata/JdbcMetadataCatalog.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/metadata/JdbcMetadataCatalog.scala
@@ -30,25 +30,26 @@ class JdbcMetadataCatalog(context: FileSystemContext) extends StorageMetadataCat
   // fail fast if url is not defined or invalid
   private val conf = JdbcMetadataConfig(context.conf)
   private val driver = JdbcMetadataCatalog.createConnectionFactory(conf)
-  private val metaTable = new MetadataTable(conf.schema, conf.tablePrefix)
   private val root = context.root.toString
 
   override def getTypeNames: Seq[String] = {
+    val meta = new MetadataTable(conf.schema, conf.tablePrefix, root, null)
     WithClose(driver.createConnection()) { cx =>
-      WithClose(cx.getMetaData.getTables(null, metaTable.schema, metaTable.tableName, null)) { rs =>
+      WithClose(cx.getMetaData.getTables(null, meta.schema, meta.tableName, null)) { rs =>
         if (!rs.next()) {
           return Seq.empty
         }
       }
-      metaTable.selectTypeNames(cx, root)
+      meta.selectTypeNames(cx, root)
     }
   }
 
   override def load(typeName: String): StorageMetadata = {
     val pool = JdbcMetadataCatalog.createDataSource(driver, conf)
     try {
-      val meta = WithClose(pool.getConnection())(metaTable.selectMetadata(_, root, typeName))
-      newJdbcMeta(pool, meta)
+      val meta = new MetadataTable(conf.schema, conf.tablePrefix, root, typeName)
+      val files = new FilesTable(conf.schema, conf.tablePrefix, root, typeName)
+      new JdbcMetadata(pool, meta, files, context.namespace)
     } catch {
       case NonFatal(e) => CloseQuietly(pool).foreach(e.addSuppressed); throw e
     }
@@ -57,22 +58,22 @@ class JdbcMetadataCatalog(context: FileSystemContext) extends StorageMetadataCat
   override def create(sft: SimpleFeatureType, partitions: Seq[String], targetFileSize: Option[Long]): StorageMetadata = {
     // load the partition scheme first in case it fails
     partitions.foreach(PartitionSchemeFactory.load(sft, _))
-    val meta = Metadata(sft, partitions, targetFileSize)
     val pool = JdbcMetadataCatalog.createDataSource(driver, conf)
     try {
+      val meta = new MetadataTable(conf.schema, conf.tablePrefix, root, sft.getTypeName)
+      val files = new FilesTable(conf.schema, conf.tablePrefix, root, sft.getTypeName)
       WithClose(pool.getConnection()) { cx =>
-        metaTable.create(cx)
-        metaTable.insert(cx, root, meta)
-        new FilesTable(conf.schema, conf.tablePrefix).create(cx)
+        meta.create(cx)
+        meta.insert(cx, sft)
+        meta.insert(cx, partitions)
+        targetFileSize.foreach(size => meta.insert(cx, Metadata.TargetFileSize, size.toString))
+        files.create(cx)
       }
-      newJdbcMeta(pool, meta)
+      new JdbcMetadata(pool, meta, files, context.namespace)
     } catch {
       case NonFatal(e) => CloseQuietly(pool).foreach(e.addSuppressed); throw e
     }
   }
-
-  private def newJdbcMeta(pool: PoolingDataSource[PoolableConnection], meta: Metadata): JdbcMetadata =
-    new JdbcMetadata(pool, root, conf.schema, conf.tablePrefix, meta.copy(sft = namespaced(meta.sft, context.namespace)))
 }
 
 private object JdbcMetadataCatalog extends LazyLogging {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/utils/FileSize.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/utils/FileSize.scala
@@ -83,7 +83,7 @@ object FileSize {
   val FileSizeErrorThreshold: SystemProperty = SystemProperty("geomesa.fs.size.threshold", "0.05")
 
   class UpdatingFileSizeEstimator(target: Long, instance: FileSize)
-    extends FileSizeEstimator(target, instance.fileSizeError, instance.averageBytesPerFeature) with Closeable {
+      extends FileSizeEstimator(target, instance.fileSizeError, instance.averageBytesPerFeature) with Closeable {
     override def close(): Unit = getBytesPerFeature.foreach(instance.updateFileSize)
   }
 }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/utils/FileSize.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-core/src/main/scala/org/locationtech/geomesa/fs/storage/core/utils/FileSize.scala
@@ -67,8 +67,8 @@ class FileSize(fs: ObjectStore, metadata: StorageMetadata) {
     if (metadata.get(FileSize.UseDynamicSizing).forall(_.toBoolean)) {
       synchronized {
         if (math.abs((bytesPerFeature / averageBytesPerFeature) - 1f) > fileSizeError) {
-          metadata.set(FileSize.BytesPerFeature, java.lang.Float.toString(bytesPerFeature))
           averageBytesPerFeature = bytesPerFeature
+          metadata.set(FileSize.BytesPerFeature, java.lang.Float.toString(bytesPerFeature))
         }
       }
     }

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet-io/src/main/scala/org/locationtech/geomesa/fs/storage/parquet/io/ParquetFileSystemWriter.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet-io/src/main/scala/org/locationtech/geomesa/fs/storage/parquet/io/ParquetFileSystemWriter.scala
@@ -49,8 +49,10 @@ class ParquetFileSystemWriter(
   SimpleFeatureParquetSchema.setSft(parquetConf, sft)
 
   private val writer = ParquetFileSystemWriter.builder(fs, file, parquetConf).build()
+  @volatile
+  private var closed = false
 
-  def getDataSize: Long = writer.getDataSize
+  override def size: Long = if (closed) { fs.size(file) }  else { writer.getDataSize }
 
   override def write(f: SimpleFeature): Unit = {
     writer.write(f)
@@ -59,7 +61,10 @@ class ParquetFileSystemWriter(
 
   override def flush(): Unit = observer.flush()
 
-  override def close(): Unit = CloseQuietly(Seq(writer, observer)).foreach(e => throw e)
+  override def close(): Unit = {
+    closed = true
+    CloseQuietly(Seq(writer, observer)).foreach(e => throw e)
+  }
 }
 
 object ParquetFileSystemWriter extends LazyLogging {

--- a/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/CompactionTest.scala
+++ b/geomesa-fs/geomesa-fs-storage/geomesa-fs-storage-parquet/src/test/scala/org/locationtech/geomesa/parquet/CompactionTest.scala
@@ -13,7 +13,7 @@ import org.geotools.api.data.Query
 import org.geotools.filter.text.ecql.ECQL
 import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.features.ScalaSimpleFeature
-import org.locationtech.geomesa.fs.storage.core.{FileSystemContext, Partition, StorageMetadataCatalog}
+import org.locationtech.geomesa.fs.storage.core.{FileSystemContext, Metadata, Partition, StorageMetadataCatalog}
 import org.locationtech.geomesa.fs.storage.parquet.ParquetFileSystemStorageFactory
 import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
@@ -90,12 +90,15 @@ class CompactionTest extends SpecificationWithJUnit {
 
           // compact to a given file size
           // verify if file is appropriately sized, it won't be modified
+
           val paths = storage.metadata.getFiles(partition).map(_.file)
           val size = paths.map(f => storage.fs.size(context.root.resolve(f))).sum
-          storage.compact(partition, Some(size))
+          storage.metadata.set(Metadata.TargetFileSize, size.toString)
+          storage.compact(partition)
           storage.metadata.getFiles(partition).map(_.file) mustEqual paths
           // verify files are split into smaller ones
-          storage.compact(partition, Some(size / 2))
+          storage.metadata.set(Metadata.TargetFileSize, (size / 2).toString)
+          storage.compact(partition)
           storage.metadata.getFiles(partition).size must beGreaterThan(1)
           CloseableIterator(storage.getReader(Query.ALL)).toList must haveSize(299)
         }

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/compact/FileSystemCompactionJob.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/compact/FileSystemCompactionJob.scala
@@ -39,7 +39,6 @@ trait FileSystemCompactionJob extends StorageConfiguration with JobWithLibJars {
   def run(
       storage: FileSystemStorage,
       partitions: Seq[Partition],
-      targetFileSize: Option[Long],
       tempPath: Option[Path],
       libjarsFiles: Seq[String],
       libjarsPaths: Iterator[() => Seq[File]],
@@ -72,7 +71,7 @@ trait FileSystemCompactionJob extends StorageConfiguration with JobWithLibJars {
     StorageConfiguration.setSft(job.getConfiguration, storage.metadata.sft)
     StorageConfiguration.setPartitions(job.getConfiguration, partitions)
     StorageConfiguration.setFileType(job.getConfiguration, FileType.Compacted)
-    targetFileSize.foreach(StorageConfiguration.setTargetFileSize(job.getConfiguration, _))
+    storage.sizer.targetSize.foreach(StorageConfiguration.setTargetFileSize(job.getConfiguration, _))
 
     FileOutputFormat.setOutputPath(job, tempPath.getOrElse(new Path(S3ObjectStore.s3aUri(storage.context.root))))
 
@@ -82,9 +81,9 @@ trait FileSystemCompactionJob extends StorageConfiguration with JobWithLibJars {
 
     configureOutput(storage.metadata.sft, job)
 
-    // save the existing files so we can delete them afterwards
+    // save the existing files so we can delete them afterward
     // mimic the filtering done in PartitionInputFormat
-    val sizeCheck = targetFileSize.orElse(storage.sizer.targetSize).map(t => (p: URI) => storage.sizer.fileIsSized(p, t))
+    val sizeCheck = storage.sizer.targetSize.map(t => (p: URI) => storage.sizer.fileIsSized(p, t))
     val existingDataFiles = partitions.toList.flatMap { p =>
       val files = storage.metadata.getFiles(p).filterNot(f => sizeCheck.exists(_.apply(storage.context.root.resolve(f.file))))
       // TODO get counts right... use m/r counters?

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/compact/FsCompactCommand.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/compact/FsCompactCommand.scala
@@ -21,7 +21,6 @@ import org.locationtech.geomesa.tools.Command.CommandException
 import org.locationtech.geomesa.tools.DistributedRunParam.RunModes
 import org.locationtech.geomesa.tools._
 import org.locationtech.geomesa.tools.ingest.IngestCommand
-import org.locationtech.geomesa.tools.utils.ParameterConverters.BytesConverter
 import org.locationtech.geomesa.tools.utils.TerminalCallback
 import org.locationtech.geomesa.utils.io.PathUtils
 import org.locationtech.geomesa.utils.text.TextTools
@@ -65,7 +64,6 @@ object FsCompactCommand {
       val mode = params.mode.getOrElse {
         if (PathUtils.isRemote(storage.context.root.toString)) { RunModes.Distributed } else { RunModes.Local }
       }
-      val fileSize = Option(params.targetFileSize).map(_.longValue)
 
       Command.user.info(s"Compacting ${toCompact.size} files in ${mode.toString.toLowerCase(Locale.US)} mode")
 
@@ -85,7 +83,7 @@ object FsCompactCommand {
                   override def run(): Unit = {
                     try {
                       logger.info(s"Compacting $p")
-                      storage.compact(p, fileSize)
+                      storage.compact(p)
                     } catch {
                       case NonFatal(e) => logger.error(s"Error processing partition '$p':", e)
                     } finally {
@@ -109,7 +107,7 @@ object FsCompactCommand {
         case RunModes.Distributed =>
           val job = new ParquetCompactionJob()
           val tempDir = Option(params.tempPath).map(t => new Path(t))
-          job.run(storage, toCompact.toSeq, fileSize, tempDir, libjarsFiles, libjarsPaths, status) match {
+          job.run(storage, toCompact.toSeq, tempDir, libjarsFiles, libjarsPaths, status) match {
             case JobSuccess(message, counts) =>
               Command.user.info(s"Distributed compaction complete in ${TextTools.getTime(start)}")
               val success = counts(FileSystemCompactionJob.MappedCounter)
@@ -130,11 +128,5 @@ object FsCompactCommand {
 
     @Parameter(names = Array("-t", "--threads"), description = "Number of threads if using local mode")
     var threads: Integer = 4
-
-    @Parameter(
-      names = Array("--target-file-size"),
-      description = "Target size for data files",
-      converter = classOf[BytesConverter])
-    var targetFileSize: java.lang.Long = _
   }
 }

--- a/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/FsManageMetadataCommand.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/main/scala/org/locationtech/geomesa/fs/tools/ingest/FsManageMetadataCommand.scala
@@ -19,7 +19,7 @@ import org.locationtech.geomesa.fs.storage.core.{FileSystemStorage, Partition, S
 import org.locationtech.geomesa.fs.tools.FsDataStoreCommand
 import org.locationtech.geomesa.fs.tools.FsDataStoreCommand.{FsParams, MetadataTypeValidator}
 import org.locationtech.geomesa.fs.tools.ingest.FsManageMetadataCommand.CheckConsistencyCommand.ConsistencyChecker
-import org.locationtech.geomesa.fs.tools.ingest.FsManageMetadataCommand.MigrateCommand
+import org.locationtech.geomesa.fs.tools.ingest.FsManageMetadataCommand.{ConfigureCommand, MigrateCommand}
 import org.locationtech.geomesa.index.index.attribute.AttributeIndexKey
 import org.locationtech.geomesa.tools.utils.NoopParameterSplitter
 import org.locationtech.geomesa.tools.utils.ParameterConverters.KeyValueConverter
@@ -45,7 +45,7 @@ class FsManageMetadataCommand extends CommandWithSubCommands {
   override val name: String = "manage-metadata"
   override val params = new ManageMetadataParams
   override val subCommands: Seq[Command] =
-    Seq(new RegisterCommand(), new UnregisterCommand(), new CheckConsistencyCommand(), new MigrateCommand())
+    Seq(new RegisterCommand(), new UnregisterCommand(), new ConfigureCommand(), new CheckConsistencyCommand(), new MigrateCommand())
 }
 
 object FsManageMetadataCommand extends LazyLogging {
@@ -128,9 +128,25 @@ object FsManageMetadataCommand extends LazyLogging {
     }
   }
 
-  private class MigrateCommand extends FsDataStoreCommand {
+  private class ConfigureCommand extends FsDataStoreCommand {
 
-    import scala.collection.JavaConverters._
+    override val params = new ConfigureParams()
+
+    override val name: String = "configure"
+
+    override def execute(): Unit = withDataStore { ds =>
+      val metadata = ds.storage(params.featureName).metadata
+      params.conf.asScala.foreach { case (k, v) =>
+        val key = k.trim
+        val value = Option(v.trim).filterNot(_.isEmpty)
+        val current = metadata.get(key)
+        metadata.set(k, value.orNull)
+        Command.output.info(s"Updated $key from '${current.getOrElse("<unset>")}' to '${value.getOrElse("<unset>")}'")
+      }
+    }
+  }
+
+  private class MigrateCommand extends FsDataStoreCommand {
 
     override val params = new MigrateParams()
 
@@ -333,6 +349,20 @@ object FsManageMetadataCommand extends LazyLogging {
     @Parameter(description = "Path of the file to unregister, relative to the storage root", required = true)
     var file: String = _
   }
+
+
+  @Parameters(commandDescription = "Configure storage-level options")
+  // noinspection VarCouldBeVal
+  private class ConfigureParams extends FsParams with RequiredTypeNameParam {
+    @Parameter(
+      names = Array("--set"),
+      description = "Storage properties to set, in the form k=v",
+      converter = classOf[KeyValueConverter],
+      splitter = classOf[NoopParameterSplitter],
+      required = true)
+    var conf: java.util.List[(String, String)] = new java.util.ArrayList[(String, String)]()
+  }
+
 
   @Parameters(commandDescription = "Migrate metadata from one type to another")
   // noinspection VarCouldBeVal

--- a/geomesa-fs/geomesa-fs-tools/src/test/scala/org/locationtech/geomesa/fs/tools/ingest/CompactCommandTest.scala
+++ b/geomesa-fs/geomesa-fs-tools/src/test/scala/org/locationtech/geomesa/fs/tools/ingest/CompactCommandTest.scala
@@ -12,6 +12,7 @@ import org.geotools.api.data.{DataStoreFinder, Query, Transaction}
 import org.geotools.api.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.locationtech.geomesa.features.ScalaSimpleFeature
 import org.locationtech.geomesa.fs.data.FileSystemDataStore
+import org.locationtech.geomesa.fs.storage.core.Metadata
 import org.locationtech.geomesa.fs.tools.compact.FsCompactCommand
 import org.locationtech.geomesa.tools.DistributedRunParam.RunModes
 import org.locationtech.geomesa.utils.geotools.{FeatureUtils, SimpleFeatureTypes}
@@ -146,12 +147,14 @@ class CompactCommandTest extends SpecificationWithJUnit with BeforeAfterAll {
     }
 
     "run successfully with target file size" in {
+      WithClose(DataStoreFinder.getDataStore(params.asJava).asInstanceOf[FileSystemDataStore]) { ds =>
+        ds.storage(sft.getTypeName).metadata.set(Metadata.TargetFileSize, targetFileSize.toString)
+      }
       val command = new FsCompactCommand()
       command.params.featureName = sft.getTypeName
       command.params.path = path
       command.params.metadataType = "file"
       command.params.runMode = RunModes.Distributed.toString
-      command.params.targetFileSize = targetFileSize
       command.params.configuration = configFlags.toList.asJava
       command.execute() must not(throwAn[Exception])
     }


### PR DESCRIPTION
* Target file size must be set explicitly
* Avoids updating metadata for one-off commands
* Store configs in separate rows in JdbcMetadata to reduce update cost
* Fix potential conflict between feature types in JdbcMetadata