### PR TITLE
Add extended type-mapping support for nested object and json types to geomesa-trino-datastore

### DIFF
--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureReader.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureReader.java
@@ -8,6 +8,10 @@
 
 package org.locationtech.geomesa.trino.datastore;
 
+import io.trino.jdbc.Row;
+import io.trino.jdbc.RowField;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.geotools.api.data.FeatureReader;
 import org.geotools.api.feature.IllegalAttributeException;
 import org.geotools.api.feature.simple.SimpleFeature;
@@ -18,19 +22,31 @@ import org.locationtech.geomesa.security.SecurityUtils;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKBReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.sql.*;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeature> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TrinoFeatureReader.class);
 
     private final SimpleFeatureType sft;
     private final Connection conn;
     private final Statement stmt;
     private final ResultSet rs;
     private final WKBReader wkbReader = new WKBReader();
+
+    /** Renders structural values for {@code json=true} attributes. */
+    private static final ObjectMapper JSON = new ObjectMapper()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     private final SimpleFeatureBuilder builder;
     private final String fidColumn;
     private final String visColumn;
@@ -93,15 +109,16 @@ class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeatu
                 AttributeDescriptor desc = sft.getDescriptor(i);
                 String col = desc.getLocalName();
 
+                Class<?> binding = desc.getType().getBinding();
                 Object value;
-                if (Geometry.class.isAssignableFrom(desc.getType().getBinding())) {
+                if (Geometry.class.isAssignableFrom(binding)) {
                     byte[] wkb = rs.getBytes(col);
                     value = wkb != null ? wkbReader.read(wkb) : null;
-                } else if (Date.class.isAssignableFrom(desc.getType().getBinding())) {
+                } else if (Date.class.isAssignableFrom(binding)) {
                     Timestamp ts = rs.getTimestamp(col);
                     value = ts != null ? new Date(ts.getTime()) : null;
                 } else {
-                    value = rs.getObject(col);
+                    value = coerce(rs.getObject(col), desc, col);
                 }
 
                 builder.set(col, value);
@@ -118,6 +135,94 @@ class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeatu
             SecurityUtils.setFeatureVisibility(feature, vis);
         }
         return feature;
+    }
+
+    /**
+     * Brings a structural JDBC value in line with the attribute's declared binding.
+     *
+     * <p>The Trino driver hands back {@code java.sql.Array} for arrays and {@link Map} for maps, with {@code row}
+     * values arriving as maps of field name to value. Historically these were declared {@code byte[]} and passed through
+     * uncoerced, which happened to work but promised the wrong type to anything reading the schema.
+     *
+     * @param value raw JDBC value
+     * @param desc the attribute it belongs to
+     * @param col column name, for diagnostics
+     * @return a value assignable to the declared binding
+     */
+    private Object coerce(Object value, AttributeDescriptor desc, String col) throws SQLException {
+        if (value == null) {
+            return null;
+        }
+        Class<?> binding = desc.getType().getBinding();
+        if (List.class.isAssignableFrom(binding) || Map.class.isAssignableFrom(binding)) {
+            return normalize(value);
+        }
+        if (String.class.equals(binding)
+                && "true".equals(String.valueOf(desc.getUserData().get(TrinoTypeMapper.OPT_JSON)))
+                && !(value instanceof String)) {
+            Object plain = normalize(value);
+            try {
+                return JSON.writeValueAsString(plain);
+            } catch (Exception e) {
+                // One unrenderable value must not abort the scan, but emitting non-JSON into a json=true attribute
+                // would break downstream consumers, so drop it and warn.
+                LOG.warn("Could not render column '{}' as JSON; returning null", col, e);
+                return null;
+            }
+        }
+        return value;
+    }
+
+    /**
+     * Recursively rewrites driver-specific containers into plain JDK types.
+     *
+     * <p>{@code java.sql.Array} becomes a {@link List}, {@code row} as {@link Row},
+     * Both nest cleanly: i.e. {@code array(row(... array(row(...))))}, handled via recursion.
+     * n.b. package-private for testing
+     */
+    static Object normalize(Object value) throws SQLException {
+        if (value instanceof Row row) {
+            Map<Object, Object> out = new LinkedHashMap<>();
+            List<RowField> fields = row.getFields();
+            for (RowField f : fields) {
+                out.put(f.getName().orElseGet(() -> "field" + f.getOrdinal()),
+                        normalize(f.getValue()));
+            }
+            return out;
+        }
+        if (value instanceof Struct struct) {
+            Object[] attrs = struct.getAttributes();
+            List<Object> out = new ArrayList<>(attrs.length);
+            for (Object o : attrs) {
+                out.add(normalize(o));
+            }
+            return out;
+        }
+        if (value instanceof Array array) {
+            Object raw = array.getArray();
+            List<Object> out = new ArrayList<>();
+            if (raw instanceof Object[] elements) {
+                for (Object e : elements) {
+                    out.add(normalize(e));
+                }
+            }
+            return out;
+        }
+        if (value instanceof List<?> list) {
+            List<Object> out = new ArrayList<>(list.size());
+            for (Object e : list) {
+                out.add(normalize(e));
+            }
+            return out;
+        }
+        if (value instanceof Map<?, ?> map) {
+            Map<Object, Object> out = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> e : map.entrySet()) {
+                out.put(e.getKey(), normalize(e.getValue()));
+            }
+            return out;
+        }
+        return value;
     }
 
     /**

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureReader.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureReader.java
@@ -27,12 +27,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.sql.*;
-import java.util.ArrayList;
+import java.util.*;
 import java.util.Date;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
 
 class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeature> {
 
@@ -50,8 +47,24 @@ class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeatu
     private final SimpleFeatureBuilder builder;
     private final String fidColumn;
     private final String visColumn;
+    /** Per-attribute lookups, resolved once instead of per row. */
+    private final Column[] columns;
     private Boolean hasNext = null;
     private long nextId = 0;
