### PR TITLE
Updated geomesa-trino structural type handling to adopt ISO UTC timestamps and handle decimals to avoid the lossyness of floats/doubles

### DIFF
--- a/geomesa-trino/geomesa-trino-datastore/pom.xml
+++ b/geomesa-trino/geomesa-trino-datastore/pom.xml
@@ -87,7 +87,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureReader.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureReader.java
@@ -10,8 +10,6 @@ package org.locationtech.geomesa.trino.datastore;
 
 import io.trino.jdbc.Row;
 import io.trino.jdbc.RowField;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import org.geotools.api.data.FeatureReader;
 import org.geotools.api.feature.IllegalAttributeException;
 import org.geotools.api.feature.simple.SimpleFeature;
@@ -26,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.sql.*;
 import java.util.*;
 import java.util.Date;
@@ -41,9 +40,6 @@ class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeatu
     private final ResultSet rs;
     private final WKBReader wkbReader = new WKBReader();
 
-    /** Renders structural values for {@code json=true} attributes. */
-    private static final ObjectMapper JSON = new ObjectMapper()
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     private final SimpleFeatureBuilder builder;
     private final String fidColumn;
     private final String visColumn;
@@ -181,6 +177,9 @@ class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeatu
      * values arriving as maps of field name to value. Historically these were declared {@code byte[]} and passed through
      * uncoerced, which happened to work but promised the wrong type to anything reading the schema.
      *
+     * <p>{@code decimal} is the other type with no GeoTools equivalent: it arrives as a {@link BigDecimal} for an
+     * attribute declared {@code String}, and is rendered rather than left to a generic converter.
+     *
      * @param value raw JDBC value
      * @param column the attribute it belongs to
      * @return a value assignable to the declared binding
