### PR TITLE
GEOMESA-3584 Derive geometry type + name information from geomesa SFT spec metadata

### DIFF
--- a/geomesa-trino/geomesa-trino-datastore/pom.xml
+++ b/geomesa-trino/geomesa-trino-datastore/pom.xml
@@ -64,6 +64,11 @@
       <artifactId>geomesa-security_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.locationtech.geomesa</groupId>
+      <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/geomesa-trino/geomesa-trino-datastore/pom.xml
+++ b/geomesa-trino/geomesa-trino-datastore/pom.xml
@@ -62,14 +62,11 @@
     <dependency>
       <groupId>org.locationtech.geomesa</groupId>
       <artifactId>geomesa-security_${scala.binary.version}</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.locationtech.geomesa</groupId>
       <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
-      <version>${project.version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoSchemaDiscovery.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoSchemaDiscovery.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.sql.*;
 import java.util.*;
 
+import static org.locationtech.geomesa.trino.datastore.TrinoDataStore.escapeQuotes;
+
 class TrinoSchemaDiscovery {
 
     private static final Logger LOG = LoggerFactory.getLogger(TrinoSchemaDiscovery.class);
@@ -43,8 +45,12 @@ class TrinoSchemaDiscovery {
         tb.setName(typeName);
         tb.setNamespaceURI(store.getNamespaceURI());
 
-        String sql = String.format("SELECT * FROM \"%s\".\"%s\".\"%s\" LIMIT 0",
-            store.catalog(), store.trinoSchema(), typeName);
+        String sql = String.format(
+            "SELECT * FROM %s.%s.%s LIMIT 0",
+            escapeQuotes(store.catalog()),
+            escapeQuotes(store.trinoSchema()),
+            escapeQuotes(typeName)
+        );
 
         Map<String, String> sftProps = readSftProperties(typeName);
         String sftSpec = sftProps.get(SFT_SPEC_PROPERTY);
@@ -141,8 +147,12 @@ class TrinoSchemaDiscovery {
      *  binding/name for this table. */
     private Map<String, String> readSftProperties(String typeName) {
         String sql = String.format(
-            "SELECT key, value FROM \"%s\".\"%s\".\"%s$properties\" WHERE key IN ('%s', '%s')",
-            store.catalog(), store.trinoSchema(), typeName, SFT_SPEC_PROPERTY, SFT_NAME_PROPERTY);
+            "SELECT key, value FROM %s.%s.%s WHERE key IN ('%s', '%s')",
+            escapeQuotes(store.catalog()),
+            escapeQuotes(store.trinoSchema()),
+            escapeQuotes(typeName + "$properties"),
+            SFT_SPEC_PROPERTY, SFT_NAME_PROPERTY
+        );
         Map<String, String> props = new HashMap<>();
         try (Connection conn = store.connect();
              Statement stmt = conn.createStatement();

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoSchemaDiscovery.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoSchemaDiscovery.java
@@ -9,13 +9,28 @@
 package org.locationtech.geomesa.trino.datastore;
 
 import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.feature.type.AttributeDescriptor;
+import org.geotools.api.feature.type.GeometryDescriptor;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.sql.*;
 import java.util.*;
 
 class TrinoSchemaDiscovery {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TrinoSchemaDiscovery.class);
+
+    /** Iceberg table property holding the GeoMesa-encoded SimpleFeatureType spec. */
+    static final String SFT_SPEC_PROPERTY = "geomesa.sft.spec";
+
+    /** Iceberg table property holding the GeoMesa type name. */
+    static final String SFT_NAME_PROPERTY = "geomesa.sft.name";
 
     private final TrinoDataStore store;
 
@@ -30,6 +45,11 @@ class TrinoSchemaDiscovery {
 
         String sql = String.format("SELECT * FROM \"%s\".\"%s\".\"%s\" LIMIT 0",
             store.catalog(), store.trinoSchema(), typeName);
+
+        Map<String, String> sftProps = readSftProperties(typeName);
+        String sftSpec = sftProps.get(SFT_SPEC_PROPERTY);
+        Map<String, Class<?>> sftBindings = (sftSpec == null || sftSpec.isBlank())
+            ? Map.of() : geometryBindingsFromSpec(typeName, sftSpec);
 
         String visColumn = null;
         try (Connection conn = store.connect();
@@ -54,16 +74,14 @@ class TrinoSchemaDiscovery {
             for (int i = 1; i <= meta.getColumnCount(); i++) {
                 String name = meta.getColumnName(i);
                 if (TrinoTypeMapper.isHidden(name)) continue;
-                if (name.equals(visColumn)) continue;  // vis column is metadata, not a SFT attribute
+                if (name.equals(visColumn)) continue;  // vis column is metadata, not an SFT attribute
 
                 boolean isGeom = geometryColumnNames.contains(name);
-                // A __X_z2__ companion marks a point-only geometry column, so the
-                // attribute can be bound to Point rather than the generic Geometry.
-                boolean isPoint = isGeom && isPointColumn(name, allNames);
+                Class<?> geomBinding = isGeom ? resolveGeometryBinding(name, allNames, sftBindings) : null;
                 // SRID is no longer carried in a table property; default to WGS84.
                 int srid = isGeom ? 4326 : 0;
                 var descriptor =
-                    TrinoTypeMapper.toDescriptor(name, meta.getColumnType(i), isGeom, isPoint, srid);
+                    TrinoTypeMapper.toDescriptor(name, meta.getColumnType(i), isGeom, geomBinding, srid);
                 tb.add(descriptor);
 
                 if (isGeom && !defaultGeomSet) {
@@ -79,7 +97,64 @@ class TrinoSchemaDiscovery {
         if (visColumn != null) {
             sft.getUserData().put(VIS_COLUMN_KEY, visColumn);
         }
+        String sftName = sftProps.get(SFT_NAME_PROPERTY);
+        if (sftName != null && !sftName.isBlank()) {
+            sft.getUserData().put(SFT_NAME_PROPERTY, sftName);
+        }
         return sft;
+    }
+
+    /** The JTS geometry binding for a geometry column: the subtype declared by the stored SFT
+     *  when it names this attribute, else {@link Point} for a {@code __<name>_z2__} companion,
+     *  generic {@link Geometry} otherwise. */
+    static Class<?> resolveGeometryBinding(String name, Set<String> allNames,
+                                           Map<String, Class<?>> sftBindings) {
+        Class<?> fromSft = sftBindings.get(name);
+        if (fromSft != null) {
+            return fromSft;
+        }
+        return isPointColumn(name, allNames) ? Point.class : Geometry.class;
+    }
+
+    /** Parses a GeoMesa SFT spec into geometry-attribute-name → JTS subtype. */
+    static Map<String, Class<?>> geometryBindingsFromSpec(String typeName, String spec) {
+        try {
+            SimpleFeatureType sft = SimpleFeatureTypes.createType(typeName, spec);
+            Map<String, Class<?>> bindings = new LinkedHashMap<>();
+            for (AttributeDescriptor d : sft.getAttributeDescriptors()) {
+                if (d instanceof GeometryDescriptor) {
+                    bindings.put(d.getLocalName(), d.getType().getBinding());
+                }
+            }
+            return bindings;
+        } catch (RuntimeException e) {
+            LOG.warn("Could not parse stored GeoMesa SFT for '{}' ({}='{}'): {}; "
+                + "falling back to heuristic geometry binding",
+                typeName, SFT_SPEC_PROPERTY, spec, e.getMessage());
+            return Map.of();
+        }
+    }
+
+    /** Reads the {@code geomesa.sft.*} properties (spec + name) from the Iceberg
+     *  {@code <table>$properties} metadata table in one query; empty when the table carries none
+     *  or doesn't expose {@code $properties}. Non-fatal: any failure just disables SFT-driven
+     *  binding/name for this table. */
+    private Map<String, String> readSftProperties(String typeName) {
+        String sql = String.format(
+            "SELECT key, value FROM \"%s\".\"%s\".\"%s$properties\" WHERE key IN ('%s', '%s')",
+            store.catalog(), store.trinoSchema(), typeName, SFT_SPEC_PROPERTY, SFT_NAME_PROPERTY);
+        Map<String, String> props = new HashMap<>();
+        try (Connection conn = store.connect();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery(sql)) {
+            while (rs.next()) {
+                props.put(rs.getString(1), rs.getString(2));
+            }
+        } catch (SQLException e) {
+            LOG.debug("No readable $properties for '{}' (no SFT metadata): {}",
+                typeName, e.getMessage());
+        }
+        return props;
     }
 
     /** Returns the set of column names that are geometry columns under the

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapper.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapper.java
@@ -12,7 +12,6 @@ import org.geotools.api.feature.type.AttributeDescriptor;
 import org.geotools.feature.AttributeTypeBuilder;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.Point;
 
 import java.sql.Types;
 import java.util.Date;
@@ -36,7 +35,7 @@ class TrinoTypeMapper {
     }
 
     static AttributeDescriptor toDescriptor(String name, int sqlType,
-                                             boolean isGeometry, boolean isPoint, int srid) {
+                                             boolean isGeometry, Class<?> geometryBinding, int srid) {
         AttributeTypeBuilder b = new AttributeTypeBuilder();
         b.setName(name);
         b.setNillable(true);
@@ -52,10 +51,9 @@ class TrinoTypeMapper {
                 }
             }
             b.setCRS(crs);
-            // Point when the column carries a __<name>_z2__ companion; this enables the
-            // point/rectangle bbox fast path in TrinoFilterToSQL. Generic Geometry
-            // otherwise (XZ2-companioned columns may hold any geometry type).
-            b.setBinding(isPoint ? Point.class : Geometry.class);
+            Class<?> binding = geometryBinding != null && Geometry.class.isAssignableFrom(geometryBinding)
+                ? geometryBinding : Geometry.class;
+            b.setBinding(binding);
             return b.buildDescriptor(name, b.buildGeometryType());
         }
 

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/GeometrySubtypeIT.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/GeometrySubtypeIT.java
@@ -1,0 +1,100 @@
+/***********************************************************************
+ * Copyright (c) 2013-2025 General Atomics Integrated Intelligence, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ ***********************************************************************/
+
+package org.locationtech.geomesa.trino.datastore;
+
+import org.geotools.api.data.DataStore;
+import org.geotools.api.data.DataStoreFinder;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end check for GEOMESA-3584: when an Iceberg table carries a GeoMesa-encoded SFT
+ * (written by the tooling ingest as the {@code geomesa.sft.spec} table property), schema
+ * discovery binds each geometry attribute to the subtype the SFT declares.
+ *
+ * <p>Requires a running Trino at localhost:8080 with the synthetic demo re-ingested by a build
+ * that writes the SFT property (the {@code spatial.regions} table is XZ2-partitioned, so the
+ * naming heuristic alone would bind it to generic {@code Geometry} — binding {@code Polygon}
+ * proves the SFT drove it). Skips when the tables are absent.
+ */
+@Tag("integration")
+class GeometrySubtypeIT {
+
+    private static DataStore ds;
+    private static Set<String> tables = Set.of();
+
+    @BeforeAll
+    static void connect() throws Exception {
+        try (var socket = new java.net.Socket()) {
+            socket.connect(new java.net.InetSocketAddress("localhost", 8080), 2000);
+        } catch (Exception e) {
+            Assumptions.assumeTrue(false, "Trino not reachable at localhost:8080 — skipping");
+        }
+        ds = DataStoreFinder.getDataStore(Map.of(
+            "trino.host", "localhost", "trino.port", 8080,
+            "trino.catalog", "spatial_iceberg", "trino.schema", "spatial"));
+        assertThat(ds).as("DataStoreFinder must locate TrinoDataStoreFactory").isNotNull();
+        tables = Arrays.stream(ds.getTypeNames()).collect(Collectors.toSet());
+    }
+
+    @AfterAll
+    static void disconnect() {
+        if (ds != null) ds.dispose();
+    }
+
+    @Test
+    void xz2PolygonColumnBindsToPolygonFromSft() throws Exception {
+        Assumptions.assumeTrue(tables.contains("regions"),
+            "spatial.regions not ingested (needs an SFT-writing ingest) — skipping");
+        SimpleFeatureType sft = ds.getSchema("regions");
+        assertThat(sft.getGeometryDescriptor().getType().getBinding())
+            .as("XZ2 column bound to its SFT-declared subtype, not generic Geometry")
+            .isEqualTo(Polygon.class);
+    }
+
+    @Test
+    void sftNameRecordedInUserData() throws Exception {
+        Assumptions.assumeTrue(tables.contains("regions"),
+            "spatial.regions not ingested (needs an SFT-writing ingest) — skipping");
+        SimpleFeatureType sft = ds.getSchema("regions");
+        assertThat(sft.getUserData().get(TrinoSchemaDiscovery.SFT_NAME_PROPERTY))
+            .as("original GeoMesa type name recorded from geomesa.sft.name")
+            .isEqualTo("regions");
+    }
+
+    @Test
+    void z2PointColumnRemainsPoint() throws Exception {
+        Assumptions.assumeTrue(tables.contains("observations"),
+            "spatial.observations not ingested — skipping");
+        SimpleFeatureType sft = ds.getSchema("observations");
+        assertThat(sft.getGeometryDescriptor().getType().getBinding()).isEqualTo(Point.class);
+    }
+
+    @Test
+    void multiGeomBindsEachSubtypeIndependently() throws Exception {
+        Assumptions.assumeTrue(tables.contains("observations_2geom"),
+            "spatial.observations_2geom not ingested — skipping");
+        SimpleFeatureType sft = ds.getSchema("observations_2geom");
+        assertThat(sft.getDescriptor("center").getType().getBinding()).isEqualTo(Point.class);
+        assertThat(sft.getDescriptor("ellipse").getType().getBinding()).isEqualTo(Polygon.class);
+    }
+}

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoSchemaDiscoveryTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoSchemaDiscoveryTest.java
@@ -9,7 +9,11 @@
 package org.locationtech.geomesa.trino.datastore;
 
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,5 +50,59 @@ class TrinoSchemaDiscoveryTest {
     void xz2CompanionIsNotPointColumn() {
         assertThat(TrinoSchemaDiscovery.isPointColumn("ellipse",
             Set.of("ellipse", "__ellipse_xz2__", "__ellipse_bbox__"))).isFalse();
+    }
+
+    @Test
+    void sftBindingWinsOverHeuristic() {
+        // The stored SFT declares the exact subtype; it overrides the companion heuristic —
+        // both directions: an XZ2 column (heuristic would say generic Geometry) bound to
+        // Polygon, and a Z2 column (heuristic would say Point) bound to whatever the SFT says.
+        var allNames = Set.of("region", "__region_xz2__", "__region_bbox__");
+        assertThat(TrinoSchemaDiscovery.resolveGeometryBinding(
+            "region", allNames, Map.of("region", Polygon.class))).isEqualTo(Polygon.class);
+        assertThat(TrinoSchemaDiscovery.resolveGeometryBinding(
+            "center", Set.of("center", "__center_z2__"), Map.of("center", Polygon.class)))
+            .isEqualTo(Polygon.class);
+    }
+
+    @Test
+    void parsesRealWorldSftWithOptionsAndUserData() {
+        // The exact geomesa.sft.spec stored on the production trino_test.rawob_harrisnextgen
+        // table: per-attribute options (fs.bounds, default), a *-marked default Point geometry,
+        // and trailing ;-delimited user data. Must parse and yield geom → Point.
+        String spec = "flightId:String:fs.bounds=true,timeUp:Date:default=true:fs.bounds=true,"
+            + "lat:Double,lon:Double,alt:Double,classification:String,course:Double,speed:Double,"
+            + "callsign:String:fs.bounds=true,origin:String,destination:String,mode3a:String,"
+            + "modeS:String,tailNumber:String:fs.bounds=true,aircraftType:String,facilityName:String,"
+            + "facilityHash:String,airGround:String,updateType:String,altChange:String,"
+            + "processTime:Date,rcptTime:Date,iconHeading:Double,*geom:Point:srid=4326,"
+            + "recordHash:String,source:String,trackId:String,trueAirSpeed:Double,windDirection:Double,"
+            + "windSpeed:Double,windIsAccurate:Boolean,ingestLatency:Long;geomesa.index.dtg='timeUp'";
+        Map<String, Class<?>> bindings =
+            TrinoSchemaDiscovery.geometryBindingsFromSpec("rawob_harrisnextgen", spec);
+        assertThat(bindings).containsExactly(Map.entry("geom", Point.class));
+    }
+
+    @Test
+    void multiGeomSpecYieldsEachSubtype() {
+        Map<String, Class<?>> bindings = TrinoSchemaDiscovery.geometryBindingsFromSpec(
+            "t", "*center:Point:srid=4326,ellipse:Polygon:srid=4326,dtg:Date,label:String");
+        assertThat(bindings).containsOnly(
+            Map.entry("center", Point.class), Map.entry("ellipse", Polygon.class));
+    }
+
+    @Test
+    void unparseableSpecYieldsEmptyForHeuristicFallback() {
+        assertThat(TrinoSchemaDiscovery.geometryBindingsFromSpec("t", "]not a valid spec["))
+            .isEmpty();
+    }
+
+    @Test
+    void fallsBackToHeuristicWhenSftAbsent() {
+        // No SFT entry for this column → z2 companion ⇒ Point, xz2 companion ⇒ generic Geometry.
+        assertThat(TrinoSchemaDiscovery.resolveGeometryBinding(
+            "center", Set.of("center", "__center_z2__"), Map.of())).isEqualTo(Point.class);
+        assertThat(TrinoSchemaDiscovery.resolveGeometryBinding(
+            "ellipse", Set.of("ellipse", "__ellipse_xz2__"), Map.of())).isEqualTo(Geometry.class);
     }
 }

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoSchemaDiscoveryTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoSchemaDiscoveryTest.java
@@ -66,20 +66,12 @@ class TrinoSchemaDiscoveryTest {
     }
 
     @Test
-    void parsesRealWorldSftWithOptionsAndUserData() {
-        // The exact geomesa.sft.spec stored on the production trino_test.rawob_harrisnextgen
-        // table: per-attribute options (fs.bounds, default), a *-marked default Point geometry,
-        // and trailing ;-delimited user data. Must parse and yield geom → Point.
-        String spec = "flightId:String:fs.bounds=true,timeUp:Date:default=true:fs.bounds=true,"
-            + "lat:Double,lon:Double,alt:Double,classification:String,course:Double,speed:Double,"
-            + "callsign:String:fs.bounds=true,origin:String,destination:String,mode3a:String,"
-            + "modeS:String,tailNumber:String:fs.bounds=true,aircraftType:String,facilityName:String,"
-            + "facilityHash:String,airGround:String,updateType:String,altChange:String,"
-            + "processTime:Date,rcptTime:Date,iconHeading:Double,*geom:Point:srid=4326,"
-            + "recordHash:String,source:String,trackId:String,trueAirSpeed:Double,windDirection:Double,"
-            + "windSpeed:Double,windIsAccurate:Boolean,ingestLatency:Long;geomesa.index.dtg='timeUp'";
+    void parsesSftWithOptionsAndUserData() {
+        String spec = "id:String:fs.bounds=true,dtg:Date:default=true:fs.bounds=true,"
+            + "name:String,count:Long,score:Double:fs.bounds=true,active:Boolean,"
+            + "*geom:Point:srid=4326;geomesa.index.dtg='dtg'";
         Map<String, Class<?>> bindings =
-            TrinoSchemaDiscovery.geometryBindingsFromSpec("rawob_harrisnextgen", spec);
+            TrinoSchemaDiscovery.geometryBindingsFromSpec("example", spec);
         assertThat(bindings).containsExactly(Map.entry("geom", Point.class));
     }
 

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapperTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapperTest.java
@@ -21,63 +21,81 @@ class TrinoTypeMapperTest {
 
     @Test
     void varcharMapsToString() {
-        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("fid", Types.VARCHAR, false, false, 0);
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("fid", Types.VARCHAR, false, null, 0);
         assertThat(d.getType().getBinding()).isEqualTo(String.class);
         assertThat(d.getLocalName()).isEqualTo("fid");
     }
 
     @Test
     void bigintMapsToLong() {
-        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("count_col", Types.BIGINT, false, false, 0);
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("count_col", Types.BIGINT, false, null, 0);
         assertThat(d.getType().getBinding()).isEqualTo(Long.class);
     }
 
     @Test
     void integerMapsToInteger() {
-        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("taxi_id", Types.INTEGER, false, false, 0);
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("taxi_id", Types.INTEGER, false, null, 0);
         assertThat(d.getType().getBinding()).isEqualTo(Integer.class);
     }
 
     @Test
     void doubleMapsToDouble() {
-        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("value", Types.DOUBLE, false, false, 0);
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("value", Types.DOUBLE, false, null, 0);
         assertThat(d.getType().getBinding()).isEqualTo(Double.class);
     }
 
     @Test
     void booleanMapsToBoolean() {
-        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("active", Types.BOOLEAN, false, false, 0);
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("active", Types.BOOLEAN, false, null, 0);
         assertThat(d.getType().getBinding()).isEqualTo(Boolean.class);
     }
 
     @Test
     void timestampWithTimezoneMapsToDate() {
-        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("dtg", Types.TIMESTAMP_WITH_TIMEZONE, false, false, 0);
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("dtg", Types.TIMESTAMP_WITH_TIMEZONE, false, null, 0);
         assertThat(d.getType().getBinding()).isEqualTo(Date.class);
     }
 
     @Test
-    void varbinaryWithGeometryFlagMapsToGeometry() {
-        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("geom_wkb", Types.VARBINARY, true, false, 4326);
-        assertThat(d.getType().getBinding()).isEqualTo(Geometry.class);
-        assertThat(d).isInstanceOf(org.geotools.api.feature.type.GeometryDescriptor.class);
+    void geometryBindingPassesThroughTheResolvedSubtype() {
+        // The caller resolves the subtype (from the stored SFT or the heuristic); the mapper
+        // binds exactly that. Covers the full JTS geometry hierarchy the SFT can declare.
+        for (Class<?> subtype : java.util.List.of(
+                org.locationtech.jts.geom.Point.class,
+                org.locationtech.jts.geom.LineString.class,
+                org.locationtech.jts.geom.Polygon.class,
+                org.locationtech.jts.geom.MultiPoint.class,
+                org.locationtech.jts.geom.MultiLineString.class,
+                org.locationtech.jts.geom.MultiPolygon.class,
+                org.locationtech.jts.geom.GeometryCollection.class,
+                Geometry.class)) {
+            AttributeDescriptor d = TrinoTypeMapper.toDescriptor("geom", Types.VARBINARY, true, subtype, 4326);
+            assertThat(d.getType().getBinding()).as(subtype.getSimpleName()).isEqualTo(subtype);
+            assertThat(d).isInstanceOf(org.geotools.api.feature.type.GeometryDescriptor.class);
+        }
+    }
+
+    @Test
+    void geometryDescriptorCarriesWgs84() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("geom_wkb", Types.VARBINARY, true, Geometry.class, 4326);
         assertThat(((org.geotools.api.feature.type.GeometryDescriptor) d)
             .getCoordinateReferenceSystem())
             .isEqualTo(org.geotools.referencing.crs.DefaultGeographicCRS.WGS84);
     }
 
     @Test
-    void varbinaryWithPointFlagMapsToPoint() {
-        // A __X_z2__ companion marks a point-only column; discovery passes isPoint=true
-        // so the descriptor binds Point (enables the rectangle/point bbox fast path).
-        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("center", Types.VARBINARY, true, true, 4326);
-        assertThat(d.getType().getBinding()).isEqualTo(org.locationtech.jts.geom.Point.class);
-        assertThat(d).isInstanceOf(org.geotools.api.feature.type.GeometryDescriptor.class);
+    void nullOrNonGeometryBindingDefaultsToGenericGeometry() {
+        // Defensive: a null binding (or a non-Geometry class slipping through) falls back to
+        // generic Geometry rather than producing an invalid descriptor.
+        assertThat(TrinoTypeMapper.toDescriptor("geom", Types.VARBINARY, true, null, 4326)
+            .getType().getBinding()).isEqualTo(Geometry.class);
+        assertThat(TrinoTypeMapper.toDescriptor("geom", Types.VARBINARY, true, String.class, 4326)
+            .getType().getBinding()).isEqualTo(Geometry.class);
     }
 
     @Test
     void varbinaryWithoutGeometryFlagMapsToBytesArray() {
-        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("raw_data", Types.VARBINARY, false, false, 0);
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("raw_data", Types.VARBINARY, false, null, 0);
         assertThat(d.getType().getBinding()).isEqualTo(byte[].class);
     }
 


### PR DESCRIPTION
## GEOMESA-3584: Derive geometry tyes from their stored SFT metadata attibutes

Deferred from #3573.

### Background

`TrinoTypeMapper` bound every geometry column to `Point` or generic `Geometry` — `Point`when the column carried a `__X_z2__` companion, `Geometry` otherwise. Consumers of the discovered GeoTools schema got no more than that, even though the table's geometry is often a precise subtype (`LineString`, `Polygon`, `MultiPolygon`, …).

### Change

When an Iceberg table carries a GeoMesa-encoded SimpleFeatureType, schema discovery now parses it and binds each geometry attribute to the subtype it declares; it falls back to the previous naming heuristic when no SFT metadata is present.

- **`TrinoSchemaDiscovery`** reads the `geomesa.sft.spec` (and `geomesa.sft.name`) table properties from the Iceberg `"<table>$properties"` metadata table.  The spec is parsed with GeoMesa's `SimpleFeatureTypes.createType`, and each geometry attribute's JTS binding drives the descriptor. 
- **`TrinoTypeMapper.toDescriptor`** takes the resolved geometry binding `Class`.
- **failsafe**: an absent property, an unreadable `$properties`, or an unparseable spec all fall back to the Point | Geometry heuristic.
- Declared `geomesa-utils` explicitly in the datastore pom since `SimpleFeatureTypes` is now used directly.

closes #3584 