+    private enum Kind { GEOMETRY, DATE, STRUCTURAL, JSON, PLAIN }
+
+    /**
+     * An attribute's name, position and handling, all of which are fixed for the life of the reader.
+     *
+     * @param index position in the feature type
+     * @param name column name
+     * @param kind how to convert the raw JDBC value
+     */
+    private record Column(int index, String name, Kind kind) {
+        static Column of(int index, AttributeDescriptor desc) {
+            return new Column(index, desc.getLocalName(), kindOf(desc));
+        }
+    }
 
     TrinoFeatureReader(SimpleFeatureType sft, Connection conn,
                        Statement stmt, ResultSet rs, String fidColumn, String visColumn) {
@@ -62,6 +75,31 @@ class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeatu
         this.builder   = new SimpleFeatureBuilder(sft);
         this.fidColumn = fidColumn;
         this.visColumn = visColumn;
+        this.columns   = IntStream.range(0, sft.getAttributeCount())
+                             .mapToObj(i -> Column.of(i, sft.getDescriptor(i)))
+                             .toArray(Column[]::new);
+    }
+
+    /**
+     * Classifies an attribute by the conversion its declared binding needs.
+     *
+     * @param desc the attribute
+     * @return the handling to apply to every value read for it
+     */
+    private static Kind kindOf(AttributeDescriptor desc) {
+        Class<?> binding = desc.getType().getBinding();
+        if (Geometry.class.isAssignableFrom(binding)) return Kind.GEOMETRY;
+        if (Date.class.isAssignableFrom(binding)) return Kind.DATE;
+        if (List.class.isAssignableFrom(binding) || Map.class.isAssignableFrom(binding)) return Kind.STRUCTURAL;
+        if (String.class.equals(binding) && isJson(desc)) return Kind.JSON;
+        return Kind.PLAIN;
+    }
+
+    /**
+     * Whether the attribute is marked {@code json=true}, i.e. its string value is a rendered JSON document.
+     */
+    private static boolean isJson(AttributeDescriptor desc) {
+        return Boolean.parseBoolean(String.valueOf(desc.getUserData().get(TrinoTypeMapper.OPT_JSON)));
     }
 
     /**
@@ -105,23 +143,22 @@ class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeatu
             // note: rs.getString should never return null here, but if it does SimpleFeatureBuilder will handle it
             fid = fidColumn == null ? Long.toString(nextId++) : rs.getString(fidColumn);
 
-            for (int i = 0; i < sft.getAttributeCount(); i++) {
-                AttributeDescriptor desc = sft.getDescriptor(i);
-                String col = desc.getLocalName();
-
-                Class<?> binding = desc.getType().getBinding();
+            for (Column column : columns) {
+                String col = column.name();
                 Object value;
-                if (Geometry.class.isAssignableFrom(binding)) {
-                    byte[] wkb = rs.getBytes(col);
-                    value = wkb != null ? wkbReader.read(wkb) : null;
-                } else if (Date.class.isAssignableFrom(binding)) {
-                    Timestamp ts = rs.getTimestamp(col);
-                    value = ts != null ? new Date(ts.getTime()) : null;
-                } else {
-                    value = coerce(rs.getObject(col), desc, col);
+                switch (column.kind()) {
+                    case GEOMETRY -> {
+                        byte[] wkb = rs.getBytes(col);
+                        value = wkb != null ? wkbReader.read(wkb) : null;
+                    }
+                    case DATE -> {
+                        Timestamp ts = rs.getTimestamp(col);
+                        value = ts != null ? new Date(ts.getTime()) : null;
+                    }
+                    default -> value = coerce(rs.getObject(col), column);
                 }
 
-                builder.set(col, value);
+                builder.set(column.index(), value);
             }
             if (visColumn != null) {
                 vis = rs.getString(visColumn);
@@ -145,28 +182,24 @@ class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeatu
      * uncoerced, which happened to work but promised the wrong type to anything reading the schema.
      *
      * @param value raw JDBC value
-     * @param desc the attribute it belongs to
-     * @param col column name, for diagnostics
+     * @param column the attribute it belongs to
      * @return a value assignable to the declared binding
      */
