### PR TITLE
Standardizes GeoMesa JUnit to surefire-junit-platform

### DIFF
--- a/geomesa-trino/geomesa-trino-datastore/pom.xml
+++ b/geomesa-trino/geomesa-trino-datastore/pom.xml
@@ -92,16 +92,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
-        <!-- Note: the parent injects the surefire-junit47 (JUnit 4) provider via
-             pluginManagement, which a child cannot remove. Without junit:junit on the test
-             classpath that provider crashes on missing org/junit/runner/notification/RunListener.
-             With it, junit47 finds 0 JUnit 4 tests and junit-platform runs all our JUnit 5 tests.
-             Do not remove even though no test imports org.junit. -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/geomesa-trino/geomesa-trino-plugin/pom.xml
+++ b/geomesa-trino/geomesa-trino-plugin/pom.xml
@@ -140,16 +140,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-
-        <!-- Note: the parent injects the surefire-junit47 (JUnit 4) provider via
-             pluginManagement, which a child cannot remove. Without junit:junit on the test
-             classpath that provider crashes on missing org/junit/runner/notification/RunListener.
-             With it, junit47 finds 0 JUnit 4 tests and junit-platform runs all our JUnit 5 tests.
-             Do not remove even though no test imports org.junit. -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -544,6 +544,13 @@
             <groupId>ch.qos.reload4j</groupId>
             <artifactId>reload4j</artifactId>
         </dependency>
+        <!-- JUnit Platform engine supporting JUnit 4 / specs2 (@RunWith JUnitRunner) specs,
+             replacing the surefire-junit47 provider. -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -2515,6 +2522,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
@@ -2868,7 +2881,7 @@
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.surefire</groupId>
-                            <artifactId>surefire-junit47</artifactId>
+                            <artifactId>surefire-junit-platform</artifactId>
                             <version>${maven.surefire.plugin.version}</version>
                         </dependency>
                     </dependencies>


### PR DESCRIPTION
- Standardizes GeoMesa project to use surefire-junit-plaform for unit/integration tests
- Adds vintage-junit-engine for backported JUnit4/specs2 support
- Dispatches with surefire-junit47
