### PR TITLE
GEOMESA-3583 Trino datastore: pool JDBC connections by unique authorization set

### DIFF
--- a/geomesa-trino/geomesa-trino-datastore/pom.xml
+++ b/geomesa-trino/geomesa-trino-datastore/pom.xml
@@ -35,6 +35,15 @@
       <groupId>io.trino</groupId>
       <artifactId>trino-jdbc</artifactId>
     </dependency>
+    <!-- JDBC connection pooling -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-pool2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+    </dependency>
     <!-- WKBReader -->
     <dependency>
       <groupId>org.locationtech.jts</groupId>

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/ConnectionPool.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/ConnectionPool.java
@@ -1,0 +1,133 @@
+/***********************************************************************
+ * Copyright (c) 2013-2025 General Atomics Integrated Intelligence, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ ***********************************************************************/
+
+package org.locationtech.geomesa.trino.datastore;
+
+import org.apache.commons.pool2.BaseKeyedPooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeSet;
+
+/**
+ * JDBC connection pool keyed by the caller's normalized authorization set.
+ *
+ * <p>Borrowed connections are wrapped in a {@link PooledConnection} so
+ * {@link Connection#close()} returns them to the pool instead of closing them; callers
+ * keep ordinary try-with-resources semantics. Any other use after close throws.
+ * {@link #close()} closes all idle connections; in-flight ones are destroyed as
+ * their holders return them.
+ */
+final class ConnectionPool implements AutoCloseable {
+
+    /** Idle connections kept per auth set. Excess returns are closed rather than pooled. */
+    private static final int MAX_IDLE_PER_KEY = 10;
+
+    /** How long an idle connection may sit unused before the evictor closes it. */
+    private static final Duration IDLE_TTL = Duration.ofMinutes(5);
+
+    /** How often the background evictor sweeps for expired idle connections. */
+    private static final Duration EVICTION_INTERVAL = Duration.ofMinutes(1);
+
+    /** Opens a real connection for a normalized (sorted, deduped) auth set. */
+    interface Opener {
+        Connection open(List<String> normalizedAuths) throws SQLException;
+    }
+
+    private final GenericKeyedObjectPool<String, Connection> pool;
+
+    ConnectionPool(Opener opener) {
+        GenericKeyedObjectPoolConfig<Connection> config = new GenericKeyedObjectPoolConfig<>();
+        config.setMaxTotalPerKey(-1);
+        config.setMaxTotal(-1);
+        config.setBlockWhenExhausted(false);
+        config.setMaxIdlePerKey(MAX_IDLE_PER_KEY);
+        config.setMinEvictableIdleDuration(IDLE_TTL);
+        config.setTimeBetweenEvictionRuns(EVICTION_INTERVAL);
+        config.setTestOnBorrow(true);
+        config.setJmxEnabled(false);
+        this.pool = new GenericKeyedObjectPool<>(new Factory(opener), config);
+    }
+
+    /** Sorted, deduped, validated copy of the auths; empty for null/empty input. */
+    static List<String> normalize(List<String> auths) {
+        if (auths == null || auths.isEmpty()) {
+            return Collections.emptyList();
+        }
+        AuthTokens.validate(auths);
+        return List.copyOf(new TreeSet<>(auths));
+    }
+
+    /** Returns a connection whose extra credential carries exactly the given auths. */
+    Connection borrow(List<String> auths) throws SQLException {
+        String key = String.join(",", normalize(auths));
+        Connection conn;
+        try {
+            conn = pool.borrowObject(key);
+        } catch (SQLException | RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SQLException("Failed to obtain pooled connection", e);
+        }
+        return new PooledConnection(pool, key, conn);
+    }
+
+    /** Closes all idle connections; subsequent returns are destroyed. In-flight
+     *  connections are unaffected until their consumers close them. */
+    @Override
+    public void close() {
+        pool.close();
+    }
+
+    GenericKeyedObjectPool<String, Connection> delegate() {
+        return pool;
+    }
+
+    /** Opens/validates/destroys pooled connections. */
+    private static final class Factory extends BaseKeyedPooledObjectFactory<String, Connection> {
+
+        private final Opener opener;
+
+        private Factory(Opener opener) {
+            this.opener = opener;
+        }
+
+        @Override
+        public Connection create(String key) throws SQLException {
+            List<String> auths = key.isEmpty() ? List.of() : Arrays.asList(key.split(","));
+            return opener.open(auths);
+        }
+
+        @Override
+        public PooledObject<Connection> wrap(Connection conn) {
+            return new DefaultPooledObject<>(conn);
+        }
+
+        @Override
+        public boolean validateObject(String key, PooledObject<Connection> p) {
+            try {
+                return !p.getObject().isClosed();
+            } catch (SQLException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public void destroyObject(String key, PooledObject<Connection> p) throws SQLException {
+            p.getObject().close();
+        }
+    }
+}

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/PooledConnection.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/PooledConnection.java
@@ -1,0 +1,60 @@
+/***********************************************************************
+ * Copyright (c) 2013-2025 General Atomics Integrated Intelligence, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ ***********************************************************************/
+
+package org.locationtech.geomesa.trino.datastore;
+
+import org.apache.commons.dbcp2.DelegatingConnection;
+import org.apache.commons.pool2.KeyedObjectPool;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A borrowed {@link Connection} that returns itself to its {@link ConnectionPool} on
+ * {@link #close()} (exactly once) instead of closing, preserving callers'
+ * try-with-resources semantics. Any other use after close throws — by then the underlying
+ * connection may already be serving another request with the same auths.
+ *
+ * <p>Extends dbcp2's {@link DelegatingConnection}: {@link #passivate()} closes any
+ * statements this wrapper handed out, so a straggler statement can't touch the
+ * underlying connection after it has been recycled to another consumer.
+ */
+final class PooledConnection extends DelegatingConnection<Connection> {
+
+    private final KeyedObjectPool<String, Connection> pool;
+    private final String key;
+    private final AtomicBoolean returned = new AtomicBoolean(false);
+
+    PooledConnection(KeyedObjectPool<String, Connection> pool, String key, Connection real) {
+        super(real);
+        this.pool = pool;
+        this.key = key;
+    }
+
+    /** Returns the underlying connection to the pool; a closed pool destroys it
+     *  instead. The wrapper then reports closed and the inherited guards reject
+     *  further use. */
+    @Override
+    public void close() throws SQLException {
+        if (returned.compareAndSet(false, true)) {
+            try {
+                passivate();
+            } finally {
+                setClosedInternal(true);
+                try {
+                    pool.returnObject(key, getDelegateInternal());
+                } catch (SQLException | RuntimeException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new SQLException("Failed to return connection to pool", e);
+                }
+            }
+        }
+    }
+}

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoDataStore.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoDataStore.java
@@ -28,9 +28,9 @@ import java.util.concurrent.TimeUnit;
  * Trino store is read-only to function primarily as a query engine and does not expose the write-based operations
  * provided by {@code JDBCDataStore}. {@code ContentDataStore} is the lighter, correct base for a query-only source,
  * it lets us push filter/projection/sort/count/bounds down as Trino SQL (see {@link TrinoFeatureSource}), and
- * offers per-request-authenticated connections per query and visibility/entitlement filtering. A consequence is that
- * there is no shared connection pool: each query opens its own connection so the forwarded authorizations always
- * reflect the current caller context (see {@link #connect(List)}).
+ * offers per-request-authenticated connections per query and visibility/entitlement filtering. Because the
+ * forwarded authorizations are fixed on a connection at creation, connections are pooled keyed by the normalized
+ * auth set ({@link ConnectionPool}): requests with the same effective auths reuse connections (see {@link #connect(List)}).
  */
 public class TrinoDataStore extends ContentDataStore {
 
@@ -66,6 +66,9 @@ public class TrinoDataStore extends ContentDataStore {
     private List<Name> cachedTypeNames;
     private long cachedTypeNamesExpiry;
 
+    /** Connections keyed by normalized auth set — see {@link #connect(List)}. */
+    private final ConnectionPool pool = new ConnectionPool(this::openConnection);
+
     TrinoDataStore(String host, int port, String catalog, String schema,
                    AuthorizationsProvider authProvider, String user, String secret) {
         this.host = host;
@@ -87,17 +90,31 @@ public class TrinoDataStore extends ContentDataStore {
         return connect(null);
     }
 
-    /** Opens a per-query Trino connection, forwarding the caller's authorizations
-     *  as a Trino extra credential. The {@code spatial_iceberg} connector's
+    /** Returns a Trino connection carrying the caller's authorizations as a Trino
+     *  extra credential. The {@code spatial_iceberg} connector's
      *  ExtraCredentialAuthorizationResolver reads it to build the row-level
-     *  visibility filter for THIS request. A fresh connection is opened per query,
-     *  so the credential always reflects the current per-request auths. When
-     *  {@code auths} is null/empty no credential is sent (the caller then sees only
-     *  unrestricted rows — fail-closed). */
+     *  visibility filter for THIS request. Because the credential is fixed at
+     *  connection creation, connections are pooled keyed by the normalized
+     *  (sorted, deduped) auth set: a request only ever gets a connection whose
+     *  credential matches its own auths exactly. Close the connection to return
+     *  it to the pool. When {@code auths} is null/empty no credential is sent
+     *  (the caller then sees only unrestricted rows — fail-closed). */
     Connection connect(List<String> auths) throws SQLException {
+        return pool.borrow(auths);
+    }
+
+    /** Opens a real connection for a normalized auth set (pool miss). */
+    private Connection openConnection(List<String> normalizedAuths) throws SQLException {
         String url = String.format("jdbc:trino://%s:%d/%s/%s",
             host, port, catalog, trinoSchema);
-        return DriverManager.getConnection(url, connectionProperties(user, auths, secret));
+        return DriverManager.getConnection(url, connectionProperties(user, normalizedAuths, secret));
+    }
+
+    /** Closes all pooled connections. */
+    @Override
+    public void dispose() {
+        pool.close();
+        super.dispose();
     }
 
     /** Builds the JDBC connection properties. Extracted so the extra-credential

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/ConnectionPoolTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/ConnectionPoolTest.java
@@ -1,0 +1,196 @@
+/***********************************************************************
+ * Copyright (c) 2013-2025 General Atomics Integrated Intelligence, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ ***********************************************************************/
+
+package org.locationtech.geomesa.trino.datastore;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConnectionPoolTest {
+
+    /** Records every open: the auths requested and a stub connection whose only real
+     *  behavior is a local closed flag. */
+    private static final class RecordingOpener implements ConnectionPool.Opener {
+        final List<List<String>> openedWith = new ArrayList<>();
+        final List<StubConnection> opened = new ArrayList<>();
+
+        @Override
+        public Connection open(List<String> normalizedAuths) {
+            StubConnection stub = new StubConnection();
+            openedWith.add(normalizedAuths);
+            opened.add(stub);
+            return stub.conn;
+        }
+    }
+
+    /** Stub {@link Connection}: close()/isClosed() work, everything else returns null. */
+    private static final class StubConnection {
+        final AtomicBoolean closed = new AtomicBoolean(false);
+        final Connection conn = (Connection) Proxy.newProxyInstance(
+            Connection.class.getClassLoader(), new Class<?>[]{Connection.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "close"    -> { closed.set(true); yield null; }
+                case "isClosed" -> closed.get();
+                case "hashCode" -> System.identityHashCode(proxy);
+                case "equals"   -> proxy == args[0];
+                case "toString" -> "stub";
+                default         -> null;
+            });
+    }
+
+    @Test
+    void sameAuthSetReusesConnection() throws SQLException {
+        RecordingOpener opener = new RecordingOpener();
+        ConnectionPool pool = new ConnectionPool(opener);
+        pool.borrow(List.of("a", "b")).close();
+        pool.borrow(List.of("a", "b")).close();
+        assertThat(opener.opened).hasSize(1);
+    }
+
+    @Test
+    void orderAndDuplicatesDoNotFragmentThePool() throws SQLException {
+        RecordingOpener opener = new RecordingOpener();
+        ConnectionPool pool = new ConnectionPool(opener);
+        pool.borrow(List.of("b", "a")).close();
+        pool.borrow(List.of("a", "b", "a")).close();
+        assertThat(opener.opened).hasSize(1);
+        // the opener sees the normalized set, so the credential matches the pool key
+        assertThat(opener.openedWith.get(0)).containsExactly("a", "b");
+    }
+
+    @Test
+    void differentAuthSetsNeverShareConnections() throws SQLException {
+        RecordingOpener opener = new RecordingOpener();
+        ConnectionPool pool = new ConnectionPool(opener);
+        pool.borrow(List.of("a")).close();
+        pool.borrow(List.of("a", "b")).close();  // superset: distinct connection
+        pool.borrow(List.of()).close();          // no auths:  distinct connection
+        assertThat(opener.opened).hasSize(3);
+        // each set reuses its own
+        pool.borrow(List.of("a")).close();
+        pool.borrow(List.of("b", "a")).close();
+        pool.borrow(null).close();               // null normalizes like empty
+        assertThat(opener.opened).hasSize(3);
+    }
+
+    @Test
+    void concurrentBorrowsOfSameKeyGetDistinctConnections() throws SQLException {
+        RecordingOpener opener = new RecordingOpener();
+        ConnectionPool pool = new ConnectionPool(opener);
+        Connection first = pool.borrow(List.of("a"));
+        Connection second = pool.borrow(List.of("a"));  // first not yet returned
+        assertThat(opener.opened).hasSize(2);
+        first.close();
+        second.close();
+        pool.borrow(List.of("a")).close();
+        assertThat(opener.opened).hasSize(2);  // both reusable after return
+    }
+
+    @Test
+    void perKeyIdleCapClosesExcessReturns() throws SQLException {
+        RecordingOpener opener = new RecordingOpener();
+        ConnectionPool pool = new ConnectionPool(opener);
+        List<Connection> borrowed = new ArrayList<>();
+        for (int i = 0; i < 12; i++) {
+            borrowed.add(pool.borrow(List.of("a")));
+        }
+        for (Connection c : borrowed) {
+            c.close();
+        }
+        long stillOpen = opener.opened.stream().filter(s -> !s.closed.get()).count();
+        assertThat(stillOpen).isEqualTo(10);  // MAX_IDLE_PER_KEY
+    }
+
+    @Test
+    void configuredForUnboundedNonBlockingBorrowsWithIdleTtl() {
+        // The non-default commons-pool2 config is load-bearing: with the defaults
+        // (maxTotalPerKey=8, blockWhenExhausted=true) a burst of same-auth queries
+        // would QUEUE — a latency cliff the old connection-per-query code never had.
+        var delegate = new ConnectionPool(new RecordingOpener()).delegate();
+        assertThat(delegate.getMaxTotalPerKey()).isEqualTo(-1);
+        assertThat(delegate.getMaxTotal()).isEqualTo(-1);
+        assertThat(delegate.getBlockWhenExhausted()).isFalse();
+        assertThat(delegate.getMaxIdlePerKey()).isEqualTo(10);
+        assertThat(delegate.getMinEvictableIdleDuration()).isEqualTo(java.time.Duration.ofMinutes(5));
+        assertThat(delegate.getDurationBetweenEvictionRuns()).isPositive();  // evictor enabled
+        assertThat(delegate.getTestOnBorrow()).isTrue();  // discard connections closed underneath
+    }
+
+    @Test
+    void poolCloseClosesIdleAndStopsPooling() throws SQLException {
+        RecordingOpener opener = new RecordingOpener();
+        ConnectionPool pool = new ConnectionPool(opener);
+        Connection inFlight = pool.borrow(List.of("a"));
+        pool.borrow(List.of("b")).close();  // idle at pool close
+        pool.close();
+        assertThat(opener.opened.get(1).closed).isTrue();       // idle: closed by pool
+        assertThat(opener.opened.get(0).closed).isFalse();      // in-flight: untouched
+        inFlight.close();
+        assertThat(opener.opened.get(0).closed).isTrue();       // return after close = real close
+    }
+
+    @Test
+    void doubleCloseReturnsToPoolOnlyOnce() throws SQLException {
+        RecordingOpener opener = new RecordingOpener();
+        ConnectionPool pool = new ConnectionPool(opener);
+        Connection conn = pool.borrow(List.of("a"));
+        conn.close();
+        conn.close();  // no double-pooling of the same underlying connection
+        Connection reuse1 = pool.borrow(List.of("a"));
+        Connection reuse2 = pool.borrow(List.of("a"));
+        assertThat(opener.opened).hasSize(2);  // second borrow required a fresh open
+        reuse1.close();
+        reuse2.close();
+    }
+
+    @Test
+    void usingConnectionAfterCloseThrows() throws SQLException {
+        ConnectionPool pool = new ConnectionPool(new RecordingOpener());
+        Connection conn = pool.borrow(List.of("a"));
+        conn.close();
+        assertThat(conn.isClosed()).isTrue();
+        // the underlying connection may already be serving another request — reject use
+        assertThatThrownBy(conn::createStatement).isInstanceOf(SQLException.class);
+    }
+
+    @Test
+    void connectionClosedUnderneathIsNotHandedOut() throws SQLException {
+        RecordingOpener opener = new RecordingOpener();
+        ConnectionPool pool = new ConnectionPool(opener);
+        pool.borrow(List.of("a")).close();
+        opener.opened.get(0).closed.set(true);  // dies while idle (e.g. server-side)
+        pool.borrow(List.of("a")).close();
+        assertThat(opener.opened).hasSize(2);
+    }
+
+    @Test
+    void invalidTokensRejectedBeforeKeying() {
+        ConnectionPool pool = new ConnectionPool(new RecordingOpener());
+        // ',' joins tokens in the pool key (and the is_visible SQL literal) — a token
+        // containing it would collide with a two-token set that was never issued
+        assertThatThrownBy(() -> pool.borrow(List.of("a,b")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("authorization token");
+    }
+
+    @Test
+    void normalizeSortsDedupesAndCopies() {
+        assertThat(ConnectionPool.normalize(null)).isEmpty();
+        assertThat(ConnectionPool.normalize(List.of())).isEmpty();
+        assertThat(ConnectionPool.normalize(List.of("b", "a", "b"))).containsExactly("a", "b");
+    }
+}


### PR DESCRIPTION
# Trino datastore: pool JDBC connections keyed by authorization set

Closes #3583 (deferred from #3573).

## Problem

The Trino datastore forwards each caller's authorizations to Trino as an
`extraCredentials` entry that is **fixed on the connection at creation** — a
connection *is* its authorization context. The initial implementation therefore
opened a fresh connection per query, so deployments could never reuse
connections across requests, paying the connection setup cost on every query.

## Approach

Connections are now pooled, keyed by the **normalized authorization set**
(sorted, deduped, validated): requests with the same effective auths reuse
connections; requests with different auths structurally cannot share one.

- **`ConnectionPool`** — wraps a commons-pool2 `GenericKeyedObjectPool`. 
- **`PooledConnection`** — a `dbcp2 DelegatingConnection` subclass whose
  `close()` returns the delegate to the pool exactly once; callers keep
  ordinary try-with-resources semantics and **no call sites changed**. Any
  other use after close throws, and `passivate()` closes straggler statements
  before the connection is re-lent.
- The **same normalized list** feeds both the pool key and the credential
  encoding, so a pooled connection's credential always matches its key.
  `TrinoDataStore.dispose()` drains the pool.

## New dependencies

`commons-pool2` and `commons-dbcp2`- Deployments that stage this module's
 JAR directly onto a classpath must stage these alongside it.