-    private Object coerce(Object value, AttributeDescriptor desc, String col) throws SQLException {
+    private Object coerce(Object value, Column column) throws SQLException {
         if (value == null) {
             return null;
         }
-        Class<?> binding = desc.getType().getBinding();
-        if (List.class.isAssignableFrom(binding) || Map.class.isAssignableFrom(binding)) {
+        if (column.kind() == Kind.STRUCTURAL) {
             return normalize(value);
         }
-        if (String.class.equals(binding)
-                && "true".equals(String.valueOf(desc.getUserData().get(TrinoTypeMapper.OPT_JSON)))
-                && !(value instanceof String)) {
+        if (column.kind() == Kind.JSON && !(value instanceof String)) {
             Object plain = normalize(value);
             try {
                 return JSON.writeValueAsString(plain);
             } catch (Exception e) {
                 // One unrenderable value must not abort the scan, but emitting non-JSON into a json=true attribute
                 // would break downstream consumers, so drop it and warn.
-                LOG.warn("Could not render column '{}' as JSON; returning null", col, e);
+                LOG.warn("Could not render column '{}' as JSON; returning null", column.name(), e);
                 return null;
             }
         }
@@ -176,8 +209,11 @@ class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeatu
     /**
      * Recursively rewrites driver-specific containers into plain JDK types.
      *
-     * <p>{@code java.sql.Array} becomes a {@link List}, {@code row} as {@link Row},
+     * <p>{@code java.sql.Array} becomes a {@link List}, {@code row} a {@link Map} keyed by field name.
      * Both nest cleanly: i.e. {@code array(row(... array(row(...))))}, handled via recursion.
+     *
+     * <p>The driver models {@code row} as {@link Row} and never as {@code java.sql.Struct}
+     * ({@code TrinoConnection.createStruct} is unsupported), so there is no {@code Struct} branch here.
      * n.b. package-private for testing
      */
     static Object normalize(Object value) throws SQLException {
@@ -190,23 +226,21 @@ class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeatu
             }
             return out;
         }
-        if (value instanceof Struct struct) {
-            Object[] attrs = struct.getAttributes();
-            List<Object> out = new ArrayList<>(attrs.length);
-            for (Object o : attrs) {
-                out.add(normalize(o));
-            }
-            return out;
-        }
         if (value instanceof Array array) {
             Object raw = array.getArray();
-            List<Object> out = new ArrayList<>();
+            if (raw == null) {
+                return null;
+            }
             if (raw instanceof Object[] elements) {
+                List<Object> out = new ArrayList<>(elements.length);
                 for (Object e : elements) {
                     out.add(normalize(e));
                 }
+                return out;
             }
-            return out;
+            LOG.warn("Expected an Object[] payload from column of type '{}' but got {}; passing it through uncoerced",
+                    array.getBaseTypeName(), raw.getClass().getName());
+            return raw;
         }
         if (value instanceof List<?> list) {
             List<Object> out = new ArrayList<>(list.size());

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoSchemaDiscovery.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoSchemaDiscovery.java
@@ -142,10 +142,10 @@ class TrinoSchemaDiscovery {
 
                 boolean isGeom = geometryColumnNames.contains(name);
                 Class<?> geomBinding = isGeom ? resolveGeometryBinding(name, allNames, sftBindings) : null;
-                // SRID is no longer carried in a table property; default to WGS84.
-                int srid = isGeom ? 4326 : 0;
-                var descriptor =
-                        TrinoTypeMapper.toDescriptor(name, meta.getColumnType(i), isGeom, geomBinding, srid);
+
+                var descriptor = TrinoTypeMapper.toDescriptor(
+                    name, meta.getColumnType(i), meta.getColumnTypeName(i),isGeom, geomBinding, isGeom ? 4326 : 0
+                );
                 tb.add(descriptor);
 
                 if (isGeom && !defaultGeomSet) {

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapper.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapper.java
@@ -15,12 +15,24 @@ import org.locationtech.jts.geom.Geometry;
 
 import java.sql.Types;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class TrinoTypeMapper {
 
     private static final Logger LOG = LoggerFactory.getLogger(TrinoTypeMapper.class);
+
+    /** GeoMesa attribute-option keys. Mirrors {@code SimpleFeatureTypes.AttributeOptions}:
+     *  {@code List} attribute declares its element type under {@code subtype},
+     *  {@code Map} declares its key and value types under {@code keyclass}/{@code valueclass},
+     *  {@code String} holding JSON sets {@code json=true}
+     */
+    static final String OPT_SUBTYPE     = "subtype";
+    static final String OPT_KEY_CLASS   = "keyclass";
+    static final String OPT_VALUE_CLASS = "valueclass";
+    static final String OPT_JSON        = "json";
 
     /**
      * Columns hidden from the GeoTools schema: the spatial extension's
@@ -34,8 +46,40 @@ class TrinoTypeMapper {
         return columnName.startsWith("__") && columnName.endsWith("__");
     }
 
+    /**
+     * Back-compatible overload for callers with no parameterized type name.
+     */
     static AttributeDescriptor toDescriptor(String name, int sqlType,
-                                             boolean isGeometry, Class<?> geometryBinding, int srid) {
+                                            boolean isGeometry, Class<?> geometryBinding, int srid) {
+        return toDescriptor(name, sqlType, null, isGeometry, geometryBinding, srid);
+    }
+
+    /**
+     * Maps one Trino column onto a GeoTools attribute descriptor.
+     *
+     * <p>Scalars map directly.
+     * Structural types — {@code array}, {@code map}, {@code row} use {@code typeName}.
+     * Given typeName:
+     *
+     * <ul>
+     *   <li>{@code array(<scalar>)} becomes a {@link List} with {@code subtype};</li>
+     *   <li>{@code map(<scalar>,<scalar>)} becomes a {@link Map} with {@code keyclass}/{@code valueclass};</li>
+     *   <li>nested data — {@code row(...)}, {@code array(row(...))} becomes a {@link String} marked {@code json=true},
+     *       and {@link TrinoFeatureReader} renders the value as JSON.</li>
+     * </ul>
+     *
+     * <p>Any other unmapped SQL type keeps falls back to byte[].
+     *
+     * @param name column name
+     * @param sqlType {@link java.sql.Types} code
+     * @param typeName parameterized Trino type name, or null when unavailable
+     * @param isGeometry whether the column was identified as a geometry
+     * @param geometryBinding resolved JTS subtype for a geometry column
+     * @param srid geometry SRID, 0 when not applicable
+     * @return the attribute descriptor
+     */
+    static AttributeDescriptor toDescriptor(String name, int sqlType, String typeName,
+                                            boolean isGeometry, Class<?> geometryBinding, int srid) {
         AttributeTypeBuilder b = new AttributeTypeBuilder();
         b.setName(name);
         b.setNillable(true);
@@ -58,28 +102,68 @@ class TrinoTypeMapper {
         }
 
         Class<?> binding = switch (sqlType) {
-            case Types.VARCHAR, Types.LONGNVARCHAR, Types.NVARCHAR -> String.class;
+            case Types.VARCHAR, Types.LONGNVARCHAR, Types.NVARCHAR  -> String.class;
             case Types.BIGINT                                       -> Long.class;
-            case Types.INTEGER, Types.SMALLINT, Types.TINYINT      -> Integer.class;
-            case Types.DOUBLE, Types.FLOAT, Types.REAL             -> Double.class;
-            case Types.BOOLEAN, Types.BIT                          -> Boolean.class;
-            case Types.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE    -> Date.class;
+            case Types.INTEGER, Types.SMALLINT, Types.TINYINT       -> Integer.class;
+            case Types.DOUBLE, Types.FLOAT, Types.REAL              -> Double.class;
+            case Types.BOOLEAN, Types.BIT                           -> Boolean.class;
+            case Types.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE     -> Date.class;
             case Types.BINARY, Types.VARBINARY, Types.LONGVARBINARY -> byte[].class;
-            // Truly unmapped SQL type (e.g. DECIMAL, ARRAY, ROW): fall back to opaque bytes,
-            // but warn so the unhandled column type is visible rather than silently lossy.
-            default                                                 -> unmappedBinding(sqlType, name);
+            default                                                 -> null;
         };
+        if (binding != null) {
+            b.setBinding(binding);
+            return b.buildDescriptor(name);
+        }
+        return structuralDescriptor(b, name, sqlType, typeName);
+    }
 
-        b.setBinding(binding);
+    /**
+     *  Descriptor for a structural column. Parsing of the type signature lives in {@link TrinoTypeSignature}.
+     */
+    private static AttributeDescriptor structuralDescriptor(AttributeTypeBuilder b, String name,
+                                                            int sqlType, String typeName) {
+        String t = TrinoTypeSignature.normalize(typeName);
+
+        String element = TrinoTypeSignature.arrayElement(t);
+        if (element != null) {
+            Class<?> binding = TrinoTypeSignature.scalarBinding(element);
+            if (binding != null) {
+                b.setBinding(List.class);
+                b.userData(OPT_SUBTYPE, binding.getName());
+                return b.buildDescriptor(name);
+            }
+            return jsonDescriptor(b, name);            // array of row/array/map
+        }
+
+        String[] kv = TrinoTypeSignature.mapKeyValue(t);
+        if (kv != null) {
+            Class<?> key = TrinoTypeSignature.scalarBinding(kv[0]);
+            Class<?> value = TrinoTypeSignature.scalarBinding(kv[1]);
+            if (key != null && value != null) {
+                b.setBinding(Map.class);
+                b.userData(OPT_KEY_CLASS, key.getName());
+                b.userData(OPT_VALUE_CLASS, value.getName());
+                return b.buildDescriptor(name);
+            }
+            return jsonDescriptor(b, name);            // map with a structural side
+        }
+
+        if (TrinoTypeSignature.isRowOrVariant(t)) {
+            return jsonDescriptor(b, name);
+        }
+
+        // Unrecognized type fallback.
+        LOG.warn("No GeoTools binding for SQL type {}{} on column '{}'; exposing it as byte[] (opaque).",
+                 sqlType, t.isEmpty() ? "" : " ('" + t + "')", name);
+        b.setBinding(byte[].class);
         return b.buildDescriptor(name);
     }
 
-    /** Fallback binding for an SQL type with no explicit mapping: opaque bytes, logged once
-     *  per occurrence at WARNING so an unhandled column type (DECIMAL, ARRAY, ROW, …) surfaces
-     *  instead of silently becoming a byte[]. */
-    private static Class<?> unmappedBinding(int sqlType, String name) {
-        LOG.warn("No GeoTools binding for SQL type " + sqlType + " on column '" + name
-            + "'; exposing it as byte[] (opaque).");
-        return byte[].class;
+    /** A String attribute flagged {@code json=true}; the reader renders the value as JSON. */
+    private static AttributeDescriptor jsonDescriptor(AttributeTypeBuilder b, String name) {
+        b.setBinding(String.class);
+        b.userData(OPT_JSON, "true");
+        return b.buildDescriptor(name);
     }
 }

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoTypeSignature.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoTypeSignature.java
@@ -1,0 +1,122 @@
+/***********************************************************************
+ * Copyright (c) 2013-2025 General Atomics Integrated Intelligence, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ ***********************************************************************/
+
+package org.locationtech.geomesa.trino.datastore;
+
+import java.util.Date;
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * Trino type-signature grammar.
+ *
+ */
+final class TrinoTypeSignature {
+
+    private TrinoTypeSignature() {}
+
+    /** Lower-cased and trimmed, or "" for null. Trino reports type names lower-case,
+     *  but normalizing costs nothing and makes the reader order-independent. It also
+     *  lower-cases quoted {@code row} field names, which is harmless: field names are
+     *  never surfaced, because any {@code row} becomes {@code json=true}. */
+    static String normalize(String typeName) {
+        return typeName == null ? "" : typeName.trim().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * The element type of {@code array(...)}, or null when {@code t} is not an array.
+     * The text is returned raw; the caller decides whether it is scalar.
+     */
+    static String arrayElement(String t) {
+        return argsOf(t, "array");
+    }
+
+    /**
+     * The key and value types of {@code map(k,v)}, or null when {@code t} is not a map
+     * or its two arguments cannot be separated.
+     */
+    static String[] mapKeyValue(String t) {
+        String args = argsOf(t, "map");
+        if (args == null) {
+            return null;
+        }
+        int comma = topLevelComma(args);
+        if (comma <= 0 || comma == args.length() - 1) {
+            return null;
+        }
+        return new String[] { args.substring(0, comma), args.substring(comma + 1) };
+    }
+
+    /** Whether {@code t} is a structural type with no flat GeoTools equivalent. */
+    static boolean isRowOrVariant(String t) {
+        return t.startsWith("row(") || t.equals("variant") || t.startsWith("variant(");
+    }
+
+    /** Whether {@code t} names any structural type at all. */
+    static boolean isStructural(String t) {
+        return t.startsWith("array(") || t.startsWith("map(") || isRowOrVariant(t);
+    }
+
+    /**
+     * Java binding for a scalar Trino type name, or null when it is structural or is
+     * something GeoMesa's {@code ObjectType} cannot carry as a list element or map
+     * key/value. Returning null routes the whole column to JSON, which beats declaring
+     * an element type GeoMesa could not then serialize.
+     *
+     * <p>{@code decimal} deliberately returns null: there is no {@code ObjectType} for
+     * it, {@code Double} would be lossy and {@code String} would lose arithmetic.
+     */
+    static Class<?> scalarBinding(String typeName) {
+        String t = typeName.trim();
+        int paren = t.indexOf('(');                 // varchar(32), timestamp(6), decimal(10,2)
+        String base = (paren > 0 ? t.substring(0, paren) : t).trim();
+        if (base.startsWith("timestamp") || base.startsWith("time ")) {
+            return Date.class;                      // incl. "timestamp(6) with time zone"
+        }
+        return switch (base) {
+            case "varchar", "char" -> String.class;
+            case "bigint"          -> Long.class;
+            case "integer", "int", "smallint", "tinyint" -> Integer.class;
+            case "double"          -> Double.class;
+            case "real"            -> Float.class;
+            case "boolean"         -> Boolean.class;
+            case "date", "timestamp", "time" -> Date.class;
+            case "uuid"            -> UUID.class;
+            case "varbinary"       -> byte[].class;
+            default                -> null;
+        };
+    }
+
+    /** The argument list of {@code <kind>(...)}, or null when {@code t} is not that kind. */
+    private static String argsOf(String t, String kind) {
+        String prefix = kind + "(";
+        if (!t.startsWith(prefix) || !t.endsWith(")")) {
+            return null;                            // includes unterminated input
+        }
+        return t.substring(prefix.length(), t.length() - 1).trim();
+    }
+
+    /** Index of the comma separating a map type's key and value, ignoring nested parens and
+     *  anything inside a double-quoted identifier. A doubled quote — SQL's escape for a
+     *  quote within a quoted identifier — needs no special case: the two toggles cancel,
+     *  so {@code "a""b"} correctly ends outside quotes with nothing counted.
+     */
+    private static int topLevelComma(String s) {
+        int depth = 0;
+        boolean inQuotes = false;
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '"') inQuotes = !inQuotes;
+            else if (inQuotes) continue;          // parens/commas in an identifier are not structure
+            else if (c == '(') depth++;
+            else if (c == ')') depth--;
+            else if (c == ',' && depth == 0) return i;
+        }
+        return -1;
+    }
+}

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureReaderNormalizeTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureReaderNormalizeTest.java
@@ -33,9 +33,14 @@ class TrinoFeatureReaderNormalizeTest {
         return (Map<String, Object>) o;
     }
 
-    /** Minimal java.sql.Array stand-in; only getArray() is exercised. */
+    /** Minimal java.sql.Array stand-in; only getArray() and getBaseTypeName() are exercised. */
     private static Array array(Object... elements) {
         return new StubArray(elements);
+    }
+
+    /** As above, but for drivers that hand back something other than an Object[]. */
+    private static Array rawArray(Object raw) {
+        return new StubArray(raw);
     }
 
     private static Row row(String n1, Object v1) {
@@ -106,9 +111,30 @@ class TrinoFeatureReaderNormalizeTest {
         assertThat(asMap(out).get("k")).isEqualTo(List.of("v"));
     }
 
+    /**
+     * A primitive array is a legal {@code java.sql.Array} payload in general, but {@code TrinoArray} holds an
+     * {@code Object[]}, so it cannot arrive from this driver. It is out of contract: logged, not converted.
+     */
+    @Test
+    void primitiveArrayPayloadIsOutOfContractAndPassesThrough() throws SQLException {
+        int[] raw = {1, 2, 3};
+        assertThat(TrinoFeatureReader.normalize(rawArray(raw))).isSameAs(raw);
+    }
+
+    @Test
+    void nullArrayPayloadBecomesNull() throws SQLException {
+        assertThat(TrinoFeatureReader.normalize(rawArray(null))).isNull();
+    }
+
+    /** Nothing sensible to convert, so it is logged and passed through rather than silently emptied. */
+    @Test
+    void nonArrayPayloadPassesThrough() throws SQLException {
+        assertThat(TrinoFeatureReader.normalize(rawArray("not an array"))).isEqualTo("not an array");
+    }
+
     private static final class StubArray implements Array {
-        private final Object[] elements;
-        StubArray(Object[] elements) { this.elements = elements; }
+        private final Object elements;
+        StubArray(Object elements) { this.elements = elements; }
         @Override public Object getArray() { return elements; }
         @Override public String getBaseTypeName() { return "unused"; }
         @Override public int getBaseType() { return 0; }

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureReaderNormalizeTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureReaderNormalizeTest.java
@@ -1,0 +1,124 @@
+/***********************************************************************
+ * Copyright (c) 2013-2025 General Atomics Integrated Intelligence, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ ***********************************************************************/
+
+package org.locationtech.geomesa.trino.datastore;
+
+import io.trino.jdbc.Row;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Array;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code normalize} turns driver-specific containers into plain JDK types so a
+ * {@code json=true} attribute can be serialized and a {@code List}/{@code Map}
+ * attribute can be assigned. The shapes here support nested datatypes:
+ * {@code array(varchar)}, {@code array(row(...))}, and {@code array(row(...
+ * array(row(...))))}, whose row elements arrive as {@link Row}.
+ */
+@SuppressWarnings("unchecked")
+class TrinoFeatureReaderNormalizeTest {
+
+    /** AssertJ's map assertions need concrete key/value types, not wildcards. */
+    private static Map<String, Object> asMap(Object o) {
+        return (Map<String, Object>) o;
+    }
+
+    /** Minimal java.sql.Array stand-in; only getArray() is exercised. */
+    private static Array array(Object... elements) {
+        return new StubArray(elements);
+    }
+
+    private static Row row(String n1, Object v1) {
+        return Row.builder().addField(n1, v1).build();
+    }
+
+    @Test
+    void scalarsPassThrough() throws SQLException {
+        assertThat(TrinoFeatureReader.normalize("x")).isEqualTo("x");
+        assertThat(TrinoFeatureReader.normalize(7)).isEqualTo(7);
+        assertThat(TrinoFeatureReader.normalize(null)).isNull();
+    }
+
+    @Test
+    void sqlArrayBecomesList() throws SQLException {
+        Object out = TrinoFeatureReader.normalize(array("a", "b"));
+        assertThat(out).isInstanceOf(List.class).isEqualTo(List.of("a", "b"));
+    }
+
+    @Test
+    void emptyArrayBecomesEmptyList() throws SQLException {
+        assertThat(TrinoFeatureReader.normalize(array())).isEqualTo(List.of());
+    }
+
+    @Test
+    void rowBecomesMapKeyedByFieldName() throws SQLException {
+        Object out = TrinoFeatureReader.normalize(
+                Row.builder().addField("realm", "MMSI").addField("selector", "123").build());
+        assertThat(out).isInstanceOf(Map.class);
+        assertThat(asMap(out)).containsEntry("realm", "MMSI").containsEntry("selector", "123");
+    }
+
+    @Test
+    void anonymousRowFieldsFallBackToTheirOrdinal() throws SQLException {
+        Object out = TrinoFeatureReader.normalize(
+                Row.builder().addUnnamedField("a").addUnnamedField("b").build());
+        assertThat(asMap(out)).containsKeys("field0", "field1");
+    }
+
+    @Test
+    void arrayOfRowBecomesListOfMap() throws SQLException {
+        Object out = TrinoFeatureReader.normalize(
+                array(row("path", "/messageHeader"), row("path", "/position")));
+        assertThat(out).isInstanceOf(List.class);
+        List<?> list = (List<?>) out;
+        assertThat(list).hasSize(2);
+        assertThat(asMap(list.get(0))).containsEntry("path", "/messageHeader");
+    }
+
+    @Test
+    void nestingRecursesAllTheWayDown() throws SQLException {
+        Object out = TrinoFeatureReader.normalize(array(
+                Row.builder()
+                   .addField("weight", 0.75)
+                   .addField("joint_identities", array(row("realm", "MMSI")))
+                   .build()));
+        List<?> hypotheses = (List<?>) out;
+        Map<String, Object> h = asMap(hypotheses.get(0));
+        assertThat(h).containsEntry("weight", 0.75);
+        assertThat(h.get("joint_identities")).isInstanceOf(List.class);
+        List<?> jis = (List<?>) h.get("joint_identities");
+        assertThat(asMap(jis.get(0))).containsEntry("realm", "MMSI");
+    }
+
+    @Test
+    void mapValuesAreNormalizedToo() throws SQLException {
+        Object out = TrinoFeatureReader.normalize(Map.of("k", array("v")));
+        assertThat(asMap(out).get("k")).isEqualTo(List.of("v"));
+    }
+
+    private static final class StubArray implements Array {
+        private final Object[] elements;
+        StubArray(Object[] elements) { this.elements = elements; }
+        @Override public Object getArray() { return elements; }
+        @Override public String getBaseTypeName() { return "unused"; }
+        @Override public int getBaseType() { return 0; }
+        @Override public Object getArray(Map<String, Class<?>> m) { return elements; }
+        @Override public Object getArray(long index, int count) { return elements; }
+        @Override public Object getArray(long i, int c, Map<String, Class<?>> m) { return elements; }
+        @Override public java.sql.ResultSet getResultSet() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.ResultSet getResultSet(Map<String, Class<?>> m) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.ResultSet getResultSet(long i, int c) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.ResultSet getResultSet(long i, int c, Map<String, Class<?>> m) { throw new UnsupportedOperationException(); }
+        @Override public void free() { }
+    }
+}

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapperGeoMesaSpecTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapperGeoMesaSpecTest.java
@@ -1,0 +1,121 @@
+/***********************************************************************
+ * Copyright (c) 2013-2025 General Atomics Integrated Intelligence, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ ***********************************************************************/
+
+package org.locationtech.geomesa.trino.datastore;
+
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.feature.type.AttributeDescriptor;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.junit.jupiter.api.Test;
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes;
+
+import java.sql.Types;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The bindings this mapper emits have to be ones GeoMesa itself recognizes, not merely
+ * ones GeoTools will accept — {@code AttributeTypeBuilder.setBinding} takes any class,
+ * so an unsupported one fails later and elsewhere.
+ *
+ * <p>Two distinct contracts are involved, and only the first is obvious.
+ * {@code AttributeDescriptor.getListType()} resolves the {@code subtype} option with
+ * {@code Class.forName}, so any class name works at runtime. But GeoMesa also encodes
+ * a feature type to its own spec string — {@code geomesa.sft.spec} is stored as a table
+ * property by the ingest tooling — and that path goes through a short-name table
+ * ({@code List[UUID]}, not {@code List[java.util.UUID]}). A binding absent from that
+ * table survives a read and then fails to round-trip. These tests pin the round-trip.
+ */
+class TrinoTypeMapperGeoMesaSpecTest {
+
+    /** One-attribute feature type built from the mapper, for round-tripping. */
+    private static SimpleFeatureType sftOf(String name, int sqlType, String typeName) {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(name, sqlType, typeName, false, null, 0);
+        SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
+        b.setName("t");
+        b.add(d);
+        return b.buildFeatureType();
+    }
+
+    private static SimpleFeatureType roundTrip(SimpleFeatureType sft) {
+        String spec = SimpleFeatureTypes.encodeType(sft);
+        return SimpleFeatureTypes.createType(sft.getTypeName(), spec);
+    }
+
+    @Test
+    void listOfStringRoundTripsThroughTheGeoMesaSpec() {
+        SimpleFeatureType in = sftOf("ids", Types.ARRAY, "array(varchar)");
+        String spec = SimpleFeatureTypes.encodeType(in);
+        assertThat(spec).contains("List[String]");
+        SimpleFeatureType out = roundTrip(in);
+        assertThat(out.getDescriptor("ids").getType().getBinding()).isEqualTo(List.class);
+    }
+
+    /** Every element type the mapper can emit must be in GeoMesa's short-name table. */
+    @Test
+    void everyEmittableListElementTypeRoundTrips() {
+        record Case(String trinoType, Class<?> expected, String specToken) {}
+        List<Case> cases = List.of(
+            new Case("array(varchar)",  String.class,  "List[String]"),
+            new Case("array(bigint)",   Long.class,    "List[Long]"),
+            new Case("array(integer)",  Integer.class, "List[Integer]"),
+            new Case("array(double)",   Double.class,  "List[Double]"),
+            new Case("array(real)",     Float.class,   "List[Float]"),
+            new Case("array(boolean)",  Boolean.class, "List[Boolean]"),
+            new Case("array(uuid)",     UUID.class,    "List[UUID]"),
+            new Case("array(date)",     Date.class,    "List[Date]"),
+            new Case("array(timestamp(6) with time zone)", Date.class, "List[Date]"),
+            new Case("array(varbinary)", byte[].class, "List[Bytes]"));
+        for (Case c : cases) {
+            SimpleFeatureType in = sftOf("a", Types.ARRAY, c.trinoType());
+            assertThat(in.getDescriptor("a").getUserData())
+                    .as("subtype for %s", c.trinoType())
+                    .containsEntry(TrinoTypeMapper.OPT_SUBTYPE, c.expected().getName());
+            String spec = SimpleFeatureTypes.encodeType(in);
+            assertThat(spec).as("spec for %s", c.trinoType()).contains(c.specToken());
+            SimpleFeatureType out = SimpleFeatureTypes.createType("t", spec);
+            assertThat(out.getDescriptor("a").getType().getBinding())
+                    .as("binding after round-trip of %s", c.trinoType())
+                    .isEqualTo(List.class);
+        }
+    }
+
+    @Test
+    void mapOfScalarsRoundTripsWithBothKeyAndValueTypes() {
+        SimpleFeatureType in = sftOf("m", Types.JAVA_OBJECT, "map(varchar,double)");
+        String spec = SimpleFeatureTypes.encodeType(in);
+        assertThat(spec).contains("Map[String,Double]");
+        SimpleFeatureType out = SimpleFeatureTypes.createType("t", spec);
+        assertThat(out.getDescriptor("m").getType().getBinding()).isEqualTo(Map.class);
+    }
+
+    @Test
+    void jsonFlaggedStringRoundTripsAndKeepsTheOption() {
+        SimpleFeatureType in = sftOf("identifiers", Types.ARRAY,
+                "array(row(realm varchar, selector varchar))");
+        String spec = SimpleFeatureTypes.encodeType(in);
+        assertThat(spec).contains("String").contains("json=true");
+        SimpleFeatureType out = SimpleFeatureTypes.createType("t", spec);
+        AttributeDescriptor d = out.getDescriptor("identifiers");
+        assertThat(d.getType().getBinding()).isEqualTo(String.class);
+        assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_JSON, "true");
+    }
+
+    /** The historic opaque fallback is a supported GeoMesa binding too (Bytes). */
+    @Test
+    void opaqueFallbackAlsoRoundTrips() {
+        SimpleFeatureType in = sftOf("amount", Types.DECIMAL, "decimal(10,2)");
+        assertThat(SimpleFeatureTypes.encodeType(in)).contains("Bytes");
+        assertThat(roundTrip(in).getDescriptor("amount").getType().getBinding())
+                .isEqualTo(byte[].class);
+    }
+}

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapperTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapperTest.java
@@ -118,4 +118,124 @@ class TrinoTypeMapperTest {
         assertThat(TrinoTypeMapper.isHidden("center")).isFalse();
         assertThat(TrinoTypeMapper.isHidden("sensor_id")).isFalse();
     }
+
+    // ── structural types ──────────────────────────────────────────────────────
+    //
+    // The bare java.sql.Types code cannot tell array(varchar) from array(row(...)),
+    // so these all hinge on the parameterized type name being supplied.
+
+    @Test
+    void arrayOfScalarMapsToListWithSubtype() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "provenance_umr_ids", Types.ARRAY, "array(varchar)", false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(java.util.List.class);
+        assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_SUBTYPE, "java.lang.String");
+    }
+
+    @Test
+    void arrayElementTypeParametersAreIgnored() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "codes", Types.ARRAY, "array(varchar(64))", false, null, 0);
+        assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_SUBTYPE, "java.lang.String");
+    }
+
+    @Test
+    void arrayOfBigintMapsToListOfLong() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "counts", Types.ARRAY, "array(bigint)", false, null, 0);
+        assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_SUBTYPE, "java.lang.Long");
+    }
+
+    @Test
+    void mapOfScalarsMapsToMapWithKeyAndValueClasses() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "source_fields", Types.JAVA_OBJECT, "map(varchar,varchar)", false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(java.util.Map.class);
+        assertThat(d.getUserData())
+                .containsEntry(TrinoTypeMapper.OPT_KEY_CLASS, "java.lang.String")
+                .containsEntry(TrinoTypeMapper.OPT_VALUE_CLASS, "java.lang.String");
+    }
+
+    @Test
+    void mapWithSpacesAndValueParametersStillResolves() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "m", Types.JAVA_OBJECT, "map(varchar, double)", false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(java.util.Map.class);
+        assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_VALUE_CLASS, "java.lang.Double");
+    }
+
+    @Test
+    void arrayOfRowMapsToJsonString() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "identifiers", Types.ARRAY, "array(row(realm varchar,selector varchar))",
+                false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(String.class);
+        assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_JSON, "true");
+    }
+
+    @Test
+    void deeplyNestedArrayOfRowStillMapsToJsonString() {
+        String t = "array(row(weight double, joint_identities "
+                 + "array(row(identifiers array(row(realm varchar, selector varchar))))))";
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "probabilistic_identities", Types.ARRAY, t, false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(String.class);
+        assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_JSON, "true");
+    }
+
+    @Test
+    void rowMapsToJsonString() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "bbox", Types.JAVA_OBJECT, "row(xmin real,ymin real)", false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(String.class);
+        assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_JSON, "true");
+    }
+
+    @Test
+    void variantMapsToJsonString() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "payload", Types.JAVA_OBJECT, "variant", false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(String.class);
+        assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_JSON, "true");
+    }
+
+    @Test
+    void arrayOfMapFallsBackToJsonRatherThanClaimingAnElementType() {
+        // GeoMesa list element types are the primitive set; declaring subtype=Map
+        // would promise a shape it cannot serialize, so the column goes to JSON.
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "a", Types.ARRAY, "array(map(varchar,varchar))", false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(String.class);
+        assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_JSON, "true");
+    }
+
+    @Test
+    void mapWithStructuralValueFallsBackToJson() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "m", Types.JAVA_OBJECT, "map(varchar,row(a int))", false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(String.class);
+        assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_JSON, "true");
+    }
+
+    @Test
+    void decimalKeepsTheOpaqueFallback() {
+        // decimal has no ObjectType and is not structural; changing it is a separate
+        // judgment call, so the historic behavior is deliberately preserved.
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "amount", Types.DECIMAL, "decimal(10,2)", false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(byte[].class);
+    }
+
+    @Test
+    void structuralTypeWithoutATypeNameKeepsTheOpaqueFallback() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "unknown", Types.ARRAY, null, false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(byte[].class);
+    }
+
+    @Test
+    void fiveArgOverloadStillCompilesAndDefersToTheOpaqueFallback() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor("x", Types.ARRAY, false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(byte[].class);
+    }
 }

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeSignatureTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeSignatureTest.java
@@ -1,0 +1,155 @@
+/***********************************************************************
+ * Copyright (c) 2013-2025 General Atomics Integrated Intelligence, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ ***********************************************************************/
+
+package org.locationtech.geomesa.trino.datastore;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.locationtech.geomesa.trino.datastore.TrinoTypeSignature.arrayElement;
+import static org.locationtech.geomesa.trino.datastore.TrinoTypeSignature.isRowOrVariant;
+import static org.locationtech.geomesa.trino.datastore.TrinoTypeSignature.isStructural;
+import static org.locationtech.geomesa.trino.datastore.TrinoTypeSignature.mapKeyValue;
+import static org.locationtech.geomesa.trino.datastore.TrinoTypeSignature.normalize;
+import static org.locationtech.geomesa.trino.datastore.TrinoTypeSignature.scalarBinding;
+
+/**
+ * A hand-written reader of someone else's grammar earns its own tests. The last group
+ * is the important one: it pins the safety property the class claims — corruption of
+ * paren depth by a quoted identifier can only fail toward "not a typed collection",
+ * never toward a typed binding the value would not satisfy.
+ */
+class TrinoTypeSignatureTest {
+
+    @Test
+    void normalizeHandlesNullAndCase() {
+        assertThat(normalize(null)).isEmpty();
+        assertThat(normalize("  ARRAY(VARCHAR) ")).isEqualTo("array(varchar)");
+    }
+
+    @Test
+    void arrayElementIsReturnedRaw() {
+        assertThat(arrayElement("array(varchar)")).isEqualTo("varchar");
+        assertThat(arrayElement("array(row(a int))")).isEqualTo("row(a int)");
+        assertThat(arrayElement("array(array(varchar))")).isEqualTo("array(varchar)");
+    }
+
+    @Test
+    void arrayElementRejectsNonArrays() {
+        assertThat(arrayElement("map(varchar,varchar)")).isNull();
+        assertThat(arrayElement("varchar")).isNull();
+        assertThat(arrayElement("")).isNull();
+        assertThat(arrayElement("array(varchar")).isNull();   // unterminated
+    }
+
+    @Test
+    void mapKeyValueSplitsAtTheTopLevelComma() {
+        assertThat(mapKeyValue("map(varchar,varchar)")).containsExactly("varchar", "varchar");
+        assertThat(mapKeyValue("map(varchar, double)")).containsExactly("varchar", " double");
+    }
+
+    @Test
+    void mapKeyValueIgnoresCommasNestedInParens() {
+        assertThat(mapKeyValue("map(varchar,row(a int, b int))"))
+                .containsExactly("varchar", "row(a int, b int)");
+        assertThat(mapKeyValue("map(row(a int, b int),varchar)"))
+                .containsExactly("row(a int, b int)", "varchar");
+        assertThat(mapKeyValue("map(varchar,decimal(10,2))"))
+                .containsExactly("varchar", "decimal(10,2)");
+    }
+
+    @Test
+    void mapKeyValueRejectsNonMapsAndDegenerateInput() {
+        assertThat(mapKeyValue("array(varchar)")).isNull();
+        assertThat(mapKeyValue("map(varchar)")).isNull();     // no comma
+        assertThat(mapKeyValue("map(varchar,)")).isNull();    // trailing comma
+        assertThat(mapKeyValue("map(,varchar)")).isNull();    // leading comma
+    }
+
+    @Test
+    void structuralTypesAreRecognized() {
+        assertThat(isStructural("array(varchar)")).isTrue();
+        assertThat(isStructural("map(varchar,varchar)")).isTrue();
+        assertThat(isStructural("row(a int)")).isTrue();
+        assertThat(isStructural("variant")).isTrue();
+        assertThat(isStructural("varchar")).isFalse();
+        assertThat(isRowOrVariant("row(a int)")).isTrue();
+        assertThat(isRowOrVariant("array(row(a int))")).isFalse();
+    }
+
+    @Test
+    void scalarBindingsCoverWhatObjectTypeCanCarry() {
+        assertThat(scalarBinding("varchar")).isEqualTo(String.class);
+        assertThat(scalarBinding("varchar(64)")).isEqualTo(String.class);
+        assertThat(scalarBinding("bigint")).isEqualTo(Long.class);
+        assertThat(scalarBinding("integer")).isEqualTo(Integer.class);
+        assertThat(scalarBinding("double")).isEqualTo(Double.class);
+        assertThat(scalarBinding("real")).isEqualTo(Float.class);
+        assertThat(scalarBinding("boolean")).isEqualTo(Boolean.class);
+        assertThat(scalarBinding("uuid")).isEqualTo(UUID.class);
+        assertThat(scalarBinding("varbinary")).isEqualTo(byte[].class);
+        assertThat(scalarBinding("date")).isEqualTo(Date.class);
+        assertThat(scalarBinding("timestamp(6)")).isEqualTo(Date.class);
+        assertThat(scalarBinding("timestamp(6) with time zone")).isEqualTo(Date.class);
+    }
+
+    @Test
+    void scalarBindingRefusesWhatGeoMesaCannotCarry() {
+        assertThat(scalarBinding("decimal(10,2)")).isNull();   // no ObjectType for it
+        assertThat(scalarBinding("row(a int)")).isNull();
+        assertThat(scalarBinding("array(varchar)")).isNull();
+        assertThat(scalarBinding("map(varchar,varchar)")).isNull();
+        assertThat(scalarBinding("variant")).isNull();
+        assertThat(scalarBinding("json")).isNull();
+    }
+
+    // ── quoted identifiers ───────────────────────────────────────────────
+    //
+    // Depth tracking skips double-quoted identifiers, so parens and commas inside a row
+    // field name no longer corrupt the count and the split is correct. The mapper's end
+    // state is unchanged: a row on either side is not scalar, so the column still goes
+    // to JSON. Getting the split right is what frees the safety argument from having to
+    // reason about where quotes can appear.
+
+    @Test
+    void quotedCloseParenDoesNotCorruptTheDepthCount() {
+        assertThat(mapKeyValue("map(row(\"a)b\" int),varchar)"))
+                .containsExactly("row(\"a)b\" int)", "varchar");
+    }
+
+    @Test
+    void quotedOpenParenDoesNotCorruptTheDepthCount() {
+        assertThat(mapKeyValue("map(row(\"x(\" int),varchar)"))
+                .containsExactly("row(\"x(\" int)", "varchar");
+    }
+
+    @Test
+    void quotedCommaIsNotTreatedAsTheSeparator() {
+        assertThat(mapKeyValue("map(row(\"a,b\" int),varchar)"))
+                .containsExactly("row(\"a,b\" int)", "varchar");
+        assertThat(mapKeyValue("map(varchar,row(\"a,b\" int))"))
+                .containsExactly("varchar", "row(\"a,b\" int)");
+    }
+
+    @Test
+    void doubledQuoteEscapeNeedsNoSpecialCase() {
+        // "a""b" is one identifier containing a quote; the two toggles cancel out.
+        assertThat(mapKeyValue("map(row(\"a\"\"b\" int),varchar)"))
+                .containsExactly("row(\"a\"\"b\" int)", "varchar");
+    }
+
+    @Test
+    void aQuotedFieldNameStillNeverYieldsATypedBinding() {
+        // However the split lands, a row side is not scalar, so the column goes to JSON.
+        assertThat(scalarBinding("row(\"a)b\" int)")).isNull();
+        assertThat(scalarBinding(arrayElement("array(row(\"weird(name\" int))"))).isNull();
+    }
+}


### PR DESCRIPTION
Add extended type-mapping support for nested object and json types to geomesa-trino-datastore