### PR TITLE
FS/Trino - Fix iceberg field ids to support schema evolution

### DIFF
--- a/geomesa-convert/geomesa-convert-parquet/src/main/scala/org/locationtech/geomesa/convert/parquet/ParquetConverterFactory.scala
+++ b/geomesa-convert/geomesa-convert-parquet/src/main/scala/org/locationtech/geomesa/convert/parquet/ParquetConverterFactory.scala
@@ -36,7 +36,6 @@ import org.locationtech.geomesa.utils.io.PathUtils
 import org.locationtech.geomesa.utils.text.StringSerialization
 
 import java.io.InputStream
-import java.util.concurrent.atomic.AtomicInteger
 import scala.util.{Failure, Success, Try}
 
 class ParquetConverterFactory
@@ -311,7 +310,7 @@ object ParquetConverterFactory extends LazyLogging {
   private def isNativeType(field: Type, objectType: ObjectType): Boolean = {
     if (field.isRepetition(Repetition.REPEATED)) { false } else {
       // custom compare, so we don't consider optional vs required, id, name, logicalTypes, etc
-      compareGeomFields(field, GeoParquetNative.schema(objectType, new AtomicInteger(1), new AtomicInteger(1000)).named(field.getName))
+      compareGeomFields(field, GeoParquetNative.schema(objectType).named(field.getName))
     }
   }
 

--- a/geomesa-features/geomesa-feature-exporters/src/main/scala/org/locationtech/geomesa/features/exporters/GeoParquetExporter.scala
+++ b/geomesa-features/geomesa-feature-exporters/src/main/scala/org/locationtech/geomesa/features/exporters/GeoParquetExporter.scala
@@ -39,7 +39,7 @@ class GeoParquetExporter(path: String) extends FeatureExporter with LazyLogging 
     // use PathUtils.getUrl to handle local file paths (without a scheme)
     val uri = PathUtils.getUrl(path).toURI
     fs = ObjectStore(uri.getScheme, conf)
-    writer = new ParquetFileSystemWriter(sft, conf, fs, uri.toString)
+    writer = ParquetFileSystemWriter(sft, conf, fs, uri.toString)
   }
 
   override def export(features: Iterator[SimpleFeature]): Option[Long] = {

--- a/geomesa-fs/geomesa-fs-jobs/src/main/scala/org/locationtech/geomesa/fs/storage/jobs/parquet/ParquetSimpleFeatureOutputFormat.scala
+++ b/geomesa-fs/geomesa-fs-jobs/src/main/scala/org/locationtech/geomesa/fs/storage/jobs/parquet/ParquetSimpleFeatureOutputFormat.scala
@@ -44,9 +44,9 @@ object ParquetSimpleFeatureOutputFormat {
     override def commitJob(jobContext: JobContext): Unit = {
       super.commitJob(jobContext)
       val conf = ContextUtil.getConfiguration(jobContext)
-      listFiles(outputPath, conf).map(_.getParent).distinct.foreach { path =>
+      listFiles(outputPath, conf).map(_.getParent).groupBy(p => p).foreach { case (path, count) =>
         ParquetOutputCommitter.writeMetaDataFile(conf, path)
-        logger.info(s"Wrote metadata file for path $path")
+        logger.info(s"Wrote metadata file for ${count.size} file(s) under directory $path")
       }
     }
   }

--- a/geomesa-fs/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterCatalog.scala
+++ b/geomesa-fs/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterCatalog.scala
@@ -16,7 +16,7 @@ import org.locationtech.geomesa.convert.{ConfArgs, ConverterConfigResolver}
 import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.fs.storage.converter.pathfilter.{PathFiltering, PathFilteringFactory}
 import org.locationtech.geomesa.fs.storage.converter.schemes.{NamedOptions, PartitionSchemeFactory}
-import org.locationtech.geomesa.fs.storage.core.iceberg.SimpleFeatureIcebergSchema
+import org.locationtech.geomesa.fs.storage.core.iceberg.{IcebergCatalog, SimpleFeatureIcebergSchema}
 import org.locationtech.geomesa.fs.storage.core.parquet.schema.GeometrySchema.GeometryEncoding.GeoParquetWkb
 import org.locationtech.geomesa.fs.storage.core.{FileSystemStorage, StorageCatalog}
 import org.locationtech.geomesa.utils.geotools.{SftArgResolver, SftArgs}
@@ -94,7 +94,9 @@ class ConverterCatalog(val conf: Map[String, String]) extends StorageCatalog wit
       val ns = Namespace.of("geomesa")
       catalog.createNamespace(ns)
       val table = catalog.createTable(TableIdentifier.of(ns, "converter"), SimpleFeatureIcebergSchema.create(sft, GeoParquetWkb))
-      table.updateProperties().set("geomesa.sft.name", sft.getTypeName).commit()
+      val update = table.updateProperties()
+      IcebergCatalog.sftTableProperties(sft).foreach { case (k, v) => update.set(k, v) }
+      update.commit()
       val schema = SimpleFeatureIcebergSchema(table, conf.get(StorageCatalog.NamespaceConfigKey))
       new ConverterStorage(table, schema, schemes, conf, converterPath, converter, pathFiltering, leafStorage)
     } else {

--- a/geomesa-fs/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterCatalog.scala
+++ b/geomesa-fs/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterCatalog.scala
@@ -17,6 +17,7 @@ import org.locationtech.geomesa.convert2.SimpleFeatureConverter
 import org.locationtech.geomesa.fs.storage.converter.pathfilter.{PathFiltering, PathFilteringFactory}
 import org.locationtech.geomesa.fs.storage.converter.schemes.{NamedOptions, PartitionSchemeFactory}
 import org.locationtech.geomesa.fs.storage.core.iceberg.SimpleFeatureIcebergSchema
+import org.locationtech.geomesa.fs.storage.core.parquet.schema.GeometrySchema.GeometryEncoding.GeoParquetWkb
 import org.locationtech.geomesa.fs.storage.core.{FileSystemStorage, StorageCatalog}
 import org.locationtech.geomesa.utils.geotools.{SftArgResolver, SftArgs}
 
@@ -92,8 +93,9 @@ class ConverterCatalog(val conf: Map[String, String]) extends StorageCatalog wit
       catalog.initialize("geomesa", java.util.Map.of())
       val ns = Namespace.of("geomesa")
       catalog.createNamespace(ns)
-      val schema = SimpleFeatureIcebergSchema(sft, conf)
-      val table = catalog.createTable(TableIdentifier.of(ns, "converter"), schema.schema)
+      val table = catalog.createTable(TableIdentifier.of(ns, "converter"), SimpleFeatureIcebergSchema.create(sft, GeoParquetWkb))
+      table.updateProperties().set("geomesa.sft.name", sft.getTypeName).commit()
+      val schema = SimpleFeatureIcebergSchema(table, None)
       new ConverterStorage(table, schema, schemes, conf, converterPath, converter, pathFiltering, leafStorage)
     } else {
       throw new IllegalArgumentException(s"Schema '$typeName' doesn't exist - available schemas: ${sft.getTypeName}")

--- a/geomesa-fs/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterCatalog.scala
+++ b/geomesa-fs/geomesa-fs-storage-convert/src/main/scala/org/locationtech/geomesa/fs/storage/converter/ConverterCatalog.scala
@@ -95,7 +95,7 @@ class ConverterCatalog(val conf: Map[String, String]) extends StorageCatalog wit
       catalog.createNamespace(ns)
       val table = catalog.createTable(TableIdentifier.of(ns, "converter"), SimpleFeatureIcebergSchema.create(sft, GeoParquetWkb))
       table.updateProperties().set("geomesa.sft.name", sft.getTypeName).commit()
-      val schema = SimpleFeatureIcebergSchema(table, None)
+      val schema = SimpleFeatureIcebergSchema(table, conf.get(StorageCatalog.NamespaceConfigKey))
       new ConverterStorage(table, schema, schemes, conf, converterPath, converter, pathFiltering, leafStorage)
     } else {
       throw new IllegalArgumentException(s"Schema '$typeName' doesn't exist - available schemas: ${sft.getTypeName}")

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/FileSystemStorage.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/FileSystemStorage.scala
@@ -181,8 +181,7 @@ case class FileSystemStorage(
    * @return writer
    */
   def getWriter(partition: Partition): FileSystemWriter = {
-    val compression = Option(System.getProperty(ParquetCompressionOpt)).map(ParquetCompressionOpt -> _).toMap
-    val conf = compression ++ this.conf ++ Map(SimpleFeatureSchema.PartitionKey -> partition.toString)
+    val conf = this.conf ++ Map(SimpleFeatureSchema.PartitionKey -> partition.toString)
 
     def newWriter(): FileSystemWriter = {
       val path = newFilePath()
@@ -190,7 +189,7 @@ case class FileSystemStorage(
       val observer = if (observers.isEmpty) { tableObserver } else {
         new CompositeObserver(observers.map(_.apply(path)).+:(tableObserver))
       }
-      new ParquetFileSystemWriter(sft, conf, table.io(), path, observer)
+      ParquetFileSystemWriter(schema, conf, table.io(), path, observer)
     }
 
     sizer.targetSize match {

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/iceberg/IcebergCatalog.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/iceberg/IcebergCatalog.scala
@@ -10,25 +10,20 @@ package org.locationtech.geomesa.fs.storage.core.iceberg
 
 import com.github.benmanes.caffeine.cache.{CacheLoader, Caffeine}
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.iceberg._
 import org.apache.iceberg.catalog.{Catalog, Namespace, SupportsNamespaces, TableIdentifier}
-import org.apache.iceberg.types.Types.NestedField
-import org.apache.iceberg.{CatalogUtil, PartitionSpec, RowLevelOperationMode, TableProperties}
-import org.geotools.api.feature.`type`.{AttributeDescriptor, GeometryDescriptor}
 import org.geotools.api.feature.simple.SimpleFeatureType
-import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.locationtech.geomesa.fs.storage.core.fs.S3ObjectStore
-import org.locationtech.geomesa.fs.storage.core.parquet.schema.GeometrySchema.GeometryEncoding.GeoParquetWkb
-import org.locationtech.geomesa.fs.storage.core.schema.{ColumnName, SimpleFeatureSchema}
+import org.locationtech.geomesa.fs.storage.core.parquet.schema.GeometrySchema.GeometryEncoding
+import org.locationtech.geomesa.fs.storage.core.schema.ColumnName
+import org.locationtech.geomesa.fs.storage.core.schema.SimpleFeatureSchema.GeometryEncodingKey
 import org.locationtech.geomesa.fs.storage.core.schemes.PartitionSchemeFactory
-import org.locationtech.geomesa.fs.storage.core.{FileSystemStorage, Metadata, StorageCatalog, namespaced}
+import org.locationtech.geomesa.fs.storage.core.{FileSystemStorage, Metadata, StorageCatalog}
 import org.locationtech.geomesa.index.metadata.TableBasedMetadata
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
-import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.AttributeOptions
 import org.locationtech.geomesa.utils.io.CloseWithLogging
 
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
-import scala.util.control.NonFatal
 
 /**
  * Catalog implementation backed by iceberg
@@ -38,7 +33,6 @@ import scala.util.control.NonFatal
 class IcebergCatalog(config: Map[String, String]) extends StorageCatalog with LazyLogging {
 
   import IcebergCatalog.{RichCatalog, RichConf, UserDataPrefix}
-  import SimpleFeatureSchema.InternalFieldDelimiter
   import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
 
   import scala.collection.JavaConverters._
@@ -70,43 +64,18 @@ class IcebergCatalog(config: Map[String, String]) extends StorageCatalog with La
     }
   }
 
-  override def load(typeName: String): FileSystemStorage = {
-    val table = catalog.loadTable(tableId(typeName))
+  override def load(typeName: String): FileSystemStorage = load(catalog.loadTable(tableId(typeName)))
+
+  private def load(table: Table): FileSystemStorage = {
     val ns = conf.get(StorageCatalog.NamespaceConfigKey)
-    val sft = {
-      val typeName = table.properties().get("geomesa.sft.name")
-      val attributes = table.schema().columns().asScala.flatMap(deriveDescriptor)
-      if (attributes.isEmpty) {
-        // back compatibility check
-        SimpleFeatureTypes.createType(ns.fold(typeName)(n => s"$n:$typeName"), table.properties().get("geomesa.sft.spec"))
-      } else {
-        val b = new SimpleFeatureTypeBuilder()
-        b.setNamespaceURI(ns.orNull) // important to set this null if not defined so it doesn't default to gml namespace
-        b.setName(typeName)
-        b.addAll(attributes.asJava)
-        attributes.find(d => d.getUserData.get(AttributeOptions.OptDefault) == "true" && d.isInstanceOf[GeometryDescriptor]).foreach { d =>
-          b.setDefaultGeometry(d.getLocalName)
-        }
-        val sft = b.buildFeatureType()
-        table.properties().asScala.foreach { case (k, v) =>
-          if (k.startsWith(UserDataPrefix)) {
-            sft.getUserData.put(k.substring(UserDataPrefix.length), v)
-          }
-        }
-        sft
-      }
-    }
-    val schema = SimpleFeatureIcebergSchema(sft, conf)
+    val schema = SimpleFeatureIcebergSchema(table, ns)
     val schemes = PartitionSchemeFactory.load(schema, table.spec())
     FileSystemStorage(table, schemes, schema, conf)
   }
 
   override def create(sft: SimpleFeatureType, partitions: Seq[String], targetFileSize: Option[Long] = None): FileSystemStorage = {
-    val schema = SimpleFeatureIcebergSchema(namespaced(sft, conf.get(StorageCatalog.NamespaceConfigKey)), conf)
-    if (schema.geometries != GeoParquetWkb) {
-      // TODO supports native geometry encoding
-      throw new UnsupportedOperationException(s"Only WKB geometry encoding is supported: ${schema.geometries}")
-    }
+    val geoms = conf.get(GeometryEncodingKey).map(GeometryEncoding.apply).getOrElse(GeometryEncoding.GeoParquetWkb)
+    val schema = SimpleFeatureIcebergSchema.create(sft, geoms)
     // load the partition scheme first in case it fails
     val schemes = partitions.map(PartitionSchemeFactory.load(sft, _)).sortBy(_.name)
     val tableProps = {
@@ -118,40 +87,29 @@ class IcebergCatalog(config: Map[String, String]) extends StorageCatalog with La
         }
       }
       val size = targetFileSize.map(s => s"${Metadata.PropertyPrefix}${Metadata.TargetFileSize}" -> s.toString).toMap
-      // for back-compatibility
-      val spec = Map("geomesa.sft.spec" -> SimpleFeatureTypes.encodeType(sft, includeUserData = true))
       // file format v3 lets us use variant encoding
        val format =
          Map(TableProperties.FORMAT_VERSION -> "3", TableProperties.DELETE_MODE -> RowLevelOperationMode.MERGE_ON_READ.modeName())
-      typeName ++ userData ++ size ++ spec ++ format
+      typeName ++ userData ++ size ++ format
     }
 
-    val spec = schemes.foldLeft(PartitionSpec.builderFor(schema.schema))((b, m) => m.spec(b)).build()
+    val spec = schemes.foldLeft(PartitionSpec.builderFor(schema))((b, m) => m.spec(b)).build()
     catalog.ensureNamespace(namespace)
-    val table = catalog.createTable(tableId(sft.getTypeName), schema.schema, spec, null, tableProps.asJava)
-    FileSystemStorage(table, schemes, schema, conf)
+    val table = catalog.createTable(tableId(sft.getTypeName), schema, spec, null, tableProps.asJava)
+    // re-load to pick up the correct schema field ids
+    load(table)
   }
 
   override def close(): Unit = catalog.close()
 
   private def tableId(typeName: String): TableIdentifier = TableIdentifier.of(namespace, ColumnName.encode(typeName))
-
-  private def deriveDescriptor(f: NestedField): Option[AttributeDescriptor] = {
-    if (f.name().startsWith(InternalFieldDelimiter) && f.name().endsWith(InternalFieldDelimiter)) { None } else {
-      Option(f.doc()).flatMap { d =>
-        try { Some(SimpleFeatureTypes.createDescriptor(d)) } catch {
-          case NonFatal(e) => logger.warn(s"Error parsing column doc as descriptor: $d", e); None
-        }
-      }
-    }
-  }
 }
 
 object IcebergCatalog {
 
   import scala.collection.JavaConverters._
 
-  private val UserDataPrefix = "geomesa.userdata."
+  val UserDataPrefix = "geomesa.userdata."
 
   private implicit class RichConf(val conf: Map[String, String]) extends AnyVal {
     def required(k: String): String =

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/iceberg/IcebergCatalog.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/iceberg/IcebergCatalog.scala
@@ -32,8 +32,7 @@ import java.util.concurrent.TimeUnit
  */
 class IcebergCatalog(config: Map[String, String]) extends StorageCatalog with LazyLogging {
 
-  import IcebergCatalog.{RichCatalog, RichConf, UserDataPrefix}
-  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+  import IcebergCatalog.{RichCatalog, RichConf}
 
   import scala.collection.JavaConverters._
 
@@ -78,21 +77,13 @@ class IcebergCatalog(config: Map[String, String]) extends StorageCatalog with La
     val schema = SimpleFeatureIcebergSchema.create(sft, geoms)
     // load the partition scheme first in case it fails
     val schemes = partitions.map(PartitionSchemeFactory.load(sft, _)).sortBy(_.name)
-    val tableProps = {
-      val typeName = Map("geomesa.sft.name" -> sft.getTypeName)
-      val userData = {
-        val prefixes = sft.getUserDataPrefixes
-        sft.getUserData.asScala.collect {
-          case (k, v) if v != null && prefixes.exists(k.toString.startsWith) => s"$UserDataPrefix$k" -> v.toString
-        }
-      }
+    val tableProps = IcebergCatalog.sftTableProperties(sft) ++ {
       val size = targetFileSize.map(s => s"${Metadata.PropertyPrefix}${Metadata.TargetFileSize}" -> s.toString).toMap
       // file format v3 lets us use variant encoding
        val format =
          Map(TableProperties.FORMAT_VERSION -> "3", TableProperties.DELETE_MODE -> RowLevelOperationMode.MERGE_ON_READ.modeName())
-      typeName ++ userData ++ size ++ format
+      size ++ format
     }
-
     val spec = schemes.foldLeft(PartitionSpec.builderFor(schema))((b, m) => m.spec(b)).build()
     catalog.ensureNamespace(namespace)
     val table = catalog.createTable(tableId(sft.getTypeName), schema, spec, null, tableProps.asJava)
@@ -107,9 +98,28 @@ class IcebergCatalog(config: Map[String, String]) extends StorageCatalog with La
 
 object IcebergCatalog {
 
+  import org.locationtech.geomesa.utils.geotools.RichSimpleFeatureType.RichSimpleFeatureType
+
   import scala.collection.JavaConverters._
 
   val UserDataPrefix = "geomesa.userdata."
+
+  /**
+   * Table-level properties needed to reconstruct the feature type
+   *
+   * @param sft simple feature type
+   * @return
+   */
+  def sftTableProperties(sft: SimpleFeatureType): Map[String, String] = {
+    val typeName = Map("geomesa.sft.name" -> sft.getTypeName)
+    val userData = {
+      val prefixes = sft.getUserDataPrefixes
+      sft.getUserData.asScala.collect {
+        case (k, v) if v != null && prefixes.exists(k.toString.startsWith) => s"$UserDataPrefix$k" -> v.toString
+      }
+    }
+    typeName ++ userData
+  }
 
   private implicit class RichConf(val conf: Map[String, String]) extends AnyVal {
     def required(k: String): String =

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/iceberg/SimpleFeatureIcebergSchema.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/iceberg/SimpleFeatureIcebergSchema.scala
@@ -171,7 +171,10 @@ object SimpleFeatureIcebergSchema extends LazyLogging {
       val name = ColumnName(d.getLocalName)
       val objectType = ObjectType.selectType(d)
       val doc = SimpleFeatureTypes.encodeDescriptor(sft, d)
-      if (objectType.head == ObjectType.GEOMETRY) {
+      if (objectType.head == ObjectType.STRING) {
+        val typed = if (objectType.last == ObjectType.JSON) { VariantType.get() } else { StringType.get() }
+        builder += buildField(name.column, fieldIds.getAndIncrement(), doc, typed)
+      } else if (objectType.head == ObjectType.GEOMETRY) {
         // TODO supports native geometry encoding
         require(geometries == GeometryEncoding.GeoParquetWkb, "Only WKB encoding is supported for Geometry types")
         val geomDoc = doc + SimpleFeatureSpec.encodeAttributeOption(GeometryEncodingKey, geometries.toString)

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/iceberg/SimpleFeatureIcebergSchema.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/iceberg/SimpleFeatureIcebergSchema.scala
@@ -22,7 +22,6 @@ import org.locationtech.geomesa.fs.storage.core.schema.{BoundingBoxField, Column
 import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.AttributeOptions
 import org.locationtech.geomesa.utils.geotools.Transform.{ExpressionTransform, PropertyTransform, RenameTransform, Transforms}
-import org.locationtech.geomesa.utils.geotools.sft.SimpleFeatureSpec
 import org.locationtech.geomesa.utils.geotools.{ObjectType, SimpleFeatureTypes}
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -177,7 +176,12 @@ object SimpleFeatureIcebergSchema extends LazyLogging {
       } else if (objectType.head == ObjectType.GEOMETRY) {
         // TODO supports native geometry encoding
         require(geometries == GeometryEncoding.GeoParquetWkb, "Only WKB encoding is supported for Geometry types")
-        val geomDoc = doc + SimpleFeatureSpec.encodeAttributeOption(GeometryEncodingKey, geometries.toString)
+        val geomDoc = {
+          // note: geotools AttributeTypeBuilder shares the user data map - reparse instead so we don't change the original
+          val descriptor = SimpleFeatureTypes.createDescriptor(doc)
+          descriptor.getUserData.put(GeometryEncodingKey, geometries.toString)
+          SimpleFeatureTypes.encodeDescriptor(sft, d)
+        }
         // not yet supported in spark or trino: GeometryType.crs84()
         builder += buildField(name.column, fieldIds.getAndIncrement(), geomDoc, BinaryType.get())
         builder += BoundingBoxField.icebergSchema(name.column, fieldIds)

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/iceberg/SimpleFeatureIcebergSchema.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/iceberg/SimpleFeatureIcebergSchema.scala
@@ -8,38 +8,33 @@
 
 package org.locationtech.geomesa.fs.storage.core.iceberg
 
-import org.apache.iceberg.types.Types
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.iceberg.types.Types._
-import org.apache.iceberg.{MetadataColumns, Schema}
+import org.apache.iceberg.types.{Type, Types}
+import org.apache.iceberg.{MetadataColumns, Schema, Table}
+import org.geotools.api.feature.`type`.{AttributeDescriptor, GeometryDescriptor}
 import org.geotools.api.feature.simple.SimpleFeatureType
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.locationtech.geomesa.filter.FilterHelper
-import org.locationtech.geomesa.fs.storage.core.iceberg.SimpleFeatureIcebergSchema.IcebergFields
 import org.locationtech.geomesa.fs.storage.core.parquet.schema.GeometrySchema.GeometryEncoding
 import org.locationtech.geomesa.fs.storage.core.schema.SimpleFeatureSchema.{FeatureIdField, VisibilitiesField}
 import org.locationtech.geomesa.fs.storage.core.schema.{BoundingBoxField, ColumnName, SimpleFeatureSchema, ZValueField}
 import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
+import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes.AttributeOptions
 import org.locationtech.geomesa.utils.geotools.Transform.{ExpressionTransform, PropertyTransform, RenameTransform, Transforms}
+import org.locationtech.geomesa.utils.geotools.sft.SimpleFeatureSpec
 import org.locationtech.geomesa.utils.geotools.{ObjectType, SimpleFeatureTypes}
-import org.locationtech.jts.geom.Geometry
 
 import java.util.concurrent.atomic.AtomicInteger
+import scala.util.control.NonFatal
 
 /**
  * Holder for info about a geomesa/iceberg schema
  *
  * @param sft simple feature type represented by this schema
- * @param geometries geometry encoding
- * @param metadata table metadata
  * @param schema iceberg schema
- * @param fields field mappings, allowing for read transforms
  */
-class SimpleFeatureIcebergSchema private (
-    val sft: SimpleFeatureType,
-    val geometries: GeometryEncoding,
-    val metadata: java.util.Map[String, String],
-    val schema: Schema,
-    fields: IcebergFields) {
+class SimpleFeatureIcebergSchema private (val sft: SimpleFeatureType, val schema: Schema) {
 
   import scala.collection.JavaConverters._
 
@@ -82,121 +77,11 @@ class SimpleFeatureIcebergSchema private (
         readSft.getUserData.putAll(sft.getUserData)
         (readCols, readSft)
     }
-    val schema = fields.toSchema(readCols, includeRowPositions)
-    new SimpleFeatureIcebergSchema(readSft, geometries, metadata, schema, fields)
-  }
-}
-
-object SimpleFeatureIcebergSchema {
-
-  import SimpleFeatureSchema._
-
-  import scala.collection.JavaConverters._
-
-  /**
-   * Get a schema based on a simple feature type. Encoding can be configured through `geomesa.parquet.geometries`.
-   *
-   * @param conf write configuration, including the sft spec
-   * @return
-   */
-  def apply(sft: SimpleFeatureType, conf: Map[String, String]): SimpleFeatureIcebergSchema = {
-    val geometries = conf.get(GeometryEncodingKey).map(GeometryEncoding.apply).getOrElse(GeometryEncoding.GeoParquetWkb)
-    val metadata = Map(
-      SftNameKey -> sft.getTypeName,
-      SftSpecKey -> SimpleFeatureTypes.encodeType(sft, includeUserData = true),
-      GeometryEncodingKey -> geometries.toString,
-    ) ++ conf.get(PartitionKey).map(PartitionKey -> _)
-    val iceberg = schema(sft, geometries)
-    new SimpleFeatureIcebergSchema(sft, geometries, metadata.asJava, iceberg.toSchema, iceberg)
-  }
-
-  private def schema(sft: SimpleFeatureType, geometries: GeometryEncoding): IcebergFields = {
-    // note: for iceberg compatibility, field ids need to start at one and increment (without gaps) across all top-level fields.
-    // All nested fields (structs, lists) get ids *after* all the top-level fields, once again incrementing without gaps
-    val fieldIds = new AtomicInteger(1)
-    val nestedFieldIds = {
-      val extraGeomCount = 2 * sft.getAttributeDescriptors.asScala.count {
-        case d if classOf[Geometry].isAssignableFrom(d.getType.getBinding) => true
-        case _ => false
-      }
-      new AtomicInteger(3 + sft.getAttributeCount + extraGeomCount)
-    }
-
-    val builder = Seq.newBuilder[NestedField]
-    builder += NestedField.required(fieldIds.getAndIncrement(), FeatureIdField, StringType.get())
-    builder += NestedField.optional(fieldIds.getAndIncrement(), VisibilitiesField, StringType.get())
-
-    sft.getAttributeDescriptors.asScala.foreach { d =>
-      val name = ColumnName(d.getLocalName)
-      val objectType = ObjectType.selectType(d)
-      val doc = SimpleFeatureTypes.encodeDescriptor(sft, d)
-      builder += buildField(name.column, objectType, doc, geometries, fieldIds, nestedFieldIds)
-      if (objectType.head == ObjectType.GEOMETRY) {
-        builder += BoundingBoxField.icebergSchema(name.column, fieldIds, nestedFieldIds)
-        builder += ZValueField.icebergSchema(name.column, objectType(1), fieldIds)
-      }
-    }
-
-    val fields = builder.result()
-    val aliases = fields.map(f => f.name() -> Int.box(f.fieldId())).toMap
-
-    IcebergFields(fields, aliases)
-  }
-
-  /**
-   * Builds the schema type for an attribute
-   *
-   * @param name field name
-   * @param bindings object type
-   * @param geometries geometry type encodings
-   * @return
-   */
-  private def buildField(
-      name: String,
-      bindings: Seq[ObjectType],
-      doc: String,
-      geometries: GeometryEncoding,
-      fieldIds: AtomicInteger,
-      nestedFieldIds: AtomicInteger): NestedField = {
-    val builder = NestedField.optional(name).withId(fieldIds.getAndIncrement()).withDoc(doc)
-    val typed: NestedField.Builder = bindings.head match {
-      case ObjectType.INT     => builder.ofType(IntegerType.get())
-      case ObjectType.DOUBLE  => builder.ofType(DoubleType.get())
-      case ObjectType.LONG    => builder.ofType(LongType.get())
-      case ObjectType.FLOAT   => builder.ofType(FloatType.get())
-      case ObjectType.BOOLEAN => builder.ofType(BooleanType.get())
-      case ObjectType.BYTES   => builder.ofType(BinaryType.get())
-      case ObjectType.DATE    => builder.ofType(TimestampType.withZone())
-      case ObjectType.UUID    => builder.ofType(UUIDType.get())
-
-      case ObjectType.STRING if bindings.last == ObjectType.JSON => builder.ofType(VariantType.get())
-      case ObjectType.STRING => builder.ofType(StringType.get())
-
-      case ObjectType.LIST =>
-        val subType = buildField("", bindings.drop(1), null, geometries, nestedFieldIds, null /* should not be used*/)
-        builder.ofType(ListType.ofRequired(subType.fieldId(), subType.`type`()))
-
-      case ObjectType.MAP =>
-        val keyType = buildField("", bindings.slice(1, 2), null, geometries, nestedFieldIds, null /* should not be used*/)
-        val valueType = buildField("", bindings.slice(2, 3), null, geometries, nestedFieldIds, null /* should not be used*/)
-        builder.ofType(MapType.ofRequired(keyType.fieldId(), valueType.fieldId(), keyType.`type`(), valueType.`type`()))
-
-      case ObjectType.GEOMETRY =>
-        // not yet supported in spark or trino
-        // builder.ofType(GeometryType.crs84())
-        builder.ofType(BinaryType.get())
-
-      case binding =>
-        throw new UnsupportedOperationException(s"No mapping defined for type: $binding")
-    }
-    typed.build()
-  }
-
-  private case class IcebergFields(fields: Seq[NestedField], aliases: Map[String, Integer]) {
-    def toSchema: Schema = new Schema(fields.asJava, aliases.asJava, java.util.Set.of[Integer](1))
-    def toSchema(cols: Seq[String], includeRowPositions: Boolean): Schema = {
+    val readSchema = {
+      // here we handle the case where  we're only reading some nested fields out of a given top-level field,
+      // so that we're not reading things we don't have to
       val parsedCols = new java.util.LinkedHashMap[String, Seq[String]]()
-      cols.foreach { col =>
+      readCols.foreach { col =>
         val sep = col.indexOf('.')
         if (sep == -1) { parsedCols.put(col, Seq.empty) } else {
           parsedCols.compute(col.substring(0, sep),
@@ -204,7 +89,10 @@ object SimpleFeatureIcebergSchema {
         }
       }
       val projection = parsedCols.asScala.toSeq.map { case (name, children) =>
-        val field = fields.find(_.name() == name).getOrElse(throw new IllegalStateException(s"Unexpected projection: $name"))
+        val field = schema.findField(name)
+        if (field == null) {
+          throw new IllegalStateException(s"Unexpected projection: $name")
+        }
         if (children.isEmpty || children.size == field.`type`().asStructType().fields().size()) { field } else {
           val subfields = field.`type`().asStructType().fields().asScala.filter(f => children.contains(f.name()))
           Types.NestedField.optional(field.fieldId(), field.name(), Types.StructType.of(subfields.asJava))
@@ -213,7 +101,134 @@ object SimpleFeatureIcebergSchema {
       val withRows =
         if (includeRowPositions) { projection ++ Seq(MetadataColumns.FILE_PATH, MetadataColumns.ROW_POSITION) } else { projection }
       val ids = projection.collectFirst { case f if f.name() == FeatureIdField => Int.box(f.fieldId()) }
-      new Schema(withRows.asJava, aliases.asJava, ids.toSet.asJava)
+      new Schema(withRows.asJava, schema.getAliases, ids.toSet.asJava)
+    }
+    new SimpleFeatureIcebergSchema(readSft, readSchema)
+  }
+}
+
+object SimpleFeatureIcebergSchema extends LazyLogging {
+
+  import SimpleFeatureSchema._
+
+  import scala.collection.JavaConverters._
+
+  val GeometryEncodingKey = "encoding"
+
+  def apply(table: Table, namespace: Option[String] = None): SimpleFeatureIcebergSchema = {
+    val sft = {
+      val typeName = table.properties().get("geomesa.sft.name")
+      val attributes = table.schema().columns().asScala.flatMap(deriveDescriptor)
+      if (attributes.isEmpty) {
+        // back compatibility check
+        SimpleFeatureTypes.createType(namespace.fold(typeName)(n => s"$n:$typeName"), table.properties().get("geomesa.sft.spec"))
+      } else {
+        val b = new SimpleFeatureTypeBuilder()
+        b.setNamespaceURI(namespace.orNull) // important to set this null if not defined so it doesn't default to gml namespace
+        b.setName(typeName)
+        b.addAll(attributes.asJava)
+        attributes.find(d => d.getUserData.get(AttributeOptions.OptDefault) == "true" && d.isInstanceOf[GeometryDescriptor]).foreach { d =>
+          b.setDefaultGeometry(d.getLocalName)
+        }
+        val sft = b.buildFeatureType()
+        table.properties().asScala.foreach { case (k, v) =>
+          if (k.startsWith(IcebergCatalog.UserDataPrefix)) {
+            sft.getUserData.put(k.substring(IcebergCatalog.UserDataPrefix.length), v)
+          }
+        }
+        sft
+      }
+    }
+    new SimpleFeatureIcebergSchema(sft, table.schema())
+  }
+
+  private def deriveDescriptor(f: NestedField): Option[AttributeDescriptor] = {
+    if (f.name().startsWith(InternalFieldDelimiter) && f.name().endsWith(InternalFieldDelimiter)) { None } else {
+      Option(f.doc()).flatMap { d =>
+        try { Some(SimpleFeatureTypes.createDescriptor(d)) } catch {
+          case NonFatal(e) => logger.warn(s"Error parsing column doc as descriptor: $d", e); None
+        }
+      }
+    }
+  }
+
+  /**
+   * Get a schema based on a simple feature type. Encoding can be configured through `geomesa.parquet.geometries`.
+   *
+   * Note: this should only be called for creating a new schema, for an existing table the field ids will not be correct
+   *
+   * @param sft simple feature type
+   * @param geometries geometry encoding
+   * @return
+   */
+  def create(sft: SimpleFeatureType, geometries: GeometryEncoding): Schema = {
+    val builder = Seq.newBuilder[NestedField]
+    // note: we have to use unique field ids, but iceberg will throw them out and regenerate them when creating a table
+    val fieldIds = new AtomicInteger(1)
+    builder += NestedField.required(FeatureIdField).withId(fieldIds.getAndIncrement()).ofType(StringType.get()).build()
+    builder += buildField(VisibilitiesField, fieldIds.getAndIncrement(), null, StringType.get())
+    sft.getAttributeDescriptors.asScala.foreach { d =>
+      val name = ColumnName(d.getLocalName)
+      val objectType = ObjectType.selectType(d)
+      val doc = SimpleFeatureTypes.encodeDescriptor(sft, d)
+      if (objectType.head == ObjectType.GEOMETRY) {
+        // TODO supports native geometry encoding
+        require(geometries == GeometryEncoding.GeoParquetWkb, "Only WKB encoding is supported for Geometry types")
+        val geomDoc = doc + SimpleFeatureSpec.encodeAttributeOption(GeometryEncodingKey, geometries.toString)
+        // not yet supported in spark or trino: GeometryType.crs84()
+        builder += buildField(name.column, fieldIds.getAndIncrement(), geomDoc, BinaryType.get())
+        builder += BoundingBoxField.icebergSchema(name.column, fieldIds)
+        builder += ZValueField.icebergSchema(name.column, objectType(1), fieldIds)
+      } else {
+        builder += buildField(name.column, fieldIds.getAndIncrement(), doc, getType(objectType, fieldIds))
+      }
+    }
+
+    new Schema(builder.result().asJava,  java.util.Set.of[Integer](1))
+  }
+
+  /**
+   * Builds the schema type for an attribute
+   *
+   * @param name field name
+   * @param fieldId field id
+   * @param doc field doc
+   * @param fieldType field type
+   * @return
+   */
+  private def buildField(name: String, fieldId: Int, doc: String, fieldType: Type): NestedField =
+    NestedField.optional(name).withId(fieldId).withDoc(doc).ofType(fieldType).build()
+
+  /**
+   * Builds the schema type for an attribute
+   *
+   * @param bindings object type
+   * @param fieldIds ids for nested fields (as needed)
+   * @return
+   */
+  private def getType(bindings: Seq[ObjectType], fieldIds: AtomicInteger): Type = {
+    bindings.head match {
+      case ObjectType.INT     => IntegerType.get()
+      case ObjectType.DOUBLE  => DoubleType.get()
+      case ObjectType.LONG    => LongType.get()
+      case ObjectType.FLOAT   => FloatType.get()
+      case ObjectType.BOOLEAN => BooleanType.get()
+      case ObjectType.BYTES   => BinaryType.get()
+      case ObjectType.DATE    => TimestampType.withZone()
+      case ObjectType.UUID    => UUIDType.get()
+      case ObjectType.STRING  => StringType.get()
+
+      case ObjectType.LIST =>
+        val subType = buildField("", fieldIds.getAndIncrement(), null, getType(bindings.drop(1), fieldIds))
+        ListType.ofRequired(subType.fieldId(), subType.`type`())
+
+      case ObjectType.MAP =>
+        val keyType = buildField("", fieldIds.getAndIncrement(), null, getType(bindings.slice(1, 2), fieldIds))
+        val valueType = buildField("", fieldIds.getAndIncrement(), null, getType(bindings.slice(2, 3), fieldIds))
+        MapType.ofRequired(keyType.fieldId(), valueType.fieldId(), keyType.`type`(), valueType.`type`())
+
+      case binding =>
+        throw new UnsupportedOperationException(s"No mapping defined for type: $binding")
     }
   }
 }

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/iceberg/StructSimpleFeature.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/iceberg/StructSimpleFeature.scala
@@ -9,11 +9,13 @@
 package org.locationtech.geomesa.fs.storage.core.iceberg
 
 import org.apache.iceberg.{Accessor, MetadataColumns, StructLike}
+import org.geotools.api.feature.`type`.AttributeDescriptor
 import org.geotools.api.feature.simple.SimpleFeatureType
 import org.geotools.api.filter.identity.FeatureId
 import org.locationtech.geomesa.features.AbstractSimpleFeature.AbstractMutableSimpleFeature
 import org.locationtech.geomesa.fs.storage.core.iceberg.StructSimpleFeature.ColumnAccessor
-import org.locationtech.geomesa.fs.storage.core.parquet.schema.GeometrySchema.GeometryEncoding.{GeoParquetNative, GeoParquetWkb}
+import org.locationtech.geomesa.fs.storage.core.parquet.schema.GeometrySchema.GeometryEncoding
+import org.locationtech.geomesa.fs.storage.core.parquet.schema.GeometrySchema.GeometryEncoding.GeoParquetWkb
 import org.locationtech.geomesa.fs.storage.core.schema.{ColumnName, SimpleFeatureSchema}
 import org.locationtech.geomesa.security.SecurityUtils
 import org.locationtech.geomesa.utils.geotools.ObjectType
@@ -122,8 +124,7 @@ object StructSimpleFeature {
     val hasId = cols.headOption.exists(_.name() == SimpleFeatureSchema.FeatureIdField)
     while (i < accessors.length) {
       val descriptor = schema.sft.getDescriptor(i)
-      val types = ObjectType.selectType(descriptor)
-      val converter = Converter(types, schema)
+      val converter = Converter(descriptor)
       val col = ColumnName.encode(descriptor.getLocalName)
       val offset = cols.indexWhere(_.name() == col)
       accessors(i) = converter match {
@@ -156,14 +157,36 @@ object StructSimpleFeature {
   private sealed trait Converter extends (AnyRef => AnyRef)
 
   private object Converter {
-    def apply(types: Seq[ObjectType], schema: SimpleFeatureIcebergSchema): Option[Converter] = types.head match {
-      case ObjectType.GEOMETRY if schema.geometries == GeoParquetWkb => Some(FromWkbConverter)
-      case ObjectType.GEOMETRY if schema.geometries == GeoParquetNative => throw new UnsupportedOperationException()
-      case ObjectType.GEOMETRY => throw new UnsupportedOperationException("An implementation is missing")
-      case ObjectType.DATE     => Some(FromDateConverter)
-      case ObjectType.BYTES    => Some(FromBytesConverter)
-      case ObjectType.LIST     => ListConverter(types.last, schema)
-      case ObjectType.MAP      => MapConverter(types(1), types(2), schema)
+    def apply(descriptor: AttributeDescriptor): Option[Converter] = {
+      val types = ObjectType.selectType(descriptor)
+      if (types.head == ObjectType.GEOMETRY) {
+        val encoding = descriptor.getUserData.get(SimpleFeatureIcebergSchema.GeometryEncodingKey) match {
+          case e: String => GeometryEncoding(e)
+          case _ => GeometryEncoding.GeoParquetWkb
+        }
+        encoding match {
+          case GeoParquetWkb => Some(FromWkbConverter)
+          case _ => throw new UnsupportedOperationException(encoding.toString)
+        }
+      } else if (types.head == ObjectType.LIST) {
+        primitive(types.last).map(new ListConverter(_))
+      } else if (types.head == ObjectType.MAP) {
+        val keyConverter = primitive(types(1))
+        val valueConverter = primitive(types(2))
+        (keyConverter, valueConverter) match {
+          case (None, None) => None
+          case (Some(k), None) => Some(new MapKeyConverter(k))
+          case (None, Some(v)) => Some(new MapValueConverter(v))
+          case (Some(k), Some(v)) => Some(new MapConverter(k, v))
+        }
+      } else {
+        primitive(types.head)
+      }
+    }
+
+    private def primitive(types: ObjectType): Option[Converter] = types match {
+      case ObjectType.DATE  => Some(FromDateConverter)
+      case ObjectType.BYTES => Some(FromBytesConverter)
       case _ => None
     }
   }
@@ -183,13 +206,6 @@ object StructSimpleFeature {
     }
   }
 
-  private object ListConverter extends Converter {
-    def apply(subtype: ObjectType, schema: SimpleFeatureIcebergSchema): Option[Converter] =
-      Converter(Seq(subtype), schema).map(new ListConverter(_))
-
-    override def apply(value: AnyRef): AnyRef = java.util.List.copyOf(value.asInstanceOf[java.util.List[AnyRef]])
-  }
-
   private class ListConverter(subtype: Converter) extends Converter {
     override def apply(value: AnyRef): AnyRef = {
       val list = value.asInstanceOf[java.util.List[AnyRef]]
@@ -197,22 +213,6 @@ object StructSimpleFeature {
       list.forEach(v => result.add(subtype(v)))
       result
     }
-  }
-
-  private object MapConverter extends Converter {
-    def apply(keyType: ObjectType, valueType: ObjectType, schema: SimpleFeatureIcebergSchema): Option[Converter] = {
-      val keyConverter = Converter(Seq(keyType), schema)
-      val valueConverter = Converter(Seq(valueType), schema)
-      (keyConverter, valueConverter) match {
-        case (None, None) => None
-        case (Some(k), None) => Some(new MapKeyConverter(k))
-        case (None, Some(v)) => Some(new MapValueConverter(v))
-        case (Some(k), Some(v)) => Some(new MapConverter(k, v))
-      }
-    }
-
-    override def apply(value: AnyRef): AnyRef =
-      java.util.Map.copyOf[AnyRef, AnyRef](value.asInstanceOf[java.util.Map[AnyRef, AnyRef]])
   }
 
   private class MapConverter(keyType: Converter, valueType: Converter) extends Converter {

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/parquet/io/ParquetFileSystemWriter.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/parquet/io/ParquetFileSystemWriter.scala
@@ -11,6 +11,7 @@ package org.locationtech.geomesa.fs.storage.core.parquet.io
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.conf.Configuration
 import org.apache.iceberg.io.FileIO
+import org.apache.iceberg.mapping.{MappingUtil, NameMappingParser}
 import org.apache.parquet.column.ParquetProperties.WriterVersion
 import org.apache.parquet.conf.{ParquetConfiguration, PlainParquetConfiguration}
 import org.apache.parquet.hadoop.api.WriteSupport
@@ -18,13 +19,15 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.apache.parquet.hadoop.{ParquetFileWriter, ParquetWriter}
 import org.apache.parquet.io.{LocalOutputFile, OutputFile, PositionOutputStream}
 import org.geotools.api.feature.simple.{SimpleFeature, SimpleFeatureType}
-import org.locationtech.geomesa.fs.storage.core.FileSystemStorage.FileSystemWriter
+import org.locationtech.geomesa.fs.storage.core.FileSystemStorage.{FileSystemWriter, ParquetCompressionOpt}
 import org.locationtech.geomesa.fs.storage.core.fs.{LocalObjectStore, ObjectStore, S3ObjectStore}
+import org.locationtech.geomesa.fs.storage.core.iceberg.SimpleFeatureIcebergSchema
 import org.locationtech.geomesa.fs.storage.core.observer.FileSystemObserver
 import org.locationtech.geomesa.fs.storage.core.observer.FileSystemObserverFactory.NoOpObserver
-import org.locationtech.geomesa.fs.storage.core.parquet.io.ParquetFileSystemWriter.{FileOutput, IcebergOutput, ObjectStoreOutput}
+import org.locationtech.geomesa.fs.storage.core.parquet.io.ParquetFileSystemWriter.FileOutput
 import org.locationtech.geomesa.fs.storage.core.parquet.s3.S3OutputFile
 import org.locationtech.geomesa.fs.storage.core.parquet.schema.SimpleFeatureParquetSchema
+import org.locationtech.geomesa.fs.storage.core.schema.SimpleFeatureSchema
 import org.locationtech.geomesa.utils.io.CloseQuietly
 
 import java.net.URI
@@ -33,40 +36,17 @@ import java.nio.file.Path
 /**
  * Parquet writer
  *
- * @param sft simple feature type
  * @param conf configuration
  * @param output file to write
  * @param observer any observers
  */
-class ParquetFileSystemWriter(
-    sft: SimpleFeatureType,
-    conf: Map[String, String],
-    output: FileOutput,
-    observer: FileSystemObserver
-  ) extends FileSystemWriter {
-
-  import scala.collection.JavaConverters._
-
-  // TODO consolidate this on FileIO instead of ObjectStore
-  def this(sft: SimpleFeatureType, conf: Map[String, String], fs: ObjectStore, file: String, observer: FileSystemObserver) =
-    this(sft, conf, ObjectStoreOutput(fs, URI.create(file)), observer)
-
-  def this(sft: SimpleFeatureType, conf: Map[String, String], fs: ObjectStore, file: String) =
-    this(sft, conf, fs, file, NoOpObserver)
-
-  def this(sft: SimpleFeatureType, conf: Map[String, String], io: FileIO, file: String, observer: FileSystemObserver) =
-    this(sft, conf, IcebergOutput(io, file), observer)
-
-  def this(sft: SimpleFeatureType, conf: Map[String, String], io: FileIO, file: String) =
-    this(sft, conf, io, file, NoOpObserver)
-
-  private val parquetConf = new PlainParquetConfiguration(conf.asJava)
-  SimpleFeatureParquetSchema.setSft(parquetConf, sft)
-
-  private val writer = ParquetFileSystemWriter.builder(output.file, parquetConf).build()
+class ParquetFileSystemWriter private (conf: ParquetConfiguration, output: FileOutput, observer: FileSystemObserver)
+    extends FileSystemWriter {
 
   @volatile
   private var closed = false
+
+  private val writer = ParquetFileSystemWriter.builder(output.file, conf).build()
 
   override def size: Long = if (closed) { output.size }  else { writer.getDataSize }
 
@@ -85,6 +65,59 @@ class ParquetFileSystemWriter(
 
 object ParquetFileSystemWriter extends LazyLogging {
 
+  import scala.collection.JavaConverters._
+
+  /**
+   * Primary iceberg constructor - when writing to iceberg, needs to use this constructor in order to ensure field ids align
+   *
+   * @param schema iceberg schema
+   * @param conf conf
+   * @param io file io
+   * @param file file to write
+   * @param observer observer
+   */
+  def apply(
+      schema: SimpleFeatureIcebergSchema,
+      conf: Map[String, String],
+      io: FileIO,
+      file: String,
+      observer: FileSystemObserver): ParquetFileSystemWriter = {
+    // stamp the written parquet files with the table's iceberg field ids (by name) so reads resolve by id
+    val nameMapping = Map(SimpleFeatureSchema.IcebergNameMappingKey -> NameMappingParser.toJson(MappingUtil.create(schema.schema)))
+    val sft = SimpleFeatureParquetSchema.sftConf(schema.sft)
+    apply(conf ++ nameMapping ++ sft, IcebergOutput(io, file), observer)
+  }
+
+  /**
+   * Secondary constructor - for non-iceberg exports. Note: *will not* align with Iceberg field ids
+   *
+   * TODO consolidate this on FileIO instead of ObjectStore
+   *
+   * @param sft simple feature type
+   * @param conf configuration options
+   * @param fs object store
+   * @param file output file path
+   * @return
+   */
+  def apply(sft: SimpleFeatureType, conf: Map[String, String], fs: ObjectStore, file: String): ParquetFileSystemWriter = {
+    val sftConf = SimpleFeatureParquetSchema.sftConf(sft)
+    apply(conf ++ sftConf, ObjectStoreOutput(fs, URI.create(file)), NoOpObserver)
+  }
+
+  /**
+   * Constructor - requires the sft to be encoded in the conf
+   *
+   * @param conf configuration options
+   * @param output file output
+   * @param observer observer
+   * @return
+   */
+  private def apply(conf: Map[String, String], output: FileOutput, observer: FileSystemObserver): ParquetFileSystemWriter = {
+    val compression = Option(System.getProperty(ParquetCompressionOpt)).map(ParquetCompressionOpt -> _).toMap
+    val parquetConf = new PlainParquetConfiguration((compression ++ conf).asJava)
+    new ParquetFileSystemWriter(parquetConf, output, observer)
+  }
+
   /**
    * Create a new configurable writer
    *
@@ -92,7 +125,7 @@ object ParquetFileSystemWriter extends LazyLogging {
    * @param conf write configuration
    * @return
    */
-  def builder(file: OutputFile, conf: ParquetConfiguration): Builder = {
+  private def builder(file: OutputFile, conf: ParquetConfiguration): Builder = {
     val version = WriterVersion.fromString(conf.get("parquet.writer.version", WriterVersion.PARQUET_2_0.name()))
     val codec = CompressionCodecName.fromConf(conf.get("parquet.compression", "ZSTD"))
     logger.debug(s"Using Parquet file version $version with compression ${codec.name()}")

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/parquet/schema/GeometrySchema.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/parquet/schema/GeometrySchema.scala
@@ -14,8 +14,6 @@ import org.apache.parquet.schema.{Type, Types}
 import org.locationtech.geomesa.utils.geotools.ObjectType
 import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 
-import java.util.concurrent.atomic.AtomicInteger
-
 object GeometrySchema {
 
   val GeometryColumnX = "x"
@@ -30,11 +28,9 @@ object GeometrySchema {
      * Create a builder for a parquet geometry field
      *
      * @param binding geometry type
-     * @param fieldIds field id tracker
-     * @param nestedFieldIds nested field id tracker
      * @return
      */
-    def schema(binding: ObjectType, fieldIds: AtomicInteger, nestedFieldIds: AtomicInteger): Types.Builder[_, _ <: Type]
+    def schema(binding: ObjectType): Types.Builder[_, _ <: Type]
   }
 
   object GeometryEncoding {
@@ -49,60 +45,60 @@ object GeometrySchema {
     }
 
     case object GeoParquetNative extends GeometryEncoding {
-      override def schema(binding: ObjectType, fieldIds: AtomicInteger, nestedFieldIds: AtomicInteger): Types.Builder[_, _ <: Type] = {
+      override def schema(binding: ObjectType): Types.Builder[_, _ <: Type] = {
         binding match {
           case ObjectType.POINT =>
-            Types.optionalGroup().id(fieldIds.getAndIncrement())
-              .required(PrimitiveTypeName.DOUBLE).id(nestedFieldIds.getAndIncrement()).named(GeometryColumnX)
-              .required(PrimitiveTypeName.DOUBLE).id(nestedFieldIds.getAndIncrement()).named(GeometryColumnY)
+            Types.optionalGroup()
+              .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnX)
+              .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnY)
 
           case ObjectType.LINESTRING =>
             // TODO do we need multiple levels of nesting field ids???
-            Types.optionalList().id(fieldIds.getAndIncrement())
-              .requiredGroupElement().id(nestedFieldIds.getAndIncrement()) // the coordinate
-              .required(PrimitiveTypeName.DOUBLE).id(nestedFieldIds.getAndIncrement()).named(GeometryColumnX)
-              .required(PrimitiveTypeName.DOUBLE).id(nestedFieldIds.getAndIncrement()).named(GeometryColumnY)
+            Types.optionalList()
+              .requiredGroupElement() // the coordinate
+              .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnX)
+              .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnY)
 
           case ObjectType.MULTIPOINT =>
-            Types.optionalList.id(fieldIds.getAndIncrement())
-              .requiredGroupElement().id(nestedFieldIds.getAndIncrement()) // the coordinate
-              .required(PrimitiveTypeName.DOUBLE).id(nestedFieldIds.getAndIncrement()).named(GeometryColumnX)
-              .required(PrimitiveTypeName.DOUBLE).id(nestedFieldIds.getAndIncrement()).named(GeometryColumnY)
+            Types.optionalList
+              .requiredGroupElement() // the coordinate
+              .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnX)
+              .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnY)
 
           case ObjectType.POLYGON =>
-            Types.optionalList.id(fieldIds.getAndIncrement())
-              .requiredListElement().id(nestedFieldIds.getAndIncrement()) // the coordinates of one ring
-              .requiredGroupElement().id(nestedFieldIds.getAndIncrement()) // the coordinate
-              .required(PrimitiveTypeName.DOUBLE).id(nestedFieldIds.getAndIncrement()).named(GeometryColumnX)
-              .required(PrimitiveTypeName.DOUBLE).id(nestedFieldIds.getAndIncrement()).named(GeometryColumnY)
+            Types.optionalList
+              .requiredListElement() // the coordinates of one ring
+              .requiredGroupElement() // the coordinate
+              .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnX)
+              .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnY)
 
           case ObjectType.MULTILINESTRING =>
-            Types.optionalList.id(fieldIds.getAndIncrement())
-              .requiredListElement().id(nestedFieldIds.getAndIncrement()) // the coordinates of one line string
-              .requiredGroupElement().id(nestedFieldIds.getAndIncrement()) // the coordinate
-              .required(PrimitiveTypeName.DOUBLE).id(nestedFieldIds.getAndIncrement()).named(GeometryColumnX)
-              .required(PrimitiveTypeName.DOUBLE).id(nestedFieldIds.getAndIncrement()).named(GeometryColumnY)
+            Types.optionalList
+              .requiredListElement() // the coordinates of one line string
+              .requiredGroupElement() // the coordinate
+              .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnX)
+              .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnY)
 
           case ObjectType.MULTIPOLYGON =>
-            Types.optionalList.id(fieldIds.getAndIncrement())
-              .requiredListElement().id(nestedFieldIds.getAndIncrement()) // the rings of the MultiPolygon
-              .requiredListElement().id(nestedFieldIds.getAndIncrement()) // the coordinates of one ring
-              .requiredGroupElement().id(nestedFieldIds.getAndIncrement()) // the coordinate
-              .required(PrimitiveTypeName.DOUBLE).id(nestedFieldIds.getAndIncrement()).named(GeometryColumnX)
-              .required(PrimitiveTypeName.DOUBLE).id(nestedFieldIds.getAndIncrement()).named(GeometryColumnY)
+            Types.optionalList
+              .requiredListElement() // the rings of the MultiPolygon
+              .requiredListElement() // the coordinates of one ring
+              .requiredGroupElement() // the coordinate
+              .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnX)
+              .required(PrimitiveTypeName.DOUBLE).named(GeometryColumnY)
 
           case ObjectType.GEOMETRY_COLLECTION =>
-            Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL).id(fieldIds.getAndIncrement())
+            Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL)
 
           case ObjectType.GEOMETRY =>
-            Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL).id(fieldIds.getAndIncrement())
+            Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL)
         }
       }
     }
 
     case object GeoParquetWkb extends GeometryEncoding {
-      override def schema(binding: ObjectType, fieldIds: AtomicInteger, nestedFieldIds: AtomicInteger): Types.Builder[_, _ <: Type] =
-        Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL).id(fieldIds.getAndIncrement())
+      override def schema(binding: ObjectType): Types.Builder[_, _ <: Type] =
+        Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL)
     }
   }
 }

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/parquet/schema/SimpleFeatureParquetSchema.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/parquet/schema/SimpleFeatureParquetSchema.scala
@@ -9,6 +9,8 @@
 package org.locationtech.geomesa.fs.storage.core.parquet.schema
 
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.iceberg.mapping.NameMappingParser
+import org.apache.iceberg.parquet.ParquetSchemaUtil
 import org.apache.parquet.conf.{ParquetConfiguration, PlainParquetConfiguration}
 import org.apache.parquet.hadoop.api.InitContext
 import org.apache.parquet.hadoop.metadata.FileMetaData
@@ -22,9 +24,6 @@ import org.locationtech.geomesa.fs.storage.core.parquet.schema.SimpleFeatureParq
 import org.locationtech.geomesa.fs.storage.core.schema.{BoundingBoxField, ColumnName, SimpleFeatureSchema, ZValueField}
 import org.locationtech.geomesa.utils.geotools.ObjectType.ObjectType
 import org.locationtech.geomesa.utils.geotools.{ObjectType, SimpleFeatureTypes}
-import org.locationtech.jts.geom.Geometry
-
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * A paired simple feature type and parquet schema
@@ -67,10 +66,20 @@ object SimpleFeatureParquetSchema extends LazyLogging {
    * @param conf conf
    * @param sft feature type
    */
-  def setSft(conf: ParquetConfiguration, sft: SimpleFeatureType): Unit = {
-    val name = Option(sft.getName.getNamespaceURI).map(ns => s"$ns:${sft.getTypeName}").getOrElse(sft.getTypeName)
-    conf.set(SftNameKey, name)
-    conf.set(SftSpecKey, SimpleFeatureTypes.encodeType(sft, includeUserData = true))
+  def setSft(conf: ParquetConfiguration, sft: SimpleFeatureType): Unit =
+    sftConf(sft).foreach { case (k, v) => conf.set(k, v) }
+
+  /**
+   * Simple feature type configuration
+   *
+   * @param sft simple feature type
+   * @return
+   */
+  def sftConf(sft: SimpleFeatureType): Map[String, String] = {
+    Map(
+      SftNameKey -> Option(sft.getName.getNamespaceURI).map(ns => s"$ns:${sft.getTypeName}").getOrElse(sft.getTypeName),
+      SftSpecKey -> SimpleFeatureTypes.encodeType(sft, includeUserData = true)
+    )
   }
 
   /**
@@ -117,6 +126,7 @@ object SimpleFeatureParquetSchema extends LazyLogging {
       spec <- Option(conf.get(SftSpecKey))
     } yield {
       val sft = SimpleFeatureTypes.createImmutableType(name, spec)
+      // TODO in iceberg, geometry encoding is now specified at the column level - use that once we support more than WKB
       val geometries = Option(conf.get(GeometryEncodingKey)).map(GeometryEncoding.apply).getOrElse(GeometryEncoding.GeoParquetWkb)
       val metadata = Map(
         SftNameKey -> name,
@@ -124,7 +134,16 @@ object SimpleFeatureParquetSchema extends LazyLogging {
         GeometryEncodingKey -> geometries.toString,
       ) ++ Option(conf.get(PartitionKey)).map(PartitionKey -> _)
       val parquet = schema(sft, geometries)
-      new SimpleFeatureParquetSchema(sft, geometries, metadata.asJava, parquet.toMessageType(sft.getTypeName), parquet)
+      val messageType = {
+        val base = parquet.toMessageType(sft.getTypeName)
+        // if an iceberg name mapping is provided, stamp the table's field ids onto the schema by name,
+        // so that written files are read back by field id rather than falling back to name-based mapping
+        Option(conf.get(IcebergNameMappingKey)) match {
+          case None => base
+          case Some(json) => ParquetSchemaUtil.applyNameMapping(base, NameMappingParser.fromJson(json))
+        }
+      }
+      new SimpleFeatureParquetSchema(sft, geometries, metadata.asJava, messageType, parquet)
     }
   }
 
@@ -150,36 +169,23 @@ object SimpleFeatureParquetSchema extends LazyLogging {
    * @return
    */
   private def schema(sft: SimpleFeatureType, geometries: GeometryEncoding): ParquetFields = {
-    // note: for iceberg compatibility, field ids need to start at one and increment (without gaps) across all top-level fields.
-    // All nested fields (structs, lists) get ids *after* all the top-level fields, once again incrementing without gaps
-    val fieldIds = new AtomicInteger(1)
-    val nestedFieldIds = {
-      val extraGeomCount = 2 * sft.getAttributeDescriptors.asScala.count {
-        case d if classOf[Geometry].isAssignableFrom(d.getType.getBinding) => true
-        case _ => false
-      }
-      new AtomicInteger(3 + sft.getAttributeCount + extraGeomCount)
-    }
-
     val builder = Seq.newBuilder[Type]
     builder +=
       Types.required(PrimitiveTypeName.BINARY)
-        .id(fieldIds.getAndIncrement())
         .as(LogicalTypeAnnotation.stringType())
         .named(FeatureIdField)
     builder +=
       Types.optional(PrimitiveTypeName.BINARY)
-        .id(fieldIds.getAndIncrement())
         .as(LogicalTypeAnnotation.stringType())
         .named(VisibilitiesField)
 
     sft.getAttributeDescriptors.asScala.foreach { d =>
       val name = ColumnName(d.getLocalName)
       val objectType = ObjectType.selectType(d)
-      builder += buildType(name.column, objectType, geometries, fieldIds, nestedFieldIds)
+      builder += buildType(name.column, objectType, geometries)
       if (objectType.head == ObjectType.GEOMETRY) {
-        builder += BoundingBoxField.parquetSchema(name.column, fieldIds, nestedFieldIds)
-        builder += ZValueField.parquetSchema(name.column, objectType(1), fieldIds)
+        builder += BoundingBoxField.parquetSchema(name.column)
+        builder += ZValueField.parquetSchema(name.column, objectType(1))
       }
     }
     ParquetFields(builder.result())
@@ -198,20 +204,17 @@ object SimpleFeatureParquetSchema extends LazyLogging {
       name: String,
       bindings: Seq[ObjectType],
       geometries: GeometryEncoding,
-      fieldIds: AtomicInteger,
-      nestedFieldIds: AtomicInteger,
       repetition: Repetition = Repetition.OPTIONAL): Type = {
     val builder = bindings.head match {
-      case ObjectType.INT     => Types.primitive(PrimitiveTypeName.INT32, repetition).id(fieldIds.getAndIncrement())
-      case ObjectType.DOUBLE  => Types.primitive(PrimitiveTypeName.DOUBLE, repetition).id(fieldIds.getAndIncrement())
-      case ObjectType.LONG    => Types.primitive(PrimitiveTypeName.INT64, repetition).id(fieldIds.getAndIncrement())
-      case ObjectType.FLOAT   => Types.primitive(PrimitiveTypeName.FLOAT, repetition).id(fieldIds.getAndIncrement())
-      case ObjectType.BOOLEAN => Types.primitive(PrimitiveTypeName.BOOLEAN, repetition).id(fieldIds.getAndIncrement())
-      case ObjectType.BYTES   => Types.primitive(PrimitiveTypeName.BINARY, repetition).id(fieldIds.getAndIncrement())
+      case ObjectType.INT     => Types.primitive(PrimitiveTypeName.INT32, repetition)
+      case ObjectType.DOUBLE  => Types.primitive(PrimitiveTypeName.DOUBLE, repetition)
+      case ObjectType.LONG    => Types.primitive(PrimitiveTypeName.INT64, repetition)
+      case ObjectType.FLOAT   => Types.primitive(PrimitiveTypeName.FLOAT, repetition)
+      case ObjectType.BOOLEAN => Types.primitive(PrimitiveTypeName.BOOLEAN, repetition)
+      case ObjectType.BYTES   => Types.primitive(PrimitiveTypeName.BINARY, repetition)
 
       case ObjectType.STRING if bindings.last == ObjectType.JSON =>
         Types.buildGroup(repetition)
-          .id(fieldIds.getAndIncrement())
           .as(LogicalTypeAnnotation.variantType(1))
           // note: the iceberg api does not define nested fields for variants so we don't set id here
           .required(PrimitiveTypeName.BINARY).named("metadata")
@@ -232,33 +235,28 @@ object SimpleFeatureParquetSchema extends LazyLogging {
 
       case ObjectType.STRING =>
         Types.primitive(PrimitiveTypeName.BINARY, repetition)
-          .id(fieldIds.getAndIncrement())
           .as(LogicalTypeAnnotation.stringType())
 
       case ObjectType.DATE =>
         Types.primitive(PrimitiveTypeName.INT64, repetition)
-          .id(fieldIds.getAndIncrement())
           .as(LogicalTypeAnnotation.timestampType(true, TimeUnit.MICROS))
 
       case ObjectType.UUID =>
         Types.primitive(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, repetition)
-          .id(fieldIds.getAndIncrement())
           .length(16)
           .as(LogicalTypeAnnotation.uuidType())
 
       case ObjectType.LIST =>
         Types.optionalList()
-          .id(fieldIds.getAndIncrement())
-          .element(buildType("element", bindings.drop(1), geometries, nestedFieldIds, null /* should not be used*/, Repetition.REQUIRED))
+          .element(buildType("element", bindings.drop(1), geometries, Repetition.REQUIRED))
 
       case ObjectType.MAP =>
         Types.optionalMap()
-          .id(fieldIds.getAndIncrement())
-          .key(buildType("key", bindings.slice(1, 2), geometries, nestedFieldIds, null /* should not be used*/, Repetition.REQUIRED))
-          .value(buildType("value", bindings.slice(2, 3), geometries, nestedFieldIds, null /* should not be used*/))
+          .key(buildType("key", bindings.slice(1, 2), geometries, Repetition.REQUIRED))
+          .value(buildType("value", bindings.slice(2, 3), geometries))
 
       case ObjectType.GEOMETRY =>
-        geometries.schema(bindings(1), fieldIds, nestedFieldIds)
+        geometries.schema(bindings(1))
 
       case binding =>
         throw new UnsupportedOperationException(s"No mapping defined for type: $binding")

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/schema/BoundingBoxField.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/schema/BoundingBoxField.scala
@@ -42,14 +42,13 @@ object BoundingBoxField {
    * @param geom geometry column name
    * @return
    */
-  def parquetSchema(geom: String, fieldIds: AtomicInteger, nestedFieldIds: AtomicInteger): GroupType = {
+  def parquetSchema(geom: String): GroupType = {
     val bbox = groupName(geom)
     Types.optionalGroup()
-      .id(fieldIds.getAndIncrement())
-      .required(PrimitiveTypeName.FLOAT).id(nestedFieldIds.getAndIncrement()).named(BoundingBoxField.XMin)
-      .required(PrimitiveTypeName.FLOAT).id(nestedFieldIds.getAndIncrement()).named(BoundingBoxField.YMin)
-      .required(PrimitiveTypeName.FLOAT).id(nestedFieldIds.getAndIncrement()).named(BoundingBoxField.XMax)
-      .required(PrimitiveTypeName.FLOAT).id(nestedFieldIds.getAndIncrement()).named(BoundingBoxField.YMax)
+      .required(PrimitiveTypeName.FLOAT).named(BoundingBoxField.XMin)
+      .required(PrimitiveTypeName.FLOAT).named(BoundingBoxField.YMin)
+      .required(PrimitiveTypeName.FLOAT).named(BoundingBoxField.XMax)
+      .required(PrimitiveTypeName.FLOAT).named(BoundingBoxField.YMax)
       .named(bbox)
   }
 
@@ -59,13 +58,13 @@ object BoundingBoxField {
    * @param geom geometry column name
    * @return
    */
-  def icebergSchema(geom: String, fieldIds: AtomicInteger, nestedFieldIds: AtomicInteger): NestedField = {
+  def icebergSchema(geom: String, fieldIds: AtomicInteger): NestedField = {
     val bbox = groupName(geom)
     NestedField.optional(bbox).withId(fieldIds.getAndIncrement()).ofType(StructType.of(
-      NestedField.required(BoundingBoxField.XMin).withId(nestedFieldIds.getAndIncrement()).ofType(FloatType.get()).build(),
-      NestedField.required(BoundingBoxField.YMin).withId(nestedFieldIds.getAndIncrement()).ofType(FloatType.get()).build(),
-      NestedField.required(BoundingBoxField.XMax).withId(nestedFieldIds.getAndIncrement()).ofType(FloatType.get()).build(),
-      NestedField.required(BoundingBoxField.YMax).withId(nestedFieldIds.getAndIncrement()).ofType(FloatType.get()).build(),
+      NestedField.required(BoundingBoxField.XMin).withId(fieldIds.getAndIncrement()).ofType(FloatType.get()).build(),
+      NestedField.required(BoundingBoxField.YMin).withId(fieldIds.getAndIncrement()).ofType(FloatType.get()).build(),
+      NestedField.required(BoundingBoxField.XMax).withId(fieldIds.getAndIncrement()).ofType(FloatType.get()).build(),
+      NestedField.required(BoundingBoxField.YMax).withId(fieldIds.getAndIncrement()).ofType(FloatType.get()).build(),
     )).build()
   }
 

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/schema/SimpleFeatureSchema.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/schema/SimpleFeatureSchema.scala
@@ -19,4 +19,6 @@ object SimpleFeatureSchema {
   val SftSpecKey            = "geomesa.fs.sft.spec"
   val GeometryEncodingKey   = "geomesa.parquet.geometries"
   val PartitionKey          = "geomesa.fs.partition"
+  // serialized iceberg name mapping, used to stamp iceberg field ids onto written parquet files
+  val IcebergNameMappingKey = "geomesa.iceberg.name.mapping"
 }

--- a/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/schema/ZValueField.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/main/scala/org/locationtech/geomesa/fs/storage/core/schema/ZValueField.scala
@@ -47,8 +47,8 @@ object ZValueField {
    * @param geometryType geom type
    * @return
    */
-  def parquetSchema(geom: String, geometryType: ObjectType, fieldIds: AtomicInteger): PrimitiveType =
-    Types.optional(PrimitiveTypeName.BINARY).id(fieldIds.getAndIncrement()).as(LogicalTypeAnnotation.stringType()).named(name(geom, geometryType))
+  def parquetSchema(geom: String, geometryType: ObjectType): PrimitiveType =
+    Types.optional(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named(name(geom, geometryType))
 
   /**
    * The iceberg schema for a z-value field

--- a/geomesa-fs/geomesa-fs-storage/src/test/scala/org/locationtech/geomesa/fs/storage/core/iceberg/IcebergMapperTest.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/test/scala/org/locationtech/geomesa/fs/storage/core/iceberg/IcebergMapperTest.scala
@@ -14,6 +14,7 @@ import org.apache.iceberg.transforms.Transform
 import org.apache.iceberg.types.Types
 import org.locationtech.geomesa.curve.Z2SFC
 import org.locationtech.geomesa.features.ScalaSimpleFeature
+import org.locationtech.geomesa.fs.storage.core.parquet.schema.GeometrySchema.GeometryEncoding.GeoParquetWkb
 import org.locationtech.geomesa.fs.storage.core.schemes.{DateTimeScheme, PartitionSchemeFactory}
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.text.DateParsing
@@ -29,7 +30,7 @@ class IcebergMapperTest extends SpecificationWithJUnit {
   import scala.collection.JavaConverters._
 
   val sft = SimpleFeatureTypes.createType("test", "name:String,age:Int,dtg:Date,*geom:Point:srid=4326")
-  val schema = SimpleFeatureIcebergSchema(sft, Map.empty).schema
+  val schema = SimpleFeatureIcebergSchema.create(sft, GeoParquetWkb)
   val sf = ScalaSimpleFeature.create(sft, "", "goodbye", "11", "2026-05-06T11:12:13", "POINT (10 10)")
   val dtg = sf.getAttribute("dtg").asInstanceOf[Date].getTime * 1000 // in microseconds
 

--- a/geomesa-fs/geomesa-fs-storage/src/test/scala/org/locationtech/geomesa/fs/storage/core/parquet/GenerateParquetFiles.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/test/scala/org/locationtech/geomesa/fs/storage/core/parquet/GenerateParquetFiles.scala
@@ -18,7 +18,6 @@ import org.locationtech.geomesa.fs.storage.core.schema.SimpleFeatureSchema
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.io.WithClose
 
-import java.net.URI
 import java.util.{Locale, UUID}
 
 /**
@@ -70,7 +69,7 @@ object GenerateParquetFiles extends StrictLogging {
       val conf = Map(SimpleFeatureSchema.GeometryEncodingKey -> encoding.toString)
       val file =
         s"${sys.props("java.io.tmpdir")}/${encoding.toString.replace("GeoParquet", "geoparquet-").toLowerCase(Locale.US)}-test.parquet"
-      WithClose(new ParquetFileSystemWriter(sft, conf, LocalObjectStore, file)) { writer =>
+      WithClose(ParquetFileSystemWriter(sft, conf, LocalObjectStore, file)) { writer =>
         features.foreach(writer.write)
       }
       logger.info(s"Wrote ${features.length} features to $file")

--- a/geomesa-fs/geomesa-fs-storage/src/test/scala/org/locationtech/geomesa/fs/storage/core/parquet/io/ParquetReadWriteTest.scala
+++ b/geomesa-fs/geomesa-fs-storage/src/test/scala/org/locationtech/geomesa/fs/storage/core/parquet/io/ParquetReadWriteTest.scala
@@ -11,7 +11,6 @@ package org.locationtech.geomesa.fs.storage.core.parquet.io
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.parquet.conf.{ParquetConfiguration, PlainParquetConfiguration}
 import org.apache.parquet.filter2.compat.FilterCompat
-import org.apache.parquet.io.LocalOutputFile
 import org.geotools.api.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.geotools.data.DataUtilities
 import org.geotools.filter.text.ecql.ECQL
@@ -82,7 +81,7 @@ class ParquetReadWriteTest extends SpecificationWithJUnit with LazyLogging {
   "SimpleFeatureParquetWriter" should {
 
     "fail if a corrupt parquet file is written" >> {
-      WithClose(ParquetFileSystemWriter.builder(new LocalOutputFile(f), sftConf).build()) { writer =>
+      WithClose(ParquetFileSystemWriter(sft, Map.empty, LocalObjectStore, s"file://${f.toString}")) { writer =>
         features.foreach(writer.write)
       }
 
@@ -101,7 +100,7 @@ class ParquetReadWriteTest extends SpecificationWithJUnit with LazyLogging {
     }
 
     "write parquet files" >> {
-      WithClose(ParquetFileSystemWriter.builder(new LocalOutputFile(f), sftConf).build()) { writer =>
+      WithClose(ParquetFileSystemWriter(sft, Map.empty, LocalObjectStore, s"file://${f.toString}")) { writer =>
         features.foreach(writer.write)
       }
       Files.size(f) must beGreaterThan(0L)


### PR DESCRIPTION
* Use the field ids from the Iceberg table
* Previously we were computing field ids dynamically, but that won't work if the table schema is updated