### PR TITLE
Add explicit groupIds for 3rd party Maven repos

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Daether.remoteRepositoryFilter.groupId=true
+-Daether.remoteRepositoryFilter.groupId.basedir=${session.rootDirectory}/.mvn/rrf/
+

--- a/.mvn/rrf/groupId-confluent.txt
+++ b/.mvn/rrf/groupId-confluent.txt
@@ -1,0 +1,2 @@
+io.confluent
+

--- a/.mvn/rrf/groupId-osgeo.txt
+++ b/.mvn/rrf/groupId-osgeo.txt
@@ -1,0 +1,10 @@
+it.geosolutions.imageio-ext
+it.geosolutions.jgridshift
+org.apache.xml
+org.eclipse.imagen
+org.geotools
+org.geotools.jdbc
+org.geotools.ogc
+org.geotools.xsd
+org.huldra.math
+

--- a/geomesa-cassandra/geomesa-cassandra-datastore/src/test/resources/application.conf
+++ b/geomesa-cassandra/geomesa-cassandra-datastore/src/test/resources/application.conf
@@ -1,0 +1,3 @@
+datastax-java-driver {
+  basic.request.timeout = 10 seconds
+}


### PR DESCRIPTION
* Prevents checking osgeo and confluent repos for every single dependency
* Increase timeout in Cassandra tests