@@ -195,13 +194,16 @@ class TrinoFeatureReader implements FeatureReader<SimpleFeatureType, SimpleFeatu
         if (column.kind() == Kind.JSON && !(value instanceof String)) {
             Object plain = normalize(value);
             try {
-                return JSON.writeValueAsString(plain);
+                return TrinoJson.render(plain);
             } catch (Exception e) {
                 // One unrenderable value must not abort the scan, but emitting non-JSON into a json=true attribute
                 // would break downstream consumers, so drop it and warn.
                 LOG.warn("Could not render column '{}' as JSON; returning null", column.name(), e);
                 return null;
             }
+        }
+        if (value instanceof BigDecimal decimal) {
+            return decimal.toPlainString();
         }
         return value;
     }

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoJson.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoJson.java
@@ -1,0 +1,198 @@
+/***********************************************************************
+ * Copyright (c) 2013-2025 General Atomics Integrated Intelligence, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ ***********************************************************************/
+
+package org.locationtech.geomesa.trino.datastore;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Renders a structural value as the JSON document a {@code json=true} attribute promises.
+ *
+ * <p>How each leaf is formatted is a compatibility contract rather than a local choice. The same
+ * document can reach a consumer two ways: through the FileSystem DataStore, where the Parquet
+ * {@code variant} holding it is rendered by {@code VariantJsonWriter}, or through this DataStore,
+ * where the Trino JDBC driver decodes the variant and this class renders the result. Anything that
+ * compares the two - a parity test, a cache key, a diff between an FSDS export and a Trino export -
+ * needs the same string from both, so the table below reproduces that writer's output for the
+ * corresponding variant type:
+ *
+ * <ul>
+ *   <li>timestamps that carry an offset: {@link DateTimeFormatter#ISO_OFFSET_DATE_TIME} at UTC,
+ *       so a zero offset prints as {@code Z};</li>
+ *   <li>timestamps that do not: {@link DateTimeFormatter#ISO_LOCAL_DATE_TIME};</li>
+ *   <li>dates and times: {@link DateTimeFormatter#ISO_LOCAL_DATE} and
+ *       {@link DateTimeFormatter#ISO_LOCAL_TIME};</li>
+ *   <li>{@code decimal}: an unquoted JSON number, at the scale it was stored with;</li>
+ *   <li>{@code real}: written as a {@code float}, not widened - that writer reaches Gson's
+ *       {@code value(float)} overload, so {@code 0.1f} is {@code 0.1} and not the
+ *       {@code 0.10000000149011612} a widening to {@code double} would produce;</li>
+ *   <li>NaN and the infinities: {@code null}, which is what that writer emits, JSON having no
+ *       literal for them;</li>
+ *   <li>{@code varbinary}: base64 in the standard padded alphabet with no line breaks, matching
+ *       {@code java.util.Base64.getEncoder()}.</li>
+ * </ul>
+ *
+ */
+final class TrinoJson {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TrinoJson.class);
+
+    /** Stateless, thread-safe; a generator is created per call. */
+    private static final JsonFactory FACTORY = new JsonFactory();
+
+    @FunctionalInterface
+    private interface JsonLeaf<T> {
+        void write(JsonGenerator gen, T value) throws IOException;
+    }
+
+    private static final JsonLeaf<Number> INTEGRAL = (gen, value) -> gen.writeNumber(value.longValue());
+
+    /**
+     * Keyed on the exact class, because that is what the driver hands back and an exact lookup has no
+     * precedence to get wrong: {@link Timestamp}, {@link java.sql.Date} and {@link Time} all extend
+     * {@link Date} and each renders differently, which an ordered chain of {@code instanceof} tests has
+     * to encode as a comment and this does not.
+     */
+    private static final Map<Class<?>, JsonLeaf<Object>> LEAVES = Map.ofEntries(
+            leaf(String.class,         JsonGenerator::writeString),
+            leaf(Boolean.class,        JsonGenerator::writeBoolean),
+            leaf(Byte.class,           INTEGRAL),
+            leaf(Short.class,          INTEGRAL),
+            leaf(Integer.class,        INTEGRAL),
+            leaf(Long.class,           INTEGRAL),
+            leaf(Float.class,          TrinoJson::writeFloat),
+            leaf(Double.class,         TrinoJson::writeDouble),
+            leaf(BigDecimal.class,     JsonGenerator::writeNumber),
+            leaf(BigInteger.class,     JsonGenerator::writeNumber),
+            leaf(byte[].class,         JsonGenerator::writeBinary),
+            leaf(UUID.class,           (gen, value) -> gen.writeString(value.toString())),
+            leaf(Instant.class,        TrinoJson::writeUtc),
+            leaf(OffsetDateTime.class, TrinoJson::writeUtc),
+            leaf(ZonedDateTime.class,  TrinoJson::writeUtc),
+            leaf(Timestamp.class,      (gen, value) -> writeUtc(gen, value.toInstant())),
+            leaf(LocalDateTime.class,  (gen, value) -> writeIso(gen, value, DateTimeFormatter.ISO_LOCAL_DATE_TIME)),
+            leaf(LocalDate.class,      (gen, value) -> writeIso(gen, value, DateTimeFormatter.ISO_LOCAL_DATE)),
+            leaf(LocalTime.class,      (gen, value) -> writeIso(gen, value, DateTimeFormatter.ISO_LOCAL_TIME)),
+            leaf(java.sql.Date.class,  (gen, value) -> writeIso(gen, value.toLocalDate(), DateTimeFormatter.ISO_LOCAL_DATE)),
+            leaf(Time.class,           (gen, value) -> writeIso(gen, value.toLocalTime(), DateTimeFormatter.ISO_LOCAL_TIME)));
+
+    /**
+     * Consulted when the exact class is not in the table, for a value that is still recognizable
+     * by supertype. Order drives precedence, so the first assignable entry wins.
+     */
+    private static final List<Map.Entry<Class<?>, JsonLeaf<Object>>> SUPERTYPES = List.of(
+            leaf(CharSequence.class, (gen, value) -> gen.writeString(value.toString())),
+            leaf(Date.class,         (gen, value) -> writeUtc(gen, value.toInstant())),
+            leaf(Number.class,       INTEGRAL));
+
+    private static final JsonLeaf<Object> UNRECOGNIZED = (gen, value) -> {
+        LOG.warn("No JSON rendering for a leaf of type {}; writing it as a string", value.getClass().getName());
+        gen.writeString(value.toString());
+    };
+
+    private TrinoJson() {}
+
+    /**
+     * Renders a value already flattened by {@link TrinoFeatureReader#normalize(Object)}.
+     *
+     * @param value normalized value, possibly null
+     * @return the JSON document for it
+     */
+    static String render(Object value) throws IOException {
+        StringWriter out = new StringWriter();
+        try (JsonGenerator gen = FACTORY.createGenerator(out)) {
+            write(gen, value);
+        }
+        return out.toString();
+    }
+
+    private static void write(JsonGenerator gen, Object value) throws IOException {
+        if (value == null) {
+            gen.writeNull();
+        } else if (value instanceof Map<?, ?> fields) {
+            gen.writeStartObject();
+            for (Map.Entry<?, ?> field : fields.entrySet()) {
+                gen.writeFieldName(String.valueOf(field.getKey()));
+                write(gen, field.getValue());
+            }
+            gen.writeEndObject();
+        } else if (value instanceof Collection<?> elements) {
+            gen.writeStartArray();
+            for (Object element : elements) {
+                write(gen, element);
+            }
+            gen.writeEndArray();
+        } else {
+            writerFor(value.getClass()).write(gen, value);
+        }
+    }
+
+    private static JsonLeaf<Object> writerFor(Class<?> type) {
+        JsonLeaf<Object> exact = LEAVES.get(type);
+        return exact != null ? exact
+                : SUPERTYPES.stream()
+                            .filter(candidate -> candidate.getKey().isAssignableFrom(type))
+                            .findFirst()
+                            .map(Map.Entry::getValue)
+                            .orElse(UNRECOGNIZED);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Map.Entry<Class<?>, JsonLeaf<Object>> leaf(Class<T> type, JsonLeaf<? super T> writer) {
+        return Map.entry(type, (gen, value) -> writer.write(gen, (T) value));
+    }
+
+    private static void writeDouble(JsonGenerator gen, double value) throws IOException {
+        if (Double.isNaN(value) || Double.isInfinite(value)) {
+            gen.writeNull();
+        } else {
+            gen.writeNumber(value);
+        }
+    }
+
+    private static void writeFloat(JsonGenerator gen, float value) throws IOException {
+        if (Float.isNaN(value) || Float.isInfinite(value)) {
+            gen.writeNull();
+        } else {
+            gen.writeNumber(value);
+        }
+    }
+
+    private static void writeUtc(JsonGenerator gen, TemporalAccessor value) throws IOException {
+        writeIso(gen, Instant.from(value).atOffset(ZoneOffset.UTC), DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
+    private static void writeIso(JsonGenerator gen, TemporalAccessor value, DateTimeFormatter format)
+            throws IOException {
+        gen.writeString(format.format(value));
+    }
+}

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapper.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapper.java
@@ -68,6 +68,11 @@ class TrinoTypeMapper {
      *       and {@link TrinoFeatureReader} renders the value as JSON.</li>
      * </ul>
      *
+     * <p>{@code decimal} becomes a plain {@link String}, having no GeoTools equivalent- {@code ObjectType} has
+     * no entry for {@link java.math.BigDecimal}, and {@code Double} only supports 17 significant digits —
+     * {@code decimal(38,10)} addresses that. Note that a {@code decimal} nested inside structural data is treated differently,
+     * staying an unquoted JSON number; see {@link TrinoTypeSignature#scalarBinding}.
+     *
      * <p>Any other unmapped SQL type keeps falls back to byte[].
      *
      * @param name column name
@@ -106,6 +111,7 @@ class TrinoTypeMapper {
             case Types.BIGINT                                       -> Long.class;
             case Types.INTEGER, Types.SMALLINT, Types.TINYINT       -> Integer.class;
             case Types.DOUBLE, Types.FLOAT, Types.REAL              -> Double.class;
+            case Types.DECIMAL, Types.NUMERIC                       -> String.class;
             case Types.BOOLEAN, Types.BIT                           -> Boolean.class;
             case Types.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE     -> Date.class;
             case Types.BINARY, Types.VARBINARY, Types.LONGVARBINARY -> byte[].class;

--- a/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoTypeSignature.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/main/java/org/locationtech/geomesa/trino/datastore/TrinoTypeSignature.java
@@ -68,8 +68,11 @@ final class TrinoTypeSignature {
      * key/value. Returning null routes the whole column to JSON, which beats declaring
      * an element type GeoMesa could not then serialize.
      *
-     * <p>{@code decimal} deliberately returns null: there is no {@code ObjectType} for
-     * it, {@code Double} would be lossy and {@code String} would lose arithmetic.
+     * <p>{@code decimal} deliberately returns null, which sends the whole column to JSON.
+     * That is better than the alternatives for a nested decimal, because a JSON leaf can be an
+     * unquoted number carrying every digit — {@code Double} as a list element would be lossy, and
+     * {@code String} would quote a number that is not one. A top-level {@code decimal} has no such
+     * option and is mapped to {@code String} instead; see {@link TrinoTypeMapper#toDescriptor}.
      */
     static Class<?> scalarBinding(String typeName) {
         String t = typeName.trim();

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureReaderTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoFeatureReaderTest.java
@@ -1,0 +1,135 @@
+/***********************************************************************
+ * Copyright (c) 2013-2025 General Atomics Integrated Intelligence, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ ***********************************************************************/
+
+package org.locationtech.geomesa.trino.datastore;
+
+import io.trino.jdbc.Row;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.feature.type.AttributeDescriptor;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What a single row becomes, driven through the reader itself rather than through its helpers, so the
+ * attribute a consumer actually sees is what is asserted: the descriptor from {@link TrinoTypeMapper},
+ * the classification the reader derives from it, and the conversion it applies.
+ */
+class TrinoFeatureReaderTest {
+
+    /**
+     * A one-row {@link ResultSet} over a column-name map. Only the accessors the reader calls are
+     * implemented; anything else fails loudly rather than returning a plausible default.
+     */
+    private static ResultSet resultSet(Map<String, Object> row) {
+        AtomicBoolean read = new AtomicBoolean(false);
+        return (ResultSet) Proxy.newProxyInstance(
+                TrinoFeatureReaderTest.class.getClassLoader(),
+                new Class<?>[] { ResultSet.class },
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "next" -> read.compareAndSet(false, true);
+                    case "getObject", "getBytes", "getTimestamp" -> row.get((String) args[0]);
+                    case "getString" -> {
+                        Object value = row.get((String) args[0]);
+                        yield value == null ? null : value.toString();
+                    }
+                    default -> throw new UnsupportedOperationException(method.getName());
+                });
+    }
+
+    /** Reads the single row of {@code values} as a feature whose type is the given columns. */
+    private static SimpleFeature readOne(Map<String, Object> values, AttributeDescriptor... descriptors)
+            throws IOException {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName("t");
+        for (AttributeDescriptor descriptor : descriptors) {
+            builder.add(descriptor);
+        }
+        SimpleFeatureType sft = builder.buildFeatureType();
+        TrinoFeatureReader reader =
+                new TrinoFeatureReader(sft, null, null, resultSet(values), null, null);
+        assertThat(reader.hasNext()).isTrue();
+        return reader.next();
+    }
+
+    private static AttributeDescriptor descriptor(String name, int sqlType, String typeName) {
+        return TrinoTypeMapper.toDescriptor(name, sqlType, typeName, false, null, 0);
+    }
+
+    private static Map<String, Object> row(String column, Object value) {
+        Map<String, Object> values = new HashMap<>();
+        values.put(column, value);
+        return values;
+    }
+
+    @Test
+    void decimalArrivesAsItsExactDigits() throws IOException {
+        SimpleFeature feature = readOne(row("amount", new BigDecimal("1.50")),
+                descriptor("amount", Types.DECIMAL, "decimal(10,2)"));
+        assertThat(feature.getAttribute("amount")).isEqualTo("1.50");
+    }
+
+    /**
+     * Plain notation, not {@code BigDecimal.toString()}'s exponent form. The attribute is text a CQL
+     * predicate or a WFS response is written against, and {@code 1E-7} would not match the value as
+     * anyone would write it.
+     */
+    @Test
+    void smallDecimalsKeepPlainNotation() throws IOException {
+        SimpleFeature feature = readOne(row("amount", new BigDecimal("0.0000001")),
+                descriptor("amount", Types.DECIMAL, "decimal(38,10)"));
+        assertThat(feature.getAttribute("amount")).isEqualTo("0.0000001");
+    }
+
+    @Test
+    void aNullDecimalStaysNull() throws IOException {
+        SimpleFeature feature = readOne(row("amount", null),
+                descriptor("amount", Types.DECIMAL, "decimal(10,2)"));
+        assertThat(feature.getAttribute("amount")).isNull();
+    }
+
+    /**
+     * The end-to-end shape of issue one: a temporal leaf inside a {@code row} column, which reaches the
+     * attribute as a rendered document rather than as Jackson's date format.
+     */
+    @Test
+    void temporalLeavesInsideARowRenderWithAnIsoOffset() throws IOException {
+        Timestamp observed = Timestamp.from(Instant.parse("2026-08-28T12:34:56.123456Z"));
+        Row value = Row.builder()
+                .addField("first_observed", observed)
+                .addField("frequency_hz", new BigDecimal("1200.50"))
+                .build();
+        SimpleFeature feature = readOne(row("parametrics", value),
+                descriptor("parametrics", Types.JAVA_OBJECT,
+                        "row(first_observed timestamp(6) with time zone, frequency_hz decimal(10,2))"));
+        assertThat(feature.getAttribute("parametrics")).isEqualTo(
+                "{\"first_observed\":\"2026-08-28T12:34:56.123456Z\",\"frequency_hz\":1200.50}");
+    }
+
+    /** A {@code List} attribute is assigned, not rendered; only {@code json=true} attributes are documents. */
+    @Test
+    void arrayOfScalarsArrivesAsAList() throws IOException {
+        SimpleFeature feature = readOne(row("ids", List.of("a", "b")),
+                descriptor("ids", Types.ARRAY, "array(varchar)"));
+        assertThat(feature.getAttribute("ids")).isEqualTo(List.of("a", "b"));
+    }
+}

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoJsonTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoJsonTest.java
@@ -1,0 +1,215 @@
+/***********************************************************************
+ * Copyright (c) 2013-2025 General Atomics Integrated Intelligence, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ ***********************************************************************/
+
+package org.locationtech.geomesa.trino.datastore;
+
+import io.trino.jdbc.TrinoIntervalDayTime;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The rendered form of every leaf type the Trino driver can put inside structural data.
+ *
+ * <p>These are exact-string assertions on purpose. The same document is reachable through the
+ * FileSystem DataStore, and the two renderings have to agree; {@link TrinoJsonVariantParityTest}
+ * checks them against each other, while the expectations here pin what that agreement is so a
+ * change to either side fails loudly rather than drifting.
+ */
+class TrinoJsonTest {
+
+    private static final Instant INSTANT = Instant.parse("2026-08-28T12:34:56.123456Z");
+
+    @Test
+    void nullRendersAsTheJsonLiteral() throws IOException {
+        assertThat(TrinoJson.render(null)).isEqualTo("null");
+    }
+
+    @Test
+    void stringsAndBooleansRenderAsThemselves() throws IOException {
+        assertThat(TrinoJson.render("MMSI")).isEqualTo("\"MMSI\"");
+        assertThat(TrinoJson.render(true)).isEqualTo("true");
+    }
+
+    @Test
+    void integralNumbersRenderUnquoted() throws IOException {
+        assertThat(TrinoJson.render((byte) 7)).isEqualTo("7");
+        assertThat(TrinoJson.render((short) 7)).isEqualTo("7");
+        assertThat(TrinoJson.render(7)).isEqualTo("7");
+        assertThat(TrinoJson.render(7L)).isEqualTo("7");
+    }
+
+    @Test
+    void doublesRenderUnquoted() throws IOException {
+        assertThat(TrinoJson.render(0.75d)).isEqualTo("0.75");
+    }
+
+    /**
+     * A {@code real} leaf arrives as a {@link Float} and stays one. Widening it to {@code double} first
+     * would render {@code 0.1f} as {@code 0.10000000149011612}, which is a different string than the
+     * variant writer's, and a longer one that is no more accurate.
+     */
+    @Test
+    void realsRenderAtFloatWidth() throws IOException {
+        assertThat(TrinoJson.render(0.1f)).isEqualTo("0.1");
+    }
+
+    /** JSON has no NaN or infinity token, so these become null rather than an unparseable document. */
+    @Test
+    void nonFiniteNumbersRenderAsNull() throws IOException {
+        assertThat(TrinoJson.render(Double.NaN)).isEqualTo("null");
+        assertThat(TrinoJson.render(Double.POSITIVE_INFINITY)).isEqualTo("null");
+        assertThat(TrinoJson.render(Float.NEGATIVE_INFINITY)).isEqualTo("null");
+    }
+
+    @Test
+    void decimalsRenderUnquotedAtTheScaleTheyCarry() throws IOException {
+        assertThat(TrinoJson.render(new BigDecimal("1.50"))).isEqualTo("1.50");
+        assertThat(TrinoJson.render(new BigDecimal("-0.0000001"))).isEqualTo("-1E-7");
+    }
+
+    /**
+     * {@code timestamp with time zone} at UTC, which is how the offset is always written even when the
+     * reader's own zone is something else — the previous {@code ObjectMapper} rendering produced
+     * {@code 2026-08-28T12:34:56.123+00:00} here, at a fixed three fractional digits.
+     */
+    @Test
+    void instantsRenderAsIsoOffsetAtUtc() throws IOException {
+        assertThat(TrinoJson.render(INSTANT)).isEqualTo("\"2026-08-28T12:34:56.123456Z\"");
+    }
+
+    /** The driver's representation for both timestamp flavors; the instant it holds is what is rendered. */
+    @Test
+    void sqlTimestampsRenderAsIsoOffsetAtUtc() throws IOException {
+        assertThat(TrinoJson.render(Timestamp.from(INSTANT))).isEqualTo("\"2026-08-28T12:34:56.123456Z\"");
+    }
+
+    /** Offsets are normalized rather than preserved, so the same instant is one string however it arrives. */
+    @Test
+    void offsetAndZonedDateTimesNormalizeToUtc() throws IOException {
+        OffsetDateTime offset = INSTANT.atOffset(ZoneOffset.ofHours(-5));
+        ZonedDateTime zoned = INSTANT.atZone(ZoneOffset.ofHours(9));
+        assertThat(TrinoJson.render(offset)).isEqualTo("\"2026-08-28T12:34:56.123456Z\"");
+        assertThat(TrinoJson.render(zoned)).isEqualTo("\"2026-08-28T12:34:56.123456Z\"");
+    }
+
+    /** A variant {@code timestamp} without a zone has no offset to write, and does not gain one. */
+    @Test
+    void localDateTimesRenderWithoutAnOffset() throws IOException {
+        assertThat(TrinoJson.render(LocalDateTime.parse("2026-08-28T12:34:56.123456")))
+                .isEqualTo("\"2026-08-28T12:34:56.123456\"");
+    }
+
+    @Test
+    void datesAndTimesRenderAsIsoLocal() throws IOException {
+        assertThat(TrinoJson.render(LocalDate.parse("2026-08-28"))).isEqualTo("\"2026-08-28\"");
+        assertThat(TrinoJson.render(LocalTime.parse("12:34:56"))).isEqualTo("\"12:34:56\"");
+        assertThat(TrinoJson.render(java.sql.Date.valueOf("2026-08-28"))).isEqualTo("\"2026-08-28\"");
+        assertThat(TrinoJson.render(Time.valueOf("12:34:56"))).isEqualTo("\"12:34:56\"");
+    }
+
+    @Test
+    void varbinaryRendersAsBase64() throws IOException {
+        assertThat(TrinoJson.render(new byte[] {1, 2, 3})).isEqualTo("\"AQID\"");
+    }
+
+    @Test
+    void uuidsRenderAsTheirCanonicalText() throws IOException {
+        UUID uuid = UUID.fromString("28f5b1ce-1c1a-4b3f-9f6a-3f2e1d0c9b8a");
+        assertThat(TrinoJson.render(uuid)).isEqualTo("\"28f5b1ce-1c1a-4b3f-9f6a-3f2e1d0c9b8a\"");
+    }
+
+    @Test
+    void mapsRenderAsObjectsInIterationOrder() throws IOException {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("realm", "MMSI");
+        map.put("selector", "123");
+        assertThat(TrinoJson.render(map)).isEqualTo("{\"realm\":\"MMSI\",\"selector\":\"123\"}");
+    }
+
+    @Test
+    void listsRenderAsArrays() throws IOException {
+        assertThat(TrinoJson.render(List.of(1, 2, 3))).isEqualTo("[1,2,3]");
+    }
+
+    @Test
+    void nullsInsideContainersAreKept() throws IOException {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("present", 1);
+        map.put("absent", null);
+        assertThat(TrinoJson.render(map)).isEqualTo("{\"present\":1,\"absent\":null}");
+        assertThat(TrinoJson.render(Arrays.asList("a", null))).isEqualTo("[\"a\",null]");
+    }
+
+    /** The shape {@code parametrics} has: a row of scalars, one of them temporal. */
+    @Test
+    void nestingRecursesThroughObjectsAndArrays() throws IOException {
+        Map<String, Object> parametrics = new LinkedHashMap<>();
+        parametrics.put("first_observed", INSTANT);
+        parametrics.put("readings", List.of(Map.of("hz", 1200L)));
+        assertThat(TrinoJson.render(parametrics)).isEqualTo(
+                "{\"first_observed\":\"2026-08-28T12:34:56.123456Z\",\"readings\":[{\"hz\":1200}]}");
+    }
+
+    @Test
+    void quotesAndControlCharactersAreEscaped() throws IOException {
+        assertThat(TrinoJson.render("a\"b\\c\nd")).isEqualTo("\"a\\\"b\\\\c\\nd\"");
+    }
+
+    /**
+     * The exact-class table does not have a row for every {@link CharSequence}, {@link Number} or
+     * {@link java.util.Date}, only for the classes the driver actually produces. Anything else
+     * recognizable by supertype falls to the ordered supertype rows rather than to the warning.
+     */
+    @Test
+    void leavesRecognizableOnlyBySupertypeStillRender() throws IOException {
+        assertThat(TrinoJson.render(new StringBuilder("MMSI"))).isEqualTo("\"MMSI\"");
+        assertThat(TrinoJson.render(new AtomicInteger(7))).isEqualTo("7");
+        // a java.util.Date holds only milliseconds, so the microseconds of INSTANT are truncated
+        assertThat(TrinoJson.render(new java.util.Date(INSTANT.toEpochMilli())))
+                .isEqualTo("\"2026-08-28T12:34:56.123Z\"");
+    }
+
+    /**
+     * A {@code java.sql.Date} is a {@link java.util.Date}, and the two render differently. Its own row
+     * has to win over the supertype row, which is the hazard the exact-class lookup removes.
+     */
+    @Test
+    void anExactRowWinsOverTheSupertypeRow() throws IOException {
+        assertThat(TrinoJson.render(java.sql.Date.valueOf("2026-08-28"))).isEqualTo("\"2026-08-28\"");
+        assertThat(TrinoJson.render(Time.valueOf("12:34:56"))).isEqualTo("\"12:34:56\"");
+    }
+
+    /**
+     * An {@code interval day to second} leaf is a real driver type with no branch of its own: quoted and
+     * logged, rather than left to break the document or abort the scan.
+     */
+    @Test
+    void unknownLeafTypesRenderAsStrings() throws IOException {
+        String rendered = TrinoJson.render(new TrinoIntervalDayTime(0, 0, 0, 5, 0));
+        assertThat(rendered).startsWith("\"").endsWith("\"").contains("5");
+    }
+}

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoJsonVariantParityTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoJsonVariantParityTest.java
@@ -1,0 +1,158 @@
+/***********************************************************************
+ * Copyright (c) 2013-2025 General Atomics Integrated Intelligence, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ ***********************************************************************/
+
+package org.locationtech.geomesa.trino.datastore;
+
+import org.apache.parquet.variant.Variant;
+import org.apache.parquet.variant.VariantBuilder;
+import org.apache.parquet.variant.VariantObjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.locationtech.geomesa.fs.storage.core.parquet.io.VariantJsonWriter;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The two DataStores that can serve the same document have to render it identically.
+ *
+ * <p>A GeoMesa {@code json=true} attribute is stored as a Parquet {@code variant}. Read through the
+ * FileSystem DataStore, {@code VariantJsonWriter} renders that variant. Read through this DataStore,
+ * Trino decodes the same variant and {@link TrinoJson} renders the decoded objects. A consumer that
+ * compares the two — an FSDS export against a Trino export, a cached document against a re-read one —
+ * sees a difference for any leaf the two disagree on, so each case below renders one leaf both ways
+ * and asserts the strings are equal rather than merely both plausible.
+ *
+ * <p>The Java object each case passes to {@link TrinoJson} is the one the driver produces for that
+ * variant type: {@code Variant.toObject()} yields {@link Instant} for a timestamp with a zone,
+ * {@link LocalDateTime} for one without, {@link LocalDate}, {@link LocalTime}, {@link BigDecimal} and
+ * {@code byte[]} for the rest — which is why the offset a timestamp is rendered at survives the trip.
+ */
+class TrinoJsonVariantParityTest {
+
+    private static final long MICROS_PER_SECOND = 1_000_000L;
+
+    /** Builds a single-value variant. */
+    private static Variant variant(Consumer<VariantBuilder> append) {
+        VariantBuilder builder = new VariantBuilder();
+        append.accept(builder);
+        return builder.build();
+    }
+
+    /** Renders one leaf both ways and asserts the two agree. */
+    private static void assertParity(Consumer<VariantBuilder> append, Object decoded) throws IOException {
+        String viaFileSystem = VariantJsonWriter.toJson(variant(append));
+        String viaTrino = TrinoJson.render(decoded);
+        assertThat(viaTrino).isEqualTo(viaFileSystem);
+    }
+
+    /** The case that prompted this: a temporal leaf, rendered at UTC with an offset on both paths. */
+    @Test
+    void timestampWithAZoneAgrees() throws IOException {
+        Instant instant = Instant.parse("2026-08-28T12:34:56.123456Z");
+        long micros = instant.getEpochSecond() * MICROS_PER_SECOND + instant.getNano() / 1000L;
+        assertParity(b -> b.appendTimestampTz(micros), instant);
+    }
+
+    @Test
+    void timestampWithoutAZoneAgrees() throws IOException {
+        LocalDateTime dateTime = LocalDateTime.parse("2026-08-28T12:34:56.123456");
+        long micros = dateTime.toEpochSecond(java.time.ZoneOffset.UTC) * MICROS_PER_SECOND
+                + dateTime.getNano() / 1000L;
+        assertParity(b -> b.appendTimestampNtz(micros), dateTime);
+    }
+
+    @Test
+    void wholeSecondTimestampsAgree() throws IOException {
+        Instant instant = Instant.parse("2026-08-28T12:34:56Z");
+        assertParity(b -> b.appendTimestampTz(instant.getEpochSecond() * MICROS_PER_SECOND), instant);
+    }
+
+    @Test
+    void dateAgrees() throws IOException {
+        LocalDate date = LocalDate.parse("2026-08-28");
+        assertParity(b -> b.appendDate((int) date.toEpochDay()), date);
+    }
+
+    @Test
+    void timeAgrees() throws IOException {
+        LocalTime time = LocalTime.parse("12:34:56.123456");
+        assertParity(b -> b.appendTime(time.toNanoOfDay() / 1000L), time);
+    }
+
+    /** The leaf type that has no flat GeoTools binding; both paths keep it an unquoted number. */
+    @Test
+    void decimalAgrees() throws IOException {
+        BigDecimal decimal = new BigDecimal("1.50");
+        assertParity(b -> b.appendDecimal(decimal), decimal);
+        assertThat(TrinoJson.render(decimal)).doesNotContain("\"");
+    }
+
+    @Test
+    void scalarsAgree() throws IOException {
+        assertParity(b -> b.appendString("MMSI"), "MMSI");
+        assertParity(b -> b.appendBoolean(true), true);
+        assertParity(b -> b.appendLong(1200L), 1200L);
+        assertParity(b -> b.appendInt(7), 7);
+        assertParity(b -> b.appendDouble(0.75d), 0.75d);
+        assertParity(b -> b.appendNull(), null);
+    }
+
+    /**
+     * A float stays a float on both sides. This is the case that a plausible-looking widening to
+     * {@code double} gets wrong, and it fails here rather than in a diff of two exports.
+     */
+    @Test
+    void realAgrees() throws IOException {
+        assertParity(b -> b.appendFloat(0.1f), 0.1f);
+    }
+
+    @Test
+    void nonFiniteDoublesAgree() throws IOException {
+        assertParity(b -> b.appendDouble(Double.NaN), Double.NaN);
+        assertParity(b -> b.appendDouble(Double.POSITIVE_INFINITY), Double.POSITIVE_INFINITY);
+    }
+
+    @Test
+    void binaryAgrees() throws IOException {
+        byte[] bytes = {1, 2, 3, 4};
+        assertParity(b -> b.appendBinary(ByteBuffer.wrap(bytes)), bytes);
+    }
+
+    /**
+     * The {@code parametrics} shape end to end. Field order is the variant's, which is the order the
+     * driver hands back too, so the objects compared here are built in that same order.
+     */
+    @Test
+    void nestedObjectWithATemporalLeafAgrees() throws IOException {
+        Instant observed = Instant.parse("2026-08-28T12:34:56.123456Z");
+        long micros = observed.getEpochSecond() * MICROS_PER_SECOND + observed.getNano() / 1000L;
+
+        Map<String, Object> decoded = new LinkedHashMap<>();
+        decoded.put("first_observed", observed);
+        decoded.put("frequency_hz", new BigDecimal("1200.50"));
+
+        assertParity(b -> {
+            VariantObjectBuilder object = b.startObject();
+            object.appendKey("first_observed");
+            object.appendTimestampTz(micros);
+            object.appendKey("frequency_hz");
+            object.appendDecimal(new BigDecimal("1200.50"));
+            b.endObject();
+        }, decoded);
+    }
+}

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapperGeoMesaSpecTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapperGeoMesaSpecTest.java
@@ -110,12 +110,25 @@ class TrinoTypeMapperGeoMesaSpecTest {
         assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_JSON, "true");
     }
 
-    /** The historic opaque fallback is a supported GeoMesa binding too (Bytes). */
+    /** The remaining opaque fallback is a supported GeoMesa binding too (Bytes). */
     @Test
     void opaqueFallbackAlsoRoundTrips() {
-        SimpleFeatureType in = sftOf("amount", Types.DECIMAL, "decimal(10,2)");
+        SimpleFeatureType in = sftOf("unknown", Types.JAVA_OBJECT, "ipaddress");
         assertThat(SimpleFeatureTypes.encodeType(in)).contains("Bytes");
-        assertThat(roundTrip(in).getDescriptor("amount").getType().getBinding())
+        assertThat(roundTrip(in).getDescriptor("unknown").getType().getBinding())
                 .isEqualTo(byte[].class);
+    }
+
+    /**
+     * A decimal column round-trips as String. BigDecimal is what GeoTools would use here, but it has no
+     * {@code ObjectType}, so {@code encodeType} would throw on it — the reason the mapping is String and
+     * the reason this test exists.
+     */
+    @Test
+    void decimalRoundTripsAsString() {
+        SimpleFeatureType in = sftOf("amount", Types.DECIMAL, "decimal(38,10)");
+        assertThat(SimpleFeatureTypes.encodeType(in)).contains("String");
+        assertThat(roundTrip(in).getDescriptor("amount").getType().getBinding())
+                .isEqualTo(String.class);
     }
 }

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapperTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeMapperTest.java
@@ -217,13 +217,36 @@ class TrinoTypeMapperTest {
         assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_JSON, "true");
     }
 
+    /**
+     * A decimal column used to fall through to the opaque {@code byte[]} warning, which made it
+     * unreadable through the DataStore even though it is a scalar. String is the only binding that
+     * keeps its digits: GeoMesa's {@code ObjectType} has no {@code BigDecimal}, and {@code Double}
+     * cannot hold a {@code decimal(38,10)}.
+     */
     @Test
-    void decimalKeepsTheOpaqueFallback() {
-        // decimal has no ObjectType and is not structural; changing it is a separate
-        // judgment call, so the historic behavior is deliberately preserved.
+    void decimalMapsToStringRatherThanTheOpaqueFallback() {
         AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
                 "amount", Types.DECIMAL, "decimal(10,2)", false, null, 0);
-        assertThat(d.getType().getBinding()).isEqualTo(byte[].class);
+        assertThat(d.getType().getBinding()).isEqualTo(String.class);
+        // not a JSON document, unlike a row/array column - just a scalar rendered exactly
+        assertThat(d.getUserData()).doesNotContainKey(TrinoTypeMapper.OPT_JSON);
+    }
+
+    /** The synonym Trino's driver does not currently emit, mapped the same way rather than left opaque. */
+    @Test
+    void numericMapsToStringToo() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "amount", Types.NUMERIC, "decimal(38,10)", false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(String.class);
+    }
+
+    /** A decimal nested in structural data keeps the JSON treatment, where it stays an unquoted number. */
+    @Test
+    void arrayOfDecimalStillBecomesJson() {
+        AttributeDescriptor d = TrinoTypeMapper.toDescriptor(
+                "amounts", Types.ARRAY, "array(decimal(10,2))", false, null, 0);
+        assertThat(d.getType().getBinding()).isEqualTo(String.class);
+        assertThat(d.getUserData()).containsEntry(TrinoTypeMapper.OPT_JSON, "true");
     }
 
     @Test

--- a/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeSignatureTest.java
+++ b/geomesa-trino/geomesa-trino-datastore/src/test/java/org/locationtech/geomesa/trino/datastore/TrinoTypeSignatureTest.java
@@ -103,7 +103,7 @@ class TrinoTypeSignatureTest {
 
     @Test
     void scalarBindingRefusesWhatGeoMesaCannotCarry() {
-        assertThat(scalarBinding("decimal(10,2)")).isNull();   // no ObjectType for it
+        assertThat(scalarBinding("decimal(10,2)")).isNull();   // routed to JSON as a number
         assertThat(scalarBinding("row(a int)")).isNull();
         assertThat(scalarBinding("array(varchar)")).isNull();
         assertThat(scalarBinding("map(varchar,varchar)")).isNull();


### PR DESCRIPTION
Addresses the following two identified deficiencies:

```
- Temporal leaves render differently on the two paths. Elsewhere in GeoMesa ISO_OFFSET_DATE_TIME is used; TrinoFeatureReader uses Jackson with WRITE_DATES_AS_TIMESTAMPS disabled. parametrics.first_observed read via FSDS vs. via Trino won't be string-equal.

- Top-level decimal is still opaque on your Trino side (falls through to the byte[] warn), while upstream handles decimal leaves inside structural JSON.
```