### PR TITLE
GEOMESA-3581 Base64-encode authorization credentials

### DIFF
--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/AuthTokens.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/AuthTokens.java
@@ -15,9 +15,9 @@ import java.util.Collection;
  * meaning somewhere in the auth transport chain:
  *
  * <ul>
- *   <li>{@code |} — joins tokens in the JDBC {@code auths} extra credential;</li>
  *   <li>{@code ,} — joins tokens in the {@code is_visible} SQL literal (and splits them
- *       again inside the UDF), and delimits auth-mapping file lists;</li>
+ *       again inside the UDF), splits the decoded {@code auths} credential payload,
+ *       and delimits auth-mapping file lists;</li>
  *   <li>{@code ;} / {@code :} — delimit the Trino JDBC {@code extraCredentials}
  *       {@code name:value;name:value} wire encoding;</li>
  *   <li>whitespace and non-printable/non-ASCII — rejected by the Trino JDBC driver's
@@ -45,7 +45,7 @@ final class AuthTokens {
         }
         for (int i = 0; i < token.length(); i++) {
             char c = token.charAt(i);
-            if (c <= ' ' || c > '~' || c == ',' || c == '|' || c == ';' || c == ':') {
+            if (c <= ' ' || c > '~' || c == ',' || c == ';' || c == ':') {
                 return false;
             }
         }
@@ -62,8 +62,7 @@ final class AuthTokens {
             if (!isValid(token)) {
                 throw new IllegalArgumentException(
                     "Invalid authorization token '" + token + "': tokens must be non-empty printable"
-                    + " ASCII without ',', '|', ';', ':', or whitespace (structural delimiters in the"
-                    + " auth transport)");
+                    + " ASCII without ',', ';', ':', or whitespace");
             }
         }
     }

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/AuthTokens.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/AuthTokens.java
@@ -11,24 +11,17 @@ package org.locationtech.geomesa.trino.datastore;
 import java.util.Collection;
 
 /**
- * Validation for authorization tokens against the characters that carry structural
- * meaning somewhere in the auth transport chain:
+ * Validates authorization tokens against their join/split delimiter (,):
  *
  * <ul>
- *   <li>{@code ,} — joins tokens in the {@code is_visible} SQL literal (and splits them
- *       again inside the UDF), splits the decoded {@code auths} credential payload,
- *       and delimits auth-mapping file lists;</li>
- *   <li>{@code ;} / {@code :} — delimit the Trino JDBC {@code extraCredentials}
- *       {@code name:value;name:value} wire encoding;</li>
- *   <li>whitespace and non-printable/non-ASCII — rejected by the Trino JDBC driver's
- *       extraCredentials validation.</li>
+ *   <li>{@code ,} — joins tokens in the {@code is_visible} SQL literal, splits the decoded
+ *   {@code auths} credential payload, and delimits auth-mapping file lists. A comma inside
+ *   a token (invalid) would be split into sub-tokens, granting each fragment as an
+ *   authorization that was never issued.</li>
  * </ul>
  *
- * <p>A token containing any of these cannot round-trip losslessly between the datastore's
- * client-side conjunct and the plugin's server-side row filter: it would be silently split
- * into sub-tokens, GRANTING each fragment as an authorization that was never issued. So
- * producers reject such tokens loudly (see {@link #validate}) and resolvers drop them
- * (fail-closed) rather than propagate them.
+ * <p>Producers reject a comma-bearing token loudly (see {@link #validate}) and resolvers drop
+ * it (fail-closed) rather than propagate it.
  *
  * <p>Mirrors the plugin's {@code org.locationtech.geomesa.trino.security.AuthTokens}
  * byte-for-byte — the two modules are isolated (neither is on the other's classpath), so
@@ -38,18 +31,11 @@ final class AuthTokens {
 
     private AuthTokens() {}
 
-    /** True iff the token is non-empty printable ASCII with no delimiter characters. */
+    /** True iff the token is non-empty and contains no comma — the sole delimiter
+     *  once the auths payload is base64url-encoded for transport and the {@code is_visible}
+     *  literal is quote-escaped. */
     static boolean isValid(String token) {
-        if (token == null || token.isEmpty()) {
-            return false;
-        }
-        for (int i = 0; i < token.length(); i++) {
-            char c = token.charAt(i);
-            if (c <= ' ' || c > '~' || c == ',' || c == ';' || c == ':') {
-                return false;
-            }
-        }
-        return true;
+        return token != null && !token.isEmpty() && token.indexOf(',') < 0;
     }
 
     /** Throws on the first invalid token. Call before joining tokens for transport —
@@ -61,8 +47,8 @@ final class AuthTokens {
         for (String token : auths) {
             if (!isValid(token)) {
                 throw new IllegalArgumentException(
-                    "Invalid authorization token '" + token + "': tokens must be non-empty printable"
-                    + " ASCII without ',', ';', ':', or whitespace");
+                    "Invalid authorization token '" + token + "': tokens must be non-empty and"
+                    + " must not contain ','");
             }
         }
     }

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoDataStore.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoDataStore.java
@@ -15,6 +15,7 @@ import org.geotools.data.store.ContentFeatureSource;
 import org.locationtech.geomesa.security.AuthorizationsProvider;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.*;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -122,18 +123,26 @@ public class TrinoDataStore extends ContentDataStore {
      *
      *  <p>The Trino JDBC {@code extraCredentials} property is {@code name:value}
      *  pairs delimited by SEMICOLONS (NOT commas), and each value must be printable
-     *  ASCII with no spaces. So auth tokens are joined with PIPES and the secret is
-     *  a second pair: {@code auths:basic|privileged;secret:<value>}. Throws
-     *  {@code IllegalArgumentException} on a token containing a transport delimiter —
-     *  the server-side resolver would re-split it into auths that were never issued
-     *  (see {@link AuthTokens}). */
+     *  ASCII with no spaces. The auth tokens are comma-joined and then base64url
+     *  encoded (unpadded) into a single value — the base64url alphabet can never
+     *  collide with the wire delimiters, so the transport is injection-proof by
+     *  construction: {@code auths:<base64url(tok1,tok2)>;secret:<value>}. The
+     *  server-side {@code ExtraCredentialAuthorizationResolver} decodes the same
+     *  format.
+     *
+     *  <p>Tokens are still validated against {@link AuthTokens} before encoding:
+     *  the SQL row-filter layer joins tokens with commas into the
+     *  {@code is_visible} literal, so the no-delimiter token contract remains
+     *  load-bearing there even though the wire itself no longer requires it. */
     static Properties connectionProperties(String user, List<String> auths, String secret) {
         AuthTokens.validate(auths);
         Properties props = new Properties();
         props.setProperty("user", user);
         StringBuilder creds = new StringBuilder();
         if (auths != null && !auths.isEmpty()) {
-            creds.append(AUTHS_CREDENTIAL).append(':').append(String.join("|", auths));
+            String encoded = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(String.join(",", auths).getBytes(StandardCharsets.UTF_8));
+            creds.append(AUTHS_CREDENTIAL).append(':').append(encoded);
         }
         if (secret != null && !secret.isEmpty()) {
             if (creds.length() > 0) creds.append(';');  // semicolon delimits pairs

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoDataStoreConnectionTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoDataStoreConnectionTest.java
@@ -32,25 +32,22 @@ class TrinoDataStoreConnectionTest {
     }
 
     @Test
-    void authsBecomePipeDelimitedExtraCredential() {
-        // Pipe-delimited, NOT space/comma: the Trino JDBC extraCredentials value
-        // forbids spaces and uses comma/colon as structural separators. The
-        // resolver splits the value on pipes, commas, or whitespace.
+    void authsBecomeBase64UrlExtraCredential() {
         Properties props = TrinoDataStore.connectionProperties("svc", List.of("basic", "privileged"), null);
-        assertThat(props.getProperty("extraCredentials")).isEqualTo("auths:basic|privileged");
+        assertThat(props.getProperty("extraCredentials")).isEqualTo("auths:YmFzaWMscHJpdmlsZWdlZA");
     }
 
     @Test
     void singleAuthEncodes() {
         Properties props = TrinoDataStore.connectionProperties("svc", List.of("basic"), null);
-        assertThat(props.getProperty("extraCredentials")).isEqualTo("auths:basic");
+        assertThat(props.getProperty("extraCredentials")).isEqualTo("auths:YmFzaWM");
     }
 
     @Test
     void secretAddedAsSecondPairDelimitedBySemicolon() {
         // Trino JDBC extraCredentials delimits name:value pairs with SEMICOLONS.
         Properties props = TrinoDataStore.connectionProperties("svc", List.of("basic", "privileged"), "tok3n");
-        assertThat(props.getProperty("extraCredentials")).isEqualTo("auths:basic|privileged;secret:tok3n");
+        assertThat(props.getProperty("extraCredentials")).isEqualTo("auths:YmFzaWMscHJpdmlsZWdlZA;secret:tok3n");
     }
 
     @Test
@@ -68,11 +65,8 @@ class TrinoDataStoreConnectionTest {
     }
 
     @Test
-    void authTokenContainingTransportDelimiterIsRejected() {
-        // '|' joins tokens in the credential value, ';'/':' delimit its pairs, and the
-        // server-side resolver splits on pipes/commas/whitespace — a token containing
-        // any of them would be silently re-split into auths that were never issued.
-        for (String bad : List.of("FOO,BAR", "FOO|BAR", "FOO;BAR", "FOO:BAR", "FOO BAR", "")) {
+    void authTokenContainingDelimiterIsRejected() {
+        for (String bad : List.of("FOO,BAR", "FOO BAR", "FOO;BAR", "FOO:BAR", "FOO BAR", "")) {
             assertThatThrownBy(() ->
                 TrinoDataStore.connectionProperties("svc", List.of("basic", bad), null))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoDataStoreConnectionTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoDataStoreConnectionTest.java
@@ -65,8 +65,8 @@ class TrinoDataStoreConnectionTest {
     }
 
     @Test
-    void authTokenContainingDelimiterIsRejected() {
-        for (String bad : List.of("FOO,BAR", "FOO BAR", "FOO;BAR", "FOO:BAR", "FOO BAR", "")) {
+    void authTokenContainingCommaIsRejected() {
+        for (String bad : List.of("FOO,BAR", "")) {
             assertThatThrownBy(() ->
                 TrinoDataStore.connectionProperties("svc", List.of("basic", bad), null))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureSourceVisibilityTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureSourceVisibilityTest.java
@@ -43,13 +43,19 @@ class TrinoFeatureSourceVisibilityTest {
     }
 
     @Test
-    void authTokenContainingTransportDelimiterIsRejected() {
-        for (String bad : List.of("FOO,BAR", "FOO;BAR", "FOO:BAR", "FOO BAR", "")) {
+    void authTokenContainingCommaIsRejected() {
+        for (String bad : List.of("FOO,BAR", "")) {
             assertThatThrownBy(() ->
                 TrinoFeatureSource.visibilityConjunct("__vis__", List.of("basic", bad)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("authorization token");
         }
+    }
+
+    @Test
+    void nonCommaSpecialCharsAreAllowed() {
+        assertThat(TrinoFeatureSource.visibilityConjunct("__vis__", List.of("FOO;BAR", "FOO:BAR", "FOO BAR")))
+            .isEqualTo("is_visible(\"__vis__\", 'FOO;BAR,FOO:BAR,FOO BAR')");
     }
 
     @Test

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureSourceVisibilityTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureSourceVisibilityTest.java
@@ -44,7 +44,7 @@ class TrinoFeatureSourceVisibilityTest {
 
     @Test
     void authTokenContainingTransportDelimiterIsRejected() {
-        for (String bad : List.of("FOO,BAR", "FOO|BAR", "FOO;BAR", "FOO:BAR", "FOO BAR", "")) {
+        for (String bad : List.of("FOO,BAR", "FOO;BAR", "FOO:BAR", "FOO BAR", "")) {
             assertThatThrownBy(() ->
                 TrinoFeatureSource.visibilityConjunct("__vis__", List.of("basic", bad)))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/geomesa-trino/geomesa-trino-plugin/src/main/java/org/locationtech/geomesa/trino/security/AuthTokens.java
+++ b/geomesa-trino/geomesa-trino-plugin/src/main/java/org/locationtech/geomesa/trino/security/AuthTokens.java
@@ -11,24 +11,17 @@ package org.locationtech.geomesa.trino.security;
 import java.util.Collection;
 
 /**
- * Validation for authorization tokens against the characters that carry structural
- * meaning somewhere in the auth transport chain:
+ * Validates authorization tokens against their join/split delimiter (,):
  *
  * <ul>
- *   <li>{@code ,} — joins tokens in the {@code is_visible} SQL literal (and splits them
- *       again inside the UDF), splits the decoded {@code auths} credential payload,
- *       and delimits auth-mapping file lists;</li>
- *   <li>{@code ;} / {@code :} — delimit the Trino JDBC {@code extraCredentials}
- *       {@code name:value;name:value} wire encoding;</li>
- *   <li>whitespace and non-printable/non-ASCII — rejected by the Trino JDBC driver's
- *       extraCredentials validation.</li>
+ *   <li>{@code ,} — joins tokens in the {@code is_visible} SQL literal, splits the decoded
+ *   {@code auths} credential payload, and * delimits auth-mapping file lists. A comma inside
+ *   a token would be split into sub-tokens, GRANTING each fragment as an authorization that
+ *   was never issued.</li>
  * </ul>
  *
- * <p>A token containing any of these cannot round-trip losslessly between the datastore's
- * client-side conjunct and the plugin's server-side row filter: it would be silently split
- * into sub-tokens, GRANTING each fragment as an authorization that was never issued. So
- * producers reject such tokens loudly (see {@link #validate}) and resolvers drop them
- * (fail-closed) rather than propagate them.
+ * <p>Producers reject a comma-bearing token loudly (see {@link #validate}) and resolvers drop
+ * it (fail-closed) rather than propagate it.
  *
  * <p>Mirrors the datastore's {@code org.locationtech.geomesa.trino.datastore.AuthTokens}
  * byte-for-byte — the two modules are isolated (neither is on the other's classpath), so
@@ -38,18 +31,11 @@ final class AuthTokens {
 
     private AuthTokens() {}
 
-    /** True iff the token is non-empty printable ASCII with no delimiter characters. */
+    /** True iff the token is non-empty and contains no comma — the sole structural delimiter
+     *  once the auths payload is base64url-encoded for transport and the {@code is_visible}
+     *  literal is quote-escaped. */
     static boolean isValid(String token) {
-        if (token == null || token.isEmpty()) {
-            return false;
-        }
-        for (int i = 0; i < token.length(); i++) {
-            char c = token.charAt(i);
-            if (c <= ' ' || c > '~' || c == ',' || c == ';' || c == ':') {
-                return false;
-            }
-        }
-        return true;
+        return token != null && !token.isEmpty() && token.indexOf(',') < 0;
     }
 
     /** Throws on the first invalid token. Call before joining tokens for transport —
@@ -61,9 +47,8 @@ final class AuthTokens {
         for (String token : auths) {
             if (!isValid(token)) {
                 throw new IllegalArgumentException(
-                    "Invalid authorization token '" + token + "': tokens must be non-empty printable"
-                    + " ASCII without ',', ';', ':', or whitespace (structural delimiters in the"
-                    + " auth transport)");
+                    "Invalid authorization token '" + token + "': tokens must be non-empty and"
+                    + " must not contain ','");
             }
         }
     }

--- a/geomesa-trino/geomesa-trino-plugin/src/main/java/org/locationtech/geomesa/trino/security/AuthTokens.java
+++ b/geomesa-trino/geomesa-trino-plugin/src/main/java/org/locationtech/geomesa/trino/security/AuthTokens.java
@@ -15,9 +15,9 @@ import java.util.Collection;
  * meaning somewhere in the auth transport chain:
  *
  * <ul>
- *   <li>{@code |} — joins tokens in the JDBC {@code auths} extra credential;</li>
  *   <li>{@code ,} — joins tokens in the {@code is_visible} SQL literal (and splits them
- *       again inside the UDF), and delimits auth-mapping file lists;</li>
+ *       again inside the UDF), splits the decoded {@code auths} credential payload,
+ *       and delimits auth-mapping file lists;</li>
  *   <li>{@code ;} / {@code :} — delimit the Trino JDBC {@code extraCredentials}
  *       {@code name:value;name:value} wire encoding;</li>
  *   <li>whitespace and non-printable/non-ASCII — rejected by the Trino JDBC driver's
@@ -45,7 +45,7 @@ final class AuthTokens {
         }
         for (int i = 0; i < token.length(); i++) {
             char c = token.charAt(i);
-            if (c <= ' ' || c > '~' || c == ',' || c == '|' || c == ';' || c == ':') {
+            if (c <= ' ' || c > '~' || c == ',' || c == ';' || c == ':') {
                 return false;
             }
         }
@@ -62,7 +62,7 @@ final class AuthTokens {
             if (!isValid(token)) {
                 throw new IllegalArgumentException(
                     "Invalid authorization token '" + token + "': tokens must be non-empty printable"
-                    + " ASCII without ',', '|', ';', ':', or whitespace (structural delimiters in the"
+                    + " ASCII without ',', ';', ':', or whitespace (structural delimiters in the"
                     + " auth transport)");
             }
         }

--- a/geomesa-trino/geomesa-trino-plugin/src/main/java/org/locationtech/geomesa/trino/security/ExtraCredentialAuthorizationResolver.java
+++ b/geomesa-trino/geomesa-trino-plugin/src/main/java/org/locationtech/geomesa/trino/security/ExtraCredentialAuthorizationResolver.java
@@ -12,6 +12,7 @@ import io.trino.spi.security.ConnectorIdentity;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Base64;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -20,12 +21,14 @@ import org.slf4j.LoggerFactory;
 
 /**
  * {@link AuthorizationResolver} that reads a session's authorization tokens
- * straight from a Trino <em>extra credential</em> carrying a comma-delimited
- * list (e.g. {@code auths=basic,privileged}). Intended for deployments fronted by a
- * trusted service mesh that authenticates the caller and injects the
- * authoritative token set: the mesh rewrites its identity header (e.g.
- * {@code x-auths}) into Trino's {@code X-Trino-Extra-Credential} client
- * header, which Trino exposes here via {@link ConnectorIdentity#getExtraCredentials()}.
+ * from a Trino <em>extra credential</em> carrying a base64url-encoded
+ * token list. The decoded payload is a comma or whitespace delimited list.
+ * Base64url keeps the wire value free of the extraCredentials pair delimiters
+ * by construction. Intended for deployments fronted by a trusted service mesh
+ * that authenticates the caller and injects the authoritative token set:
+ * the mesh base64url-encodes its identity header (e.g. {@code x-auths}) into Trino's
+ * {@code X-Trino-Extra-Credential} client header, which Trino exposes here
+ * via {@link ConnectorIdentity#getExtraCredentials()}.
  *
  * <p>Because the tokens flow through unchanged there is no mapping file to
  * maintain and nothing to drift from the platform's clearances. Selected with:
@@ -102,12 +105,16 @@ public final class ExtraCredentialAuthorizationResolver implements Authorization
         return MessageDigest.isEqual(expectedSecret, presented.getBytes(StandardCharsets.UTF_8));
     }
 
-    private static void addTokens(Set<String> out, String csv) {
-        if (csv == null) return;
-        // Split on pipes, commas, or whitespace. The JDBC datastore joins tokens
-        // with pipes (extraCredentials values forbid spaces); a mesh header may use
-        // a comma or space list. Accept all three.
-        for (String token : csv.split("[\\s,|]+")) {
+    private static void addTokens(Set<String> out, String encoded) {
+        if (encoded == null) return;
+        String decoded;
+        try {
+            decoded = new String(Base64.getUrlDecoder().decode(encoded.trim()), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Authorization extra credential is not valid base64url; resolving to no auths");
+            return;
+        }
+        for (String token : decoded.split("[\\s,]+")) {
             String t = token.trim();
             if (t.isEmpty()) continue;
             if (!AuthTokens.isValid(t)) {

--- a/geomesa-trino/geomesa-trino-plugin/src/main/java/org/locationtech/geomesa/trino/security/ExtraCredentialAuthorizationResolver.java
+++ b/geomesa-trino/geomesa-trino-plugin/src/main/java/org/locationtech/geomesa/trino/security/ExtraCredentialAuthorizationResolver.java
@@ -114,7 +114,7 @@ public final class ExtraCredentialAuthorizationResolver implements Authorization
             LOG.warn("Authorization extra credential is not valid base64url; resolving to no auths");
             return;
         }
-        for (String token : decoded.split("[\\s,]+")) {
+        for (String token : decoded.split(",")) {
             String t = token.trim();
             if (t.isEmpty()) continue;
             if (!AuthTokens.isValid(t)) {

--- a/geomesa-trino/geomesa-trino-plugin/src/test/java/org/locationtech/geomesa/trino/security/ExtraCredentialAuthorizationResolverTest.java
+++ b/geomesa-trino/geomesa-trino-plugin/src/test/java/org/locationtech/geomesa/trino/security/ExtraCredentialAuthorizationResolverTest.java
@@ -11,6 +11,9 @@ package org.locationtech.geomesa.trino.security;
 import io.trino.spi.security.ConnectorIdentity;
 import org.junit.jupiter.api.Test;
 
+import java.util.Base64;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,26 +28,22 @@ class ExtraCredentialAuthorizationResolverTest {
         return new ExtraCredentialAuthorizationResolver(config);
     }
 
+    private static String enc(String tokenList) {
+        return Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(tokenList.getBytes(StandardCharsets.UTF_8));
+    }
+
     @Test
     void readsTokensFromDefaultCredential() {
         var r = resolver(Map.of());
-        assertThat(r.authorizationsFor(identity(Map.of("auths", "basic,privileged"))))
+        assertThat(r.authorizationsFor(identity(Map.of("auths", enc("basic,privileged")))))
             .containsExactlyInAnyOrder("basic", "privileged");
     }
 
     @Test
     void honorsConfiguredCredentialName() {
         var r = resolver(Map.of(ExtraCredentialAuthorizationResolver.CREDENTIAL_KEY, "x-auths"));
-        assertThat(r.authorizationsFor(identity(Map.of("x-auths", "basic,privileged"))))
-            .containsExactlyInAnyOrder("basic", "privileged");
-    }
-
-    @Test
-    void readsPipeDelimitedTokens() {
-        // The JDBC datastore joins tokens with pipes (spaces are rejected by the
-        // Trino JDBC extraCredentials value validation).
-        var r = resolver(Map.of());
-        assertThat(r.authorizationsFor(identity(Map.of("auths", "basic|privileged"))))
+        assertThat(r.authorizationsFor(identity(Map.of("x-auths", enc("basic,privileged")))))
             .containsExactlyInAnyOrder("basic", "privileged");
     }
 
@@ -52,40 +51,40 @@ class ExtraCredentialAuthorizationResolverTest {
     void readsSpaceOrCommaDelimitedTokens() {
         // Robust to a mesh-injected header carrying a space or comma list too.
         var r = resolver(Map.of());
-        assertThat(r.authorizationsFor(identity(Map.of("auths", "basic, privileged"))))
+        assertThat(r.authorizationsFor(identity(Map.of("auths", enc("basic, privileged")))))
             .containsExactlyInAnyOrder("basic", "privileged");
     }
 
     @Test
     void whitespaceAndBlankTokensAreTrimmedAndDropped() {
         var r = resolver(Map.of());
-        assertThat(r.authorizationsFor(identity(Map.of("auths", " basic , privileged ,,"))))
+        assertThat(r.authorizationsFor(identity(Map.of("auths", enc(" basic , privileged ,,")))))
             .containsExactlyInAnyOrder("basic", "privileged");
     }
 
     @Test
     void missingCredentialFailsClosedEmpty() {
         var r = resolver(Map.of());
-        assertThat(r.authorizationsFor(identity(Map.of("other", "basic,privileged")))).isEmpty();
+        assertThat(r.authorizationsFor(identity(Map.of("other", enc("basic,privileged"))))).isEmpty();
     }
 
     @Test
     void secretGateHonorsAuthsWhenSecretMatches() {
         var r = resolver(Map.of(ExtraCredentialAuthorizationResolver.SECRET_KEY, "s3cr3t"));
-        assertThat(r.authorizationsFor(identity(Map.of("secret", "s3cr3t", "auths", "basic privileged"))))
+        assertThat(r.authorizationsFor(identity(Map.of("secret", "s3cr3t", "auths", enc("basic privileged")))))
             .containsExactlyInAnyOrder("basic", "privileged");
     }
 
     @Test
     void secretGateFailsClosedWhenSecretWrong() {
         var r = resolver(Map.of(ExtraCredentialAuthorizationResolver.SECRET_KEY, "s3cr3t"));
-        assertThat(r.authorizationsFor(identity(Map.of("secret", "nope", "auths", "basic privileged")))).isEmpty();
+        assertThat(r.authorizationsFor(identity(Map.of("secret", "nope", "auths", enc("basic privileged"))))).isEmpty();
     }
 
     @Test
     void secretGateFailsClosedWhenSecretMissing() {
         var r = resolver(Map.of(ExtraCredentialAuthorizationResolver.SECRET_KEY, "s3cr3t"));
-        assertThat(r.authorizationsFor(identity(Map.of("auths", "basic privileged")))).isEmpty();
+        assertThat(r.authorizationsFor(identity(Map.of("auths", enc("basic privileged"))))).isEmpty();
     }
 
     @Test
@@ -95,12 +94,22 @@ class ExtraCredentialAuthorizationResolverTest {
     }
 
     @Test
-    void tokensCarryingPairDelimitersAreDroppedFailClosed() {
-        // ';'/':' survive the pipe/comma/whitespace split but delimit the extraCredentials
-        // wire pairs — no legitimate producer can grant such a token (AuthTokens rejects
-        // them at the source), so the resolver drops rather than honors it.
+    void pinnedWireEncodingDecodesToTokens() {
         var r = resolver(Map.of());
-        assertThat(r.authorizationsFor(identity(Map.of("auths", "basic|FOO:BAR|privileged"))))
+        assertThat(r.authorizationsFor(identity(Map.of("auths", "YmFzaWMscHJpdmlsZWdlZA"))))
+            .containsExactlyInAnyOrder("basic", "privileged");
+    }
+
+    @Test
+    void nonBase64CredentialFailsClosedEmpty() {
+        var r = resolver(Map.of());
+        assertThat(r.authorizationsFor(identity(Map.of("auths", "basic,privileged")))).isEmpty();
+    }
+
+    @Test
+    void tokensCarryingPairDelimitersAreDroppedFailClosed() {
+        var r = resolver(Map.of());
+        assertThat(r.authorizationsFor(identity(Map.of("auths", enc("basic,FOO:BAR,privileged")))))
             .containsExactlyInAnyOrder("basic", "privileged");
     }
 }

--- a/geomesa-trino/geomesa-trino-plugin/src/test/java/org/locationtech/geomesa/trino/security/ExtraCredentialAuthorizationResolverTest.java
+++ b/geomesa-trino/geomesa-trino-plugin/src/test/java/org/locationtech/geomesa/trino/security/ExtraCredentialAuthorizationResolverTest.java
@@ -71,20 +71,20 @@ class ExtraCredentialAuthorizationResolverTest {
     @Test
     void secretGateHonorsAuthsWhenSecretMatches() {
         var r = resolver(Map.of(ExtraCredentialAuthorizationResolver.SECRET_KEY, "s3cr3t"));
-        assertThat(r.authorizationsFor(identity(Map.of("secret", "s3cr3t", "auths", enc("basic privileged")))))
+        assertThat(r.authorizationsFor(identity(Map.of("secret", "s3cr3t", "auths", enc("basic,privileged")))))
             .containsExactlyInAnyOrder("basic", "privileged");
     }
 
     @Test
     void secretGateFailsClosedWhenSecretWrong() {
         var r = resolver(Map.of(ExtraCredentialAuthorizationResolver.SECRET_KEY, "s3cr3t"));
-        assertThat(r.authorizationsFor(identity(Map.of("secret", "nope", "auths", enc("basic privileged"))))).isEmpty();
+        assertThat(r.authorizationsFor(identity(Map.of("secret", "nope", "auths", enc("basic,privileged"))))).isEmpty();
     }
 
     @Test
     void secretGateFailsClosedWhenSecretMissing() {
         var r = resolver(Map.of(ExtraCredentialAuthorizationResolver.SECRET_KEY, "s3cr3t"));
-        assertThat(r.authorizationsFor(identity(Map.of("auths", enc("basic privileged"))))).isEmpty();
+        assertThat(r.authorizationsFor(identity(Map.of("auths", enc("basic,privileged"))))).isEmpty();
     }
 
     @Test
@@ -107,9 +107,9 @@ class ExtraCredentialAuthorizationResolverTest {
     }
 
     @Test
-    void tokensCarryingPairDelimitersAreDroppedFailClosed() {
+    void tokensCarryingPairDelimitersAreHonored() {
         var r = resolver(Map.of());
         assertThat(r.authorizationsFor(identity(Map.of("auths", enc("basic,FOO:BAR,privileged")))))
-            .containsExactlyInAnyOrder("basic", "privileged");
+            .containsExactlyInAnyOrder("basic", "FOO:BAR", "privileged");
     }
 }

--- a/geomesa-trino/geomesa-trino-plugin/src/test/java/org/locationtech/geomesa/trino/security/FileAuthorizationResolverTest.java
+++ b/geomesa-trino/geomesa-trino-plugin/src/test/java/org/locationtech/geomesa/trino/security/FileAuthorizationResolverTest.java
@@ -70,11 +70,11 @@ class FileAuthorizationResolverTest {
 
     @Test
     void invalidTokensAreDroppedFailClosed(@TempDir Path dir) throws Exception {
-        // A token carrying a transport delimiter ('|' here, or ':'/';'/interior space)
+        // A token carrying a transport delimiter (':'/';'/interior space)
         // can't round-trip through the row-filter chain — dropped with a warning
         // (narrowing = fail-closed) rather than honored.
         Path f = dir.resolve("m.properties");
-        Files.write(f, java.util.List.of("user.alice=basic,FOO|BAR,privileged"));
+        Files.write(f, java.util.List.of("user.alice=basic,FOO;BAR,privileged"));
         var resolver = new FileAuthorizationResolver(f);
         assertThat(resolver.authorizationsFor(identity("alice", Set.of())))
             .containsExactlyInAnyOrder("basic", "privileged");

--- a/geomesa-trino/geomesa-trino-plugin/src/test/java/org/locationtech/geomesa/trino/security/FileAuthorizationResolverTest.java
+++ b/geomesa-trino/geomesa-trino-plugin/src/test/java/org/locationtech/geomesa/trino/security/FileAuthorizationResolverTest.java
@@ -69,15 +69,12 @@ class FileAuthorizationResolverTest {
     }
 
     @Test
-    void invalidTokensAreDroppedFailClosed(@TempDir Path dir) throws Exception {
-        // A token carrying a transport delimiter (':'/';'/interior space)
-        // can't round-trip through the row-filter chain — dropped with a warning
-        // (narrowing = fail-closed) rather than honored.
+    void pairDelimiterTokensAreHonored(@TempDir Path dir) throws Exception {
         Path f = dir.resolve("m.properties");
         Files.write(f, java.util.List.of("user.alice=basic,FOO;BAR,privileged"));
         var resolver = new FileAuthorizationResolver(f);
         assertThat(resolver.authorizationsFor(identity("alice", Set.of())))
-            .containsExactlyInAnyOrder("basic", "privileged");
+            .containsExactlyInAnyOrder("basic", "FOO;BAR", "privileged");
     }
 
     @Test

--- a/geomesa-trino/geomesa-trino-plugin/src/test/java/org/locationtech/geomesa/trino/security/VisibilityRowFilterTest.java
+++ b/geomesa-trino/geomesa-trino-plugin/src/test/java/org/locationtech/geomesa/trino/security/VisibilityRowFilterTest.java
@@ -49,11 +49,17 @@ class VisibilityRowFilterTest {
     }
 
     @Test
-    void authTokenContainingTransportDelimiterIsRejected() {
-        for (String bad : List.of("FOO,BAR", "FOO;BAR", "FOO:BAR", "FOO BAR", "")) {
+    void authTokenContainingCommaIsRejected() {
+        for (String bad : List.of("FOO,BAR", "")) {
             assertThatThrownBy(() -> VisibilityRowFilter.conjunct("__vis__", List.of("basic", bad)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("authorization token");
         }
+    }
+
+    @Test
+    void nonCommaSpecialCharsAreAllowed() {
+        assertThat(VisibilityRowFilter.conjunct("__vis__", List.of("FOO;BAR", "FOO:BAR", "FOO BAR")))
+            .isEqualTo("is_visible(\"__vis__\", 'FOO;BAR,FOO:BAR,FOO BAR')");
     }
 }

--- a/geomesa-trino/geomesa-trino-plugin/src/test/java/org/locationtech/geomesa/trino/security/VisibilityRowFilterTest.java
+++ b/geomesa-trino/geomesa-trino-plugin/src/test/java/org/locationtech/geomesa/trino/security/VisibilityRowFilterTest.java
@@ -50,7 +50,7 @@ class VisibilityRowFilterTest {
 
     @Test
     void authTokenContainingTransportDelimiterIsRejected() {
-        for (String bad : List.of("FOO,BAR", "FOO|BAR", "FOO;BAR", "FOO:BAR", "FOO BAR", "")) {
+        for (String bad : List.of("FOO,BAR", "FOO;BAR", "FOO:BAR", "FOO BAR", "")) {
             assertThatThrownBy(() -> VisibilityRowFilter.conjunct("__vis__", List.of("basic", bad)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("authorization token");


### PR DESCRIPTION
## Summary

Changes the authorization encoding between geomesa-trino-datastore and the `spatial_iceberg` connector from a pipe-delimited list to a single base64url-encoded value: `auths:<base64url(join(tokens, ","))>` 

The Trino JDBC `extraCredentials` property is `name:value` pairs with `;`/`:` as structural delimiters, and the previous pipe-joined value shared its alphabet with that format — requiring delimiter validation on both ends to prevent a spoofed token from being re-split into authorizations that were never issued. The base64url alphabet (`A-Za-z0-9-_`) cannot collide with the delimiters, making the transport injection-proof.

## Changes

**geomesa-trino-datastore**
- `TrinoDataStore.connectionProperties` comma-joins the validated tokens and base64url encodes the result into the `auths` extra credential

**geomesa-trino-plugin**
- `ExtraCredentialAuthorizationResolver` base64url-decodes the credential value  (padded or unpadded accepted) before tokenizing. A value that is not valid base64 resolves to **no authorizations**. The decoded payload is still split liberally on
  comma/pipe/whitespace, so mesh-injected headers can encode whatever list format they already carry.
